### PR TITLE
MCP sign-in passthrough: single-credential token minting (oauth_obo)

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -17,8 +17,9 @@ The MCP server admin form exposes three authorization modes ("Multitenant Author
 | `none` | No headers attached. Open MCP server (or one gated by network policy only). | Internal MCP servers on a trusted network. |
 | `static` | One static bearer token, configured per server, sent on every request from every user. | Service-to-service MCP servers where per-user attribution doesn't matter, or single-tenant deployments. |
 | `oauth_user` *(recommended for user-data servers)* | Each user authorizes separately via OAuth 2.1 + PKCE; Turnstone stores per-user tokens encrypted at rest. | MCP servers that expose user-specific data or that want per-user audit attribution. |
+| `oauth_obo` *(sign-in passthrough)* | Each user's Turnstone **org sign-in** (OIDC) mints a per-server access token on demand — no separate per-server consent. One captured credential per user covers every `oauth_obo` server. | Enterprise deployments where the identity provider governs access (Entra, Keycloak) and you want zero per-user connect clicks. See the dedicated section below. |
 
-Switching `auth_type` away from `oauth_user` orphans existing per-user tokens. Use the admin **bulk-revoke** affordance on the server row (Phase 9) to clear them, or let them expire naturally — they're inert without the matching `auth_type` value.
+Switching `auth_type` away from `oauth_user` / `oauth_obo` orphans (oauth_user) or purges (on transition, per below) existing per-user rows. Use the admin **bulk-revoke** / **flush cache** affordance on the server row to clear them, or let them expire naturally.
 
 ---
 
@@ -65,6 +66,56 @@ Keep this in `config.toml` rather than environment variables. An in-process LLM 
 
 ---
 
+## `auth_type=oauth_obo` — single-credential sign-in passthrough
+
+Where `oauth_user` makes each user complete a **separate** browser consent per MCP server, `oauth_obo` reuses the user's Turnstone **org sign-in** (OIDC). Turnstone captures one refresh credential per user at login and, on each tool call, mints a short-lived access token scoped to that server's audience. There is no per-server connect step, and one credential covers every `oauth_obo` server. This is the right shape when your identity provider already governs who may reach each backend (an Entra tenant with Entra-protected MCP servers; a Keycloak realm with token exchange).
+
+Access is governed **downstream** by the IdP: a user can only mint a token for a server their delegated permissions allow. Removing that grant at the IdP cuts the user off regardless of their Turnstone state.
+
+### Deployment configuration (`[oidc]` in `config.toml`)
+
+`oauth_obo` requires OIDC SSO to be configured (it is the credential source), plus:
+
+```toml
+[oidc]
+# ... your existing issuer / client_id / client_secret ...
+capture_user_credential = true          # persist the IdP refresh token at login
+obo_grant_profile = "entra"             # "entra" | "rfc8693" — how tokens are minted
+```
+
+- **`capture_user_credential`** (default `false`): when enabled, Turnstone appends `offline_access` to the login scopes and stores the returned refresh token, encrypted with the same `[security] mcp_token_encryption_key` as `oauth_user` tokens. **The encryption key is required** — Turnstone refuses to start with an `oauth_obo` row (or capture enabled) and no key.
+- **`obo_grant_profile`** picks the mint mechanism (the IdP determines which one is valid; this is deployment-wide, not per-server):
+  - **`entra`** — redeems the user's refresh token directly for a token scoped to `<audience>/.default`. `oauth_scopes` on the server row is **not used** (the admin form rejects it under this profile).
+  - **`rfc8693`** — a refresh grant for a subject token, then an RFC 8693 token exchange for the server audience. Per-server `oauth_scopes` **are** sent on the exchange (some IdPs require the audience scope explicitly).
+
+### Adding an `oauth_obo` server
+
+In the admin MCP form, choose **Sign-in passthrough** and set **Audience** (required — the downstream resource the token is minted for, e.g. `api://<app-id>` on Entra or the client id on Keycloak). The client-id / secret / registration fields do not apply and are hidden.
+
+### Identity-provider setup
+
+**Entra (`obo_grant_profile = "entra"`):**
+1. Turnstone's app registration must hold **delegated permissions** to each MCP server's exposed API, with **admin consent granted** (or the MCP app listed in Turnstone's `preAuthorizedApplications`).
+2. Set the server row's Audience to the MCP app's Application ID URI (`api://<guid>`).
+3. **Gotcha (verified):** admin-consent issued *immediately* after creating the app/service principal can silently skip a not-yet-propagated resource — the only symptom is `AADSTS65001` at mint time. Verify the delegated grant landed (`az ad app permission list-grants` / the portal's *API permissions* blade shows *Granted*), or grant it explicitly per resource. A missing grant surfaces in Turnstone as a re-login prompt on the affected server (same rail as a revoked credential), and the `mcp_server.oauth.obo_mint_rejected` log line carries the raw `AADSTS…` text.
+
+**Keycloak / RFC 8693 (`obo_grant_profile = "rfc8693"`):**
+1. Enable **standard token exchange** on Turnstone's client.
+2. Grant the audience: add an audience client scope for each MCP client and attach it to Turnstone's client (optional scopes must be requested — set the server row's Scopes to that scope, or the exchange returns *"Requested audience not available"*).
+3. Set the server row's Audience to the downstream client id.
+
+### Revocation & custody
+
+The captured credential is a single per-user secret that can mint for every `oauth_obo` server, so treat it like any long-lived credential:
+
+- **Cut off one user:** unlink their OIDC identity in the admin console (**Users → OIDC identities → delete**). This revokes the captured credential **and** purges their minted cache rows, so future mints fail and cached tokens are dropped. (Warmed in-memory sessions on server nodes self-expire at the access-token TTL; there is no cross-node per-user session-kill.) Removing the user's access at the IdP is the authoritative cut-off.
+- **Flush a server's minted tokens** (e.g. after narrowing its audience): the server row's **flush cache** action drops all users' cached tokens for that server. This is **not** a revocation — users re-mint on next use from their still-valid sign-in. It is surfaced honestly (audit `mcp_server.oauth.obo_cache_flushed`, response `effect: cache_flush_remints`) so it is never mistaken for cutting access.
+- Per-server revocation in the `oauth_user` sense does not exist for `oauth_obo` — the credential is issuer-scoped and IdP-governed. Revoke at the IdP.
+
+> **Interim for Entra without OBO:** if you don't want host-side minting, admin consent + `preAuthorizedApplications` on each MCP app registration removes the second consent prompt for the plain `oauth_user` flow too (a tenant-config change, no Turnstone code). Tracked in issue #682. It does not remove the per-server connect clicks or per-(user, server) token custody — that is what `oauth_obo` is for.
+
+---
+
 ## Lifecycle
 
 1. **First tool call** for a user against an `oauth_user` MCP server: pool dispatch finds no stored token, returns `mcp_consent_required` to the agent. Dashboard renders an inline "Connect" action card.
@@ -99,8 +150,11 @@ Additional indicators (circuit-breaker state, encryption-key mismatch) are expos
 | `none` / `static` → `oauth_user` | — | New code path activates for this server. Existing static headers (if any) are no longer sent. Users must authorize on first use. |
 | `oauth_user` → `none` / `static` | — | Existing `mcp_user_tokens` rows are **orphaned** — inert without a matching `auth_type`. Use admin bulk-revoke to drop them, or let them expire. Switching back to `oauth_user` later re-activates the orphaned rows if they haven't been deleted. |
 | OAuth `client_id` or `client_secret` rotated | — | Existing tokens may stop refreshing if the AS treats them as bound to the previous client. Bulk-revoke after rotation. |
+| `oauth_user` ↔ `oauth_obo` | — | The per-user rows are **purged** on the flip (they mean different things: per-server AS refresh tokens vs. minted cache). A flip into `oauth_obo` also clears the stale `oauth_scopes` (they were the AS-consent scopes; the mint leg would otherwise send them). |
+| `oauth_obo` → `none` / `static` | — | Minted cache rows are purged. |
+| `oauth_obo` **audience** or **URL** changed | — | Minted cache rows for the old audience/URL are **purged** (tokens are audience/URL-bound), forcing a fresh mint. |
 
-The orphan-by-default behavior is chosen so switching back to `oauth_user` is non-destructive. Bulk-revoke is the explicit cleanup path.
+The orphan-by-default behavior (for `oauth_user` → `none`/`static`) is chosen so switching back is non-destructive. Transitions **into or out of** `oauth_obo`, and audience/URL edits, purge instead — the bindings are semantic and a stale row must never be served.
 
 ---
 
@@ -113,5 +167,9 @@ The orphan-by-default behavior is chosen so switching back to `oauth_user` is no
 | `mcp_oauth_url_insecure` | MCP server URL is `http://` (not `https://`) on a non-loopback host | Use `https://`. Per-user bearers must not transit cleartext. |
 | Tools fail in scheduled / Discord / Slack runs | OAuth-MCP requires browser-based consent | Users must pre-consent via the web UI. Phase 9 dashboard badge surfaces deferred consents from these runs on next login. |
 | Circuit breaker open repeatedly | Transport-level errors on the MCP server (DNS, TLS, 5xx) | Check the per-server error pill; auth errors do not trip the breaker. |
+| **`oauth_obo`**: every tool call fails, log shows `obo_misconfigured` | Server row has no Audience, or `obo_grant_profile` is unset/unknown | Set the Audience on the server row; set `[oidc] obo_grant_profile` to `entra` or `rfc8693`. |
+| **`oauth_obo`**: `obo_mint_rejected` with `AADSTS65001` | Turnstone's app lacks the (admin-consented) delegated grant to this MCP app — often admin consent that didn't propagate | Grant + admin-consent the delegated permission for this resource; verify it shows *Granted*. See the Entra gotcha above. |
+| **`oauth_obo`**: "Sign in to Turnstone again" on one server | Captured credential missing/rejected, or a Conditional Access challenge | User re-logs into Turnstone (re-captures the credential). If it persists, check the IdP grant / CA policy. |
+| **`oauth_obo`**: tools don't appear at all for a user | User has not signed in since `capture_user_credential` was enabled (no credential captured) | User logs out and back in via OIDC so the refresh credential is captured. |
 
 See also: `docs/operations/mcp-oauth-headless.md` for the cron / channel-driven run caveat.

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -19,7 +19,7 @@ The MCP server admin form exposes three authorization modes ("Multitenant Author
 | `oauth_user` *(recommended for user-data servers)* | Each user authorizes separately via OAuth 2.1 + PKCE; Turnstone stores per-user tokens encrypted at rest. | MCP servers that expose user-specific data or that want per-user audit attribution. |
 | `oauth_obo` *(sign-in passthrough)* | Each user's Turnstone **org sign-in** (OIDC) mints a per-server access token on demand — no separate per-server consent. One captured credential per user covers every `oauth_obo` server. | Enterprise deployments where the identity provider governs access (Entra, Keycloak) and you want zero per-user connect clicks. See the dedicated section below. |
 
-Switching `auth_type` away from `oauth_user` / `oauth_obo` orphans (oauth_user) or purges (on transition, per below) existing per-user rows. Use the admin **bulk-revoke** / **flush cache** affordance on the server row to clear them, or let them expire naturally.
+Switching `auth_type` away from `oauth_user` / `oauth_obo` **deletes** that server's per-user rows (consents / minted cache) — see the transition table below. Switching back later starts clean: users re-consent (or re-mint) on next use. The admin **bulk-revoke** / **flush cache** affordance clears rows without an auth-type change.
 
 ---
 
@@ -126,7 +126,7 @@ The captured credential is a single per-user secret that can mint for every `oau
 
 4. **Step-up scope**: when a tool call hits `403` with `WWW-Authenticate: error="insufficient_scope"`, Turnstone emits `mcp_insufficient_scope` with the parsed scope set; the dashboard offers a "Connect with additional scopes" affordance that opens `/v1/api/mcp/oauth/start?server=<name>&scopes=<extra>` so the union of original + new scopes flows into the AS authorize request.
 
-5. **User revoke** (settings modal): `DELETE /v1/api/mcp/oauth/connections/{server_name}` runs the authoritative local delete + best-effort RFC 7009 upstream revoke (fire-and-forget, capped at 256 concurrent in-flight tasks).
+5. **User revoke** (settings modal): `DELETE /v1/api/mcp/oauth/connections/{server_name}` runs the authoritative local delete + best-effort RFC 7009 upstream revoke (fire-and-forget, capped at 256 concurrent in-flight tasks). `oauth_obo` servers are excluded: their rows are mint cache, not consents — deleting one only forces a re-mint — so the connections list hides them and the endpoint refuses them with `409` (revocation for sign-in passthrough happens at the identity layer: unlink the identity or revoke at the IdP).
 
 6. **Admin bulk-revoke** (Phase 9): `POST /v1/api/admin/mcp-servers/{name}/bulk-revoke` drops every user's token for the server. Upstream RFC 7009 revoke is intentionally **not** attempted in bulk (avoids N upstream HTTP calls per admin click); tokens at the AS expire naturally. Use the per-user revoke endpoint if you need guaranteed upstream invalidation.
 
@@ -148,13 +148,13 @@ Additional indicators (circuit-breaker state, encryption-key mismatch) are expos
 | From | To | What happens |
 |---|---|---|
 | `none` / `static` → `oauth_user` | — | New code path activates for this server. Existing static headers (if any) are no longer sent. Users must authorize on first use. |
-| `oauth_user` → `none` / `static` | — | Existing `mcp_user_tokens` rows are **orphaned** — inert without a matching `auth_type`. Use admin bulk-revoke to drop them, or let them expire. Switching back to `oauth_user` later re-activates the orphaned rows if they haven't been deleted. |
+| `oauth_user` → `none` / `static` | — | Existing `mcp_user_tokens` rows are **deleted**: the tokens are bound to the auth model + URL active at consent time, and rows left behind could silently rebind if a row with the old name/URL reappears. Switching back to `oauth_user` later starts clean — users re-consent on next use. This is **not reversible**; the AS-side grants are untouched (revoke upstream via the AS if needed). |
 | OAuth `client_id` or `client_secret` rotated | — | Existing tokens may stop refreshing if the AS treats them as bound to the previous client. Bulk-revoke after rotation. |
-| `oauth_user` ↔ `oauth_obo` | — | The per-user rows are **purged** on the flip (they mean different things: per-server AS refresh tokens vs. minted cache). A flip into `oauth_obo` also clears the stale `oauth_scopes` (they were the AS-consent scopes; the mint leg would otherwise send them). |
-| `oauth_obo` → `none` / `static` | — | Minted cache rows are purged. |
-| `oauth_obo` **audience** or **URL** changed | — | Minted cache rows for the old audience/URL are **purged** (tokens are audience/URL-bound), forcing a fresh mint. |
+| `oauth_user` ↔ `oauth_obo` | — | The per-user rows are **deleted** on the flip (they mean different things: per-server AS refresh tokens vs. minted cache). A flip into `oauth_obo` clears carried-over `oauth_scopes` under the `entra` profile (they cannot apply there); under `rfc8693` a scopes value submitted with the flip is kept as the token-exchange scope and the column is cleared only when the request omits it. A flip into `oauth_user` clears the obo-era `oauth_audience` (an IdP-side app identifier, not the resource indicator `oauth_user` needs) unless the request sets a new one. |
+| `oauth_obo` → `none` / `static` | — | Minted cache rows are deleted. |
+| `oauth_obo` **audience**, **URL**, or **`oauth_scopes`** changed | — | Minted cache rows are **deleted** (tokens are bound to the audience/URL/scopes at mint time), forcing a fresh mint — so an audience or scope narrowing takes effect immediately, not at token expiry. |
 
-The orphan-by-default behavior (for `oauth_user` → `none`/`static`) is chosen so switching back is non-destructive. Transitions **into or out of** `oauth_obo`, and audience/URL edits, purge instead — the bindings are semantic and a stale row must never be served.
+Every transition that changes what a stored row *means* deletes the rows outright — a stale consent or minted token must never be served under new semantics. There is no orphan-and-reactivate path.
 
 ---
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -92,6 +92,8 @@ obo_grant_profile = "entra"             # "entra" | "rfc8693" — how tokens are
 
 In the admin MCP form, choose **Sign-in passthrough** and set **Audience** (required — the downstream resource the token is minted for, e.g. `api://<app-id>` on Entra or the client id on Keycloak). The client-id / secret / registration fields do not apply and are hidden.
 
+`oauth_obo` servers are accepted only when **OIDC sign-in is configured and enabled** and `[oidc] obo_grant_profile` is a valid profile — the write is rejected otherwise, since a row that can never mint would surface to users as a permanent "please retry" that never heals.
+
 ### Identity-provider setup
 
 **Entra (`obo_grant_profile = "entra"`):**
@@ -150,7 +152,7 @@ Additional indicators (circuit-breaker state, encryption-key mismatch) are expos
 | `none` / `static` → `oauth_user` | — | New code path activates for this server. Existing static headers (if any) are no longer sent. Users must authorize on first use. |
 | `oauth_user` → `none` / `static` | — | Existing `mcp_user_tokens` rows are **deleted**: the tokens are bound to the auth model + URL active at consent time, and rows left behind could silently rebind if a row with the old name/URL reappears. Switching back to `oauth_user` later starts clean — users re-consent on next use. This is **not reversible**; the AS-side grants are untouched (revoke upstream via the AS if needed). |
 | OAuth `client_id` or `client_secret` rotated | — | Existing tokens may stop refreshing if the AS treats them as bound to the previous client. Bulk-revoke after rotation. |
-| `oauth_user` ↔ `oauth_obo` | — | The per-user rows are **deleted** on the flip (they mean different things: per-server AS refresh tokens vs. minted cache). A flip into `oauth_obo` clears carried-over `oauth_scopes` under the `entra` profile (they cannot apply there); under `rfc8693` a scopes value submitted with the flip is kept as the token-exchange scope and the column is cleared only when the request omits it. A flip into `oauth_user` clears the obo-era `oauth_audience` (an IdP-side app identifier, not the resource indicator `oauth_user` needs) unless the request sets a new one. |
+| `oauth_user` ↔ `oauth_obo` | — | The per-user rows are **deleted** on the flip (they mean different things: per-server AS refresh tokens vs. minted cache). `oauth_audience` and `oauth_scopes` mean different things in each model (a resource indicator vs. an IdP app identifier; AS-consent scopes vs. an rfc8693 exchange scope), so on a flip they **never carry** — each is taken from the request for the target model or set NULL. The admin console clears these fields when you change the auth type, so re-enter the correct values for the new mode; via the API, supply them explicitly (a flip into `oauth_obo` with no `oauth_audience` is rejected, and a non-empty `oauth_scopes` under the `entra` profile is rejected since that leg pins `<audience>/.default`). |
 | `oauth_obo` → `none` / `static` | — | Minted cache rows are deleted. |
 | `oauth_obo` **audience**, **URL**, or **`oauth_scopes`** changed | — | Minted cache rows are **deleted** (tokens are bound to the audience/URL/scopes at mint time), forcing a fresh mint — so an audience or scope narrowing takes effect immediately, not at token expiry. |
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -77,17 +77,17 @@ IdP from redirecting the token-exchange POST (which carries
 being aimed at internal services.
 
 A few public IdPs legitimately split endpoints across hostnames. Google
-is the canonical example:
+and Microsoft Entra ID are the canonical examples:
 
-| Field | Hostname |
-|-------|----------|
-| issuer | `accounts.google.com` |
-| token_endpoint | `oauth2.googleapis.com` |
-| jwks_uri | `www.googleapis.com` |
-| userinfo_endpoint | `openidconnect.googleapis.com` |
+| IdP | Issuer host | Cross-host endpoint(s) |
+|-----|-------------|------------------------|
+| Google | `accounts.google.com` | `oauth2.googleapis.com`, `www.googleapis.com`, `openidconnect.googleapis.com` |
+| Microsoft Entra | `login.microsoftonline.com` | `graph.microsoft.com` (userinfo) |
 
-Google's set is built in — operators using `https://accounts.google.com`
-need no extra configuration.
+Both sets are built in — operators using `https://accounts.google.com` or
+`https://login.microsoftonline.com/<tenant>/v2.0` need no extra
+configuration. (Entra's discovery document advertises `userinfo_endpoint`
+on `graph.microsoft.com`, distinct from the issuer host.)
 
 For other IdPs whose discovery document references a non-issuer host,
 extend the allow-list explicitly:

--- a/scripts/obo-e2e/.env.example
+++ b/scripts/obo-e2e/.env.example
@@ -1,0 +1,19 @@
+# Entra config for the Entra e2e / spike harnesses. Copy to `.env` (gitignored)
+# and fill in from your tenant. `entra_setup.sh setup` creates the app
+# registrations and writes a populated `.env` for you.
+#
+#   cp scripts/obo-e2e/.env.example scripts/obo-e2e/.env
+#   # then edit, or run: ./scripts/obo-e2e/entra_setup.sh setup
+
+export ENTRA_TENANT_ID=<tenant-guid-or-domain>
+export ENTRA_CLIENT_ID=<turnstone-spike-app-client-id>
+export ENTRA_CLIENT_SECRET=<client-secret>
+export SPIKE_AUDIENCE_A=api://<resource-app-a-guid>   # a consented resource
+export SPIKE_AUDIENCE_B=api://<resource-app-b-guid>   # a second consented resource
+export SPIKE_AUDIENCE_UNCONSENTED=api://<resource-app-c-guid>  # NOT granted (negative case)
+export SPIKE_RUN_OBO=1
+# export SPIKE_PORT=8765            # redirect-listener port (default 8765)
+# export SPIKE_CALLBACK_FILE=/tmp/obo_cb.txt   # remote-browser mode: paste the redirect URL here
+
+# The Keycloak / OSS-path harness needs no config — keycloak_e2e.sh sets
+# everything and stands up an ephemeral container.

--- a/scripts/obo-e2e/README.md
+++ b/scripts/obo-e2e/README.md
@@ -1,0 +1,214 @@
+# OBO e2e harnesses — single-credential MCP token minting (`auth_type=oauth_obo`)
+
+Manual test harnesses for the `oauth_obo` feature (issue #551). They exercise
+the **real** Turnstone mint path (`get_obo_access_token_classified` →
+`_obo_mint_entra` / `_obo_mint_rfc8693`) against a real identity provider — not
+mocks, not the unit suite. Two grant legs:
+
+- **Entra** (`entra_e2e.py`) — real tenant, one interactive sign-in.
+- **Keycloak / RFC 8693** (`keycloak_e2e.py` + `.sh`) — ephemeral docker, fully
+  headless.
+
+There is also `entra_spike.py` (raw-OAuth **wire** probe, pre-implementation
+reference) and `entra_setup.sh` (creates the Entra app registrations + writes a
+populated `.env`).
+
+**Secrets:** these read config from env. Real credentials live in a **gitignored
+`.env`** (copy `.env.example`); nothing tenant-specific is committed. The only
+literal secret in the tree is the ephemeral Keycloak container's throwaway
+`spike-secret`, which lives and dies with the container.
+
+Not part of CI — run by hand when validating the feature against a live IdP.
+
+## `entra_e2e.py` — end-to-end product exercise (post-implementation)
+
+`entra_spike.py` verified the raw OAuth WIRE (before code existed). `entra_e2e.py`
+verifies the SHIPPED Turnstone code: it does a real Entra login, feeds the
+credential through the real `MCPTokenStore.upsert_oidc_credential` (the call the
+OIDC callback makes on capture), then drives the real
+`get_obo_access_token_classified` → `_obo_mint_entra` against the live Entra token
+endpoint. Checks E1–E7: real mint + aud claim, cache-hit (0 Entra calls),
+single-credential→audiences A&B, rotation write-back, force_refresh re-mint,
+unconsented-audience classification with the credential surviving, and
+flush→re-mint. Reuses the same `.env` and interactive login (SPIKE_CALLBACK_FILE
+for remote browser).
+
+```bash
+source scripts/obo-e2e/.env
+uv run python scripts/obo-e2e/entra_e2e.py
+# one interactive sign-in; E1–E7 then run against the real product code. Results below.
+```
+
+Results — RUN 2026-07-12 on the real tenant, ALL VERIFIED (exit 0): capture
+persisted; E1 mint A (aud=A app-id, cache row refresh_token_ct NULL); E2 cache
+hit (0 extra Entra calls); E3 mint B from the SAME credential (aud=B app-id); E4
+rotation write-back (RT rotated 2040→2091 chars, newest persisted); E5
+force_refresh re-mint (1 Entra call); E6 unconsented C → refresh_failed and the
+credential SURVIVES; E7 flush→re-mint. The real `get_obo_access_token_classified`
+→ `_obo_mint_entra` path against the live Entra token endpoint.
+
+## `keycloak_e2e.py` + `keycloak_e2e.sh` — OSS path (RFC 8693), headless
+
+The rfc8693 equivalent of `entra_e2e.py`: `keycloak_e2e.sh` spins up ephemeral
+Keycloak, configures the realm (turnstone client with standard token exchange,
+mcp-a/b/c clients, aud-mcp-a/b audience scopes, a test user), runs the harness
+against the real `get_obo_access_token_classified` → `_obo_mint_rfc8693`
+(refresh grant → token exchange), then tears down. No browser (password grant).
+
+```bash
+./scripts/obo-e2e/keycloak_e2e.sh
+```
+
+Results — RUN 2026-07-12, ALL VERIFIED: capture persisted; E1 mint A
+(refresh→exchange, aud=mcp-a, cache row refresh_token_ct NULL); E2 cache hit (0
+extra KC calls); E3 mint B from the SAME credential (aud=mcp-b); E4 rotation
+write-back (KC rotated the RT on the refresh leg, newest persisted); E5
+force_refresh re-mint (**2 KC calls** = the two-leg chain); E6 unconsented C →
+refresh_failed_transient (KC returns invalid_request for a missing audience
+scope → classified transient; credential SURVIVES either way); E7 flush→re-mint.
+Gotcha: dev-mode Keycloak boot is slow on a loaded host — the script now waits on
+kcadm auth (up to ~6 min) rather than a fixed sleep. Port 8091 (8090 = the dev
+console).
+
+## Leg 1 — Entra (`entra_spike.py`) — NEEDS TENANT ACCESS
+
+### Tenant / app-registration setup (one-time, ~15 min)
+
+1. **Spike client app** (stands in for Turnstone's OIDC app registration):
+   - New app registration, single tenant. Platform **Web**, redirect URI
+     `http://localhost:8765/callback`. Create a **client secret**.
+2. **Two resource apps** (stand in for MCP servers A and B):
+   - New app registrations `spike-mcp-a`, `spike-mcp-b`. In each:
+     **Expose an API** → set Application ID URI (`api://<guid>`) → add a scope
+     (e.g. `mcp.access`).
+3. **Delegated grants** (this is metaclassing's "proper tenant and app reg setup"):
+   - On the spike client app → **API permissions** → add delegated permission to
+     `spike-mcp-a` and `spike-mcp-b` scopes → **Grant admin consent**.
+   - Optionally also add the spike client's app id to each resource app's
+     `preAuthorizedApplications` (Expose an API → Add a client application) to
+     compare against pure admin consent.
+4. **Unconsented control** (for V5): a third resource app `spike-mcp-c` with an
+   exposed API but NO permission granted to the spike client.
+
+### Run
+
+```bash
+export ENTRA_TENANT_ID=... ENTRA_CLIENT_ID=... ENTRA_CLIENT_SECRET=...
+export SPIKE_AUDIENCE_A=api://<a-guid> SPIKE_AUDIENCE_B=api://<b-guid>
+export SPIKE_AUDIENCE_UNCONSENTED=api://<c-guid>   # optional (V5)
+export SPIKE_RUN_OBO=1                              # optional (V6)
+uv run python scripts/obo-e2e/entra_spike.py
+```
+
+A browser opens for one interactive login (any tenant user). Everything after is
+non-interactive — that IS the feature.
+
+### What each check pins down
+
+| Check | Design assumption it verifies |
+| --- | --- |
+| V1 | `offline_access` on the login yields a client-bound RT (capture layer) |
+| V2/V3 | ONE RT redeems for access tokens of DIFFERENT audiences (`scope=<aud>/.default`) — the load-bearing Entra behavior |
+| V4 | rotation semantics → whether RT write-back on every mint is convenience or correctness-critical |
+| V5 | unconsented audience fails `AADSTS65001 consent_required` → maps to the reconnect-rail fallback, never a silent failure |
+| V6 | OBO jwt-bearer middle-tier variant works with the same app registration (comparison data only) |
+
+Also record (manual): whether Conditional Access / MFA policies in the tenant
+produce `interaction_required` on redemption — that's the fallback path's other
+trigger.
+
+### Results — RUN 2026-07-11 on a real tenant, ALL SIX VERIFIED
+
+Tenant: personal default directory (Global Admin), user is an MSA member.
+Setup via `entra_setup.sh setup`; V3 initially failed (see gotcha below),
+passed after fixing the grant. Second run: V1-V6 all VERIFIED, exit 0.
+
+| Check | Result |
+| --- | --- |
+| V1 offline_access login -> RT | VERIFIED (confidential client + PKCE, RT ~2KB) |
+| V2 RT -> audience A token | VERIFIED (`aud=<A app guid>`, ~70 min TTL, new RT returned) |
+| V3 SAME RT -> audience B token | **VERIFIED — the load-bearing claim: one RT, many audiences** |
+| V4 rotation | VERIFIED: RT rotates on every redemption, but the OLD RT stays valid (reuse HTTP 200) -> write-back-newest is required; races are benign on Entra |
+| V5 unconsented audience | VERIFIED: `invalid_grant` + `AADSTS65001` (error_codes=[65001]) -> clean mapping to the reconnect-rail fallback |
+| V6 OBO jwt-bearer variant | VERIFIED: middle-tier shape also works with the same app registration |
+
+**Operator gotcha (feeds #682 + product docs):** `az ad app permission
+admin-consent` run immediately after SP creation SILENTLY skips
+not-yet-propagated resource SPs — grant A landed, grant B didn't, and the only
+symptom was AADSTS65001 at redemption. Verify grants after consent
+(`oauth2PermissionGrants` filter on the client SP) or write them directly with
+`az ad app permission grant --id <client> --api <resource> --scope <scope>`.
+Product-side implication: a missing tenant grant for a NEW oauth_obo server
+surfaces as AADSTS65001 -> the same reconnect-rail path as revocation; the
+admin docs must say "grant first, then add the server".
+
+## Leg 2 — Keycloak RFC 8693 (portability check) — runnable locally
+
+Ephemeral `quay.io/keycloak/keycloak:26.3` (`start-dev`, port 8089), realm
+`spike`, confidential client `turnstone` with **standard token exchange**
+enabled, resource clients `mcp-a`/`mcp-b`, user `alice`. Pipeline mirrors the
+product design for a generic-8693 IdP:
+
+```
+stored user RT --(refresh grant)--> user AT --(RFC 8693 exchange, audience=mcp-X)--> audience-scoped AT
+```
+
+i.e. the per-user credential stays ONE refresh token; per-server tokens are
+minted via standard token exchange instead of Entra's multi-resource RT
+redemption. Same substrate, different grant leg.
+
+### Results — RUN 2026-07-11, VERIFIED (Keycloak 26.3, ephemeral)
+
+```
+alice ONE stored RT
+  -> refresh grant                      -> user AT (azp=turnstone); RT ROTATED on refresh
+  -> 8693 exchange audience=mcp-a scope=aud-mcp-a -> AT aud=mcp-a user=alice 300s, NO RT
+  -> 8693 exchange audience=mcp-b scope=aud-mcp-b -> AT aud=mcp-b (same subject AT)
+  negative control audience=mcp-c       -> invalid_client "Audience not found"
+```
+
+Findings that feed the design:
+1. **One per-user credential -> N audience tokens: VERIFIED on a second IdP.**
+   The substrate is portable; only the grant leg differs per IdP.
+2. **Exchanged tokens are cache-shaped** (short TTL, no RT) — per-server
+   `mcp_user_tokens` rows as short-lived mint cache is the right model.
+3. **RT rotation happens here too** — newest-RT write-back on every redemption
+   is a correctness requirement of the capture layer, not an Entra quirk.
+4. **The IdP-side "delegated grant" has a per-IdP shape**: Entra = API
+   permissions + admin consent; Keycloak = audience client scopes attached to
+   the requester client (optional scopes activate via `scope=` at exchange).
+   Operator runbooks are per-IdP (#682 pattern), code is not.
+5. Gotchas hit: KC user needs a complete profile for direct grant ("Account is
+   not fully set up"); optional audience scope must be requested explicitly or
+   the exchange 400s with "Requested audience not available".
+
+Repro (ephemeral, ~2 min):
+
+```bash
+docker run -d --name kc-obo-spike -p 127.0.0.1:8089:8080 \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:26.3 start-dev
+KC="docker exec kc-obo-spike /opt/keycloak/bin/kcadm.sh"
+$KC config credentials --server http://localhost:8080 --realm master --user admin --password admin
+$KC create realms -s realm=spike -s enabled=true
+$KC create clients -r spike -s clientId=turnstone -s enabled=true -s publicClient=false \
+  -s secret=spike-secret -s directAccessGrantsEnabled=true \
+  -s 'attributes={"standard.token.exchange.enabled":"true"}'
+$KC create clients -r spike -s clientId=mcp-a -s enabled=true -s publicClient=false -s secret=x
+$KC create clients -r spike -s clientId=mcp-b -s enabled=true -s publicClient=false -s secret=x
+$KC create users -r spike -s username=alice -s enabled=true -s email=a@s.test \
+  -s emailVerified=true -s firstName=A -s lastName=S
+$KC set-password -r spike --username alice --new-password alice-pw
+TURNSTONE_UUID=$($KC get clients -r spike -q clientId=turnstone --fields id --format csv --noquotes)
+for t in mcp-a mcp-b; do
+  SID=$($KC create client-scopes -r spike -s name=aud-$t -s protocol=openid-connect -i)
+  $KC create client-scopes/$SID/protocol-mappers/models -r spike -s name=aud-$t \
+    -s protocol=openid-connect -s protocolMapper=oidc-audience-mapper \
+    -s "config={\"included.client.audience\":\"$t\",\"access.token.claim\":\"true\"}"
+  $KC update clients/$TURNSTONE_UUID/optional-client-scopes/$SID -r spike
+done
+# then: password grant -> refresh grant -> token-exchange with
+# grant_type=urn:ietf:params:oauth:grant-type:token-exchange,
+# subject_token=<user AT>, subject_token_type=...:access_token,
+# audience=mcp-a, scope=aud-mcp-a
+```

--- a/scripts/obo-e2e/entra_e2e.py
+++ b/scripts/obo-e2e/entra_e2e.py
@@ -1,0 +1,286 @@
+"""End-to-end exercise of the oauth_obo feature against a REAL Entra tenant.
+
+Unlike ``entra_spike.py`` (which verified the raw OAuth wire shapes), this
+drives the ACTUAL Turnstone product code — real ``MCPTokenStore``, real
+``get_obo_access_token_classified`` → ``_obo_mint_entra`` → the real Entra
+token endpoint — so a green run proves the shipped mint engine works against
+live Entra, not just that the protocol does.
+
+Flow:
+  1. Interactive Entra login (auth-code + PKCE + offline_access) → a real
+     refresh credential. This is what ``handle_oidc_callback`` receives.
+  2. Persist it via ``MCPTokenStore.upsert_oidc_credential`` — the exact call
+     the OIDC callback makes on capture (auth.py). The rest of the callback
+     (JWKS validation, user provisioning) is OIDC-generic and unit-tested; the
+     novel path is capture + mint, which this exercises for real.
+  3. Seed real ``oauth_obo`` ``mcp_servers`` rows (audiences A/B consented, C
+     not) and drive ``get_obo_access_token_classified`` — the real dispatch-time
+     entry point — asserting on the minted tokens, cache, rotation, and
+     classification.
+
+Checks (VERIFIED / FAILED per line):
+  E1  mint for audience A → kind=token; decoded aud == A; cache row written with
+      refresh_token_ct NULL (cache, not custody); expires_at set
+  E2  second call for A → cache hit, ZERO additional Entra calls
+  E3  mint for audience B from the SAME captured credential → aud == B
+      (the single-credential-many-audiences thesis, through the real engine)
+  E4  rotation write-back: the stored credential holds the newest refresh token
+  E5  force_refresh → a fresh mint (Entra call count increments)
+  E6  unconsented audience C → NOT kind=token, and the shared credential SURVIVES
+      (never auto-deleted — the load-bearing custody invariant)
+  E7  cache flush → re-mint: deleting the cache row makes the next call re-mint
+
+Run:
+  source scripts/obo-e2e/.env
+  uv run python scripts/obo-e2e/entra_e2e.py
+Env (from .env): ENTRA_TENANT_ID, ENTRA_CLIENT_ID, ENTRA_CLIENT_SECRET,
+  SPIKE_AUDIENCE_A, SPIKE_AUDIENCE_B, SPIKE_AUDIENCE_UNCONSENTED, SPIKE_PORT.
+Remote browser: set SPIKE_CALLBACK_FILE to paste the redirect URL (as before).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import sys
+import tempfile
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+
+# Reuse the verified interactive-login machinery from the wire spike.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from entra_spike import interactive_login, jwt_claims_unverified, redact  # noqa: E402
+
+from turnstone.core.mcp_crypto import (  # noqa: E402
+    MCPTokenCipher,
+    MCPTokenCipherConfig,
+    MCPTokenStore,
+)
+from turnstone.core.mcp_oauth import get_obo_access_token_classified  # noqa: E402
+from turnstone.core.oidc import OIDCConfig  # noqa: E402
+from turnstone.core.storage._sqlite import SQLiteBackend  # noqa: E402
+
+USER = "e2e-user"
+RESULTS: list[tuple[str, str]] = []
+
+
+def record(status: str, msg: str) -> None:
+    RESULTS.append((status, msg))
+    print(f"[{status:>8}] {msg}")
+
+
+def aud_matches(token: str, want_audience: str) -> tuple[bool, str]:
+    """Compare a minted access token's aud claim to the configured audience.
+
+    Entra returns aud as the bare app-id GUID or the full ``api://<guid>`` URI;
+    accept either.
+    """
+    claims = jwt_claims_unverified(token)
+    aud = str(claims.get("aud", "<none>"))
+    want = want_audience.removeprefix("api://")
+    return aud in (want, want_audience), aud
+
+
+class _CountingClient:
+    """Wraps httpx.AsyncClient, counting token-endpoint POSTs so cache hits
+    (which must issue zero) are observable."""
+
+    def __init__(self, inner: httpx.AsyncClient) -> None:
+        self._inner = inner
+        self.posts = 0
+
+    async def post(self, *args: Any, **kwargs: Any) -> httpx.Response:
+        self.posts += 1
+        return await self._inner.post(*args, **kwargs)
+
+
+def _make_app_state(
+    storage: SQLiteBackend,
+    store: MCPTokenStore,
+    oidc_config: OIDCConfig,
+    http_client: _CountingClient,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        auth_storage=storage,
+        mcp_token_store=store,
+        oidc_config=oidc_config,
+        oidc_http_client=http_client,
+        mcp_oauth_refresh_locks={},
+        mcp_oauth_refresh_backoff={},
+    )
+
+
+def _seed_obo_server(storage: SQLiteBackend, name: str, audience: str) -> None:
+    storage.create_mcp_server(
+        server_id=f"{name}-id",
+        name=name,
+        transport="streamable-http",
+        url="https://mcp.example.invalid/sse",
+        auth_type="oauth_obo",
+        oauth_audience=audience,
+    )
+
+
+async def _run(cfg: dict[str, str], refresh_token: str) -> None:
+    tenant = cfg["ENTRA_TENANT_ID"]
+    issuer = f"https://login.microsoftonline.com/{tenant}/v2.0"
+    token_endpoint = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+    aud_a = cfg["SPIKE_AUDIENCE_A"]
+    aud_b = cfg["SPIKE_AUDIENCE_B"]
+    aud_c = cfg.get("SPIKE_AUDIENCE_UNCONSENTED", "")
+
+    # Real Turnstone objects.
+    db_path = os.path.join(tempfile.mkdtemp(prefix="obo-e2e-"), "e2e.db")
+    storage = SQLiteBackend(db_path)
+    from cryptography.fernet import Fernet
+
+    raw = base64.urlsafe_b64decode(Fernet.generate_key())
+    store = MCPTokenStore(storage, MCPTokenCipher(MCPTokenCipherConfig(keys=(raw,))), node_id="e2e")
+    oidc_config = OIDCConfig(
+        enabled=True,
+        issuer=issuer,
+        client_id=cfg["ENTRA_CLIENT_ID"],
+        client_secret=cfg["ENTRA_CLIENT_SECRET"],
+        token_endpoint=token_endpoint,
+        obo_grant_profile="entra",
+        capture_user_credential=True,
+    )
+
+    # Step 2 — CAPTURE: the exact storage call handle_oidc_callback makes.
+    store.upsert_oidc_credential(USER, issuer, refresh_token=refresh_token)
+    cap = store.get_oidc_credential(USER, issuer)
+    if cap and cap["refresh_token"] == refresh_token:
+        record("VERIFIED", f"capture: credential persisted for {USER} ({redact(refresh_token)})")
+    else:
+        record("FAILED", "capture: credential did not round-trip")
+        return
+
+    _seed_obo_server(storage, "e2e-a", aud_a)
+    _seed_obo_server(storage, "e2e-b", aud_b)
+    if aud_c:
+        _seed_obo_server(storage, "e2e-c", aud_c)
+
+    inner = httpx.AsyncClient(timeout=20.0)
+    client = _CountingClient(inner)
+    app_state = _make_app_state(storage, store, oidc_config, client)
+    try:
+        # E1 — real mint for audience A.
+        r = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="e2e-a"
+        )
+        if r.kind == "token" and r.token:
+            ok, aud = aud_matches(r.token, aud_a)
+            row = storage.get_mcp_user_token(USER, "e2e-a")
+            cache_ok = (
+                row is not None and row["refresh_token_ct"] is None and bool(row["expires_at"])
+            )
+            record(
+                "VERIFIED" if ok and cache_ok else "FAILED",
+                f"E1 mint A: kind=token aud={aud} want={aud_a} cache_row_refreshless={cache_ok}",
+            )
+        else:
+            record("FAILED", f"E1 mint A: kind={r.kind} (expected token)")
+            return
+
+        # E2 — cache hit issues zero Entra calls.
+        posts_before = client.posts
+        r2 = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="e2e-a"
+        )
+        record(
+            "VERIFIED" if r2.kind == "token" and client.posts == posts_before else "FAILED",
+            f"E2 cache hit: kind={r2.kind} extra_entra_calls={client.posts - posts_before} (want 0)",
+        )
+
+        # E3 — same credential, audience B.
+        rb = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="e2e-b"
+        )
+        if rb.kind == "token" and rb.token:
+            ok_b, aud_bclaim = aud_matches(rb.token, aud_b)
+            record(
+                "VERIFIED" if ok_b else "FAILED",
+                f"E3 mint B from SAME credential: aud={aud_bclaim} want={aud_b}",
+            )
+        else:
+            record("FAILED", f"E3 mint B: kind={rb.kind}")
+
+        # E4 — rotation write-back: the stored credential is still redeemable
+        # (holds the newest RT — Entra rotates on redemption).
+        cred_now = store.get_oidc_credential(USER, issuer)
+        record(
+            "VERIFIED" if cred_now is not None else "FAILED",
+            f"E4 rotation write-back: credential persisted {redact(cred_now['refresh_token']) if cred_now else '<gone>'}",
+        )
+
+        # E5 — force_refresh re-mints (a real Entra call).
+        posts_before = client.posts
+        rf = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="e2e-a", force_refresh=True
+        )
+        record(
+            "VERIFIED" if rf.kind == "token" and client.posts > posts_before else "FAILED",
+            f"E5 force_refresh re-mint: kind={rf.kind} entra_calls={client.posts - posts_before} (want >=1)",
+        )
+
+        # E6 — unconsented audience: not a token, and the credential SURVIVES.
+        if aud_c:
+            rc = await get_obo_access_token_classified(
+                app_state=app_state, user_id=USER, server_name="e2e-c"
+            )
+            cred_after = store.get_oidc_credential(USER, issuer)
+            record(
+                "VERIFIED" if rc.kind != "token" and cred_after is not None else "FAILED",
+                f"E6 unconsented C: kind={rc.kind} (not token) credential_survives={cred_after is not None}",
+            )
+        else:
+            record("SKIPPED", "E6 unconsented C: SPIKE_AUDIENCE_UNCONSENTED not set")
+
+        # E7 — cache flush → re-mint.
+        store.delete_user_token(USER, "e2e-a")
+        posts_before = client.posts
+        r7 = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="e2e-a"
+        )
+        record(
+            "VERIFIED" if r7.kind == "token" and client.posts > posts_before else "FAILED",
+            f"E7 flush→re-mint: kind={r7.kind} entra_calls={client.posts - posts_before} (want >=1)",
+        )
+    finally:
+        await inner.aclose()
+
+
+def main() -> int:
+    required = [
+        "ENTRA_TENANT_ID",
+        "ENTRA_CLIENT_ID",
+        "ENTRA_CLIENT_SECRET",
+        "SPIKE_AUDIENCE_A",
+        "SPIKE_AUDIENCE_B",
+    ]
+    cfg = {k: os.environ[k] for k in os.environ if k.startswith(("ENTRA_", "SPIKE_"))}
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        print(f"Missing env: {', '.join(missing)} — did you `source scripts/obo-e2e/.env`?")
+        return 2
+
+    print("Signing in to Entra (this is the login the feature captures)...")
+    tokens = interactive_login(cfg)
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        print(f"No refresh_token from login (keys={sorted(tokens)}) — offline_access missing?")
+        return 1
+
+    asyncio.run(_run(cfg, refresh_token))
+
+    print("\n=== summary ===")
+    for status, msg in RESULTS:
+        print(f"  {status:>8}  {msg}")
+    return 0 if all(s in ("VERIFIED", "SKIPPED") for s, _ in RESULTS) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/obo-e2e/entra_e2e.py
+++ b/scripts/obo-e2e/entra_e2e.py
@@ -107,7 +107,7 @@ def _make_app_state(
         auth_storage=storage,
         mcp_token_store=store,
         oidc_config=oidc_config,
-        oidc_http_client=http_client,
+        obo_http_client=http_client,
         mcp_oauth_refresh_locks={},
         mcp_oauth_refresh_backoff={},
     )

--- a/scripts/obo-e2e/entra_setup.sh
+++ b/scripts/obo-e2e/entra_setup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Entra spike setup for entra_spike.py (#551 re-scope boundary spike).
+# Manual test tooling — not run in CI. Creates throwaway Entra app registrations.
+#
+#   ./entra_setup.sh setup     create app registrations + consent + .env
+#   ./entra_setup.sh cleanup   delete everything it created (incl. .env)
+#
+# Creates in the logged-in tenant (az login first):
+#   spike-turnstone   confidential client (stands in for Turnstone's OIDC app)
+#   spike-mcp-a/b     resource apps exposing scope mcp.access, admin-consented
+#   spike-mcp-c       resource app with NO grant to the client (V5 control)
+# Requires: the logged-in user can create apps + grant admin consent
+# (Global Admin on a personal tenant qualifies).
+
+set -euo pipefail
+cd "$(dirname "$0")"
+ENV_FILE=".env"
+NAMES=(spike-turnstone spike-mcp-a spike-mcp-b spike-mcp-c)
+
+log() { printf '>> %s\n' "$*"; }
+
+graph_patch_api() { # $1=appId  $2=scope-uuid  $3=display-name
+  local obj_id
+  obj_id=$(az ad app show --id "$1" --query id -o tsv)
+  az rest --method PATCH \
+    --url "https://graph.microsoft.com/v1.0/applications/${obj_id}" \
+    --headers 'Content-Type=application/json' \
+    --body "{
+      \"identifierUris\": [\"api://$1\"],
+      \"api\": {
+        \"requestedAccessTokenVersion\": 2,
+        \"oauth2PermissionScopes\": [{
+          \"id\": \"$2\",
+          \"value\": \"mcp.access\",
+          \"type\": \"Admin\",
+          \"isEnabled\": true,
+          \"adminConsentDisplayName\": \"Access $3\",
+          \"adminConsentDescription\": \"Spike scope for $3\"
+        }]
+      }
+    }"
+}
+
+make_resource_app() { # $1=display-name ; echoes "appId scopeId"
+  local app_id scope_id
+  app_id=$(az ad app create --display-name "$1" \
+    --sign-in-audience AzureADMyOrg --query appId -o tsv)
+  scope_id=$(python3 -c 'import uuid; print(uuid.uuid4())')
+  graph_patch_api "$app_id" "$scope_id" "$1" >/dev/null
+  az ad sp create --id "$app_id" >/dev/null 2>&1 || true
+  echo "$app_id $scope_id"
+}
+
+cmd_setup() {
+  local tenant_id
+  tenant_id=$(az account show --query tenantId -o tsv)
+  log "tenant: ${tenant_id}"
+
+  log "creating resource apps (a, b, c)..."
+  read -r APP_A SCOPE_A <<<"$(make_resource_app spike-mcp-a)"
+  read -r APP_B SCOPE_B <<<"$(make_resource_app spike-mcp-b)"
+  read -r APP_C _ <<<"$(make_resource_app spike-mcp-c)"
+  log "  a=${APP_A}  b=${APP_B}  c=${APP_C} (c stays unconsented)"
+
+  log "creating confidential client spike-turnstone..."
+  CLIENT_ID=$(az ad app create --display-name spike-turnstone \
+    --sign-in-audience AzureADMyOrg \
+    --web-redirect-uris "http://localhost:8765/callback" \
+    --query appId -o tsv)
+  az ad sp create --id "$CLIENT_ID" >/dev/null 2>&1 || true
+  SECRET=$(az ad app credential reset --id "$CLIENT_ID" \
+    --display-name spike --years 1 --query password -o tsv 2>/dev/null)
+
+  log "adding delegated permissions (a, b — NOT c)..."
+  az ad app permission add --id "$CLIENT_ID" \
+    --api "$APP_A" --api-permissions "${SCOPE_A}=Scope" 2>/dev/null
+  az ad app permission add --id "$CLIENT_ID" \
+    --api "$APP_B" --api-permissions "${SCOPE_B}=Scope" 2>/dev/null
+
+  log "granting admin consent (retries while SPs propagate)..."
+  local ok=""
+  for i in 1 2 3 4 5; do
+    if az ad app permission admin-consent --id "$CLIENT_ID" 2>/dev/null; then
+      ok=1; break
+    fi
+    log "  not yet (attempt $i) — waiting 15s"
+    sleep 15
+  done
+  [ -n "$ok" ] || { log "admin-consent failed after retries — grant manually in the portal (API permissions blade) and re-run the spike"; }
+
+  umask 177
+  cat > "$ENV_FILE" <<EOF
+export ENTRA_TENANT_ID=${tenant_id}
+export ENTRA_CLIENT_ID=${CLIENT_ID}
+export ENTRA_CLIENT_SECRET=${SECRET}
+export SPIKE_AUDIENCE_A=api://${APP_A}
+export SPIKE_AUDIENCE_B=api://${APP_B}
+export SPIKE_AUDIENCE_UNCONSENTED=api://${APP_C}
+export SPIKE_RUN_OBO=1
+EOF
+  log "wrote ${ENV_FILE} (chmod 600). Next:"
+  log "  source scripts/obo-e2e/.env && uv run python scripts/obo-e2e/entra_spike.py"
+  log "cleanup later with: ./entra_setup.sh cleanup"
+}
+
+cmd_cleanup() {
+  for name in "${NAMES[@]}"; do
+    for app_id in $(az ad app list --display-name "$name" --query '[].appId' -o tsv); do
+      log "deleting ${name} (${app_id})"
+      az ad app delete --id "$app_id"
+    done
+  done
+  rm -f "$ENV_FILE"
+  log "cleanup done (app registrations + .env removed)"
+}
+
+case "${1:-}" in
+  setup)   cmd_setup ;;
+  cleanup) cmd_cleanup ;;
+  *) echo "usage: $0 setup|cleanup"; exit 2 ;;
+esac

--- a/scripts/obo-e2e/entra_setup.sh
+++ b/scripts/obo-e2e/entra_setup.sh
@@ -88,14 +88,19 @@ cmd_setup() {
   done
   [ -n "$ok" ] || { log "admin-consent failed after retries — grant manually in the portal (API permissions blade) and re-run the spike"; }
 
+  # Single-quote the values in the generated .env: the AS-issued client secret
+  # can contain $ / backtick, and an unquoted RHS would be re-expanded (or
+  # partially executed) when the operator `source`s the file. The heredoc still
+  # interpolates ${...} into the single-quoted output; sourcing then treats the
+  # result literally. (Azure secrets are base64-ish — no single quotes to escape.)
   umask 177
   cat > "$ENV_FILE" <<EOF
-export ENTRA_TENANT_ID=${tenant_id}
-export ENTRA_CLIENT_ID=${CLIENT_ID}
-export ENTRA_CLIENT_SECRET=${SECRET}
-export SPIKE_AUDIENCE_A=api://${APP_A}
-export SPIKE_AUDIENCE_B=api://${APP_B}
-export SPIKE_AUDIENCE_UNCONSENTED=api://${APP_C}
+export ENTRA_TENANT_ID='${tenant_id}'
+export ENTRA_CLIENT_ID='${CLIENT_ID}'
+export ENTRA_CLIENT_SECRET='${SECRET}'
+export SPIKE_AUDIENCE_A='api://${APP_A}'
+export SPIKE_AUDIENCE_B='api://${APP_B}'
+export SPIKE_AUDIENCE_UNCONSENTED='api://${APP_C}'
 export SPIKE_RUN_OBO=1
 EOF
   log "wrote ${ENV_FILE} (chmod 600). Next:"

--- a/scripts/obo-e2e/entra_setup.sh
+++ b/scripts/obo-e2e/entra_setup.sh
@@ -68,14 +68,22 @@ cmd_setup() {
     --web-redirect-uris "http://localhost:8765/callback" \
     --query appId -o tsv)
   az ad sp create --id "$CLIENT_ID" >/dev/null 2>&1 || true
+  # No stderr suppression here: the secret is load-bearing (it lands in .env),
+  # so under `set -e` a reset failure must abort LOUDLY, not silently.
   SECRET=$(az ad app credential reset --id "$CLIENT_ID" \
-    --display-name spike --years 1 --query password -o tsv 2>/dev/null)
+    --display-name spike --years 1 --query password -o tsv)
 
   log "adding delegated permissions (a, b — NOT c)..."
+  # Tolerated failures (|| log): a re-run hits "permission already exists" and
+  # SP-propagation delays are common right after app creation — the
+  # admin-consent retry loop below is the real gate. `set -e` would otherwise
+  # turn a suppressed non-zero here into a silent mid-script abort.
   az ad app permission add --id "$CLIENT_ID" \
-    --api "$APP_A" --api-permissions "${SCOPE_A}=Scope" 2>/dev/null
+    --api "$APP_A" --api-permissions "${SCOPE_A}=Scope" \
+    || log "  warn: permission add for a failed (may already exist); admin-consent below will confirm"
   az ad app permission add --id "$CLIENT_ID" \
-    --api "$APP_B" --api-permissions "${SCOPE_B}=Scope" 2>/dev/null
+    --api "$APP_B" --api-permissions "${SCOPE_B}=Scope" \
+    || log "  warn: permission add for b failed (may already exist); admin-consent below will confirm"
 
   log "granting admin consent (retries while SPs propagate)..."
   local ok=""

--- a/scripts/obo-e2e/entra_spike.py
+++ b/scripts/obo-e2e/entra_spike.py
@@ -1,0 +1,333 @@
+"""Entra boundary spike for single-credential MCP token minting (#551 re-scope).
+
+Verifies, against a REAL Entra tenant, the assumptions behind the oauth_obo
+design (one IdP refresh token per user; per-MCP access tokens minted on
+demand). Each check prints VERIFIED / FAILED / SKIPPED plus redacted evidence.
+
+  V1  interactive confidential-client login (auth-code + PKCE + offline_access)
+      -> refresh token captured                        [capture layer works]
+  V2  RT redeemed with scope=<AUDIENCE_A>/.default     -> aud claim == A
+  V3  SAME credential redeemed for <AUDIENCE_B>        -> aud claim == B
+      KEY CHECK: Entra RTs are client-bound, not resource-bound.
+  V4  rotation semantics: does each redemption return a new RT, and does the
+      PREVIOUS RT keep working?                        [write-back design]
+  V5  redemption for an unconsented audience -> AADSTS65001 consent_required
+      [maps to the reconnect-rail fallback]
+  V6  optional: OBO jwt-bearer leg (requested_token_use=on_behalf_of) using a
+      Turnstone-audience access token as assertion     [middle-tier variant]
+
+Run:  uv run python scripts/obo-e2e/entra_spike.py
+Env:  ENTRA_TENANT_ID       tenant GUID or domain
+      ENTRA_CLIENT_ID       Turnstone spike app registration (confidential)
+      ENTRA_CLIENT_SECRET   client secret for the above
+      SPIKE_AUDIENCE_A      e.g. api://<guid-a>  (exposes a scope, consented)
+      SPIKE_AUDIENCE_B      e.g. api://<guid-b>  (exposes a scope, consented)
+      SPIKE_AUDIENCE_UNCONSENTED  optional, for V5
+      SPIKE_RUN_OBO         optional "1" to run V6
+      SPIKE_PORT            redirect listener port (default 8765; register
+                            http://localhost:<port>/callback as a Web
+                            redirect URI on the spike app registration)
+
+App-registration setup checklist: see README.md next to this file.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import threading
+import urllib.parse
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import httpx
+
+RESULTS: list[tuple[str, str, str]] = []  # (check, status, evidence)
+
+
+def record(check: str, status: str, evidence: str) -> None:
+    RESULTS.append((check, status, evidence))
+    print(f"[{status:>8}] {check}: {evidence}")
+
+
+def b64url_json(segment: str) -> dict[str, Any]:
+    pad = "=" * (-len(segment) % 4)
+    out: dict[str, Any] = json.loads(base64.urlsafe_b64decode(segment + pad))
+    return out
+
+
+def jwt_claims_unverified(token: str) -> dict[str, Any]:
+    """Spike-only unverified decode. NEVER do this in product code."""
+    try:
+        return b64url_json(token.split(".")[1])
+    except Exception:
+        return {}
+
+
+def redact(token: str | None) -> str:
+    if not token:
+        return "<absent>"
+    return f"{token[:8]}...({len(token)} chars)"
+
+
+class _CodeCatcher(BaseHTTPRequestHandler):
+    code: str | None = None
+    state: str | None = None
+    event = threading.Event()
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib API name
+        q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        _CodeCatcher.code = (q.get("code") or [None])[0]
+        _CodeCatcher.state = (q.get("state") or [None])[0]
+        body = b"Spike login captured - return to the terminal."
+        if q.get("error"):
+            body = f"IdP error: {q}".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(body)
+        _CodeCatcher.event.set()
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+
+def interactive_login(cfg: dict[str, str]) -> dict[str, Any]:
+    """V1: authorization-code + PKCE + offline_access as a confidential client.
+
+    Mirrors production shape: same grant Turnstone's OIDC login uses
+    (core/oidc.py exchange_code), plus offline_access.
+    """
+    port = int(cfg.get("SPIKE_PORT", "8765"))
+    redirect_uri = f"http://localhost:{port}/callback"
+    verifier = secrets.token_urlsafe(48)
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    )
+    state = secrets.token_urlsafe(16)
+    authorize = (
+        f"https://login.microsoftonline.com/{cfg['ENTRA_TENANT_ID']}/oauth2/v2.0/authorize?"
+        + urllib.parse.urlencode(
+            {
+                "client_id": cfg["ENTRA_CLIENT_ID"],
+                "response_type": "code",
+                "redirect_uri": redirect_uri,
+                "response_mode": "query",
+                # offline_access is THE capture-layer delta vs today's login.
+                # No resource scope here: the RT is minted client-bound.
+                "scope": "openid profile offline_access",
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }
+        )
+    )
+    server = HTTPServer(("127.0.0.1", port), _CodeCatcher)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    print(f"\nOpen (or auto-opened) in a browser with a tenant user:\n  {authorize}\n")
+    cb_file = cfg.get("SPIKE_CALLBACK_FILE", "")
+    if cb_file:
+        print(
+            "Remote-browser mode: after sign-in the browser lands on a broken\n"
+            f"http://localhost:{port}/callback?... page. Copy that FULL URL and run:\n"
+            f"  echo '<url>' > {cb_file}\n"
+        )
+
+    def _watch_callback_file() -> None:
+        # Driver-friendly fallback: the sign-in can happen on any device;
+        # whoever signed in drops the redirected URL into SPIKE_CALLBACK_FILE.
+        import time as _time
+
+        while not _CodeCatcher.event.is_set():
+            try:
+                with open(cb_file) as _f:
+                    pasted = _f.read().strip()
+            except OSError:
+                pasted = ""
+            if "?" in pasted:
+                q = urllib.parse.parse_qs(urllib.parse.urlparse(pasted).query)
+                _CodeCatcher.code = (q.get("code") or [None])[0]
+                _CodeCatcher.state = (q.get("state") or [None])[0]
+                _CodeCatcher.event.set()
+                return
+            _time.sleep(1.0)
+
+    if cb_file:
+        threading.Thread(target=_watch_callback_file, daemon=True).start()
+    webbrowser.open(authorize)
+    if not _CodeCatcher.event.wait(timeout=600):
+        server.shutdown()
+        raise SystemExit("Timed out waiting for the redirect (10 min).")
+    server.shutdown()
+    if _CodeCatcher.state != state:
+        raise SystemExit("state mismatch on redirect - aborting.")
+    if not _CodeCatcher.code:
+        raise SystemExit("No code on redirect (IdP error page shown in browser).")
+    resp = httpx.post(
+        f"https://login.microsoftonline.com/{cfg['ENTRA_TENANT_ID']}/oauth2/v2.0/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": _CodeCatcher.code,
+            "redirect_uri": redirect_uri,
+            "client_id": cfg["ENTRA_CLIENT_ID"],
+            "client_secret": cfg["ENTRA_CLIENT_SECRET"],
+            "code_verifier": verifier,
+        },
+        timeout=15.0,
+    )
+    tokens: dict[str, Any] = resp.json()
+    if resp.status_code != 200:
+        raise SystemExit(f"code exchange failed: {json.dumps(tokens, indent=2)[:800]}")
+    return tokens
+
+
+def redeem(cfg: dict[str, str], refresh_token: str, scope: str) -> tuple[int, dict[str, Any]]:
+    """Redeem a refresh token for an access token with the given scope."""
+    resp = httpx.post(
+        f"https://login.microsoftonline.com/{cfg['ENTRA_TENANT_ID']}/oauth2/v2.0/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": cfg["ENTRA_CLIENT_ID"],
+            "client_secret": cfg["ENTRA_CLIENT_SECRET"],
+            "scope": scope,
+        },
+        timeout=15.0,
+    )
+    body: dict[str, Any] = resp.json()
+    return resp.status_code, body
+
+
+def obo_exchange(cfg: dict[str, str], assertion: str, scope: str) -> tuple[int, dict[str, Any]]:
+    """V6: middle-tier OBO variant (jwt-bearer + requested_token_use)."""
+    resp = httpx.post(
+        f"https://login.microsoftonline.com/{cfg['ENTRA_TENANT_ID']}/oauth2/v2.0/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": assertion,
+            "client_id": cfg["ENTRA_CLIENT_ID"],
+            "client_secret": cfg["ENTRA_CLIENT_SECRET"],
+            "scope": scope,
+            "requested_token_use": "on_behalf_of",
+        },
+        timeout=15.0,
+    )
+    body: dict[str, Any] = resp.json()
+    return resp.status_code, body
+
+
+def check_aud(label: str, status: int, body: dict[str, Any], want_aud: str) -> str | None:
+    """Common V2/V3 assertion: 200 + aud matches. Returns the new RT if any."""
+    if status != 200:
+        record(label, "FAILED", f"HTTP {status}: {json.dumps(body)[:300]}")
+        return None
+    claims = jwt_claims_unverified(body.get("access_token", ""))
+    aud = str(claims.get("aud", "<none>"))
+    ok = aud == want_aud or aud == want_aud.removeprefix("api://")
+    record(
+        label,
+        "VERIFIED" if ok else "FAILED",
+        f"aud={aud} want={want_aud} expires_in={body.get('expires_in')} "
+        f"new_rt={redact(body.get('refresh_token'))}",
+    )
+    new_rt = body.get("refresh_token")
+    return str(new_rt) if isinstance(new_rt, str) else None
+
+
+def main() -> int:
+    required = [
+        "ENTRA_TENANT_ID",
+        "ENTRA_CLIENT_ID",
+        "ENTRA_CLIENT_SECRET",
+        "SPIKE_AUDIENCE_A",
+        "SPIKE_AUDIENCE_B",
+    ]
+    cfg = {k: os.environ[k] for k in required if k in os.environ}
+    missing = [k for k in required if k not in cfg]
+    if missing:
+        print(f"Missing env: {', '.join(missing)}\nSee module docstring.")
+        return 2
+    for opt in ("SPIKE_AUDIENCE_UNCONSENTED", "SPIKE_PORT", "SPIKE_RUN_OBO"):
+        if opt in os.environ:
+            cfg[opt] = os.environ[opt]
+
+    # V1 - capture
+    tokens = interactive_login(cfg)
+    rt0 = tokens.get("refresh_token")
+    if isinstance(rt0, str) and rt0:
+        record("V1 capture (offline_access -> RT)", "VERIFIED", redact(rt0))
+    else:
+        record("V1 capture (offline_access -> RT)", "FAILED", f"keys={sorted(tokens.keys())}")
+        return 1
+
+    # V2 - mint for audience A
+    a = cfg["SPIKE_AUDIENCE_A"]
+    s2, b2 = redeem(cfg, rt0, f"{a}/.default")
+    rt_after_a = check_aud("V2 mint audience A from RT", s2, b2, a)
+
+    # V3 - SAME credential, audience B (the design-critical check)
+    b = cfg["SPIKE_AUDIENCE_B"]
+    s3, b3 = redeem(cfg, rt0, f"{b}/.default")
+    check_aud("V3 mint audience B from SAME RT", s3, b3, b)
+
+    # V4 - rotation semantics
+    if rt_after_a and rt_after_a != rt0:
+        s4, _ = redeem(cfg, rt0, f"{a}/.default")
+        record(
+            "V4 rotation (new RT returned; old still valid?)",
+            "VERIFIED" if s4 == 200 else "VERIFIED",
+            f"rotated=yes old_rt_reuse_http={s4} "
+            "(design: persist newest RT on every mint; "
+            f"{'old stays valid - benign race window' if s4 == 200 else 'old INVALIDATED - write-back is correctness-critical'})",
+        )
+    else:
+        record(
+            "V4 rotation",
+            "VERIFIED",
+            "no rotation observed on redemption (same/absent RT) - "
+            "write-back still required for the rotating case",
+        )
+
+    # V5 - unconsented audience -> consent_required
+    unc = cfg.get("SPIKE_AUDIENCE_UNCONSENTED")
+    if unc:
+        s5, b5 = redeem(cfg, rt0, f"{unc}/.default")
+        codes = b5.get("error_codes", [])
+        hit = s5 == 400 and (65001 in codes or b5.get("suberror") == "consent_required")
+        record(
+            "V5 unconsented audience -> AADSTS65001",
+            "VERIFIED" if hit else "FAILED",
+            f"http={s5} error={b5.get('error')} codes={codes}",
+        )
+    else:
+        record("V5 unconsented audience", "SKIPPED", "SPIKE_AUDIENCE_UNCONSENTED not set")
+
+    # V6 - optional OBO middle-tier variant
+    if cfg.get("SPIKE_RUN_OBO") == "1":
+        s6a, b6a = redeem(cfg, rt0, f"{cfg['ENTRA_CLIENT_ID']}/.default")
+        at_self = b6a.get("access_token", "") if s6a == 200 else ""
+        if at_self:
+            s6, b6 = obo_exchange(cfg, at_self, f"{a}/.default")
+            check_aud("V6 OBO jwt-bearer variant", s6, b6, a)
+        else:
+            record(
+                "V6 OBO jwt-bearer variant",
+                "FAILED",
+                f"could not mint self-audience assertion: HTTP {s6a}",
+            )
+    else:
+        record("V6 OBO jwt-bearer variant", "SKIPPED", "SPIKE_RUN_OBO != 1")
+
+    print("\n=== summary ===")
+    for check, status, _ in RESULTS:
+        print(f"  {status:>8}  {check}")
+    return 0 if all(s != "FAILED" for _, s, _ in RESULTS) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/obo-e2e/keycloak_e2e.py
+++ b/scripts/obo-e2e/keycloak_e2e.py
@@ -1,0 +1,271 @@
+"""End-to-end exercise of the oauth_obo feature on the OSS path (RFC 8693).
+
+Parallel to ``entra_e2e.py`` but for ``obo_grant_profile="rfc8693"`` against an
+ephemeral Keycloak — the open-source / non-Entra deployment shape. Fully
+headless (password grant, no browser), so it runs unattended.
+
+Drives the REAL Turnstone code: ``MCPTokenStore.upsert_oidc_credential`` (capture)
+then ``get_obo_access_token_classified`` → ``_obo_mint_rfc8693`` (refresh grant →
+RFC 8693 token exchange) against the live Keycloak token endpoint.
+
+Checks E1–E7 mirror the Entra harness:
+  E1 mint audience A → token, aud claim carries A, cache row refresh_token_ct NULL
+  E2 second call → cache hit, ZERO extra Keycloak calls
+  E3 audience B from the SAME captured credential → aud carries B
+  E4 rotation write-back (KC rotates the RT on the refresh leg)
+  E5 force_refresh → re-mint (Keycloak call count increments)
+  E6 unconsented audience C → NOT token, credential SURVIVES
+  E7 cache flush → re-mint
+
+Env (set by keycloak_e2e.sh):
+  KC_TOKEN_ENDPOINT, KC_ISSUER, KC_CLIENT_ID, KC_CLIENT_SECRET,
+  KC_USER, KC_PASSWORD, AUD_A, SCOPE_A, AUD_B, SCOPE_B, AUD_C
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import sys
+import tempfile
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+
+from turnstone.core.mcp_crypto import (
+    MCPTokenCipher,
+    MCPTokenCipherConfig,
+    MCPTokenStore,
+)
+from turnstone.core.mcp_oauth import get_obo_access_token_classified
+from turnstone.core.oidc import OIDCConfig
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+USER = "e2e-user"
+RESULTS: list[tuple[str, str]] = []
+
+
+def record(status: str, msg: str) -> None:
+    RESULTS.append((status, msg))
+    print(f"[{status:>8}] {msg}")
+
+
+def redact(token: str | None) -> str:
+    return f"{token[:8]}...({len(token)} chars)" if token else "<absent>"
+
+
+def jwt_claims(token: str) -> dict[str, Any]:
+    seg = token.split(".")[1]
+    pad = "=" * (-len(seg) % 4)
+    out: dict[str, Any] = json.loads(base64.urlsafe_b64decode(seg + pad))
+    return out
+
+
+def aud_carries(token: str, want: str) -> tuple[bool, str]:
+    """KC puts the exchanged audience in the aud claim (str or list)."""
+    aud = jwt_claims(token).get("aud", [])
+    auds = aud if isinstance(aud, list) else [aud]
+    return want in auds, str(aud)
+
+
+class _CountingClient:
+    def __init__(self, inner: httpx.AsyncClient) -> None:
+        self._inner = inner
+        self.posts = 0
+
+    async def post(self, *args: Any, **kwargs: Any) -> httpx.Response:
+        self.posts += 1
+        return await self._inner.post(*args, **kwargs)
+
+
+def _password_login(cfg: dict[str, str]) -> str:
+    """Headless direct-access grant → a real refresh token for the user."""
+    resp = httpx.post(
+        cfg["KC_TOKEN_ENDPOINT"],
+        data={
+            "grant_type": "password",
+            "client_id": cfg["KC_CLIENT_ID"],
+            "client_secret": cfg["KC_CLIENT_SECRET"],
+            "username": cfg["KC_USER"],
+            "password": cfg["KC_PASSWORD"],
+            "scope": "openid",
+        },
+        timeout=15.0,
+    )
+    resp.raise_for_status()
+    return str(resp.json()["refresh_token"])
+
+
+def _seed(storage: SQLiteBackend, name: str, audience: str, scopes: str | None) -> None:
+    storage.create_mcp_server(
+        server_id=f"{name}-id",
+        name=name,
+        transport="streamable-http",
+        url="https://mcp.example.invalid/sse",
+        auth_type="oauth_obo",
+        oauth_audience=audience,
+        oauth_scopes=scopes,
+    )
+
+
+async def _run(cfg: dict[str, str], refresh_token: str) -> None:
+    issuer = cfg["KC_ISSUER"]
+    db_path = os.path.join(tempfile.mkdtemp(prefix="obo-kc-e2e-"), "e2e.db")
+    storage = SQLiteBackend(db_path)
+    from cryptography.fernet import Fernet
+
+    raw = base64.urlsafe_b64decode(Fernet.generate_key())
+    store = MCPTokenStore(storage, MCPTokenCipher(MCPTokenCipherConfig(keys=(raw,))), node_id="e2e")
+    oidc_config = OIDCConfig(
+        enabled=True,
+        issuer=issuer,
+        client_id=cfg["KC_CLIENT_ID"],
+        client_secret=cfg["KC_CLIENT_SECRET"],
+        token_endpoint=cfg["KC_TOKEN_ENDPOINT"],
+        obo_grant_profile="rfc8693",
+        capture_user_credential=True,
+    )
+
+    store.upsert_oidc_credential(USER, issuer, refresh_token=refresh_token)
+    cap = store.get_oidc_credential(USER, issuer)
+    if cap and cap["refresh_token"] == refresh_token:
+        record("VERIFIED", f"capture: credential persisted ({redact(refresh_token)})")
+    else:
+        record("FAILED", "capture: credential did not round-trip")
+        return
+
+    _seed(storage, "kc-a", cfg["AUD_A"], cfg.get("SCOPE_A"))
+    _seed(storage, "kc-b", cfg["AUD_B"], cfg.get("SCOPE_B"))
+    if cfg.get("AUD_C"):
+        _seed(storage, "kc-c", cfg["AUD_C"], None)  # no audience scope → unconsented
+
+    inner = httpx.AsyncClient(timeout=20.0)
+    client = _CountingClient(inner)
+    app_state = SimpleNamespace(
+        auth_storage=storage,
+        mcp_token_store=store,
+        oidc_config=oidc_config,
+        oidc_http_client=client,
+        mcp_oauth_refresh_locks={},
+        mcp_oauth_refresh_backoff={},
+    )
+    try:
+        # E1 — rfc8693 mint (refresh grant → token exchange) for audience A.
+        r = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="kc-a"
+        )
+        if r.kind == "token" and r.token:
+            ok, aud = aud_carries(r.token, cfg["AUD_A"])
+            row = storage.get_mcp_user_token(USER, "kc-a")
+            cache_ok = row is not None and row["refresh_token_ct"] is None
+            record(
+                "VERIFIED" if ok and cache_ok else "FAILED",
+                f"E1 mint A (refresh→exchange): kind=token aud={aud} want={cfg['AUD_A']} "
+                f"cache_row_refreshless={cache_ok}",
+            )
+        else:
+            record("FAILED", f"E1 mint A: kind={r.kind} (expected token)")
+            return
+
+        # E2 — cache hit.
+        posts_before = client.posts
+        r2 = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="kc-a"
+        )
+        record(
+            "VERIFIED" if r2.kind == "token" and client.posts == posts_before else "FAILED",
+            f"E2 cache hit: kind={r2.kind} extra_kc_calls={client.posts - posts_before} (want 0)",
+        )
+
+        # E3 — audience B from the SAME credential.
+        rb = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="kc-b"
+        )
+        if rb.kind == "token" and rb.token:
+            ok_b, aud_b = aud_carries(rb.token, cfg["AUD_B"])
+            record(
+                "VERIFIED" if ok_b else "FAILED",
+                f"E3 mint B from SAME credential: aud={aud_b} want={cfg['AUD_B']}",
+            )
+        else:
+            record("FAILED", f"E3 mint B: kind={rb.kind}")
+
+        # E4 — rotation write-back (KC rotates the RT on the refresh leg).
+        cred_now = store.get_oidc_credential(USER, issuer)
+        rotated = cred_now is not None and cred_now["refresh_token"] != refresh_token
+        record(
+            "VERIFIED" if cred_now is not None else "FAILED",
+            f"E4 rotation write-back: persisted={redact(cred_now['refresh_token']) if cred_now else '<gone>'} "
+            f"rotated_from_initial={rotated}",
+        )
+
+        # E5 — force_refresh re-mints.
+        posts_before = client.posts
+        rf = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="kc-a", force_refresh=True
+        )
+        record(
+            "VERIFIED" if rf.kind == "token" and client.posts > posts_before else "FAILED",
+            f"E5 force_refresh re-mint: kind={rf.kind} kc_calls={client.posts - posts_before} (want >=1)",
+        )
+
+        # E6 — unconsented audience: not a token, credential survives.
+        if cfg.get("AUD_C"):
+            rc = await get_obo_access_token_classified(
+                app_state=app_state, user_id=USER, server_name="kc-c"
+            )
+            cred_after = store.get_oidc_credential(USER, issuer)
+            record(
+                "VERIFIED" if rc.kind != "token" and cred_after is not None else "FAILED",
+                f"E6 unconsented C: kind={rc.kind} (not token) credential_survives={cred_after is not None}",
+            )
+        else:
+            record("SKIPPED", "E6 unconsented C: AUD_C not set")
+
+        # E7 — cache flush → re-mint.
+        store.delete_user_token(USER, "kc-a")
+        posts_before = client.posts
+        r7 = await get_obo_access_token_classified(
+            app_state=app_state, user_id=USER, server_name="kc-a"
+        )
+        record(
+            "VERIFIED" if r7.kind == "token" and client.posts > posts_before else "FAILED",
+            f"E7 flush→re-mint: kind={r7.kind} kc_calls={client.posts - posts_before} (want >=1)",
+        )
+    finally:
+        await inner.aclose()
+
+
+def main() -> int:
+    required = [
+        "KC_TOKEN_ENDPOINT",
+        "KC_ISSUER",
+        "KC_CLIENT_ID",
+        "KC_CLIENT_SECRET",
+        "KC_USER",
+        "KC_PASSWORD",
+        "AUD_A",
+        "AUD_B",
+    ]
+    cfg = {k: os.environ[k] for k in os.environ if k.startswith(("KC_", "AUD_", "SCOPE_"))}
+    missing = [k for k in required if not cfg.get(k)]
+    if missing:
+        print(f"Missing env: {', '.join(missing)} — run via keycloak_e2e.sh")
+        return 2
+
+    print("Headless password login to Keycloak (the credential the feature captures)...")
+    refresh_token = _password_login(cfg)
+
+    asyncio.run(_run(cfg, refresh_token))
+
+    print("\n=== summary ===")
+    for status, msg in RESULTS:
+        print(f"  {status:>8}  {msg}")
+    return 0 if all(s in ("VERIFIED", "SKIPPED") for s, _ in RESULTS) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/obo-e2e/keycloak_e2e.py
+++ b/scripts/obo-e2e/keycloak_e2e.py
@@ -148,7 +148,7 @@ async def _run(cfg: dict[str, str], refresh_token: str) -> None:
         auth_storage=storage,
         mcp_token_store=store,
         oidc_config=oidc_config,
-        oidc_http_client=client,
+        obo_http_client=client,
         mcp_oauth_refresh_locks={},
         mcp_oauth_refresh_backoff={},
     )

--- a/scripts/obo-e2e/keycloak_e2e.sh
+++ b/scripts/obo-e2e/keycloak_e2e.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# OSS-path (RFC 8693) end-to-end: spin up ephemeral Keycloak, configure the
+# realm, run keycloak_e2e.py against the REAL Turnstone mint engine, tear down.
+# Fully headless — no browser. Manual test tooling, not run in CI.
+set -euo pipefail
+cd "$(dirname "$0")/../.."   # repo root (uv run needs it)
+
+CONTAINER=kc-obo-e2e
+PORT=8091
+KC="docker exec $CONTAINER /opt/keycloak/bin/kcadm.sh"
+
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cleanup
+
+echo ">> starting Keycloak 26.3 (ephemeral)..."
+docker run -d --name "$CONTAINER" -p "127.0.0.1:${PORT}:8080" \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:26.3 start-dev >/dev/null
+
+echo ">> waiting for Keycloak (dev-mode boot can take a few minutes on a loaded host)..."
+# Wait on kcadm auth succeeding directly — more reliable than the host HTTP port,
+# and generous enough for a resource-starved boot (up to ~6 min).
+ready=""
+for _ in $(seq 1 90); do
+  if $KC config credentials --server http://localhost:8080 --realm master \
+      --user admin --password admin >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 4
+done
+[ -n "$ready" ] || { echo "Keycloak did not become ready in time"; docker logs "$CONTAINER" 2>&1 | tail -15; exit 1; }
+
+echo ">> configuring realm 'spike'..."
+$KC create realms -s realm=spike -s enabled=true >/dev/null
+# Confidential client with standard token exchange (the RFC 8693 leg) + direct
+# access grant (headless password login to fetch the user's refresh token).
+$KC create clients -r spike -s clientId=turnstone -s enabled=true -s publicClient=false \
+  -s secret=spike-secret -s directAccessGrantsEnabled=true \
+  -s 'attributes={"standard.token.exchange.enabled":"true"}' >/dev/null
+for t in mcp-a mcp-b mcp-c; do
+  $KC create clients -r spike -s clientId=$t -s enabled=true -s publicClient=false -s secret=x >/dev/null
+done
+$KC create users -r spike -s username=e2e-user -s enabled=true -s email=e2e@spike.test \
+  -s emailVerified=true -s firstName=E2E -s lastName=User >/dev/null
+$KC set-password -r spike --username e2e-user --new-password e2e-pw >/dev/null
+
+TURNSTONE_UUID=$($KC get clients -r spike -q clientId=turnstone --fields id --format csv --noquotes)
+# Audience client scopes for mcp-a and mcp-b ONLY (mcp-c stays unconsented → E6).
+for t in mcp-a mcp-b; do
+  SID=$($KC create client-scopes -r spike -s name=aud-$t -s protocol=openid-connect -i)
+  $KC create "client-scopes/$SID/protocol-mappers/models" -r spike -s name=aud-$t \
+    -s protocol=openid-connect -s protocolMapper=oidc-audience-mapper \
+    -s "config={\"included.client.audience\":\"$t\",\"access.token.claim\":\"true\"}" >/dev/null
+  $KC update "clients/$TURNSTONE_UUID/optional-client-scopes/$SID" -r spike >/dev/null
+done
+
+echo ">> running the product e2e harness..."
+export KC_TOKEN_ENDPOINT="http://127.0.0.1:${PORT}/realms/spike/protocol/openid-connect/token"
+export KC_ISSUER="http://127.0.0.1:${PORT}/realms/spike"
+export KC_CLIENT_ID=turnstone KC_CLIENT_SECRET=spike-secret
+export KC_USER=e2e-user KC_PASSWORD=e2e-pw
+export AUD_A=mcp-a SCOPE_A=aud-mcp-a AUD_B=mcp-b SCOPE_B=aud-mcp-b AUD_C=mcp-c
+uv run python scripts/obo-e2e/keycloak_e2e.py

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -876,6 +876,30 @@ def test_phase8_xss_safe_render_in_build_mcp_error_embed() -> None:
     )
 
 
+def test_mcp_error_button_gated_on_consent_url_not_code_alone() -> None:
+    """Review finding: the chat error card rendered a Connect / Re-consent
+    button from the error CODE alone, so an oauth_obo error (consent_url=None,
+    since sign-in passthrough has no per-server consent flow and /start rejects
+    obo rows) produced a button that dead-ended in a 'no consent URL' toast.
+    The button must render only when a valid per-server consent URL is present —
+    obo errors show the card's honest detail text without a broken affordance."""
+    body = _INTERACTIVE_JS.read_text(encoding="utf-8")
+    start = body.index("function buildMcpErrorEmbed(")
+    rest = body[start:]
+    end_match = re.search(r"\n}\n", rest)
+    assert end_match is not None
+    fn = rest[: end_match.end()]
+    # The render gate combines the category with a consent-URL presence check.
+    assert "hasConsentAffordance" in fn, (
+        "buildMcpErrorEmbed must gate the action button on the presence of a "
+        "consent URL, not on the error category alone."
+    )
+    assert 'category === "actionable" && hasConsentAffordance' in fn, (
+        "the button-render condition must require BOTH an actionable category "
+        "and a real consent URL"
+    )
+
+
 def test_phase8_css_classes_present_in_stylesheet() -> None:
     """The MCP error-embed + connections classes app.js/interactive.js reference
     must keep their CSS rules (else the consent / connections UX silently loses

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -698,6 +698,114 @@ class TestUpdateMcpServer:
             ).scalar()
         assert count_after == 0, "URL change must purge per-user tokens"
 
+    def test_admin_create_oauth_obo_requires_audience(self, client):
+        """#551: an oauth_obo row without oauth_audience is rejected at the
+        write choke point (the mint engine hard-requires it)."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-no-aud",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "oauth_audience" in r.json()["error"]
+
+    def test_admin_create_oauth_obo_without_token_store_returns_503(self, client_no_token_store):
+        """#551: creating an oauth_obo row with no encryption key is rejected —
+        accepting it would SystemExit the whole cluster at the next boot."""
+        r = client_no_token_store.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-no-key",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 503, r.text
+        assert "mcp_token_encryption_key" in r.json()["error"]
+
+    def test_admin_create_oauth_obo_happy_path(self, client):
+        """A well-formed oauth_obo row persists with its audience intact."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-ok",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["auth_type"] == "oauth_obo"
+        assert data["oauth_audience"] == "api://mcp-a"
+
+    def test_update_flip_oauth_user_to_obo_keeps_audience_and_purges_tokens(self, client, storage):
+        """#551 (findings 10344 + 10326): flipping oauth_user→oauth_obo must NOT
+        null oauth_audience (the mint engine needs it), and MUST purge the old
+        per-user consent-token rows (they carry per-server-AS refresh tokens that
+        the mint cache invariant forbids)."""
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import mcp_user_tokens
+
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "flip-to-obo",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_client_id": "cli_x",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 200, r.text
+        sid = r.json()["server_id"]
+
+        with storage._engine.connect() as conn:
+            conn.execute(
+                sa.insert(mcp_user_tokens),
+                {
+                    "user_id": "u1",
+                    "server_name": "flip-to-obo",
+                    "access_token_ct": b"\x00ct-a",
+                    "refresh_token_ct": b"\x00ct-r",
+                    "expires_at": "2026-12-31T00:00:00",
+                    "scopes": "openid",
+                    "as_issuer": "https://auth.example.com",
+                    "audience": "api://mcp-a",
+                    "created": "2026-05-04T11:00:00",
+                    "last_refreshed": None,
+                },
+            )
+            conn.commit()
+
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"auth_type": "oauth_obo", "oauth_audience": "api://mcp-a"},
+        )
+        assert r2.status_code == 200, r2.text
+        data = r2.json()
+        assert data["auth_type"] == "oauth_obo"
+        assert data["oauth_audience"] == "api://mcp-a"  # NOT nulled
+        # The oauth_user-only client_id is cleared.
+        assert data["oauth_client_id"] in (None, "")
+        # Old consent-token rows purged.
+        with storage._engine.connect() as conn:
+            remaining = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(mcp_user_tokens)
+                .where(mcp_user_tokens.c.server_name == "flip-to-obo")
+            ).scalar()
+        assert remaining == 0, "oauth_user→oauth_obo flip must purge stale per-user rows"
+
     def test_update_invalid_auth_type(self, client):
         created = _create_server(client, name="bad-auth-update")
         sid = created["server_id"]

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -864,6 +864,53 @@ class TestUpdateMcpServer:
         assert r.status_code == 400, r.text
         assert "OIDC" in r.json()["error"]
 
+    def test_obo_editable_when_oidc_discovery_transiently_failed(self, client, storage):
+        """Review finding: the console never runs runtime OIDC rediscovery, so a
+        transient discovery failure at console boot (enabled=False,
+        discovery_retryable=True) must NOT make oauth_obo servers un-editable /
+        un-disable-able. OIDC is still CONFIGURED (issuer set) — the write gate
+        accepts a discovery_retryable config; it rejects only a genuinely absent
+        OIDC (neither flag set)."""
+        # Seed an obo row (created while OIDC was healthy).
+        storage.create_mcp_server(
+            server_id="obo-retry-id",
+            name="obo-retry",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        # Console process booted while the IdP was briefly unreachable.
+        client.app.state.oidc_config = SimpleNamespace(
+            enabled=False,
+            issuer="https://idp.example.com",
+            obo_grant_profile="entra",
+            capture_user_credential=True,
+            discovery_retryable=True,
+        )
+        # Disabling the misbehaving obo server must succeed, not 400.
+        r = client.put(
+            "/v1/api/admin/mcp-servers/obo-retry-id",
+            json={"enabled": False},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["enabled"] is False
+
+        # A genuinely-absent OIDC (neither enabled nor retryable) still rejects.
+        client.app.state.oidc_config = SimpleNamespace(
+            enabled=False,
+            issuer="",
+            obo_grant_profile="entra",
+            capture_user_credential=True,
+            discovery_retryable=False,
+        )
+        r2 = client.put(
+            "/v1/api/admin/mcp-servers/obo-retry-id",
+            json={"enabled": True},
+        )
+        assert r2.status_code == 400
+        assert "OIDC" in r2.json()["error"]
+
     def test_create_obo_rejected_on_invalid_grant_profile(self, client):
         """Review finding: a typo'd deployment obo_grant_profile leaves the mint
         leg unresolved (obo_misconfigured per dispatch), so reject it at the

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -896,7 +896,10 @@ class TestUpdateMcpServer:
         assert r.status_code == 200, r.text
         assert r.json()["enabled"] is False
 
-        # A genuinely-absent OIDC (neither enabled nor retryable) still rejects.
+        # Even with OIDC fully operator-disabled (neither flag set), a same-type
+        # edit of the EXISTING obo server is still allowed — the deployment
+        # checks only fire on create / flip-into-obo, so an operator is never
+        # locked out of disabling or editing a server (review finding R8-1).
         client.app.state.oidc_config = SimpleNamespace(
             enabled=False,
             issuer="",
@@ -908,8 +911,32 @@ class TestUpdateMcpServer:
             "/v1/api/admin/mcp-servers/obo-retry-id",
             json={"enabled": True},
         )
-        assert r2.status_code == 400
-        assert "OIDC" in r2.json()["error"]
+        assert r2.status_code == 200, r2.text
+
+    def test_create_new_obo_still_rejected_when_oidc_operator_disabled(self, client):
+        """The deployment gate still fires for a NEW obo enablement: creating a
+        fresh oauth_obo server (or flipping one into obo) while OIDC is fully
+        operator-disabled is rejected — only same-type edits of an existing obo
+        server skip the deployment checks."""
+        client.app.state.oidc_config = SimpleNamespace(
+            enabled=False,
+            issuer="",
+            obo_grant_profile="entra",
+            capture_user_credential=True,
+            discovery_retryable=False,
+        )
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-new-nooidc",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "OIDC" in r.json()["error"]
 
     def test_create_obo_rejected_on_invalid_grant_profile(self, client):
         """Review finding: a typo'd deployment obo_grant_profile leaves the mint

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -829,14 +829,11 @@ class TestUpdateMcpServer:
         assert r2.status_code == 200, r2.text
         assert r2.json()["oauth_scopes"] in (None, "")  # stale scopes cleared
 
-    def test_flip_to_obo_clears_scopes_even_when_form_resubmits_them(self, client):
-        """xhigh finding: the admin form pre-fills + re-submits the old oauth_user
-        scopes on a flip, so the clear must be robust to scopes BEING in the body
-        when they equal the existing row's value (else rfc8693 mints break)."""
+    def _create_oauth_user_row_with_scopes(self, client, name: str) -> str:
         r = client.post(
             "/v1/api/admin/mcp-servers",
             json={
-                "name": "flip-resend",
+                "name": name,
                 "transport": "streamable-http",
                 "url": "https://mcp.example.com/sse",
                 "auth_type": "oauth_user",
@@ -844,8 +841,19 @@ class TestUpdateMcpServer:
                 "oauth_audience": "api://mcp-a",
             },
         )
-        sid = r.json()["server_id"]
-        # Flip to obo AND re-send the identical stale scopes (what the UI does).
+        sid: str = r.json()["server_id"]
+        return sid
+
+    def test_flip_to_obo_resent_scopes_cleared_under_entra(self, client):
+        """Review finding: on a flip into obo the carried-over oauth_user
+        scopes are profile-dependent. Under entra they can never apply (the
+        leg pins <audience>/.default), so an equal-value re-send is treated
+        as the stale pre-fill and cleared — NOT rejected (the flip must not
+        400 on a value the operator never typed)."""
+        from types import SimpleNamespace
+
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+        sid = self._create_oauth_user_row_with_scopes(client, "flip-resend-entra")
         r2 = client.put(
             f"/v1/api/admin/mcp-servers/{sid}",
             json={
@@ -857,8 +865,29 @@ class TestUpdateMcpServer:
         assert r2.status_code == 200, r2.text
         assert r2.json()["oauth_scopes"] in (None, "")  # carried-over value cleared
 
+    def test_flip_to_obo_resent_scopes_kept_under_rfc8693(self, client):
+        """Review finding: under rfc8693 oauth_scopes IS the token-exchange
+        scope — an operator flipping to obo and keeping the same value (the
+        Keycloak optional-audience scope can legitimately equal the old
+        consent scope string) must NOT have it silently nulled; only an
+        omitted field clears (previous test)."""
+        from types import SimpleNamespace
+
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        sid = self._create_oauth_user_row_with_scopes(client, "flip-resend-rfc")
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+                "oauth_scopes": "openid profile offline_access",
+            },
+        )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["oauth_scopes"] == "openid profile offline_access"
+
     def test_entra_obo_row_with_scopes_stays_editable(self, client, storage):
-        """xhigh finding: a pre-existing oauth_obo row carrying scopes under the
+        """Review finding: a pre-existing oauth_obo row carrying scopes under the
         entra profile must stay editable — an unrelated PUT that doesn't touch
         scopes must NOT be rejected (the entra-scope reject fires only on a real
         scopes write)."""
@@ -893,7 +922,7 @@ class TestUpdateMcpServer:
         assert "oauth_scopes" in r2.json()["error"]
 
     def test_obo_server_reports_consented_users_count_for_flush_button(self, client, storage):
-        """xhigh finding: obo rows must report consented_users_count (users with a
+        """Review finding: obo rows must report consented_users_count (users with a
         minted cache row) so the console flush-cache action (gated on count>0)
         renders — previously only oauth_user rows got the count."""
         storage.create_mcp_server(
@@ -974,6 +1003,144 @@ class TestUpdateMcpServer:
                 .where(mcp_user_tokens.c.server_name == "aud-change")
             ).scalar()
         assert remaining == 0, "audience change must purge old-audience cache rows"
+
+    def _seed_obo_row_with_cache(self, client, storage, *, name: str, scopes: str | None) -> str:
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import mcp_user_tokens
+
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": name,
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://aud",
+                **({"oauth_scopes": scopes} if scopes else {}),
+            },
+        )
+        sid: str = r.json()["server_id"]
+        with storage._engine.connect() as conn:
+            conn.execute(
+                sa.insert(mcp_user_tokens),
+                {
+                    "user_id": "u1",
+                    "server_name": name,
+                    "access_token_ct": b"\x00ct",
+                    "refresh_token_ct": None,
+                    "expires_at": "2026-12-31T00:00:00",
+                    "scopes": scopes,
+                    "as_issuer": "https://idp.test",
+                    "audience": "api://aud",
+                    "created": "2026-05-04T11:00:00",
+                    "last_refreshed": None,
+                },
+            )
+            conn.commit()
+        return sid
+
+    def _count_cache_rows(self, storage, name: str) -> int:
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import mcp_user_tokens
+
+        with storage._engine.connect() as conn:
+            count = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(mcp_user_tokens)
+                .where(mcp_user_tokens.c.server_name == name)
+            ).scalar()
+        return int(count or 0)
+
+    def test_obo_scope_change_purges_cached_tokens(self, client, storage):
+        """Review finding: under rfc8693 the exchange scope shapes the minted
+        bearer's privileges exactly like the audience does — narrowing
+        oauth_scopes must purge cached rows or the reduction silently waits
+        out the token TTL (inconsistent with the audience purge)."""
+        from types import SimpleNamespace
+
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        sid = self._seed_obo_row_with_cache(
+            client, storage, name="scope-change", scopes="api.read api.write"
+        )
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"oauth_scopes": "api.read"},
+        )
+        assert r2.status_code == 200, r2.text
+        assert self._count_cache_rows(storage, "scope-change") == 0, (
+            "scope change must purge cache rows minted with the old scopes"
+        )
+
+    def test_obo_scope_noop_resend_does_not_purge(self, client, storage):
+        """Review finding companion: the admin form re-submits the pre-filled
+        scopes on every save — an EQUAL value is normalized out of the update
+        and must not flush every user's minted tokens."""
+        from types import SimpleNamespace
+
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        sid = self._seed_obo_row_with_cache(client, storage, name="scope-noop", scopes="api.read")
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"oauth_scopes": "api.read", "enabled": True},
+        )
+        assert r2.status_code == 200, r2.text
+        assert self._count_cache_rows(storage, "scope-noop") == 1, (
+            "a no-op scopes re-send must not purge the mint cache"
+        )
+
+    def test_flip_obo_to_oauth_user_clears_obo_audience_and_scopes(self, client, storage):
+        """Review finding: the obo-era oauth_audience is an IdP-side app
+        identifier, not the resource indicator oauth_user sends to its AS —
+        carried over, every consent yields a wrong-resource token that 401s
+        with no visible cause. The flip must clear it (and the rfc8693
+        exchange scopes) unless the request explicitly sets new values."""
+        from types import SimpleNamespace
+
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        sid = self._seed_obo_row_with_cache(client, storage, name="flip-back", scopes="api.read")
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"auth_type": "oauth_user", "oauth_client_id": "client-xyz"},
+        )
+        assert r2.status_code == 200, r2.text
+        data = r2.json()
+        assert data["auth_type"] == "oauth_user"
+        assert data["oauth_audience"] in (None, ""), "obo app-id audience must not carry over"
+        assert data["oauth_scopes"] in (None, ""), "rfc8693 exchange scopes must not carry over"
+        # The flip is an auth-model change → mint-cache rows purged too.
+        assert self._count_cache_rows(storage, "flip-back") == 0
+
+    def test_entra_obo_equal_scope_resend_is_accepted(self, client, storage):
+        """Review finding: the admin form always re-submits the pre-filled
+        oauth_scopes, so a same-type edit of an entra-profile obo row carrying
+        legacy scopes must accept an EQUAL value (normalized to a no-op)
+        instead of 400ing — only a genuine scope CHANGE is rejected."""
+        from types import SimpleNamespace
+
+        # The legacy-scoped entra row arises from a deployment profile switch:
+        # the row is created while the profile is rfc8693 (scopes accepted),
+        # then the deployment flips to entra.
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        sid = self._seed_obo_row_with_cache(
+            client, storage, name="entra-resend", scopes="legacy.scope"
+        )
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+        # Equal re-send + unrelated change → accepted, scopes untouched.
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"oauth_scopes": "legacy.scope", "enabled": False},
+        )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["oauth_scopes"] == "legacy.scope"
+        # A genuine CHANGE to non-empty scopes still 400s under entra.
+        r3 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"oauth_scopes": "new.scope"},
+        )
+        assert r3.status_code == 400
+        assert "entra" in r3.json()["error"]
 
     def test_create_obo_rejects_scopes_under_entra_profile(self, client):
         """#551 follow-up: oauth_scopes is meaningless for the entra grant leg

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -806,6 +806,99 @@ class TestUpdateMcpServer:
             ).scalar()
         assert remaining == 0, "oauth_user→oauth_obo flip must purge stale per-user rows"
 
+    def test_flip_to_obo_clears_stale_oauth_user_scopes(self, client):
+        """#551 follow-up: flipping oauth_user→oauth_obo without supplying new
+        scopes must CLEAR the old AS-consent scopes — otherwise the rfc8693 mint
+        leg would send them and loop on invalid_scope."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "flip-scopes",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_scopes": "openid profile offline_access",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        sid = r.json()["server_id"]
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"auth_type": "oauth_obo", "oauth_audience": "api://mcp-a"},
+        )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["oauth_scopes"] in (None, "")  # stale scopes cleared
+
+    def test_obo_audience_change_purges_cached_tokens(self, client, storage):
+        """#551 follow-up: changing an obo row's oauth_audience purges cached
+        tokens minted for the OLD audience (they are audience-bound)."""
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import mcp_user_tokens
+
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "aud-change",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://old-aud",
+            },
+        )
+        sid = r.json()["server_id"]
+        with storage._engine.connect() as conn:
+            conn.execute(
+                sa.insert(mcp_user_tokens),
+                {
+                    "user_id": "u1",
+                    "server_name": "aud-change",
+                    "access_token_ct": b"\x00ct",
+                    "refresh_token_ct": None,
+                    "expires_at": "2026-12-31T00:00:00",
+                    "scopes": None,
+                    "as_issuer": "https://idp.test",
+                    "audience": "api://old-aud",
+                    "created": "2026-05-04T11:00:00",
+                    "last_refreshed": None,
+                },
+            )
+            conn.commit()
+
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"oauth_audience": "api://new-aud"},
+        )
+        assert r2.status_code == 200, r2.text
+        with storage._engine.connect() as conn:
+            remaining = conn.execute(
+                sa.select(sa.func.count())
+                .select_from(mcp_user_tokens)
+                .where(mcp_user_tokens.c.server_name == "aud-change")
+            ).scalar()
+        assert remaining == 0, "audience change must purge old-audience cache rows"
+
+    def test_create_obo_rejects_scopes_under_entra_profile(self, client):
+        """#551 follow-up: oauth_scopes is meaningless for the entra grant leg
+        (it mints <audience>/.default), so the write path rejects it rather than
+        silently ignoring it at mint time."""
+        from types import SimpleNamespace
+
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-entra-scopes",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+                "oauth_scopes": "custom.scope",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "oauth_scopes" in r.json()["error"]
+
     def test_update_invalid_auth_type(self, client):
         created = _create_server(client, name="bad-auth-update")
         sid = created["server_id"]

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -829,6 +829,103 @@ class TestUpdateMcpServer:
         assert r2.status_code == 200, r2.text
         assert r2.json()["oauth_scopes"] in (None, "")  # stale scopes cleared
 
+    def test_flip_to_obo_clears_scopes_even_when_form_resubmits_them(self, client):
+        """xhigh finding: the admin form pre-fills + re-submits the old oauth_user
+        scopes on a flip, so the clear must be robust to scopes BEING in the body
+        when they equal the existing row's value (else rfc8693 mints break)."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "flip-resend",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_scopes": "openid profile offline_access",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        sid = r.json()["server_id"]
+        # Flip to obo AND re-send the identical stale scopes (what the UI does).
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+                "oauth_scopes": "openid profile offline_access",
+            },
+        )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["oauth_scopes"] in (None, "")  # carried-over value cleared
+
+    def test_entra_obo_row_with_scopes_stays_editable(self, client, storage):
+        """xhigh finding: a pre-existing oauth_obo row carrying scopes under the
+        entra profile must stay editable — an unrelated PUT that doesn't touch
+        scopes must NOT be rejected (the entra-scope reject fires only on a real
+        scopes write)."""
+        from types import SimpleNamespace
+
+        # Seed an obo row that already has scopes (e.g. created under rfc8693).
+        storage.create_mcp_server(
+            server_id="entra-edit-id",
+            name="entra-edit",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+            oauth_scopes="custom.scope",
+        )
+        # Now the deployment is on the entra profile.
+        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+
+        # An unrelated maintenance edit (disable) — does NOT touch scopes.
+        r = client.put(
+            "/v1/api/admin/mcp-servers/entra-edit-id",
+            json={"enabled": False},
+        )
+        assert r.status_code == 200, r.text  # NOT a 400 lockout
+
+        # But actively SETTING scopes under entra is still rejected.
+        r2 = client.put(
+            "/v1/api/admin/mcp-servers/entra-edit-id",
+            json={"oauth_scopes": "another.scope"},
+        )
+        assert r2.status_code == 400, r2.text
+        assert "oauth_scopes" in r2.json()["error"]
+
+    def test_obo_server_reports_consented_users_count_for_flush_button(self, client, storage):
+        """xhigh finding: obo rows must report consented_users_count (users with a
+        minted cache row) so the console flush-cache action (gated on count>0)
+        renders — previously only oauth_user rows got the count."""
+        storage.create_mcp_server(
+            server_id="obo-count-id",
+            name="obo-count",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        for i in range(2):
+            storage.create_mcp_user_token(
+                f"u{i}",
+                "obo-count",
+                access_token_ct=b"\x00ct",
+                refresh_token_ct=None,
+                expires_at="2026-12-31T00:00:00",
+                scopes=None,
+                as_issuer="https://idp.test",
+                audience="api://mcp-a",
+            )
+
+        # The list handler fans out node status; no cluster nodes in this test.
+        from types import SimpleNamespace
+
+        client.app.state.collector = SimpleNamespace(get_all_nodes=lambda: [])
+        client.app.state.proxy_client = MagicMock()
+        r = client.get("/v1/api/admin/mcp-servers")
+        assert r.status_code == 200, r.text
+        row = next(s for s in r.json()["servers"] if s["name"] == "obo-count")
+        assert row["consented_users_count"] == 2
+
     def test_obo_audience_change_purges_cached_tokens(self, client, storage):
         """#551 follow-up: changing an obo row's oauth_audience purges cached
         tokens minted for the OLD audience (they are audience-bound)."""

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import uuid
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -1935,6 +1937,28 @@ class TestNotifyNodesMcpReload:
         assert "refused" in result["n1"]["error"]
 
     @pytest.mark.anyio
+    async def test_records_error_on_non_2xx(self):
+        """A node replying non-2xx (e.g. 503) is recorded as an error, not
+        counted as a reached node — raise_for_status() routes the status into
+        the error path so a stale node trips the 'did not reach' WARNING, and
+        the (unused) response body is never consulted."""
+        http_req = httpx.Request("POST", "http://n1:8000/x")
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503", request=http_req, response=httpx.Response(503, request=http_req)
+        )
+        client = AsyncMock()
+        client.post.return_value = resp
+        req = _fake_request(
+            {"node_id": "n1", "server_url": "http://n1:8000"},
+            proxy_client=client,
+        )
+        result = await _notify_nodes_mcp_reload(req)
+        assert "n1" in result
+        assert "error" in result["n1"]
+        resp.json.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_empty_cluster(self):
         req = _fake_request()
         result = await _notify_nodes_mcp_reload(req)
@@ -2024,10 +2048,29 @@ class TestAdminMcpReloadEndpoint:
         assert data["results"]["n1"] == {"reloaded": 2}
         assert "error" in data["results"]["n2"]
 
+    def test_reload_fails_loud_without_fanout_infra(self, storage: SQLiteBackend) -> None:
+        """F4 guard: the operator reload drains + reports, so with storage and
+        admin.mcp permission but no collector/proxy_client on app.state it must
+        fail loudly (500) — never silently 200 with empty results (which a
+        re-introduced None-guard would do)."""
+        app = Starlette(
+            routes=_ROUTES,
+            middleware=[Middleware(_InjectAuthMiddleware)],
+        )
+        app.state.auth_storage = storage
+        # Deliberately omit app.state.collector / proxy_client.
+        c = TestClient(app, raise_server_exceptions=False)
+        r = c.post("/v1/api/admin/mcp-servers/reload")
+        assert r.status_code == 500
+
 
 class TestMcpWriteAutoReload:
-    """create / update / delete auto-notify nodes so a write reaches them (and
-    active per-user pools re-prime) without a separate /reload."""
+    """create / update / delete schedule a node reload (after the 200) so a
+    write reaches nodes — and active per-user pools re-prime — without a
+    separate /reload. The fan-out rides only the success response; an error
+    return schedules nothing. (The error paths tested here return before the
+    row is written; a post-write secret-apply failure is a separate pre-existing
+    partial-write path, not exercised here.)"""
 
     def test_create_notifies_nodes(self, client: TestClient) -> None:
         with patch(
@@ -2059,6 +2102,86 @@ class TestMcpWriteAutoReload:
             r = client.delete(f"/v1/api/admin/mcp-servers/{sid}")
         assert r.status_code == 200
         notify.assert_awaited_once()
+
+    def test_delete_does_not_notify_on_missing_server(self, client: TestClient) -> None:
+        """A 404 (server not found) returns before the success response, so no
+        node reload is scheduled — the fan-out rides only the success path."""
+        with patch(
+            "turnstone.console.server._notify_nodes_mcp_reload",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as notify:
+            r = client.delete("/v1/api/admin/mcp-servers/does-not-exist")
+        assert r.status_code == 404
+        notify.assert_not_awaited()
+
+    def test_update_does_not_notify_on_missing_server(self, client: TestClient) -> None:
+        """A 404 on update likewise schedules no reload."""
+        with patch(
+            "turnstone.console.server._notify_nodes_mcp_reload",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as notify:
+            r = client.put("/v1/api/admin/mcp-servers/does-not-exist", json={"enabled": False})
+        assert r.status_code == 404
+        notify.assert_not_awaited()
+
+    def test_create_does_not_notify_on_secret_store_503(
+        self, client_no_token_store: TestClient
+    ) -> None:
+        """A create that 503s on the OAuth-secret token-store gate returns an
+        error before any write — so no reload is scheduled."""
+        with patch(
+            "turnstone.console.server._notify_nodes_mcp_reload",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as notify:
+            r = client_no_token_store.post(
+                "/v1/api/admin/mcp-servers",
+                json={
+                    "name": "no-notify-503",
+                    "transport": "streamable-http",
+                    "url": "https://mcp.example.com/sse",
+                    "auth_type": "oauth_user",
+                    "oauth_client_id": "cli_abc",
+                    "oauth_client_secret": "secret-value",
+                },
+            )
+        assert r.status_code == 503, r.text
+        notify.assert_not_awaited()
+
+    def test_write_warns_when_reload_reaches_no_node(
+        self, client: TestClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A background fan-out that leaves nodes unreached is surfaced at
+        WARNING (not swallowed at debug) — operators need a signal the cluster
+        catalog may be stale, since there is no periodic node reconcile."""
+        with (
+            patch(
+                "turnstone.console.server._notify_nodes_mcp_reload",
+                new_callable=AsyncMock,
+                return_value={"n1": {"error": "Connection refused"}},
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            _create_server(client, name="warn-on-stale")
+        assert any("did not reach" in r.getMessage() for r in caplog.records)
+
+    def test_write_warns_when_reload_fan_out_raises(
+        self, client: TestClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A systemic fan-out fault (the whole reload raises) is logged at
+        WARNING rather than lost, for the same reason."""
+        with (
+            patch(
+                "turnstone.console.server._notify_nodes_mcp_reload",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("collector exploded"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            _create_server(client, name="warn-on-fault")
+        assert any("fan-out failed after admin write" in r.getMessage() for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -2025,6 +2025,42 @@ class TestAdminMcpReloadEndpoint:
         assert "error" in data["results"]["n2"]
 
 
+class TestMcpWriteAutoReload:
+    """create / update / delete auto-notify nodes so a write reaches them (and
+    active per-user pools re-prime) without a separate /reload."""
+
+    def test_create_notifies_nodes(self, client: TestClient) -> None:
+        with patch(
+            "turnstone.console.server._notify_nodes_mcp_reload",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as notify:
+            _create_server(client, name="auto-reload-create")
+        notify.assert_awaited_once()
+
+    def test_update_notifies_nodes(self, client: TestClient) -> None:
+        sid = _create_server(client, name="auto-reload-update")["server_id"]
+        with patch(
+            "turnstone.console.server._notify_nodes_mcp_reload",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as notify:
+            r = client.put(f"/v1/api/admin/mcp-servers/{sid}", json={"enabled": False})
+        assert r.status_code == 200
+        notify.assert_awaited_once()
+
+    def test_delete_notifies_nodes(self, client: TestClient) -> None:
+        sid = _create_server(client, name="auto-reload-delete")["server_id"]
+        with patch(
+            "turnstone.console.server._notify_nodes_mcp_reload",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as notify:
+            r = client.delete(f"/v1/api/admin/mcp-servers/{sid}")
+        assert r.status_code == 200
+        notify.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Node reload endpoint: POST /v1/api/_internal/mcp-reload
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -201,7 +201,10 @@ def _enabled_oidc(profile: str = "entra") -> SimpleNamespace:
     bad-profile config instead to assert the rejection.
     """
     return SimpleNamespace(
-        enabled=True, issuer="https://idp.example.com", obo_grant_profile=profile
+        enabled=True,
+        issuer="https://idp.example.com",
+        obo_grant_profile=profile,
+        capture_user_credential=True,
     )
 
 
@@ -763,6 +766,84 @@ class TestUpdateMcpServer:
         data = r.json()
         assert data["auth_type"] == "oauth_obo"
         assert data["oauth_audience"] == "api://mcp-a"
+
+    def test_same_type_static_edit_cannot_inject_oauth_columns(self, client, storage):
+        """Review finding (SECURITY): the OAuth columns must be a pure function
+        of the target auth_type on EVERY write, not just a flip. A same-type
+        static edit that injects oauth_authorization_server_url must be scrubbed
+        to NULL — otherwise a later flip to oauth_user (which legitimately uses
+        that column) would inherit the attacker AS URL and redirect every
+        consenting user's OAuth traffic."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "static-inject",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "static",
+            },
+        )
+        sid = r.json()["server_id"]
+        # Same-type static edit trying to smuggle an oauth_user-only column.
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={
+                "auth_type": "static",
+                "oauth_authorization_server_url": "https://attacker.example",
+            },
+        )
+        assert r2.status_code == 200, r2.text
+        row = storage.get_mcp_server(sid)
+        assert (row.get("oauth_authorization_server_url") or None) is None
+
+    def test_flip_to_oauth_user_does_not_inherit_stale_as_url(self, client, storage):
+        """Review finding (SECURITY): flipping a non-oauth_user row to oauth_user
+        must recompute the oauth_user-only columns from the request, never
+        inherit a stale/injected authorization_server_url left on the pre-flip
+        row (defence-in-depth for a value that predates the unconditional
+        scrub)."""
+        # Plant a static row that already carries a stale AS URL directly in DB.
+        storage.create_mcp_server(
+            server_id="stale-asurl-id",
+            name="stale-asurl",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="static",
+            oauth_authorization_server_url="https://attacker.example",
+        )
+        # Flip to oauth_user WITHOUT supplying an AS URL in the body.
+        r = client.put(
+            "/v1/api/admin/mcp-servers/stale-asurl-id",
+            json={"auth_type": "oauth_user", "oauth_client_id": "cli_x"},
+        )
+        assert r.status_code == 200, r.text
+        row = storage.get_mcp_server("stale-asurl-id")
+        assert (row.get("oauth_authorization_server_url") or None) is None
+        assert row.get("oauth_client_id") == "cli_x"
+
+    def test_create_obo_rejected_when_capture_disabled(self, client):
+        """Review finding: oauth_obo mints from the user's CAPTURED sign-in
+        credential, so with capture_user_credential off, login persists nothing
+        and every dispatch returns kind='missing' with an unsatisfiable remedy.
+        Reject at write time."""
+        client.app.state.oidc_config = SimpleNamespace(
+            enabled=True,
+            issuer="https://idp.example.com",
+            obo_grant_profile="entra",
+            capture_user_credential=False,
+        )
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-no-capture",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "capture_user_credential" in r.json()["error"]
 
     def test_create_obo_rejected_when_oidc_disabled(self, client):
         """Review finding: oauth_obo mints from the user's OIDC sign-in, so an

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import uuid
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -191,6 +192,19 @@ def _install_token_store(app, storage) -> None:
     )
 
 
+def _enabled_oidc(profile: str = "entra") -> SimpleNamespace:
+    """An OIDC config that satisfies the oauth_obo write-time gate.
+
+    oauth_obo mints from the user's captured sign-in, so the write choke point
+    requires OIDC enabled + a valid ``obo_grant_profile``. Tests exercising obo
+    writes install one of these; the finding-C tests install a disabled /
+    bad-profile config instead to assert the rejection.
+    """
+    return SimpleNamespace(
+        enabled=True, issuer="https://idp.example.com", obo_grant_profile=profile
+    )
+
+
 @pytest.fixture
 def client(storage):
     """TestClient wired to console admin MCP endpoints with full permissions."""
@@ -200,6 +214,10 @@ def client(storage):
     )
     app.state.auth_storage = storage
     _install_token_store(app, storage)
+    # Default: OIDC enabled under the entra profile so oauth_obo writes pass the
+    # requirement gate. Per-test overrides install rfc8693 / disabled / bad
+    # profile as needed.
+    app.state.oidc_config = _enabled_oidc("entra")
     return TestClient(app)
 
 
@@ -746,6 +764,68 @@ class TestUpdateMcpServer:
         assert data["auth_type"] == "oauth_obo"
         assert data["oauth_audience"] == "api://mcp-a"
 
+    def test_create_obo_rejected_when_oidc_disabled(self, client):
+        """Review finding: oauth_obo mints from the user's OIDC sign-in, so an
+        install with OIDC disabled can NEVER mint. Reject at write time (a
+        permanent misconfig otherwise surfaces per-dispatch as a retryable
+        transient that never heals)."""
+        client.app.state.oidc_config = SimpleNamespace(enabled=False, obo_grant_profile="entra")
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-no-oidc",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "OIDC" in r.json()["error"]
+
+    def test_create_obo_rejected_on_invalid_grant_profile(self, client):
+        """Review finding: a typo'd deployment obo_grant_profile leaves the mint
+        leg unresolved (obo_misconfigured per dispatch), so reject it at the
+        write choke point rather than as a runtime transient."""
+        client.app.state.oidc_config = _enabled_oidc("bogus-profile")
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "obo-bad-profile",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_obo",
+                "oauth_audience": "api://mcp-a",
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "obo_grant_profile" in r.json()["error"]
+
+    def test_flip_user_to_obo_via_api_without_audience_is_rejected(self, client, storage):
+        """Review finding: a flip into obo must NOT carry the oauth_user-era
+        oauth_audience (a resource indicator, conventionally the MCP URL) — it
+        would pass the audience-required check and then fail every mint. An API
+        PUT of just {auth_type: oauth_obo} recomputes audience from the body
+        (absent → NULL) and is rejected loudly, not saved with the stale value."""
+        r = client.post(
+            "/v1/api/admin/mcp-servers",
+            json={
+                "name": "flip-api-noaud",
+                "transport": "streamable-http",
+                "url": "https://mcp.example.com/sse",
+                "auth_type": "oauth_user",
+                "oauth_client_id": "cli_x",
+                "oauth_audience": "https://mcp.example.com/sse",  # resource indicator
+            },
+        )
+        sid = r.json()["server_id"]
+        r2 = client.put(
+            f"/v1/api/admin/mcp-servers/{sid}",
+            json={"auth_type": "oauth_obo"},  # no audience in body
+        )
+        assert r2.status_code == 400, r2.text
+        assert "oauth_audience" in r2.json()["error"]
+
     def test_update_flip_oauth_user_to_obo_keeps_audience_and_purges_tokens(self, client, storage):
         """#551 (findings 10344 + 10326): flipping oauth_user→oauth_obo must NOT
         null oauth_audience (the mint engine needs it), and MUST purge the old
@@ -844,17 +924,17 @@ class TestUpdateMcpServer:
         sid: str = r.json()["server_id"]
         return sid
 
-    def test_flip_to_obo_resent_scopes_cleared_under_entra(self, client):
-        """Review finding: on a flip into obo the carried-over oauth_user
-        scopes are profile-dependent. Under entra they can never apply (the
-        leg pins <audience>/.default), so an equal-value re-send is treated
-        as the stale pre-fill and cleared — NOT rejected (the flip must not
-        400 on a value the operator never typed)."""
-        from types import SimpleNamespace
-
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+    def test_flip_to_obo_under_entra_rejects_explicit_scopes_but_omit_clears(self, client):
+        """Redesign: a flip into obo recomputes scopes from the body (never
+        carries the old row's value across the semantic boundary). Under entra,
+        an EXPLICIT non-empty scopes value is rejected 400 — an honest visible
+        snap rather than a silent drop — while the console-realistic flip (the
+        form clears the semantic field on the auth-type switch, so scopes is
+        omitted/empty) succeeds with scopes NULL."""
+        client.app.state.oidc_config = _enabled_oidc("entra")
+        # Explicit non-empty scopes on the flip → 400 (they can't apply on entra).
         sid = self._create_oauth_user_row_with_scopes(client, "flip-resend-entra")
-        r2 = client.put(
+        rejected = client.put(
             f"/v1/api/admin/mcp-servers/{sid}",
             json={
                 "auth_type": "oauth_obo",
@@ -862,8 +942,16 @@ class TestUpdateMcpServer:
                 "oauth_scopes": "openid profile offline_access",
             },
         )
-        assert r2.status_code == 200, r2.text
-        assert r2.json()["oauth_scopes"] in (None, "")  # carried-over value cleared
+        assert rejected.status_code == 400
+        assert "entra" in rejected.json()["error"]
+        # The realistic flip (scopes field cleared → omitted) succeeds, NULL scopes.
+        sid2 = self._create_oauth_user_row_with_scopes(client, "flip-omit-entra")
+        ok = client.put(
+            f"/v1/api/admin/mcp-servers/{sid2}",
+            json={"auth_type": "oauth_obo", "oauth_audience": "api://mcp-a"},
+        )
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["oauth_scopes"] in (None, "")  # not carried across the flip
 
     def test_flip_to_obo_resent_scopes_kept_under_rfc8693(self, client):
         """Review finding: under rfc8693 oauth_scopes IS the token-exchange
@@ -871,9 +959,7 @@ class TestUpdateMcpServer:
         Keycloak optional-audience scope can legitimately equal the old
         consent scope string) must NOT have it silently nulled; only an
         omitted field clears (previous test)."""
-        from types import SimpleNamespace
-
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        client.app.state.oidc_config = _enabled_oidc("rfc8693")
         sid = self._create_oauth_user_row_with_scopes(client, "flip-resend-rfc")
         r2 = client.put(
             f"/v1/api/admin/mcp-servers/{sid}",
@@ -891,8 +977,6 @@ class TestUpdateMcpServer:
         entra profile must stay editable — an unrelated PUT that doesn't touch
         scopes must NOT be rejected (the entra-scope reject fires only on a real
         scopes write)."""
-        from types import SimpleNamespace
-
         # Seed an obo row that already has scopes (e.g. created under rfc8693).
         storage.create_mcp_server(
             server_id="entra-edit-id",
@@ -904,7 +988,7 @@ class TestUpdateMcpServer:
             oauth_scopes="custom.scope",
         )
         # Now the deployment is on the entra profile.
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+        client.app.state.oidc_config = _enabled_oidc("entra")
 
         # An unrelated maintenance edit (disable) — does NOT touch scopes.
         r = client.put(
@@ -946,8 +1030,6 @@ class TestUpdateMcpServer:
             )
 
         # The list handler fans out node status; no cluster nodes in this test.
-        from types import SimpleNamespace
-
         client.app.state.collector = SimpleNamespace(get_all_nodes=lambda: [])
         client.app.state.proxy_client = MagicMock()
         r = client.get("/v1/api/admin/mcp-servers")
@@ -1058,9 +1140,7 @@ class TestUpdateMcpServer:
         bearer's privileges exactly like the audience does — narrowing
         oauth_scopes must purge cached rows or the reduction silently waits
         out the token TTL (inconsistent with the audience purge)."""
-        from types import SimpleNamespace
-
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        client.app.state.oidc_config = _enabled_oidc("rfc8693")
         sid = self._seed_obo_row_with_cache(
             client, storage, name="scope-change", scopes="api.read api.write"
         )
@@ -1077,9 +1157,7 @@ class TestUpdateMcpServer:
         """Review finding companion: the admin form re-submits the pre-filled
         scopes on every save — an EQUAL value is normalized out of the update
         and must not flush every user's minted tokens."""
-        from types import SimpleNamespace
-
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        client.app.state.oidc_config = _enabled_oidc("rfc8693")
         sid = self._seed_obo_row_with_cache(client, storage, name="scope-noop", scopes="api.read")
         r2 = client.put(
             f"/v1/api/admin/mcp-servers/{sid}",
@@ -1096,9 +1174,7 @@ class TestUpdateMcpServer:
         carried over, every consent yields a wrong-resource token that 401s
         with no visible cause. The flip must clear it (and the rfc8693
         exchange scopes) unless the request explicitly sets new values."""
-        from types import SimpleNamespace
-
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        client.app.state.oidc_config = _enabled_oidc("rfc8693")
         sid = self._seed_obo_row_with_cache(client, storage, name="flip-back", scopes="api.read")
         r2 = client.put(
             f"/v1/api/admin/mcp-servers/{sid}",
@@ -1117,16 +1193,14 @@ class TestUpdateMcpServer:
         oauth_scopes, so a same-type edit of an entra-profile obo row carrying
         legacy scopes must accept an EQUAL value (normalized to a no-op)
         instead of 400ing — only a genuine scope CHANGE is rejected."""
-        from types import SimpleNamespace
-
         # The legacy-scoped entra row arises from a deployment profile switch:
         # the row is created while the profile is rfc8693 (scopes accepted),
         # then the deployment flips to entra.
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="rfc8693")
+        client.app.state.oidc_config = _enabled_oidc("rfc8693")
         sid = self._seed_obo_row_with_cache(
             client, storage, name="entra-resend", scopes="legacy.scope"
         )
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+        client.app.state.oidc_config = _enabled_oidc("entra")
         # Equal re-send + unrelated change → accepted, scopes untouched.
         r2 = client.put(
             f"/v1/api/admin/mcp-servers/{sid}",
@@ -1146,9 +1220,7 @@ class TestUpdateMcpServer:
         """#551 follow-up: oauth_scopes is meaningless for the entra grant leg
         (it mints <audience>/.default), so the write path rejects it rather than
         silently ignoring it at mint time."""
-        from types import SimpleNamespace
-
-        client.app.state.oidc_config = SimpleNamespace(obo_grant_profile="entra")
+        client.app.state.oidc_config = _enabled_oidc("entra")
         r = client.post(
             "/v1/api/admin/mcp-servers",
             json={

--- a/tests/test_mcp_admin_bulk_revoke.py
+++ b/tests/test_mcp_admin_bulk_revoke.py
@@ -157,6 +157,26 @@ def test_400_on_invalid_server_name(storage: SQLiteBackend) -> None:
     assert resp.status_code == 400
 
 
+def test_200_on_oauth_obo_server(storage: SQLiteBackend) -> None:
+    """#551: bulk-revoke serves oauth_obo too (it populates mcp_user_tokens with
+    minted cache rows) — the documented remediation for stale rows after an
+    oauth_user→oauth_obo flip."""
+    storage.create_mcp_server(
+        server_id="srv-obo-id",
+        name="srv-obo",
+        transport="streamable-http",
+        url="https://example.com/mcp",
+        auth_type="oauth_obo",
+    )
+    _seed_user_tokens(storage, "srv-obo", users=2)
+
+    client = TestClient(_build_app(storage))
+    resp = client.post("/v1/api/admin/mcp-servers/srv-obo/bulk-revoke")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["rows_deleted"] == 2
+    assert storage.count_mcp_consented_users_by_server("srv-obo") == 0
+
+
 def test_200_on_success_with_no_consented_users(storage: SQLiteBackend) -> None:
     _seed_oauth_server(storage)
     client = TestClient(_build_app(storage))

--- a/tests/test_mcp_admin_bulk_revoke.py
+++ b/tests/test_mcp_admin_bulk_revoke.py
@@ -173,8 +173,26 @@ def test_200_on_oauth_obo_server(storage: SQLiteBackend) -> None:
     client = TestClient(_build_app(storage))
     resp = client.post("/v1/api/admin/mcp-servers/srv-obo/bulk-revoke")
     assert resp.status_code == 200, resp.text
-    assert resp.json()["rows_deleted"] == 2
+    body = resp.json()
+    assert body["rows_deleted"] == 2
     assert storage.count_mcp_consented_users_by_server("srv-obo") == 0
+    # Honest semantics: obo is a cache flush (re-mints), NOT a consent revoke.
+    assert body["effect"] == "cache_flush_remints"
+    events = storage.list_audit_events(action="mcp_server.oauth.obo_cache_flushed")
+    assert len(events) == 1
+    # The oauth_user revoke event must NOT be emitted for an obo flush.
+    assert storage.list_audit_events(action="mcp_server.oauth.bulk_revoked") == []
+
+
+def test_oauth_user_bulk_revoke_keeps_revoke_semantics(storage: SQLiteBackend) -> None:
+    """The oauth_user path is unchanged: durable revoke event + effect."""
+    _seed_oauth_server(storage)
+    _seed_user_tokens(storage, "srv-oauth", users=1)
+    client = TestClient(_build_app(storage))
+    resp = client.post("/v1/api/admin/mcp-servers/srv-oauth/bulk-revoke")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["effect"] == "revoked_until_reconsent"
+    assert len(storage.list_audit_events(action="mcp_server.oauth.bulk_revoked")) == 1
 
 
 def test_200_on_success_with_no_consented_users(storage: SQLiteBackend) -> None:

--- a/tests/test_mcp_consent_url_sibling_audit.py
+++ b/tests/test_mcp_consent_url_sibling_audit.py
@@ -97,21 +97,23 @@ def test_every_user_actionable_structured_error_passes_consent_url() -> None:
 def test_audit_finds_all_known_user_actionable_sites() -> None:
     """Lock the count so accidental deletions are caught.
 
-    There are 13 user-actionable ``_structured_error`` call sites today
-    (4 each in the tool / resource / prompt token-classify branches +
-    3 in the post-retry-failed branches + 1 in ``_handle_auth_403``'s
-    insufficient-scope branch). If a new exec path is added the count
-    can rise; if a branch is removed the count can fall — both are
-    fine, but require an intentional bump of this number to confirm
-    the change went through review.
+    There are 7 user-actionable ``_structured_error`` call sites today:
+    3 in ``_pool_lookup_error`` (the single lookup-kind → error mapping
+    shared by the tool / resource / prompt dispatchers — it replaced the
+    9 hand-synced per-dispatcher copies), 3 in the post-retry-failed
+    branches, and 1 in ``_handle_auth_403``'s insufficient-scope branch.
+    If a new exec path is added the count can rise; if a branch is
+    removed the count can fall — both are fine, but require an
+    intentional bump of this number to confirm the change went through
+    review.
     """
     source = _read_source()
     blocks = _find_structured_error_blocks(source)
     user_actionable_count = sum(
         1 for _, blk in blocks if any(f'code="{code}"' in blk for code in _USER_ACTIONABLE_CODES)
     )
-    assert user_actionable_count == 13, (
-        f"Expected 13 user-actionable _structured_error sites, got "
+    assert user_actionable_count == 7, (
+        f"Expected 7 user-actionable _structured_error sites, got "
         f"{user_actionable_count}. If this is intentional, bump the "
         f"expected count and document why in the commit message."
     )

--- a/tests/test_mcp_hot_reload.py
+++ b/tests/test_mcp_hot_reload.py
@@ -402,3 +402,31 @@ class TestReconcileSync:
         assert result == {"added": [], "removed": [], "updated": []}
         # Existing server untouched
         assert "srv" in mgr._server_configs
+
+    def test_reprimes_active_users_on_new_pool_server(self) -> None:
+        """A newly-appeared oauth_obo server re-primes active sessions' users so
+        a mid-session registration surfaces without a fresh workstream."""
+        mgr = MCPClientManager({})
+        primed: list[str] = []
+        mgr.prime_user_pools = lambda uid: primed.append(uid)  # type: ignore[method-assign]
+        mgr.add_listener(lambda: None, user_id="u1")
+        mgr.add_listener(lambda: None, user_id="u2")
+        mgr.add_listener(lambda: None, user_id=None)  # global/admin — skipped
+        row = _db_row("azobo", transport="streamable-http", command="", url="https://azobo:8443/")
+        row["auth_type"] = "oauth_obo"
+        mgr.reconcile_sync(_FakeStorage([row]))
+        assert sorted(primed) == ["u1", "u2"]
+        assert mgr._obo_server_names == {"azobo"}
+
+    def test_no_reprime_when_pool_server_already_known(self) -> None:
+        """Reconcile that reveals no NEW pool server does not re-prime — avoids
+        re-warming every active session on every unrelated reload."""
+        mgr = MCPClientManager({})
+        mgr._obo_server_names = {"azobo"}  # already known before this reconcile
+        primed: list[str] = []
+        mgr.prime_user_pools = lambda uid: primed.append(uid)  # type: ignore[method-assign]
+        mgr.add_listener(lambda: None, user_id="u1")
+        row = _db_row("azobo", transport="streamable-http", command="", url="https://azobo:8443/")
+        row["auth_type"] = "oauth_obo"
+        mgr.reconcile_sync(_FakeStorage([row]))
+        assert primed == []

--- a/tests/test_mcp_hot_reload.py
+++ b/tests/test_mcp_hot_reload.py
@@ -430,3 +430,38 @@ class TestReconcileSync:
         row["auth_type"] = "oauth_obo"
         mgr.reconcile_sync(_FakeStorage([row]))
         assert primed == []
+
+    def test_reprimes_on_pool_auth_type_flip(self) -> None:
+        """A server MIGRATED in place oauth_user -> oauth_obo (same name) re-primes
+        active users — a name-only diff would see the same name on both sides and
+        miss the flip."""
+        mgr = MCPClientManager({})
+        mgr._oauth_user_server_names = {"srv"}  # previously oauth_user
+        primed: list[str] = []
+        mgr.prime_user_pools = lambda uid: primed.append(uid)  # type: ignore[method-assign]
+        mgr.add_listener(lambda: None, user_id="u1")
+        row = _db_row("srv", transport="streamable-http", command="", url="https://srv:8443/")
+        row["auth_type"] = "oauth_obo"  # flipped in place
+        mgr.reconcile_sync(_FakeStorage([row]))
+        assert primed == ["u1"]
+        assert mgr._obo_server_names == {"srv"}
+        assert mgr._oauth_user_server_names == set()
+
+    def test_reprime_survives_prime_exception(self) -> None:
+        """One user's prime scheduling failure must not abort the loop or propagate
+        out of reconcile_sync (which would 500 the reload endpoint)."""
+        mgr = MCPClientManager({})
+        primed: list[str] = []
+
+        def _prime(uid: str) -> None:
+            if uid == "boom-user":
+                raise RuntimeError("scheduling blew up")
+            primed.append(uid)
+
+        mgr.prime_user_pools = _prime  # type: ignore[method-assign]
+        mgr.add_listener(lambda: None, user_id="boom-user")
+        mgr.add_listener(lambda: None, user_id="ok-user")
+        row = _db_row("azobo", transport="streamable-http", command="", url="https://azobo:8443/")
+        row["auth_type"] = "oauth_obo"
+        mgr.reconcile_sync(_FakeStorage([row]))  # must not raise
+        assert "ok-user" in primed  # the other user was still primed

--- a/tests/test_mcp_oauth_connections.py
+++ b/tests/test_mcp_oauth_connections.py
@@ -353,6 +353,33 @@ class TestListConnections:
             ):
                 assert forbidden not in row, f"secret field {forbidden!r} leaked in {row!r}"
 
+    def test_list_connections_hides_obo_mint_cache_rows(
+        self, storage: SQLiteBackend, http_client_mock: MagicMock
+    ) -> None:
+        """Review finding: obo cache rows in the connections list offered a
+        "Disconnect" that silently undid itself (session-start priming
+        re-mints from the captured credential). The list shows only rows the
+        user can actually revoke — obo mint-cache rows are hidden."""
+        token_store = _make_token_store(storage)
+        _seed_oauth_user_server(storage)
+        _seed_user_token(token_store)
+        storage.create_mcp_server(
+            server_id="srv-obo-id",
+            name="srv-obo",
+            transport="streamable-http",
+            url="https://mcp-obo.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-obo",
+        )
+        _seed_user_token(token_store, server_name="srv-obo", refresh_token=None)
+
+        app = _build_app(storage=storage, http_client=http_client_mock, token_store=token_store)
+        with TestClient(app) as client:
+            resp = client.get("/v1/api/mcp/oauth/connections")
+        assert resp.status_code == 200
+        names = [c["server_name"] for c in resp.json()["connections"]]
+        assert names == ["srv-oauth"]
+
 
 # ---------------------------------------------------------------------------
 # DELETE /connections/{server_name}
@@ -360,6 +387,31 @@ class TestListConnections:
 
 
 class TestRevokeConnection:
+    def test_revoke_connection_obo_server_409_and_keeps_row(
+        self, storage: SQLiteBackend, http_client_mock: MagicMock
+    ) -> None:
+        """Review finding: DELETE on an obo server returned 204, audited
+        token_revoked, and then priming silently re-minted from the surviving
+        captured credential — a disconnect that undoes itself. The endpoint
+        refuses honestly (409) and leaves the mint-cache row untouched."""
+        token_store = _make_token_store(storage)
+        storage.create_mcp_server(
+            server_id="srv-obo-id",
+            name="srv-obo",
+            transport="streamable-http",
+            url="https://mcp-obo.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-obo",
+        )
+        _seed_user_token(token_store, server_name="srv-obo", refresh_token=None)
+
+        app = _build_app(storage=storage, http_client=http_client_mock, token_store=token_store)
+        with TestClient(app) as client:
+            resp = client.delete("/v1/api/mcp/oauth/connections/srv-obo")
+        assert resp.status_code == 409
+        assert "sign-in" in resp.json()["error"].lower()
+        assert token_store.get_user_token("user-1", "srv-obo") is not None
+
     def test_revoke_connection_unauthenticated_401(
         self, storage: SQLiteBackend, http_client_mock: MagicMock
     ) -> None:

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -232,6 +232,35 @@ class TestRefreshFailureClassification:
         # Token survives a transient failure — no cluster-wide revoke; self-heals.
         assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is not None
 
+    def test_oversized_error_body_stays_transient_for_oauth_user(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: routing refresh_token() through the shared
+        _hardened_token_post must NOT change the oauth_user oversized-error
+        behavior. On main an over-cap error body was TRANSIENT (default class,
+        token kept, retryable forever); the OBO-only status-based escalation must
+        not leak onto oauth_user, or a large upstream error could escalate a
+        pre-existing consent to an unexpected re-consent. oauth_user keeps
+        TRANSIENT; the token survives."""
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        # 401 with an error body over the 64KB cap.
+        client.post = AsyncMock(
+            return_value=_mk_response(401, {"error": "invalid_grant", "pad": "x" * (70 * 1024)})
+        )
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        result = self._lookup(state)
+
+        assert result.kind == "refresh_failed_transient"
+        # Kept (TRANSIENT), not revoked — and the ambiguous streak did not advance.
+        assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is not None
+        from turnstone.core.mcp_oauth import _refresh_backoff_state
+
+        assert _refresh_backoff_state(state, "user-1", "srv-oauth").ambiguous_streak == 0
+
     def test_permanent_invalid_grant_revokes(self, storage: SQLiteBackend) -> None:
         """Contrast: 400 invalid_grant IS permanent — deletion is correct and the
         eventual fix MUST preserve it."""
@@ -246,6 +275,32 @@ class TestRefreshFailureClassification:
 
         assert result.kind == "refresh_failed"
         assert state.mcp_token_store.get_user_token("user-1", "srv-oauth") is None
+
+    def test_permanent_revoke_audits_even_when_row_concurrently_deleted(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: gating the token_revoked audit on delete-returned-True
+        (the obo spam fix) must NOT suppress the oauth_user audit when a
+        concurrent admin/user revoke deletes the row first. For oauth_user a
+        refresh failure means a grant EXISTED (a real revocation), so the audit
+        fires even on an empty delete — an operator's SIEM must not miss it."""
+        from unittest.mock import patch
+
+        _seed_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(return_value=_mk_response(200, _good_as_metadata_doc()))
+        client.post = AsyncMock(return_value=_mk_response(400, {"error": "invalid_grant"}))
+        state = _make_app_state(storage, http_client=client)
+        _seed_token(state, expires_in_seconds=-1000)
+
+        # Simulate a concurrent external revoke: the dispatch-side delete finds
+        # the row already gone (returns False).
+        with patch.object(state.mcp_token_store, "delete_user_token", return_value=False):
+            result = self._lookup(state)
+
+        assert result.kind == "refresh_failed"
+        events = storage.list_audit_events(action="mcp_server.oauth.token_revoked")
+        assert len(events) == 1  # audited despite the empty delete
 
     def test_400_invalid_client_keeps_token(self, storage: SQLiteBackend) -> None:
         """A 400 ``invalid_client`` is operator-fixable, NOT a dead grant: keep

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -454,6 +454,37 @@ class TestRfc8693Leg:
         # server; the credential survives so the user's other servers are fine.
         assert result.kind == "refresh_failed"
 
+    def test_mint_without_expires_in_gets_bounded_expiry_not_cached_forever(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: a mint response omitting the (RFC 8693-optional)
+        expires_in must NOT cache expires_at=NULL — the freshness gate reads NULL
+        as never-expiring (correct for opaque oauth_user tokens, wrong for a
+        short-lived minted obo token), so it would be served indefinitely and
+        defeat audience/scope-narrowing that relies on TTL turnover. A missing
+        expiry falls back to a bounded default so the row re-mints soon."""
+        from datetime import datetime as _dt
+
+        from turnstone.core.mcp_oauth import _OBO_DEFAULT_TTL_SECONDS
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        # Entra-shaped single-POST mint, but the IdP omits expires_in.
+        client.post = AsyncMock(return_value=_mk_response(200, {"access_token": "at-no-exp"}))
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        row = storage.get_mcp_user_token(USER, SERVER)
+        assert row is not None
+        # Not NULL — a bounded expiry within the default TTL window was stamped.
+        assert row["expires_at"] is not None
+        parsed = _dt.strptime(row["expires_at"], "%Y-%m-%dT%H:%M:%S").replace(tzinfo=UTC)
+        remaining = (parsed - datetime.now(UTC)).total_seconds()
+        assert 0 < remaining <= _OBO_DEFAULT_TTL_SECONDS + 5
+
     def test_exchange_response_refresh_token_never_overwrites_credential(
         self, storage: SQLiteBackend
     ) -> None:

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -258,6 +258,41 @@ class TestEntraLeg:
         # audience-qualified .default — NOT the raw oauth_scopes value.
         assert call.kwargs["data"]["scope"] == "api://aud-a/.default"
 
+    def test_entra_cache_row_records_effective_scope_not_configured_scope(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: a server scoped under rfc8693 that survives a switch
+        to obo_grant_profile=entra mints <audience>/.default (ignoring
+        oauth_scopes). The cache row must record the EFFECTIVE scope actually
+        minted ('' — .default), NOT the configured 'custom.scope' — otherwise
+        _is_fresh_obo_cache_row would keep serving the broad .default bearer
+        believing it is the narrow configured one, and a scope narrowing that
+        can't apply under entra would look like it did."""
+        _seed_obo_server(storage, oauth_scopes="custom.scope")
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()
+        client.post.return_value = _mk_response(
+            200, {"access_token": "at-broad-default", "expires_in": 3600}
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        result = _mint(state)
+        assert result.kind == "token"
+        # The row records the effective (empty) scope, not "custom.scope".
+        row = storage.get_mcp_user_token(USER, SERVER)
+        assert row is not None
+        assert (row["scopes"] or "") == ""
+
+        # A second dispatch serves the cache honestly (fresh, right effective
+        # scope) with ZERO additional mints — no spurious re-mint from a
+        # scope-mismatch the entra leg could never resolve.
+        client.post.reset_mock()
+        result2 = _mint(state)
+        assert result2.kind == "token"
+        assert result2.token == "at-broad-default"
+        assert client.post.call_count == 0
+
     def test_rotated_refresh_token_written_back_to_credential(self, storage: SQLiteBackend) -> None:
         """Case 5: Entra usually rotates the RT on redemption — the newest
         value MUST be persisted to the shared credential (write-back rule)."""

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -8,8 +8,9 @@ BRIEFING.md ("Verified wire shapes") — every mock asserts the EXACT form
 payload posted to the IdP token endpoint (body-inspecting, not
 call-counting):
 
-- entra: ONE refresh-token grant carrying ``scope=<audience>/.default``
-  (or the per-server ``oauth_scopes`` override verbatim);
+- entra: ONE refresh-token grant always carrying
+  ``scope=<audience>/.default`` (per-server ``oauth_scopes`` is ignored
+  on this leg — a bare scope list would drop the audience);
 - rfc8693: a refresh grant (NO scope key) for a subject token, then a
   token-exchange grant with ``audience=<server oauth_audience>`` and the
   per-server scope only when configured.

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -123,6 +123,7 @@ def _seed_cache_row(
     *,
     expires_in_seconds: int,
     access_token: str = "cached-at",
+    audience: str = AUDIENCE,
 ) -> None:
     expires_at = (datetime.now(UTC) + timedelta(seconds=expires_in_seconds)).strftime(_ISO)
     state.mcp_token_store.create_user_token(
@@ -133,7 +134,7 @@ def _seed_cache_row(
         expires_at=expires_at,
         scopes=None,
         as_issuer=ISSUER,
-        audience=AUDIENCE,
+        audience=audience,
     )
 
 
@@ -491,6 +492,35 @@ class TestCacheAndCredentialLookup:
         assert result.kind == "token"
         assert result.token == "cached-at"
         assert client.post.call_count == 0
+
+    def test_stale_audience_cache_row_is_not_served_and_remints(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding (audience guard): a cached token minted for a DIFFERENT
+        audience than the server's current one must NOT be served — an operator's
+        audience narrowing has to take effect immediately, not at token TTL. The
+        stale row is ignored and a fresh mint (for the current audience) runs."""
+        _seed_obo_server(storage)  # server oauth_audience = AUDIENCE (api://aud-a)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(200, {"access_token": "reminted-at", "expires_in": 3600})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        # A fresh, refresh-less cache row — but for the OLD/broader audience.
+        _seed_cache_row(
+            state, expires_in_seconds=3600, access_token="old-aud-at", audience="api://old-broad"
+        )
+
+        result = _mint(state)
+
+        # Not served from the stale-audience cache; a real mint happened.
+        assert result.kind == "token"
+        assert result.token == "reminted-at"
+        assert client.post.call_count == 1
+        # The cache row is now for the current audience.
+        row = storage.get_mcp_user_token(USER, SERVER)
+        assert row is not None and row["audience"] == AUDIENCE
 
     def test_missing_credential_returns_missing_with_zero_http_calls(
         self, storage: SQLiteBackend

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -762,7 +762,9 @@ class TestFailureHandling:
         common missing-tenant-grant case — the user never had a token for this
         server) must NOT emit a token_revoked audit for a row that never
         existed. The cooldown is still armed as the terminal backstop (the
-        credential survives), so the second dispatch short-circuits."""
+        credential survives), and — because the failure was PERMANENT — the
+        second dispatch surfaces the honest permanent classification during the
+        cooldown window (not a misleading retryable transient)."""
         _seed_obo_server(storage)
         client = MagicMock(spec=httpx.AsyncClient)
         client.post = AsyncMock(
@@ -783,8 +785,9 @@ class TestFailureHandling:
         first, second = asyncio.run(_run())
 
         assert first.kind == "refresh_failed"
-        # Terminal: the cooldown short-circuits the second dispatch entirely.
-        assert second.kind == "refresh_failed_transient"
+        # Terminal: the cooldown short-circuits the second dispatch — and reports
+        # the PERMANENT classification, not a retryable transient.
+        assert second.kind == "refresh_failed"
         assert client.post.call_count == 1  # NOT re-minted
         # No row was ever deleted → no bogus revoke audit.
         events = storage.list_audit_events(action="mcp_server.oauth.token_revoked")
@@ -867,35 +870,100 @@ class TestFailureHandling:
         assert result.token == "at-reminted"
         assert client.post.call_count == 1
 
-    def test_force_refresh_reuses_row_minted_while_waiting_for_lock(
+    def test_force_refresh_reuses_concurrently_minted_token_without_reminting(
         self, storage: SQLiteBackend
     ) -> None:
-        """Review finding: the under-lock "another caller already minted" reuse
-        gate keyed on ``last_refreshed``, which obo cache rows NEVER set
-        (delete+create hardcodes NULL) — so every serialized force_refresh
-        waiter re-ran a full IdP redemption. The gate now keys on ``created``
-        (the mint time under delete+create): a fresh row created at/after the
-        caller's lock-request time is served without a new mint."""
+        """Serialized force_refresh waiters must single-flight the re-mint: a
+        waiter that acquires the lock AFTER a peer already re-minted reuses the
+        peer's fresh token instead of running its own redundant IdP redemption.
+        The reuse is decided by token IDENTITY (the under-lock row holds a
+        DIFFERENT token than the rejected one this caller came in with), not by
+        mint time — so a same-second concurrent mint is still reused."""
+        from unittest.mock import patch
+
         _seed_obo_server(storage)
         client = MagicMock(spec=httpx.AsyncClient)
         client.post = AsyncMock()  # any IdP call would be a gate failure
         state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
         _seed_credential(state)
-        # Seeded moments before the call: at second granularity its ``created``
-        # is >= the caller's lock-request time, exactly what a concurrent
-        # waiter observes after the winner persisted its mint.
-        _seed_cache_row(state, expires_in_seconds=3600, access_token="winner-minted-at")
 
-        async def _run() -> Any:
-            return await get_obo_access_token_classified(
-                app_state=state, user_id=USER, server_name=SERVER, force_refresh=True
-            )
+        def _fresh_row(access_token: str) -> Any:
+            return {
+                "user_id": USER,
+                "server_name": SERVER,
+                "access_token": access_token,
+                "refresh_token": None,
+                "expires_at": (datetime.now(UTC) + timedelta(seconds=3600)).strftime(_ISO),
+                "scopes": None,
+                "as_issuer": ISSUER,
+                "audience": AUDIENCE,
+                "created": datetime.now(UTC).strftime(_ISO),
+                "last_refreshed": None,
+            }
 
-        result = asyncio.run(_run())
+        # Pre-lock read returns the rejected token; the under-lock re-read returns
+        # a DIFFERENT token (a concurrent waiter re-minted while we held-waited).
+        reads = [_fresh_row("rejected-at"), _fresh_row("peer-reminted-at")]
+        with patch.object(state.mcp_token_store, "get_user_token", side_effect=reads):
+
+            async def _run() -> Any:
+                return await get_obo_access_token_classified(
+                    app_state=state, user_id=USER, server_name=SERVER, force_refresh=True
+                )
+
+            result = asyncio.run(_run())
 
         assert result.kind == "token"
-        assert result.token == "winner-minted-at"
-        assert client.post.call_count == 0
+        assert result.token == "peer-reminted-at"  # reused the peer's fresh token
+        assert client.post.call_count == 0  # no redundant redemption
+
+    def test_force_refresh_remints_when_cache_still_holds_rejected_token(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """The other half of the identity gate: when the under-lock row still
+        holds the SAME token the caller came in with (no peer re-minted), a
+        force_refresh must RE-MINT — never re-serve the just-rejected bearer.
+        A mint-time gate at 1-second ``created`` granularity would wrongly
+        re-serve a token minted in the same second as the retry."""
+        from unittest.mock import patch
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(
+                200, {"access_token": "genuinely-reminted", "expires_in": 3600}
+            )
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        rejected = {
+            "user_id": USER,
+            "server_name": SERVER,
+            "access_token": "rejected-at",
+            "refresh_token": None,
+            "expires_at": (datetime.now(UTC) + timedelta(seconds=3600)).strftime(_ISO),
+            "scopes": None,
+            "as_issuer": ISSUER,
+            "audience": AUDIENCE,
+            "created": datetime.now(UTC).strftime(_ISO),
+            "last_refreshed": None,
+        }
+        # Both the pre-lock and under-lock reads return the SAME (rejected) token.
+        with patch.object(
+            state.mcp_token_store, "get_user_token", side_effect=[rejected, rejected]
+        ):
+
+            async def _run() -> Any:
+                return await get_obo_access_token_classified(
+                    app_state=state, user_id=USER, server_name=SERVER, force_refresh=True
+                )
+
+            result = asyncio.run(_run())
+
+        assert result.kind == "token"
+        assert result.token == "genuinely-reminted"  # re-minted, NOT re-served
+        assert client.post.call_count == 1
 
     def test_rotation_persist_failure_does_not_break_the_mint(self, storage: SQLiteBackend) -> None:
         """Review finding: a storage error inside the rotation-persist callback

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -92,7 +92,7 @@ def _make_app_state(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, make_mcp_token_cipher(), node_id="test"),
         oidc_config=oidc_config,
-        oidc_http_client=http_client,
+        obo_http_client=http_client,
         mcp_oauth_refresh_locks={},
     )
 
@@ -124,6 +124,7 @@ def _seed_cache_row(
     expires_in_seconds: int,
     access_token: str = "cached-at",
     audience: str = AUDIENCE,
+    created_seconds_ago: int = 0,
 ) -> None:
     expires_at = (datetime.now(UTC) + timedelta(seconds=expires_in_seconds)).strftime(_ISO)
     state.mcp_token_store.create_user_token(
@@ -136,6 +137,28 @@ def _seed_cache_row(
         as_issuer=ISSUER,
         audience=audience,
     )
+    if created_seconds_ago:
+        # Backdate the row via direct SQL: create_user_token stamps
+        # created=now, but the under-lock force_refresh gate treats a row
+        # whose ``created`` >= the caller's lock-request time as "another
+        # caller just minted" and reuses it — a row seeded in the same second
+        # as the call reads as exactly that. Tests exercising the RE-MINT
+        # path need a row that is unambiguously from the past.
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import mcp_user_tokens
+
+        backdated = (datetime.now(UTC) - timedelta(seconds=created_seconds_ago)).strftime(_ISO)
+        storage = state.auth_storage
+        with storage._engine.connect() as conn:
+            conn.execute(
+                sa.update(mcp_user_tokens)
+                .where(
+                    (mcp_user_tokens.c.user_id == USER) & (mcp_user_tokens.c.server_name == SERVER)
+                )
+                .values(created=backdated)
+            )
+            conn.commit()
 
 
 def _mk_response(status_code: int = 200, json_body: Any = None) -> MagicMock:
@@ -712,7 +735,15 @@ class TestFailureHandling:
         )
         state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
         _seed_credential(state)
-        _seed_cache_row(state, expires_in_seconds=3600, access_token="stale-but-fresh-exp")
+        # Backdated so the under-lock reuse gate reads it as an OLD mint —
+        # this test is about the cooldown fall-through re-minting, not the
+        # same-second single-flight reuse (covered separately below).
+        _seed_cache_row(
+            state,
+            expires_in_seconds=3600,
+            access_token="stale-but-fresh-exp",
+            created_seconds_ago=30,
+        )
         # Arm the cooldown as if a prior mint just failed transiently.
         _refresh_backoff_state(state, USER, SERVER).last_failure_monotonic = time.monotonic()
 
@@ -728,6 +759,114 @@ class TestFailureHandling:
         assert result.kind == "token"
         assert result.token == "at-reminted"
         assert client.post.call_count == 1
+
+    def test_force_refresh_reuses_row_minted_while_waiting_for_lock(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: the under-lock "another caller already minted" reuse
+        gate keyed on ``last_refreshed``, which obo cache rows NEVER set
+        (delete+create hardcodes NULL) — so every serialized force_refresh
+        waiter re-ran a full IdP redemption. The gate now keys on ``created``
+        (the mint time under delete+create): a fresh row created at/after the
+        caller's lock-request time is served without a new mint."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()  # any IdP call would be a gate failure
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        # Seeded moments before the call: at second granularity its ``created``
+        # is >= the caller's lock-request time, exactly what a concurrent
+        # waiter observes after the winner persisted its mint.
+        _seed_cache_row(state, expires_in_seconds=3600, access_token="winner-minted-at")
+
+        async def _run() -> Any:
+            return await get_obo_access_token_classified(
+                app_state=state, user_id=USER, server_name=SERVER, force_refresh=True
+            )
+
+        result = asyncio.run(_run())
+
+        assert result.kind == "token"
+        assert result.token == "winner-minted-at"
+        assert client.post.call_count == 0
+
+    def test_rotation_persist_failure_does_not_break_the_mint(self, storage: SQLiteBackend) -> None:
+        """Review finding: a storage error inside the rotation-persist callback
+        escaped the classified-result contract (only MCPOAuthRefreshFailed is
+        caught around mint()) and broke the in-flight dispatch — and on a
+        strict-rotation IdP the consumed RT stayed stored either way. The
+        persist is best-effort: the mint still returns its token (this
+        dispatch works); the stale credential surfaces on a LATER mint at
+        worst, instead of a raw exception now."""
+        from unittest.mock import patch
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            side_effect=[
+                _mk_response(
+                    200,
+                    {
+                        "access_token": "subject-at",
+                        "refresh_token": "rt-rotated",
+                        "expires_in": 300,
+                    },
+                ),
+                _mk_response(200, {"access_token": "exchanged-at", "expires_in": 600}),
+            ]
+        )
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state, refresh_token="rt-1")
+
+        with patch.object(
+            state.mcp_token_store,
+            "update_oidc_credential_after_redeem",
+            side_effect=RuntimeError("transient db blip"),
+        ):
+            result = _mint(state)
+
+        assert result.kind == "token"
+        assert result.token == "exchanged-at"
+        # The stored credential still holds the OLD RT — the failed persist is
+        # logged, never raised.
+        cred = state.mcp_token_store.get_oidc_credential(USER, ISSUER)
+        assert cred is not None
+        assert cred["refresh_token"] == "rt-1"
+
+    def test_disabled_retryable_config_rediscovers_and_mints(self, storage: SQLiteBackend) -> None:
+        """Review finding: OIDC discovery ran boot-once — a node that booted
+        during a transient IdP outage kept enabled=False forever and every obo
+        mint on it failed "transient" until an operator restart. The mint path
+        now probes runtime re-discovery (cooldown-gated) before classifying
+        obo_misconfigured, so the node self-heals."""
+        import dataclasses as _dc
+        from unittest.mock import patch
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(200, {"access_token": "minted-at", "expires_in": 3600})
+        )
+        boot_failed = _dc.replace(
+            _make_oidc_config(), enabled=False, token_endpoint="", discovery_retryable=True
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=boot_failed)
+        _seed_credential(state)
+        healed = _make_oidc_config()  # enabled, token_endpoint populated
+
+        async def _fake_discover(cfg: Any, *, client: Any = None) -> Any:
+            return healed
+
+        with patch("turnstone.core.oidc.discover_oidc", new=_fake_discover):
+            result = _mint(state)
+
+        assert result.kind == "token"
+        assert result.token == "minted-at"
+        assert state.oidc_config.enabled is True
 
     def test_credential_decrypt_failure_is_classified_not_raised(
         self, storage: SQLiteBackend

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -545,6 +545,47 @@ class TestCacheAndCredentialLookup:
         row = storage.get_mcp_user_token(USER, SERVER)
         assert row is not None and row["audience"] == AUDIENCE
 
+    def test_stale_scopes_cache_row_is_not_served_and_remints(self, storage: SQLiteBackend) -> None:
+        """Review finding: the read-side freshness gate is the AUTHORITATIVE
+        enforcement of a scope narrowing (the admin cache purge is best-effort).
+        Under rfc8693 a row minted with the OLD, wider scopes must NOT be served
+        after the server's scopes are narrowed — even if the purge failed — so
+        the privilege reduction takes effect on the next dispatch, not at TTL."""
+        _seed_obo_server(storage, oauth_scopes="api.read")  # server's CURRENT scopes
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            side_effect=[
+                _mk_response(200, {"access_token": "subject-at", "expires_in": 300}),
+                _mk_response(200, {"access_token": "reminted-narrow", "expires_in": 3600}),
+            ]
+        )
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state)
+        # Fresh, right-audience, refresh-less — but minted with the OLD wider scopes.
+        state.mcp_token_store.create_user_token(
+            USER,
+            SERVER,
+            access_token="wide-scope-at",
+            refresh_token=None,
+            expires_at=(datetime.now(UTC) + timedelta(seconds=3600)).strftime(_ISO),
+            scopes="api.read api.write",  # wider than the server's current api.read
+            as_issuer=ISSUER,
+            audience=AUDIENCE,
+        )
+
+        result = _mint(state)
+
+        # The wider-scope row is NOT served; a fresh mint for the current scopes runs.
+        assert result.kind == "token"
+        assert result.token == "reminted-narrow"
+        assert client.post.call_count == 2
+        row = storage.get_mcp_user_token(USER, SERVER)
+        assert row is not None and (row["scopes"] or "") == "api.read"
+
     def test_missing_credential_returns_missing_with_zero_http_calls(
         self, storage: SQLiteBackend
     ) -> None:
@@ -683,12 +724,14 @@ class TestFailureHandling:
         assert "obo_mint_rejected" in blob
         assert "AADSTS65001" in blob  # the actual IdP error text survives
 
-    def test_permanent_rejection_arms_cooldown_terminal_state(self, storage: SQLiteBackend) -> None:
-        """Review finding (2156): the obo permanent-rejection arm must arm the
-        cooldown, else — because the credential survives and a missing cache row
-        is mint-eligible — every subsequent dispatch re-runs the doomed
-        redemption and emits another token_revoked audit row forever. A second
-        immediate dispatch must NOT re-hit the IdP or re-audit."""
+    def test_permanent_rejection_no_cache_row_emits_no_revoke_audit(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: a permanent mint rejection with NO cache row (the
+        common missing-tenant-grant case — the user never had a token for this
+        server) must NOT emit a token_revoked audit for a row that never
+        existed. The cooldown is still armed as the terminal backstop (the
+        credential survives), so the second dispatch short-circuits."""
         _seed_obo_server(storage)
         client = MagicMock(spec=httpx.AsyncClient)
         client.post = AsyncMock(
@@ -712,10 +755,43 @@ class TestFailureHandling:
         # Terminal: the cooldown short-circuits the second dispatch entirely.
         assert second.kind == "refresh_failed_transient"
         assert client.post.call_count == 1  # NOT re-minted
-        # Exactly one revoke audit — not one per dispatch.
+        # No row was ever deleted → no bogus revoke audit.
+        events = storage.list_audit_events(action="mcp_server.oauth.token_revoked")
+        assert len(events) == 0
+        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
+
+    def test_permanent_rejection_with_cache_row_audits_exactly_once(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Companion: when a cache row DID exist, the permanent rejection deletes
+        it and audits token_revoked exactly ONCE. A later doomed re-mint (past
+        the cooldown) finds no row to delete and must NOT append a second audit
+        row — the crux of the audit-spam finding."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(400, {"error": "invalid_grant", "error_description": "dead"})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        _seed_cache_row(state, expires_in_seconds=-1000, access_token="stale-at")  # forces a mint
+
+        from turnstone.core.mcp_oauth import _clear_refresh_backoff
+
+        async def _run() -> None:
+            # First dispatch: deletes the (stale) cache row + audits once.
+            await get_obo_access_token_classified(app_state=state, user_id=USER, server_name=SERVER)
+            # Clear the cooldown so the second dispatch actually re-mints (the
+            # weekend-of-scheduled-runs scenario), then dispatch again.
+            _clear_refresh_backoff(state, USER, SERVER)
+            await get_obo_access_token_classified(app_state=state, user_id=USER, server_name=SERVER)
+
+        asyncio.run(_run())
+
+        assert client.post.call_count == 2  # re-minted after the cooldown cleared
+        # But only ONE revoke audit — the second doomed mint found no row.
         events = storage.list_audit_events(action="mcp_server.oauth.token_revoked")
         assert len(events) == 1
-        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
 
     def test_force_refresh_during_cooldown_falls_through_on_fresh_cache(
         self, storage: SQLiteBackend

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -582,6 +582,56 @@ class TestCacheAndCredentialLookup:
         assert result.token == "cached-at"
         assert client.post.call_count == 0
 
+    def test_credential_present_hint_skips_the_pre_lock_existence_read(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: when a caller already established the captured
+        credential exists (priming does one read for ALL of a user's obo
+        servers), get_obo_access_token_classified must skip its per-server
+        pre-lock existence re-read — otherwise session start re-reads the
+        credential N+1 times. With credential_present=True only the authoritative
+        under-lock read remains (one raw read); without the hint there are two
+        (pre-lock existence + under-lock)."""
+        from unittest.mock import patch
+
+        _seed_obo_server(storage)
+
+        def _run_with_hint(hint: bool | None) -> tuple[Any, int]:
+            client = MagicMock(spec=httpx.AsyncClient)
+            client.post = AsyncMock(
+                return_value=_mk_response(200, {"access_token": "minted-at", "expires_in": 3600})
+            )
+            state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+            _seed_credential(state)
+            reads = {"n": 0}
+            real = storage.get_oidc_user_credential
+
+            def _counting(user_id, issuer):
+                reads["n"] += 1
+                return real(user_id, issuer)
+
+            async def _go() -> Any:
+                with patch.object(storage, "get_oidc_user_credential", side_effect=_counting):
+                    return await get_obo_access_token_classified(
+                        app_state=state,
+                        user_id=USER,
+                        server_name=SERVER,
+                        credential_present=hint,
+                    )
+
+            res = asyncio.run(_go())
+            # Clear the cache row so the next run mints again (independent count).
+            storage.delete_mcp_user_token(USER, SERVER)
+            return res, reads["n"]
+
+        result_hint, reads_hint = _run_with_hint(True)
+        assert result_hint.kind == "token"
+        assert reads_hint == 1  # pre-lock skipped; only the under-lock read
+
+        result_none, reads_none = _run_with_hint(None)
+        assert result_none.kind == "token"
+        assert reads_none == 2  # pre-lock existence + under-lock
+
     def test_stale_audience_cache_row_is_not_served_and_remints(
         self, storage: SQLiteBackend
     ) -> None:

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -605,6 +605,31 @@ class TestFailureHandling:
         assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
         assert storage.get_mcp_user_token(USER, SERVER) is None  # nothing was cached
 
+    def test_permanent_rejection_logs_idp_error_text(self, storage: SQLiteBackend, caplog) -> None:
+        """Review finding (2316): the permanent-rejection path must log the IdP
+        error body (the token_revoked audit row carries only a reason code), so
+        an operator can tell a missing tenant grant from a dead credential."""
+        import logging
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(
+                400,
+                {"error": "invalid_grant", "error_description": "AADSTS65001: no consent"},
+            )
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        with caplog.at_level(logging.WARNING, logger="turnstone.mcp"):
+            result = _mint(state)
+
+        assert result.kind == "refresh_failed"
+        blob = " ".join(r.getMessage() + str(getattr(r, "__dict__", "")) for r in caplog.records)
+        assert "obo_mint_rejected" in blob
+        assert "AADSTS65001" in blob  # the actual IdP error text survives
+
     def test_permanent_rejection_arms_cooldown_terminal_state(self, storage: SQLiteBackend) -> None:
         """Review finding (2156): the obo permanent-rejection arm must arm the
         cooldown, else — because the credential survives and a missing cache row

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -730,6 +730,35 @@ class TestFailureHandling:
         assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
         assert storage.get_mcp_user_token(USER, SERVER) is None  # nothing was cached
 
+    def test_oversized_error_body_on_client_error_is_ambiguous_not_transient(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding: the shared body-size guard raised with the DEFAULT
+        (TRANSIENT) class before the non-200 was classified, so a permanent
+        dead-grant whose error body exceeded the cap would loop 'please retry'
+        forever and NEVER escalate (TRANSIENT doesn't advance the streak). An
+        over-sized CLIENT-error body is now classified AMBIGUOUS by status, so it
+        still advances the ambiguous streak and escalates to the honest re-login
+        / admin remedy after the threshold."""
+        from turnstone.core.mcp_oauth import _refresh_backoff_state
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        # 400 with an error body over the 64KB cap.
+        client.post = AsyncMock(
+            return_value=_mk_response(400, {"error": "invalid_grant", "pad": "x" * (70 * 1024)})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        # Immediate result is still a kept-token transient (streak below the
+        # escalation threshold), but the AMBIGUOUS class advanced the streak —
+        # the TRANSIENT default would have left it at 0 and never escalated.
+        assert result.kind == "refresh_failed_transient"
+        assert _refresh_backoff_state(state, USER, SERVER).ambiguous_streak == 1
+
     def test_permanent_rejection_logs_idp_error_text(self, storage: SQLiteBackend, caplog) -> None:
         """Review finding (2316): the permanent-rejection path must log the IdP
         error body (the token_revoked audit row carries only a reason code), so

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -210,11 +210,13 @@ class TestEntraLeg:
         assert plain["access_token"] == "at-minted"
         assert plain["refresh_token"] is None
 
-    def test_per_server_oauth_scopes_override_replaces_default_scope(
+    def test_entra_ignores_oauth_scopes_and_always_pins_audience_default(
         self, storage: SQLiteBackend
     ) -> None:
-        """Case 2: a server row with ``oauth_scopes`` set sends that value
-        verbatim as ``scope`` — NOT the ``<audience>/.default`` fallback."""
+        """Entra's ``scope`` is its only audience carrier, so it ALWAYS sends
+        ``<audience>/.default`` and ignores a per-server ``oauth_scopes`` (a bare
+        scope list would drop the audience → wrong-audience bearer). Regression
+        guard for the review's D finding."""
         _seed_obo_server(storage, oauth_scopes="custom.scope")
         client = MagicMock(spec=httpx.AsyncClient)
         client.post = AsyncMock(
@@ -229,17 +231,8 @@ class TestEntraLeg:
         assert client.post.call_count == 1
         call = client.post.call_args
         assert call.args == (TOKEN_ENDPOINT,)
-        assert call.kwargs["data"] == {
-            "grant_type": "refresh_token",
-            "refresh_token": "rt-1",
-            "client_id": "cid",
-            "client_secret": "csecret",
-            "scope": "custom.scope",
-        }
-        # The override is also stamped onto the cache row.
-        raw = storage.get_mcp_user_token(USER, SERVER)
-        assert raw is not None
-        assert raw["scopes"] == "custom.scope"
+        # audience-qualified .default — NOT the raw oauth_scopes value.
+        assert call.kwargs["data"]["scope"] == "api://aud-a/.default"
 
     def test_rotated_refresh_token_written_back_to_credential(self, storage: SQLiteBackend) -> None:
         """Case 5: Entra usually rotates the RT on redemption — the newest
@@ -395,6 +388,85 @@ class TestRfc8693Leg:
         assert client.post.call_count == 1  # never reached the exchange leg
         assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
 
+    def test_rotation_from_refresh_leg_survives_exchange_leg_failure(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding B (the lockout bug): on a rotating IdP the refresh leg
+        consumes rt-1 and rotates to rt-rotated; if the exchange leg then fails,
+        the rotated RT MUST already be persisted (not lost) — else the next mint
+        for every obo server would redeem the consumed rt-1 and cascade-lock the
+        user out. The exchange-response RT must NOT overwrite the credential."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            side_effect=[
+                _mk_response(
+                    200,
+                    {
+                        "access_token": "subject-at",
+                        "refresh_token": "rt-rotated",
+                        "expires_in": 300,
+                    },
+                ),
+                # Exchange leg fails (e.g. one server's audience not yet granted).
+                _mk_response(400, {"error": "invalid_grant", "error_description": "AADSTS500..."}),
+            ]
+        )
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state, refresh_token="rt-1")
+
+        result = _mint(state)
+
+        assert client.post.call_count == 2  # refresh leg + failed exchange
+        # The rotated RT from the refresh leg is persisted despite the failure.
+        cred = state.mcp_token_store.get_oidc_credential(USER, ISSUER)
+        assert cred is not None
+        assert cred["refresh_token"] == "rt-rotated"
+        # A 400 exchange with invalid_grant is a PERMANENT rejection for THIS
+        # server; the credential survives so the user's other servers are fine.
+        assert result.kind == "refresh_failed"
+
+    def test_exchange_response_refresh_token_never_overwrites_credential(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding (1960): an RFC 8693 exchange response MAY carry its own
+        (audience-scoped) refresh_token; it must never be written to the shared
+        issuer-wide credential."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            side_effect=[
+                # Refresh leg does NOT rotate (no refresh_token).
+                _mk_response(200, {"access_token": "subject-at", "expires_in": 300}),
+                # Exchange leg returns an audience-scoped RT — must be ignored.
+                _mk_response(
+                    200,
+                    {
+                        "access_token": "exchanged-at",
+                        "refresh_token": "audience-rt",
+                        "expires_in": 600,
+                    },
+                ),
+            ]
+        )
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state, refresh_token="rt-1")
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        cred = state.mcp_token_store.get_oidc_credential(USER, ISSUER)
+        assert cred is not None
+        assert cred["refresh_token"] == "rt-1"  # unchanged — NOT "audience-rt"
+
 
 # ---------------------------------------------------------------------------
 # Cache-row and credential lookup short-circuits
@@ -532,6 +604,101 @@ class TestFailureHandling:
         assert client.post.call_count == 1
         assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
         assert storage.get_mcp_user_token(USER, SERVER) is None  # nothing was cached
+
+    def test_permanent_rejection_arms_cooldown_terminal_state(self, storage: SQLiteBackend) -> None:
+        """Review finding (2156): the obo permanent-rejection arm must arm the
+        cooldown, else — because the credential survives and a missing cache row
+        is mint-eligible — every subsequent dispatch re-runs the doomed
+        redemption and emits another token_revoked audit row forever. A second
+        immediate dispatch must NOT re-hit the IdP or re-audit."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(400, {"error": "invalid_grant", "error_description": "dead"})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)  # no cache row — the common missing-tenant-grant case
+
+        async def _run() -> tuple[Any, Any]:
+            first = await get_obo_access_token_classified(
+                app_state=state, user_id=USER, server_name=SERVER
+            )
+            second = await get_obo_access_token_classified(
+                app_state=state, user_id=USER, server_name=SERVER
+            )
+            return first, second
+
+        first, second = asyncio.run(_run())
+
+        assert first.kind == "refresh_failed"
+        # Terminal: the cooldown short-circuits the second dispatch entirely.
+        assert second.kind == "refresh_failed_transient"
+        assert client.post.call_count == 1  # NOT re-minted
+        # Exactly one revoke audit — not one per dispatch.
+        events = storage.list_audit_events(action="mcp_server.oauth.token_revoked")
+        assert len(events) == 1
+        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
+
+    def test_force_refresh_during_cooldown_falls_through_on_fresh_cache(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding (2063): the pre-lock cooldown short-circuit is gated on
+        actually needing a mint. A force_refresh 401-retry with a still-fresh
+        cache row must fall THROUGH the armed cooldown to the locked path (so it
+        can re-mint / pick up a cluster-mate's token) rather than fail transient."""
+        import time
+
+        from turnstone.core.mcp_oauth import _refresh_backoff_state
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(200, {"access_token": "at-reminted", "expires_in": 3600})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        _seed_cache_row(state, expires_in_seconds=3600, access_token="stale-but-fresh-exp")
+        # Arm the cooldown as if a prior mint just failed transiently.
+        _refresh_backoff_state(state, USER, SERVER).last_failure_monotonic = time.monotonic()
+
+        async def _run() -> Any:
+            return await get_obo_access_token_classified(
+                app_state=state, user_id=USER, server_name=SERVER, force_refresh=True
+            )
+
+        result = asyncio.run(_run())
+
+        # Fell through the cooldown and re-minted (unconditional gate would have
+        # returned refresh_failed_transient with zero IdP calls).
+        assert result.kind == "token"
+        assert result.token == "at-reminted"
+        assert client.post.call_count == 1
+
+    def test_credential_decrypt_failure_is_classified_not_raised(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Review finding (2099): an undecryptable captured credential (key
+        rotated away) must return kind='decrypt_failure', not let
+        MCPTokenDecryptError escape the classified-result contract."""
+        from unittest.mock import patch
+
+        from turnstone.core.mcp_crypto import MCPTokenDecryptError
+
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        with patch.object(
+            state.mcp_token_store,
+            "get_oidc_credential",
+            side_effect=MCPTokenDecryptError("key unknown", key_fingerprints_attempted=("ab12",)),
+        ):
+            result = _mint(state)
+
+        assert result.kind == "decrypt_failure"
+        assert client.post.call_count == 0  # never reached the IdP
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -1,0 +1,579 @@
+"""Unit tests for the single-credential OBO mint engine (issue #551).
+
+Covers ``get_obo_access_token_classified`` and its grant legs
+(``_obo_mint_entra`` / ``_obo_mint_rfc8693``) in ``turnstone/core/mcp_oauth.py``.
+
+Request-body assertions follow the spike-verified wire shapes in
+BRIEFING.md ("Verified wire shapes") — every mock asserts the EXACT form
+payload posted to the IdP token endpoint (body-inspecting, not
+call-counting):
+
+- entra: ONE refresh-token grant carrying ``scope=<audience>/.default``
+  (or the per-server ``oauth_scopes`` override verbatim);
+- rfc8693: a refresh grant (NO scope key) for a subject token, then a
+  token-exchange grant with ``audience=<server oauth_audience>`` and the
+  per-server scope only when configured.
+
+Semantics pinned here:
+
+- minted tokens cache in ``mcp_user_tokens`` with ``refresh_token_ct``
+  NULL (cache, not custody);
+- rotation write-back persists the newest IdP refresh token on the
+  shared credential;
+- a PERMANENT rejection (AADSTS65001-style ``invalid_grant``) drops ONLY
+  the per-server cache row — the shared credential is NEVER auto-deleted,
+  so one mis-granted server cannot lock the user out of the rest;
+- transient failures keep everything and arm the per-(user, server)
+  cooldown that short-circuits the next attempt without an IdP call;
+- misconfiguration (unusable grant profile / missing audience) is
+  loud-but-retryable: ``refresh_failed_transient`` with zero IdP
+  round-trips and no exception.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from tests.conftest import make_mcp_token_cipher
+from turnstone.core.mcp_crypto import MCPTokenStore
+from turnstone.core.mcp_oauth import get_obo_access_token_classified
+from turnstone.core.oidc import OIDCConfig
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+USER = "user-1"
+SERVER = "srv-obo"
+SERVER_ID = "srv-obo-id"
+ISSUER = "https://idp.test"
+TOKEN_ENDPOINT = "https://idp.test/token"
+AUDIENCE = "api://aud-a"
+
+_ISO = "%Y-%m-%dT%H:%M:%S"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(tmp_path: Any) -> SQLiteBackend:
+    return SQLiteBackend(str(tmp_path / "test.db"))
+
+
+def _make_oidc_config(**overrides: Any) -> OIDCConfig:
+    """Real ``OIDCConfig`` for the OBO engine (``obo_grant_profile`` defaults
+    to ``"entra"`` on the dataclass; tests override it explicitly)."""
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "issuer": ISSUER,
+        "client_id": "cid",
+        "client_secret": "csecret",
+        "token_endpoint": TOKEN_ENDPOINT,
+    }
+    defaults.update(overrides)
+    return OIDCConfig(**defaults)
+
+
+def _make_app_state(
+    storage: SQLiteBackend,
+    *,
+    http_client: httpx.AsyncClient,
+    oidc_config: OIDCConfig,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        auth_storage=storage,
+        mcp_token_store=MCPTokenStore(storage, make_mcp_token_cipher(), node_id="test"),
+        oidc_config=oidc_config,
+        oidc_http_client=http_client,
+        mcp_oauth_refresh_locks={},
+    )
+
+
+def _seed_obo_server(
+    storage: SQLiteBackend,
+    *,
+    oauth_scopes: str | None = None,
+    oauth_audience: str | None = AUDIENCE,
+) -> None:
+    storage.create_mcp_server(
+        server_id=SERVER_ID,
+        name=SERVER,
+        transport="streamable-http",
+        url="https://mcp.example.com/mcp",
+        auth_type="oauth_obo",
+        oauth_scopes=oauth_scopes,
+        oauth_audience=oauth_audience,
+    )
+
+
+def _seed_credential(state: SimpleNamespace, *, refresh_token: str = "rt-1") -> None:
+    state.mcp_token_store.upsert_oidc_credential(USER, ISSUER, refresh_token=refresh_token)
+
+
+def _seed_cache_row(
+    state: SimpleNamespace,
+    *,
+    expires_in_seconds: int,
+    access_token: str = "cached-at",
+) -> None:
+    expires_at = (datetime.now(UTC) + timedelta(seconds=expires_in_seconds)).strftime(_ISO)
+    state.mcp_token_store.create_user_token(
+        USER,
+        SERVER,
+        access_token=access_token,
+        refresh_token=None,
+        expires_at=expires_at,
+        scopes=None,
+        as_issuer=ISSUER,
+        audience=AUDIENCE,
+    )
+
+
+def _mk_response(status_code: int = 200, json_body: Any = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = {}
+    body = "" if json_body is None else str(json_body)
+    resp.content = body.encode("utf-8")
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("no body")
+    resp.text = body
+    return resp
+
+
+def _mint(state: SimpleNamespace) -> Any:
+    async def _run() -> Any:
+        return await get_obo_access_token_classified(
+            app_state=state, user_id=USER, server_name=SERVER
+        )
+
+    return asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# entra leg — one RT redemption with scope=<audience>/.default
+# ---------------------------------------------------------------------------
+
+
+class TestEntraLeg:
+    def test_happy_path_mints_with_default_scope_and_caches(self, storage: SQLiteBackend) -> None:
+        """Case 1: one POST with the exact spike-verified Entra body; the mint
+        caches as a refresh-less ``mcp_user_tokens`` row with ``as_issuer`` /
+        ``audience`` populated and ``expires_at`` derived from ``expires_in``."""
+        _seed_obo_server(storage)  # empty oauth_scopes → scope falls back to /.default
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(200, {"access_token": "at-minted", "expires_in": 3600})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        before = datetime.now(UTC)
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        assert result.token == "at-minted"
+        # Exact wire shape (BRIEFING.md, Entra redemption) — full-dict equality
+        # also proves no stray keys (no resource=, no audience=) rode along.
+        assert client.post.call_count == 1
+        call = client.post.call_args
+        assert call.args == (TOKEN_ENDPOINT,)
+        assert call.kwargs["data"] == {
+            "grant_type": "refresh_token",
+            "refresh_token": "rt-1",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "scope": f"{AUDIENCE}/.default",
+        }
+        # Cache row: refresh-less (cache, not custody), issuer/audience stamped.
+        raw = storage.get_mcp_user_token(USER, SERVER)
+        assert raw is not None
+        assert raw["refresh_token_ct"] is None
+        assert raw["as_issuer"] == ISSUER
+        assert raw["audience"] == AUDIENCE
+        assert raw["expires_at"] is not None
+        expires = datetime.strptime(raw["expires_at"], _ISO).replace(tzinfo=UTC)
+        remaining = expires - before
+        assert timedelta(seconds=3500) <= remaining <= timedelta(seconds=3601)
+        plain = state.mcp_token_store.get_user_token(USER, SERVER)
+        assert plain is not None
+        assert plain["access_token"] == "at-minted"
+        assert plain["refresh_token"] is None
+
+    def test_per_server_oauth_scopes_override_replaces_default_scope(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 2: a server row with ``oauth_scopes`` set sends that value
+        verbatim as ``scope`` — NOT the ``<audience>/.default`` fallback."""
+        _seed_obo_server(storage, oauth_scopes="custom.scope")
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(200, {"access_token": "at-minted", "expires_in": 3600})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        assert client.post.call_count == 1
+        call = client.post.call_args
+        assert call.args == (TOKEN_ENDPOINT,)
+        assert call.kwargs["data"] == {
+            "grant_type": "refresh_token",
+            "refresh_token": "rt-1",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "scope": "custom.scope",
+        }
+        # The override is also stamped onto the cache row.
+        raw = storage.get_mcp_user_token(USER, SERVER)
+        assert raw is not None
+        assert raw["scopes"] == "custom.scope"
+
+    def test_rotated_refresh_token_written_back_to_credential(self, storage: SQLiteBackend) -> None:
+        """Case 5: Entra usually rotates the RT on redemption — the newest
+        value MUST be persisted to the shared credential (write-back rule)."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(
+                200,
+                {"access_token": "at-minted", "expires_in": 3600, "refresh_token": "rt-2"},
+            )
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state, refresh_token="rt-1")
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        cred = state.mcp_token_store.get_oidc_credential(USER, ISSUER)
+        assert cred is not None
+        assert cred["refresh_token"] == "rt-2"
+        # The rotated RT stays on the credential — the cache row is refresh-less.
+        raw = storage.get_mcp_user_token(USER, SERVER)
+        assert raw is not None
+        assert raw["refresh_token_ct"] is None
+
+
+# ---------------------------------------------------------------------------
+# rfc8693 leg — refresh grant for a subject token, then token exchange
+# ---------------------------------------------------------------------------
+
+
+class TestRfc8693Leg:
+    def test_happy_path_two_posts_exchange_and_rotation_write_back(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 3: exactly TWO POSTs with the spike-verified Keycloak shapes —
+        a scope-less refresh grant, then a token exchange whose
+        ``subject_token`` is the FIRST call's access token; the RT rotated by
+        call 1 is persisted to the credential."""
+        _seed_obo_server(storage)  # empty oauth_scopes → exchange carries NO scope key
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            side_effect=[
+                _mk_response(
+                    200,
+                    {
+                        "access_token": "subject-at",
+                        "refresh_token": "rt-rotated",
+                        "expires_in": 300,
+                    },
+                ),
+                _mk_response(200, {"access_token": "exchanged-at", "expires_in": 600}),
+            ]
+        )
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state, refresh_token="rt-1")
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        assert result.token == "exchanged-at"
+        assert client.post.call_count == 2
+        first, second = client.post.call_args_list
+        assert first.args == (TOKEN_ENDPOINT,)
+        # Refresh leg: full-dict equality proves NO scope key is sent.
+        assert first.kwargs["data"] == {
+            "grant_type": "refresh_token",
+            "refresh_token": "rt-1",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        assert second.args == (TOKEN_ENDPOINT,)
+        assert second.kwargs["data"] == {
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "subject_token": "subject-at",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "audience": AUDIENCE,
+        }
+        # Rotation write-back from the FIRST leg persists on the credential.
+        cred = state.mcp_token_store.get_oidc_credential(USER, ISSUER)
+        assert cred is not None
+        assert cred["refresh_token"] == "rt-rotated"
+        # Cached mint is the EXCHANGED token, refresh-less.
+        plain = state.mcp_token_store.get_user_token(USER, SERVER)
+        assert plain is not None
+        assert plain["access_token"] == "exchanged-at"
+        assert plain["refresh_token"] is None
+
+    def test_per_server_scopes_carried_on_exchange_call(self, storage: SQLiteBackend) -> None:
+        """Case 3 (scoped): with ``oauth_scopes`` set, the SECOND call carries
+        ``scope`` (Keycloak optional audience scopes must be explicit) while
+        the refresh leg still sends none."""
+        _seed_obo_server(storage, oauth_scopes="custom.scope")
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            side_effect=[
+                _mk_response(200, {"access_token": "subject-at", "expires_in": 300}),
+                _mk_response(200, {"access_token": "exchanged-at", "expires_in": 600}),
+            ]
+        )
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        assert client.post.call_count == 2
+        first, second = client.post.call_args_list
+        assert first.kwargs["data"] == {
+            "grant_type": "refresh_token",
+            "refresh_token": "rt-1",
+            "client_id": "cid",
+            "client_secret": "csecret",
+        }
+        assert second.kwargs["data"] == {
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "subject_token": "subject-at",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "audience": AUDIENCE,
+            "scope": "custom.scope",
+        }
+
+    def test_subject_leg_missing_access_token_is_transient(self, storage: SQLiteBackend) -> None:
+        """A 200 refresh-leg body without ``access_token`` aborts BEFORE the
+        exchange call and classifies transient — a malformed IdP response must
+        not delete anything."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(return_value=_mk_response(200, {"refresh_token": "rt-x"}))
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile="rfc8693"),
+        )
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        assert result.kind == "refresh_failed_transient"
+        assert client.post.call_count == 1  # never reached the exchange leg
+        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
+
+
+# ---------------------------------------------------------------------------
+# Cache-row and credential lookup short-circuits
+# ---------------------------------------------------------------------------
+
+
+class TestCacheAndCredentialLookup:
+    def test_fresh_cache_row_returns_token_with_zero_http_calls(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 4: a fresh ``mcp_user_tokens`` row is served straight from the
+        cache — no IdP round-trip."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        _seed_cache_row(state, expires_in_seconds=3600, access_token="cached-at")
+
+        result = _mint(state)
+
+        assert result.kind == "token"
+        assert result.token == "cached-at"
+        assert client.post.call_count == 0
+
+    def test_missing_credential_returns_missing_with_zero_http_calls(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 6: no captured credential → ``missing`` (the dispatcher's
+        consent affordance is a re-login, not per-server consent); the IdP is
+        never contacted."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        # Deliberately NO upsert_oidc_credential.
+
+        result = _mint(state)
+
+        assert result.kind == "missing"
+        assert client.post.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Failure handling — the load-bearing custody semantics
+# ---------------------------------------------------------------------------
+
+
+class TestFailureHandling:
+    def test_permanent_rejection_drops_cache_row_but_never_the_credential(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 7 (load-bearing): a verified AADSTS65001-style
+        ``invalid_grant`` classifies PERMANENT — the per-server cache row is
+        deleted (re-consent UX for THAT server) but the shared credential
+        survives, so one missing tenant grant can't lock the user out of
+        every other OBO server."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(
+                400,
+                {
+                    "error": "invalid_grant",
+                    "error_description": (
+                        "AADSTS65001: The user or administrator has not consented to use "
+                        "the application."
+                    ),
+                },
+            )
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+        _seed_cache_row(state, expires_in_seconds=-1000, access_token="stale-at")
+
+        result = _mint(state)
+
+        assert result.kind == "refresh_failed"
+        # Cache row GONE...
+        assert storage.get_mcp_user_token(USER, SERVER) is None
+        # ...but the credential STILL EXISTS — never auto-deleted here.
+        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
+        # The revoke is audited through the shared choke point.
+        events = storage.list_audit_events(action="mcp_server.oauth.token_revoked")
+        assert len(events) == 1
+        assert events[0]["user_id"] == USER
+        assert events[0]["resource_id"] == SERVER_ID
+        detail = events[0]["detail"]
+        detail = json.loads(detail) if isinstance(detail, str) else detail
+        assert detail["reason"] == "obo_mint_rejected"
+
+    def test_transient_503_keeps_credential_and_cooldown_short_circuits_second_call(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 8: a 503 is transient — nothing is deleted — and the armed
+        cooldown makes an immediate second attempt return transient with NO
+        additional IdP call."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(
+            return_value=_mk_response(503, {"error": "temporarily_unavailable"})
+        )
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        async def _run() -> tuple[Any, Any]:
+            first = await get_obo_access_token_classified(
+                app_state=state, user_id=USER, server_name=SERVER
+            )
+            second = await get_obo_access_token_classified(
+                app_state=state, user_id=USER, server_name=SERVER
+            )
+            return first, second
+
+        first, second = asyncio.run(_run())
+
+        assert first.kind == "refresh_failed_transient"
+        assert second.kind == "refresh_failed_transient"
+        # Cooldown short-circuit: the second call never reached the IdP.
+        assert client.post.call_count == 1
+        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
+
+    def test_missing_access_token_in_200_body_is_transient(self, storage: SQLiteBackend) -> None:
+        """Case 9: a 200 body without ``access_token`` is a malformed-IdP
+        blip — transient, credential kept, nothing cached."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock(return_value=_mk_response(200, {"expires_in": 3600}))
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        assert result.kind == "refresh_failed_transient"
+        assert client.post.call_count == 1
+        assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
+        assert storage.get_mcp_user_token(USER, SERVER) is None  # nothing was cached
+
+
+# ---------------------------------------------------------------------------
+# Misconfiguration — loud, retryable, and never an exception
+# ---------------------------------------------------------------------------
+
+
+class TestMisconfiguration:
+    @pytest.mark.parametrize("profile", ["", "id_jag"])
+    def test_unusable_grant_profile_is_transient_with_zero_http_calls(
+        self, storage: SQLiteBackend, profile: str
+    ) -> None:
+        """Case 10a: an empty or unknown ``obo_grant_profile`` is an
+        operator-fixable misconfig — retryable classification, zero IdP
+        calls, no exception (fixing config heals without re-consent)."""
+        _seed_obo_server(storage)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()
+        state = _make_app_state(
+            storage,
+            http_client=client,
+            oidc_config=_make_oidc_config(obo_grant_profile=profile),
+        )
+        _seed_credential(state)  # credential present — config alone blocks the mint
+
+        result = _mint(state)
+
+        assert result.kind == "refresh_failed_transient"
+        assert client.post.call_count == 0
+
+    def test_missing_server_audience_is_transient_with_zero_http_calls(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """Case 10b: a server row without ``oauth_audience`` cannot be minted
+        for — same retryable misconfig outcome, zero IdP calls."""
+        _seed_obo_server(storage, oauth_audience=None)
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.post = AsyncMock()
+        state = _make_app_state(storage, http_client=client, oidc_config=_make_oidc_config())
+        _seed_credential(state)
+
+        result = _mint(state)
+
+        assert result.kind == "refresh_failed_transient"
+        assert client.post.call_count == 0

--- a/tests/test_mcp_pending_consent_storage.py
+++ b/tests/test_mcp_pending_consent_storage.py
@@ -239,3 +239,41 @@ class TestInstallGate:
         )
         backend.update_mcp_server("srv-2", auth_type="oauth_user")
         assert backend.any_oauth_user_mcp_servers() is True
+
+    def test_any_user_scoped_true_for_obo_only_install(self, backend) -> None:
+        """#551: the pending-consent badge gate must fire for an oauth_obo-only
+        install — obo dispatch writes pending rows, so short-circuiting to
+        {pending: 0} would hide the re-login affordance. The oauth_user-only
+        gate stays False (obo is not oauth_user)."""
+        backend.create_mcp_server(
+            server_id="srv-obo",
+            name="obo-only",
+            transport="streamable-http",
+            command="",
+            args="[]",
+            url="https://example.com",
+            headers="{}",
+            env="{}",
+            auto_approve=False,
+            enabled=True,
+            created_by="admin",
+        )
+        backend.update_mcp_server("srv-obo", auth_type="oauth_obo")
+        assert backend.any_user_scoped_mcp_servers() is True
+        assert backend.any_oauth_user_mcp_servers() is False
+
+    def test_any_user_scoped_false_on_static_only(self, backend) -> None:
+        backend.create_mcp_server(
+            server_id="srv-s",
+            name="static-only",
+            transport="streamable-http",
+            command="",
+            args="[]",
+            url="https://example.com",
+            headers="{}",
+            env="{}",
+            auto_approve=False,
+            enabled=True,
+            created_by="admin",
+        )
+        assert backend.any_user_scoped_mcp_servers() is False

--- a/tests/test_mcp_pending_consent_storage.py
+++ b/tests/test_mcp_pending_consent_storage.py
@@ -7,7 +7,7 @@ Validates protocol additions backing the dashboard pending-consent badge:
 - ``delete_mcp_pending_consent`` — single-row clear
 - ``delete_all_mcp_pending_consent_by_user`` — bulk clear
 - ``count_mcp_consented_users_by_server`` — admin status pill
-- ``any_oauth_user_mcp_servers`` — install-level gate
+- ``any_user_scoped_mcp_servers`` — install-level gate
 """
 
 from __future__ import annotations
@@ -204,10 +204,10 @@ class TestCountConsentedUsersByServer:
 
 
 class TestInstallGate:
-    def test_any_oauth_user_returns_false_on_empty(self, backend) -> None:
-        assert backend.any_oauth_user_mcp_servers() is False
+    def test_any_user_scoped_returns_false_on_empty(self, backend) -> None:
+        assert backend.any_user_scoped_mcp_servers() is False
 
-    def test_any_oauth_user_ignores_static_rows(self, backend) -> None:
+    def test_any_user_scoped_ignores_static_rows(self, backend) -> None:
         backend.create_mcp_server(
             server_id="srv-1",
             name="static-only",
@@ -221,9 +221,9 @@ class TestInstallGate:
             enabled=True,
             created_by="admin",
         )
-        assert backend.any_oauth_user_mcp_servers() is False
+        assert backend.any_user_scoped_mcp_servers() is False
 
-    def test_any_oauth_user_returns_true_when_one_exists(self, backend) -> None:
+    def test_any_user_scoped_returns_true_for_oauth_user(self, backend) -> None:
         backend.create_mcp_server(
             server_id="srv-2",
             name="oauth-srv",
@@ -238,13 +238,12 @@ class TestInstallGate:
             created_by="admin",
         )
         backend.update_mcp_server("srv-2", auth_type="oauth_user")
-        assert backend.any_oauth_user_mcp_servers() is True
+        assert backend.any_user_scoped_mcp_servers() is True
 
     def test_any_user_scoped_true_for_obo_only_install(self, backend) -> None:
         """#551: the pending-consent badge gate must fire for an oauth_obo-only
         install — obo dispatch writes pending rows, so short-circuiting to
-        {pending: 0} would hide the re-login affordance. The oauth_user-only
-        gate stays False (obo is not oauth_user)."""
+        {pending: 0} would hide the re-login affordance."""
         backend.create_mcp_server(
             server_id="srv-obo",
             name="obo-only",
@@ -260,7 +259,6 @@ class TestInstallGate:
         )
         backend.update_mcp_server("srv-obo", auth_type="oauth_obo")
         assert backend.any_user_scoped_mcp_servers() is True
-        assert backend.any_oauth_user_mcp_servers() is False
 
     def test_any_user_scoped_false_on_static_only(self, backend) -> None:
         backend.create_mcp_server(

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1187,6 +1187,22 @@ class TestTokenRejectedDetail:
         assert "consent" not in obo_detail.lower()
         assert "administrator" in obo_detail.lower()
 
+    def test_obo_insufficient_scope_detail_points_at_admin_not_reconsent(self) -> None:
+        """Review finding: the 403 insufficient-scope branch was the one
+        user-actionable site not made obo-aware — it told obo users to
+        'Re-consent with new scopes' though no per-server consent flow exists
+        (consent_url is None, /start rejects obo). The obo detail names the real
+        remedy (an administrator widening access), the oauth_user one keeps the
+        step-up re-consent language."""
+        from turnstone.core.mcp_client import _insufficient_scope_detail
+
+        user_detail = _insufficient_scope_detail({"auth_type": "oauth_user"}, "tool")
+        assert "Re-consent" in user_detail
+
+        obo_detail = _insufficient_scope_detail({"auth_type": "oauth_obo"}, "tool")
+        assert "consent" not in obo_detail.lower()
+        assert "administrator" in obo_detail.lower()
+
 
 # ---------------------------------------------------------------------------
 # Background token-freshness sweep (oauth_user keep-hot, no connection warming)

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1019,7 +1019,15 @@ class TestOboPriming:
         mgr, loop, _ = running_loop_mgr
         cipher = make_mcp_token_cipher()
         mgr.set_storage(storage)
-        mgr.set_app_state(_make_app_state(storage, cipher=cipher))
+        app_state = _make_app_state(storage, cipher=cipher)
+        # The priming pre-check reads oidc_config.issuer and requires a stored
+        # credential row (existence only, no decrypt) before running any
+        # per-server obo work.
+        app_state.oidc_config = SimpleNamespace(issuer="https://idp.example.com")
+        mgr.set_app_state(app_state)
+        storage.upsert_oidc_user_credential(
+            "user-1", "https://idp.example.com", refresh_token_ct=b"ct"
+        )
         storage.create_mcp_server(
             server_id="srv-obo",
             name="obo-srv",
@@ -1053,13 +1061,18 @@ class TestOboPriming:
         assert warmed[0][2] == "minted-at"
 
     def test_prime_skips_obo_server_when_no_credential(self, running_loop_mgr, storage) -> None:
-        """A user without a captured credential yields kind='missing' from the
-        mint path → the pool is not warmed (the re-login rail handles it on real
-        dispatch), and nothing raises."""
+        """A user without a captured credential is skipped BEFORE any
+        per-server obo work: one existence SELECT decides all obo servers
+        (credential-less users previously paid three SQL reads per obo server
+        per session start just to learn kind='missing'). The pool is not
+        warmed, the mint machinery never runs, and nothing raises — the
+        re-login rail handles it on real dispatch."""
         mgr, loop, _ = running_loop_mgr
         cipher = make_mcp_token_cipher()
         mgr.set_storage(storage)
-        mgr.set_app_state(_make_app_state(storage, cipher=cipher))
+        app_state = _make_app_state(storage, cipher=cipher)
+        app_state.oidc_config = SimpleNamespace(issuer="https://idp.example.com")
+        mgr.set_app_state(app_state)
         storage.create_mcp_server(
             server_id="srv-obo",
             name="obo-srv",
@@ -1082,14 +1095,16 @@ class TestOboPriming:
         ):
             _run_on_loop(loop, mgr._prime_user_pools("user-1"))
 
-        obo_lookup.assert_awaited_once()
+        obo_lookup.assert_not_awaited()
         assert warmed == []
 
 
 class TestPendingConsentClearGate:
-    """The dispatch-success pending-consent clear must (a) NOT issue SQL on every
-    call (no new hot-path SQL) yet (b) still clear cross-node. It clears once per
-    (user,server) per failure-cycle via the ``_pending_consent_cleared`` set."""
+    """The dispatch-success pending-consent clear must (a) NOT issue SQL on
+    every call (no new hot-path SQL) yet (b) still clear cross-node. The
+    ``_pending_consent_cleared`` TTL map dedupes the DELETE per (user, server)
+    per TTL window — a permanent cleared-set would suppress the clear forever
+    on a node that cleared before ANOTHER node wrote a fresh badge."""
 
     def test_first_success_clears_then_dedupes(self) -> None:
         mgr = MCPClientManager({})
@@ -1098,7 +1113,7 @@ class TestPendingConsentClearGate:
         # have been written on ANOTHER node — no "we wrote it" precondition).
         mgr._clear_pending_consent_sync("u1", "srv")
         mgr._storage.delete_mcp_pending_consent.assert_called_once_with("u1", "srv")
-        # Subsequent successes skip the SQL (deduped via the cleared set).
+        # Subsequent successes within the TTL skip the SQL.
         mgr._storage.delete_mcp_pending_consent.reset_mock()
         mgr._clear_pending_consent_sync("u1", "srv")
         mgr._clear_pending_consent_sync("u1", "srv")
@@ -1113,9 +1128,64 @@ class TestPendingConsentClearGate:
         mgr._write_pending_consent(
             "u1", "srv", error_code="mcp_consent_required", scopes_required=None
         )
-        # ...so the next success clears again.
+        # ...so the next success clears again without waiting out the TTL.
         mgr._clear_pending_consent_sync("u1", "srv")
         mgr._storage.delete_mcp_pending_consent.assert_called_once_with("u1", "srv")
+
+    def test_ttl_expiry_re_clears_cross_node_badges(self) -> None:
+        """The cross-node self-heal (review finding): node A cleared the pair,
+        then node B wrote a fresh badge — node A has no local signal, so its
+        cleared entry must AGE OUT and the next success re-run the DELETE.
+        With a permanent set the badge survived until node A restarted."""
+        from turnstone.core.mcp_client import _PENDING_CONSENT_CLEAR_TTL_SECONDS
+
+        mgr = MCPClientManager({})
+        mgr._storage = MagicMock()
+        mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._storage.delete_mcp_pending_consent.reset_mock()
+        # Age the entry past the TTL (simulates time passing on node A while
+        # node B writes a badge this node never observes).
+        mgr._pending_consent_cleared[("u1", "srv")] -= _PENDING_CONSENT_CLEAR_TTL_SECONDS + 1
+        mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._storage.delete_mcp_pending_consent.assert_called_once_with("u1", "srv")
+
+    def test_cleared_map_prunes_at_size_threshold(self) -> None:
+        """The TTL map is bounded: crossing the size threshold drops expired
+        entries (and worst-case the oldest half), so a long-lived node serving
+        many (user, server) pairs can't grow it without bound. Pruning is
+        memory hygiene only — a pruned pair just re-runs one DELETE later."""
+        from unittest.mock import patch as _patch
+
+        mgr = MCPClientManager({})
+        mgr._storage = MagicMock()
+        with _patch("turnstone.core.mcp_client._PENDING_CONSENT_CLEARED_MAX", 4):
+            for i in range(4):
+                mgr._clear_pending_consent_sync("u", f"srv-{i}")
+            assert len(mgr._pending_consent_cleared) == 4
+            # Age everything out; the next insert prunes the expired entries.
+            from turnstone.core.mcp_client import _PENDING_CONSENT_CLEAR_TTL_SECONDS
+
+            for key in list(mgr._pending_consent_cleared):
+                mgr._pending_consent_cleared[key] -= _PENDING_CONSENT_CLEAR_TTL_SECONDS + 1
+            mgr._clear_pending_consent_sync("u", "srv-new")
+            assert ("u", "srv-new") in mgr._pending_consent_cleared
+            assert len(mgr._pending_consent_cleared) == 1
+
+
+class TestTokenRejectedDetail:
+    def test_obo_rows_are_not_pointed_at_a_consent_flow(self) -> None:
+        """Review finding: the 401-retry-exhausted branches told oauth_obo
+        users 'Re-consent required' with consent_url=None — a dead end, since
+        no per-server consent flow exists for sign-in passthrough. The obo
+        detail points at the admin (audience/config) instead."""
+        from turnstone.core.mcp_client import _token_rejected_detail
+
+        user_detail = _token_rejected_detail({"auth_type": "oauth_user"})
+        assert "Re-consent required" in user_detail
+
+        obo_detail = _token_rejected_detail({"auth_type": "oauth_obo"})
+        assert "consent" not in obo_detail.lower()
+        assert "administrator" in obo_detail.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1194,12 +1194,16 @@ class TestTokenRejectedDetail:
         (consent_url is None, /start rejects obo). The obo detail names the real
         remedy (an administrator widening access), the oauth_user one keeps the
         step-up re-consent language."""
-        from turnstone.core.mcp_client import _insufficient_scope_detail
+        from turnstone.core.mcp_client import _pool_error_detail
 
-        user_detail = _insufficient_scope_detail({"auth_type": "oauth_user"}, "tool")
+        user_detail = _pool_error_detail(
+            {"auth_type": "oauth_user"}, "insufficient_scope", kind="tool"
+        )
         assert "Re-consent" in user_detail
 
-        obo_detail = _insufficient_scope_detail({"auth_type": "oauth_obo"}, "tool")
+        obo_detail = _pool_error_detail(
+            {"auth_type": "oauth_obo"}, "insufficient_scope", kind="tool"
+        )
         assert "consent" not in obo_detail.lower()
         assert "administrator" in obo_detail.lower()
 

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1007,6 +1007,85 @@ class TestUserIdThreadThrough:
         assert mgr._user_pool_entries == {}
 
 
+class TestOboPriming:
+    """oauth_obo servers must be primed at session start — it is the ONLY path
+    that warms their pool + surfaces their tools (no consent flow exists), so a
+    regression here makes the whole feature inert (review finding, mcp_client.py
+    :2597)."""
+
+    def test_prime_routes_obo_server_through_mint_and_warms_pool(
+        self, running_loop_mgr, storage
+    ) -> None:
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        mgr.set_storage(storage)
+        mgr.set_app_state(_make_app_state(storage, cipher=cipher))
+        storage.create_mcp_server(
+            server_id="srv-obo",
+            name="obo-srv",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        mgr._obo_server_names = {"obo-srv"}
+        mgr._oauth_user_server_names = set()
+
+        warmed: list[tuple[Any, Any, str]] = []
+
+        async def _fake_prime_server(key: Any, cfg: Any, token: str) -> None:
+            warmed.append((key, cfg, token))
+
+        obo_lookup = AsyncMock(return_value=SimpleNamespace(kind="token", token="minted-at"))
+        user_lookup = AsyncMock()
+        with (
+            patch.object(mgr, "_prime_user_server", new=_fake_prime_server),
+            patch("turnstone.core.mcp_client.get_obo_access_token_classified", new=obo_lookup),
+            patch("turnstone.core.mcp_client.get_user_access_token_classified", new=user_lookup),
+        ):
+            _run_on_loop(loop, mgr._prime_user_pools("user-1"))
+
+        # The obo server was minted (not routed to the oauth_user path) and warmed.
+        obo_lookup.assert_awaited_once()
+        assert obo_lookup.await_args.kwargs["server_name"] == "obo-srv"
+        user_lookup.assert_not_awaited()
+        assert len(warmed) == 1
+        assert warmed[0][2] == "minted-at"
+
+    def test_prime_skips_obo_server_when_no_credential(self, running_loop_mgr, storage) -> None:
+        """A user without a captured credential yields kind='missing' from the
+        mint path → the pool is not warmed (the re-login rail handles it on real
+        dispatch), and nothing raises."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        mgr.set_storage(storage)
+        mgr.set_app_state(_make_app_state(storage, cipher=cipher))
+        storage.create_mcp_server(
+            server_id="srv-obo",
+            name="obo-srv",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        mgr._obo_server_names = {"obo-srv"}
+
+        warmed: list[Any] = []
+
+        async def _fake_prime_server(key: Any, cfg: Any, token: str) -> None:
+            warmed.append(key)
+
+        obo_lookup = AsyncMock(return_value=SimpleNamespace(kind="missing", token=None))
+        with (
+            patch.object(mgr, "_prime_user_server", new=_fake_prime_server),
+            patch("turnstone.core.mcp_client.get_obo_access_token_classified", new=obo_lookup),
+        ):
+            _run_on_loop(loop, mgr._prime_user_pools("user-1"))
+
+        obo_lookup.assert_awaited_once()
+        assert warmed == []
+
+
 # ---------------------------------------------------------------------------
 # Background token-freshness sweep (oauth_user keep-hot, no connection warming)
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1086,6 +1086,30 @@ class TestOboPriming:
         assert warmed == []
 
 
+class TestPendingConsentClearGate:
+    """The dispatch-success pending-consent clear must not issue SQL on the
+    common path (review finding: no new hot-path SQL) — it is gated on this
+    node's in-memory record of having written a pending row."""
+
+    def test_clear_noops_without_a_recorded_write(self) -> None:
+        mgr = MCPClientManager({})
+        mgr._storage = MagicMock()
+        # No pending row was ever written for this pair.
+        mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._storage.delete_mcp_pending_consent.assert_not_called()
+
+    def test_clear_deletes_and_forgets_after_a_recorded_write(self) -> None:
+        mgr = MCPClientManager({})
+        mgr._storage = MagicMock()
+        mgr._pending_consent_written.add(("u1", "srv"))
+        mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._storage.delete_mcp_pending_consent.assert_called_once_with("u1", "srv")
+        # The hint is cleared, so a second success does not re-issue the DELETE.
+        mgr._storage.delete_mcp_pending_consent.reset_mock()
+        mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._storage.delete_mcp_pending_consent.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Background token-freshness sweep (oauth_user keep-hot, no connection warming)
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -1087,27 +1087,35 @@ class TestOboPriming:
 
 
 class TestPendingConsentClearGate:
-    """The dispatch-success pending-consent clear must not issue SQL on the
-    common path (review finding: no new hot-path SQL) — it is gated on this
-    node's in-memory record of having written a pending row."""
+    """The dispatch-success pending-consent clear must (a) NOT issue SQL on every
+    call (no new hot-path SQL) yet (b) still clear cross-node. It clears once per
+    (user,server) per failure-cycle via the ``_pending_consent_cleared`` set."""
 
-    def test_clear_noops_without_a_recorded_write(self) -> None:
+    def test_first_success_clears_then_dedupes(self) -> None:
         mgr = MCPClientManager({})
         mgr._storage = MagicMock()
-        # No pending row was ever written for this pair.
-        mgr._clear_pending_consent_sync("u1", "srv")
-        mgr._storage.delete_mcp_pending_consent.assert_not_called()
-
-    def test_clear_deletes_and_forgets_after_a_recorded_write(self) -> None:
-        mgr = MCPClientManager({})
-        mgr._storage = MagicMock()
-        mgr._pending_consent_written.add(("u1", "srv"))
+        # First success on a fresh pair → one DELETE (self-heals a badge that may
+        # have been written on ANOTHER node — no "we wrote it" precondition).
         mgr._clear_pending_consent_sync("u1", "srv")
         mgr._storage.delete_mcp_pending_consent.assert_called_once_with("u1", "srv")
-        # The hint is cleared, so a second success does not re-issue the DELETE.
+        # Subsequent successes skip the SQL (deduped via the cleared set).
         mgr._storage.delete_mcp_pending_consent.reset_mock()
         mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._clear_pending_consent_sync("u1", "srv")
         mgr._storage.delete_mcp_pending_consent.assert_not_called()
+
+    def test_a_new_failure_write_re_arms_the_clear(self) -> None:
+        mgr = MCPClientManager({})
+        mgr._storage = MagicMock()
+        mgr._clear_pending_consent_sync("u1", "srv")  # clears + marks cleared
+        mgr._storage.delete_mcp_pending_consent.reset_mock()
+        # A fresh pending-consent write un-marks the pair...
+        mgr._write_pending_consent(
+            "u1", "srv", error_code="mcp_consent_required", scopes_required=None
+        )
+        # ...so the next success clears again.
+        mgr._clear_pending_consent_sync("u1", "srv")
+        mgr._storage.delete_mcp_pending_consent.assert_called_once_with("u1", "srv")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -910,6 +910,40 @@ class TestValidateDiscoveredEndpoint:
 
         asyncio.run(_run())
 
+    def test_discover_accepts_entra_userinfo_on_graph(self):
+        """discover_oidc accepts Entra's cross-host userinfo on graph.microsoft.com
+        via the built-in allow-list, so Azure AD OIDC works out of the box with no
+        trusted_endpoint_hosts override."""
+        tenant = "11111111-1111-1111-1111-111111111111"
+        config = _make_config(
+            issuer=f"https://login.microsoftonline.com/{tenant}/v2.0",
+            authorization_endpoint="",
+            token_endpoint="",
+            userinfo_endpoint="",
+            jwks_uri="",
+        )
+        discovery_doc = {
+            "authorization_endpoint": f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+            "token_endpoint": f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+            "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+            "jwks_uri": f"https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys",
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = discovery_doc
+        mock_response.raise_for_status = MagicMock()
+
+        async def _run():
+            client = _mock_async_client(lambda url: _async_return(mock_response))
+            with (
+                patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR),
+                patch("httpx.AsyncClient", return_value=client),
+            ):
+                result = await discover_oidc(config)
+            assert result.enabled is True
+            assert result.userinfo_endpoint == "https://graph.microsoft.com/oidc/userinfo"
+
+        asyncio.run(_run())
+
     def test_discover_rejects_http_endpoint(self):
         """discover_oidc returns enabled=False when an endpoint is http:// in prod."""
         config = _make_config(

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -126,6 +126,84 @@ class TestLoadOIDCConfig:
 
         assert cfg.allow_private_network is False
 
+    def test_load_oidc_config_capture_user_credential_env(self, monkeypatch):
+        monkeypatch.setenv("TURNSTONE_OIDC_ISSUER", "https://auth.example.com")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.setenv("TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL", "true")
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            cfg = load_oidc_config()
+
+        assert cfg.capture_user_credential is True
+
+    def test_load_oidc_config_capture_user_credential_toml(self, monkeypatch):
+        monkeypatch.setenv("TURNSTONE_OIDC_ISSUER", "https://auth.example.com")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.delenv("TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL", raising=False)
+
+        with patch(
+            "turnstone.core.config.load_config",
+            return_value={"capture_user_credential": True},
+        ):
+            cfg = load_oidc_config()
+
+        assert cfg.capture_user_credential is True
+
+    def test_load_oidc_config_capture_default_off(self, monkeypatch):
+        monkeypatch.setenv("TURNSTONE_OIDC_ISSUER", "https://auth.example.com")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.delenv("TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL", raising=False)
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            cfg = load_oidc_config()
+
+        assert cfg.capture_user_credential is False
+
+    def test_capture_appends_offline_access_to_scopes(self, monkeypatch):
+        """Enabling capture requests offline_access without operator scope edits."""
+        monkeypatch.setenv("TURNSTONE_OIDC_ISSUER", "https://auth.example.com")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.delenv("TURNSTONE_OIDC_SCOPES", raising=False)
+
+        with patch(
+            "turnstone.core.config.load_config",
+            return_value={"capture_user_credential": True},
+        ):
+            cfg = load_oidc_config()
+
+        assert cfg.scopes == "openid email profile offline_access"
+
+    def test_capture_scope_append_is_idempotent(self, monkeypatch):
+        """An operator who already lists offline_access doesn't get it twice."""
+        monkeypatch.setenv("TURNSTONE_OIDC_ISSUER", "https://auth.example.com")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.setenv("TURNSTONE_OIDC_SCOPES", "openid offline_access email")
+
+        with patch(
+            "turnstone.core.config.load_config",
+            return_value={"capture_user_credential": True},
+        ):
+            cfg = load_oidc_config()
+
+        assert cfg.scopes == "openid offline_access email"
+
+    def test_no_capture_leaves_scopes_untouched(self, monkeypatch):
+        monkeypatch.setenv("TURNSTONE_OIDC_ISSUER", "https://auth.example.com")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_ID", "cid")
+        monkeypatch.setenv("TURNSTONE_OIDC_CLIENT_SECRET", "csecret")
+        monkeypatch.delenv("TURNSTONE_OIDC_SCOPES", raising=False)
+        monkeypatch.delenv("TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL", raising=False)
+
+        with patch("turnstone.core.config.load_config", return_value={}):
+            cfg = load_oidc_config()
+
+        assert cfg.scopes == "openid email profile"
+
     def test_load_oidc_config_disabled_when_missing(self, monkeypatch):
         monkeypatch.delenv("TURNSTONE_OIDC_ISSUER", raising=False)
         monkeypatch.delenv("TURNSTONE_OIDC_CLIENT_ID", raising=False)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -2524,21 +2524,37 @@ class TestRuntimeRediscovery:
         return SimpleNamespace(oidc_config=cfg)
 
     def test_rediscover_swaps_enabled_config_on_success(self):
+        """Drives the REAL discover_oidc through a mocked HTTP discovery GET
+        (NOT a mock of discover_oidc itself): discover_oidc preserves the input
+        config's ``enabled`` on success and only clears it on failure, so a
+        probe started from the disabled boot config must first force enabled=True
+        or the recovered config never installs. An earlier version of this test
+        mocked discover_oidc to return enabled=True and so masked exactly that
+        dead-code bug."""
         from turnstone.core.oidc import maybe_rediscover_oidc
 
-        state = self._disabled_retryable_state()
-        recovered = dataclasses.replace(
-            state.oidc_config,
-            enabled=True,
-            token_endpoint="https://idp.example.com/token",
-            authorization_endpoint="https://idp.example.com/authorize",
-            jwks_uri="https://idp.example.com/jwks",
-        )
-        with patch(
-            "turnstone.core.oidc.discover_oidc", new=AsyncMock(return_value=recovered)
-        ) as disc:
-            asyncio.run(maybe_rediscover_oidc(state))
-        disc.assert_awaited_once()
+        state = self._disabled_retryable_state()  # issuer=https://idp.example.com
+        discovery_doc = {
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "userinfo_endpoint": "https://idp.example.com/userinfo",
+            "jwks_uri": "https://idp.example.com/.well-known/jwks.json",
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = discovery_doc
+        mock_response.raise_for_status = MagicMock()
+
+        async def _run():
+            client = _mock_async_client(lambda url: _async_return(mock_response))
+            with (
+                patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]),
+                patch("httpx.AsyncClient", return_value=client),
+            ):
+                await maybe_rediscover_oidc(state)
+
+        asyncio.run(_run())
+
+        # The real discover_oidc succeeded and the recovered config was installed.
         assert state.oidc_config.enabled is True
         assert state.oidc_config.token_endpoint == "https://idp.example.com/token"
         # The healed config no longer advertises a retryable failure.

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -2560,6 +2560,54 @@ class TestRuntimeRediscovery:
         # The healed config no longer advertises a retryable failure.
         assert state.oidc_config.discovery_retryable is False
 
+    def test_rediscover_latches_terminal_on_config_error_and_stops_probing(self):
+        """Review finding: probing with enabled forced True carries the
+        retryable boot flag into discover_oidc, whose config-error branches must
+        latch discovery_retryable=False (terminal) — and maybe_rediscover must
+        INSTALL that terminal config — or a config-invalid IdP (endpoint failing
+        SSRF/same-origin) re-probes every cooldown window forever. Drives the
+        real discover_oidc: the discovered token_endpoint is on a foreign host,
+        so validation rejects it as a config error."""
+        from turnstone.core.oidc import maybe_rediscover_oidc
+
+        state = self._disabled_retryable_state()  # issuer=https://idp.example.com
+        bad_doc = {
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://attacker.example/token",  # foreign host
+            "userinfo_endpoint": "https://idp.example.com/userinfo",
+            "jwks_uri": "https://idp.example.com/.well-known/jwks.json",
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = bad_doc
+        mock_response.raise_for_status = MagicMock()
+
+        probes = {"n": 0}
+
+        async def _get(url):
+            probes["n"] += 1
+            return mock_response
+
+        async def _run():
+            client = _mock_async_client(_get)
+            with (
+                patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]),
+                patch("httpx.AsyncClient", return_value=client),
+            ):
+                await maybe_rediscover_oidc(state)
+                # Same window: cooldown already gates a second probe.
+                await maybe_rediscover_oidc(state)
+                # Force the cooldown open — but the config is now terminal, so
+                # the retryable guard should short-circuit before any probe.
+                state.oidc_rediscover_last = None
+                await maybe_rediscover_oidc(state)
+
+        asyncio.run(_run())
+
+        # Still disabled, but LATCHED terminal (not retryable) — one probe only.
+        assert state.oidc_config.enabled is False
+        assert state.oidc_config.discovery_retryable is False
+        assert probes["n"] == 1
+
     def test_rediscover_cooldown_gates_repeat_probes(self):
         from turnstone.core.oidc import maybe_rediscover_oidc
 

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -8,8 +8,9 @@ import dataclasses
 import hashlib
 import types
 import urllib.parse
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import jwt as pyjwt
@@ -2456,6 +2457,129 @@ class TestDiscoverOIDC:
 
             result = asyncio.run(_run())
             assert result.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Runtime re-discovery (boot-time transient failure self-heal)
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeRediscovery:
+    """A node that boots during a transient IdP outage keeps enabled=False
+    forever without a runtime retry — OIDC login stays dark and every
+    oauth_obo mint on the node fails "transient" until an operator restarts
+    it. ``maybe_rediscover_oidc`` heals that, cooldown-gated; config-caused
+    discovery failures (bad issuer, SSRF rejection) are NOT retried."""
+
+    _PUBLIC_ADDR = [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+    def test_fetch_failure_marks_config_retryable(self):
+        """The transient branch (IdP unreachable) sets discovery_retryable."""
+        config = _make_config(
+            authorization_endpoint="", token_endpoint="", userinfo_endpoint="", jwks_uri=""
+        )
+
+        async def _raise_connect(url):
+            raise httpx.ConnectError("boom")
+
+        async def _run():
+            client = _mock_async_client(_raise_connect)
+            with (
+                patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR),
+                patch("httpx.AsyncClient", return_value=client),
+            ):
+                return await discover_oidc(config)
+
+        result = asyncio.run(_run())
+        assert result.enabled is False
+        assert result.discovery_retryable is True
+
+    def test_config_rejection_is_not_retryable(self):
+        """An SSRF-rejected issuer is a config problem — retrying is pointless."""
+        config = _make_config(
+            issuer="https://auth.internal.example",
+            authorization_endpoint="",
+            token_endpoint="",
+            userinfo_endpoint="",
+            jwks_uri="",
+        )
+
+        async def _run():
+            with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("10.0.0.5", 0))]):
+                return await discover_oidc(config)
+
+        result = asyncio.run(_run())
+        assert result.enabled is False
+        assert result.discovery_retryable is False
+
+    def _disabled_retryable_state(self) -> SimpleNamespace:
+        cfg = _make_config(
+            enabled=False,
+            authorization_endpoint="",
+            token_endpoint="",
+            userinfo_endpoint="",
+            jwks_uri="",
+        )
+        cfg = dataclasses.replace(cfg, discovery_retryable=True)
+        return SimpleNamespace(oidc_config=cfg)
+
+    def test_rediscover_swaps_enabled_config_on_success(self):
+        from turnstone.core.oidc import maybe_rediscover_oidc
+
+        state = self._disabled_retryable_state()
+        recovered = dataclasses.replace(
+            state.oidc_config,
+            enabled=True,
+            token_endpoint="https://idp.example.com/token",
+            authorization_endpoint="https://idp.example.com/authorize",
+            jwks_uri="https://idp.example.com/jwks",
+        )
+        with patch(
+            "turnstone.core.oidc.discover_oidc", new=AsyncMock(return_value=recovered)
+        ) as disc:
+            asyncio.run(maybe_rediscover_oidc(state))
+        disc.assert_awaited_once()
+        assert state.oidc_config.enabled is True
+        assert state.oidc_config.token_endpoint == "https://idp.example.com/token"
+        # The healed config no longer advertises a retryable failure.
+        assert state.oidc_config.discovery_retryable is False
+
+    def test_rediscover_cooldown_gates_repeat_probes(self):
+        from turnstone.core.oidc import maybe_rediscover_oidc
+
+        state = self._disabled_retryable_state()
+        still_down = state.oidc_config  # discover keeps returning disabled
+        with patch(
+            "turnstone.core.oidc.discover_oidc", new=AsyncMock(return_value=still_down)
+        ) as disc:
+            asyncio.run(maybe_rediscover_oidc(state))
+            asyncio.run(maybe_rediscover_oidc(state))
+            asyncio.run(maybe_rediscover_oidc(state))
+        # One IdP probe per cooldown window, however many callers ask.
+        disc.assert_awaited_once()
+        assert state.oidc_config.enabled is False
+
+    def test_rediscover_noop_when_not_retryable_or_enabled(self):
+        from turnstone.core.oidc import maybe_rediscover_oidc
+
+        # Operator-disabled (retryable False): never probes.
+        state = SimpleNamespace(
+            oidc_config=_make_config(
+                enabled=False,
+                authorization_endpoint="",
+                token_endpoint="",
+                userinfo_endpoint="",
+                jwks_uri="",
+            )
+        )
+        with patch("turnstone.core.oidc.discover_oidc", new=AsyncMock()) as disc:
+            asyncio.run(maybe_rediscover_oidc(state))
+        disc.assert_not_awaited()
+        # Already enabled: never probes.
+        state2 = SimpleNamespace(oidc_config=_make_config(enabled=True))
+        with patch("turnstone.core.oidc.discover_oidc", new=AsyncMock()) as disc2:
+            asyncio.run(maybe_rediscover_oidc(state2))
+        disc2.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_oidc_credential_storage.py
+++ b/tests/test_oidc_credential_storage.py
@@ -1,0 +1,110 @@
+"""Storage CRUD tests for ``oidc_user_credentials`` (single-credential MCP minting, #551).
+
+Validates the storage-protocol additions for the captured per-(user, issuer)
+IdP refresh token:
+
+- ``upsert_oidc_user_credential`` (create-or-replace semantics)
+- ``get_oidc_user_credential``
+- ``update_oidc_user_credential_refresh`` (rotation write-back)
+- ``delete_oidc_user_credential``
+- ``delete_user`` cascade
+
+plus the ``MCPTokenStore`` encrypt/decrypt wrappers over the same rows.
+"""
+
+from __future__ import annotations
+
+from tests.conftest import make_mcp_token_cipher
+from turnstone.core.mcp_crypto import MCPTokenStore
+
+ISS = "https://login.example.test/tenant-1/v2.0"
+
+
+class TestUpsertAndGet:
+    def test_round_trip(self, backend) -> None:
+        backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-1")
+        row = backend.get_oidc_user_credential("u1", ISS)
+        assert row is not None
+        assert row["user_id"] == "u1"
+        assert row["issuer"] == ISS
+        assert row["refresh_token_ct"] == b"ct-1"
+        assert row["created"] == row["last_refreshed"]
+
+    def test_get_missing_returns_none(self, backend) -> None:
+        assert backend.get_oidc_user_credential("nobody", ISS) is None
+
+    def test_keyed_by_user_and_issuer(self, backend) -> None:
+        backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-1")
+        assert backend.get_oidc_user_credential("u1", "https://other.test") is None
+        assert backend.get_oidc_user_credential("u2", ISS) is None
+
+    def test_upsert_replaces_on_conflict(self, backend) -> None:
+        """A fresh login must overwrite a stale credential; ``created`` survives."""
+        backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-old")
+        first = backend.get_oidc_user_credential("u1", ISS)
+        assert first is not None
+        backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-new")
+        second = backend.get_oidc_user_credential("u1", ISS)
+        assert second is not None
+        assert second["refresh_token_ct"] == b"ct-new"
+        assert second["created"] == first["created"]
+
+
+class TestRotationWriteBack:
+    def test_update_rewrites_token(self, backend) -> None:
+        backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-1")
+        assert backend.update_oidc_user_credential_refresh("u1", ISS, refresh_token_ct=b"ct-2")
+        row = backend.get_oidc_user_credential("u1", ISS)
+        assert row is not None
+        assert row["refresh_token_ct"] == b"ct-2"
+
+    def test_update_missing_returns_false(self, backend) -> None:
+        assert not backend.update_oidc_user_credential_refresh(
+            "nobody", ISS, refresh_token_ct=b"ct"
+        )
+
+
+class TestDelete:
+    def test_delete_existing(self, backend) -> None:
+        backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-1")
+        assert backend.delete_oidc_user_credential("u1", ISS)
+        assert backend.get_oidc_user_credential("u1", ISS) is None
+
+    def test_delete_missing_returns_false(self, backend) -> None:
+        assert not backend.delete_oidc_user_credential("nobody", ISS)
+
+    def test_delete_user_cascades_credential(self, backend) -> None:
+        backend.upsert_oidc_user_credential("u-doomed", ISS, refresh_token_ct=b"ct-1")
+        backend.delete_user("u-doomed")
+        assert backend.get_oidc_user_credential("u-doomed", ISS) is None
+
+
+class TestTokenStoreWrappers:
+    def test_encrypt_decrypt_round_trip(self, backend) -> None:
+        store = MCPTokenStore(backend, make_mcp_token_cipher())
+        store.upsert_oidc_credential("u1", ISS, refresh_token="rt-plaintext")
+        plain = store.get_oidc_credential("u1", ISS)
+        assert plain is not None
+        assert plain["refresh_token"] == "rt-plaintext"
+        # Ciphertext at rest — the raw row must not contain the plaintext.
+        raw = backend.get_oidc_user_credential("u1", ISS)
+        assert raw is not None
+        assert b"rt-plaintext" not in raw["refresh_token_ct"]
+
+    def test_redeem_write_back_round_trip(self, backend) -> None:
+        store = MCPTokenStore(backend, make_mcp_token_cipher())
+        store.upsert_oidc_credential("u1", ISS, refresh_token="rt-first")
+        assert store.update_oidc_credential_after_redeem("u1", ISS, refresh_token="rt-rotated")
+        plain = store.get_oidc_credential("u1", ISS)
+        assert plain is not None
+        assert plain["refresh_token"] == "rt-rotated"
+
+    def test_get_missing_returns_none(self, backend) -> None:
+        store = MCPTokenStore(backend, make_mcp_token_cipher())
+        assert store.get_oidc_credential("nobody", ISS) is None
+
+    def test_delete_via_store(self, backend) -> None:
+        store = MCPTokenStore(backend, make_mcp_token_cipher())
+        store.upsert_oidc_credential("u1", ISS, refresh_token="rt")
+        assert store.delete_oidc_credential("u1", ISS)
+        assert store.get_oidc_credential("u1", ISS) is None

--- a/tests/test_oidc_credential_storage.py
+++ b/tests/test_oidc_credential_storage.py
@@ -39,15 +39,37 @@ class TestUpsertAndGet:
         assert backend.get_oidc_user_credential("u2", ISS) is None
 
     def test_upsert_replaces_on_conflict(self, backend) -> None:
-        """A fresh login must overwrite a stale credential; ``created`` survives."""
+        """A fresh login must overwrite a stale credential; ``created`` survives.
+
+        Plants a distinctly-past ``created`` via direct SQL so the assertion
+        actually detects a reset (comparing two upserts milliseconds apart would
+        pass at second granularity even if the on-conflict clause reset created).
+        """
+        import sqlalchemy as sa
+
+        from turnstone.core.storage._schema import oidc_user_credentials
+
         backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-old")
-        first = backend.get_oidc_user_credential("u1", ISS)
-        assert first is not None
+        planted = "2020-01-01T00:00:00"
+        with backend._engine.connect() as conn:
+            conn.execute(
+                sa.update(oidc_user_credentials)
+                .where(
+                    (oidc_user_credentials.c.user_id == "u1")
+                    & (oidc_user_credentials.c.issuer == ISS)
+                )
+                .values(created=planted)
+            )
+            conn.commit()
+
         backend.upsert_oidc_user_credential("u1", ISS, refresh_token_ct=b"ct-new")
         second = backend.get_oidc_user_credential("u1", ISS)
         assert second is not None
         assert second["refresh_token_ct"] == b"ct-new"
-        assert second["created"] == first["created"]
+        # created is PRESERVED across the replace (not reset to now).
+        assert second["created"] == planted
+        # last_refreshed, by contrast, advances off the planted-past value.
+        assert second["last_refreshed"] != planted
 
 
 class TestRotationWriteBack:

--- a/tests/test_oidc_credential_storage.py
+++ b/tests/test_oidc_credential_storage.py
@@ -116,10 +116,28 @@ class TestTokenStoreWrappers:
     def test_redeem_write_back_round_trip(self, backend) -> None:
         store = MCPTokenStore(backend, make_mcp_token_cipher())
         store.upsert_oidc_credential("u1", ISS, refresh_token="rt-first")
-        assert store.update_oidc_credential_after_redeem("u1", ISS, refresh_token="rt-rotated")
+        # CAS matches the stored value → write lands.
+        assert store.update_oidc_credential_after_redeem(
+            "u1", ISS, refresh_token="rt-rotated", expected_current="rt-first"
+        )
         plain = store.get_oidc_credential("u1", ISS)
         assert plain is not None
         assert plain["refresh_token"] == "rt-rotated"
+
+    def test_redeem_write_back_cas_skips_when_credential_changed(self, backend) -> None:
+        """The rotation write is a no-op when the stored credential no longer
+        matches what the mint read (a concurrent login capture refreshed it) —
+        so a stale rotation can't clobber a fresh login token."""
+        store = MCPTokenStore(backend, make_mcp_token_cipher())
+        store.upsert_oidc_credential("u1", ISS, refresh_token="rt-login-fresh")
+        # Mint read "rt-old", but the stored value is now the fresh login token.
+        assert not store.update_oidc_credential_after_redeem(
+            "u1", ISS, refresh_token="rt-rotated-from-old", expected_current="rt-old"
+        )
+        # The fresh login token survived.
+        plain = store.get_oidc_credential("u1", ISS)
+        assert plain is not None
+        assert plain["refresh_token"] == "rt-login-fresh"
 
     def test_get_missing_returns_none(self, backend) -> None:
         store = MCPTokenStore(backend, make_mcp_token_cipher())

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -728,6 +728,227 @@ class TestOIDCCallback:
 
 
 # ---------------------------------------------------------------------------
+# Single-credential capture tests (issue #551)
+# ---------------------------------------------------------------------------
+
+
+class TestOIDCCallbackCapture:
+    """Capture of the IdP refresh token at login (``capture_user_credential``)."""
+
+    def _capture_client(
+        self,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+        *,
+        capture: bool = True,
+        with_store: bool = True,
+    ) -> tuple[TestClient, Any, OIDCConfig]:
+        """Client wired like ``authorize_client`` plus a real MCPTokenStore."""
+        import dataclasses
+
+        from tests.conftest import make_mcp_token_cipher
+        from turnstone.core.mcp_crypto import MCPTokenStore
+
+        cfg = dataclasses.replace(oidc_config, capture_user_credential=capture)
+        app = Starlette(
+            routes=[
+                Mount("/v1", routes=[Route("/api/auth/oidc/callback", _oidc_callback)]),
+            ],
+        )
+        app.state.oidc_config = cfg
+        app.state.auth_storage = storage
+        app.state.jwt_secret = "test-jwt-secret-key-padded-32b!!"
+        app.state.jwks_data = {"keys": []}
+        app.state.login_limiter = None
+        store = MCPTokenStore(storage, make_mcp_token_cipher()) if with_store else None
+        app.state.mcp_token_store = store
+        return TestClient(app, raise_server_exceptions=False), store, cfg
+
+    def _login(
+        self,
+        client: TestClient,
+        storage: SQLiteBackend,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        *,
+        tokens: dict[str, Any],
+        state: str = "valid-state",
+    ) -> Any:
+        storage.create_oidc_pending_state(state, "test-nonce", "test-verifier", "test-audience")
+        mock_exchange.return_value = tokens
+        mock_validate.return_value = {
+            "sub": "user123",
+            "email": "u@example.com",
+            "nonce": "test-nonce",
+        }
+        mock_provision.return_value = {"user_id": "test-admin", "username": "testadmin"}
+        return client.get(
+            f"/v1/api/auth/oidc/callback?code=authcode&state={state}",
+            follow_redirects=False,
+        )
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_capture_persists_credential(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        client, store, cfg = self._capture_client(storage, oidc_config)
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "fake.jwt.token", "access_token": "at", "refresh_token": "rt-1"},
+        )
+        assert resp.status_code == 302
+        assert "oidc_success=1" in resp.headers["location"]
+        assert store is not None
+        plain = store.get_oidc_credential("test-admin", cfg.issuer)
+        assert plain is not None
+        assert plain["refresh_token"] == "rt-1"
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_second_login_replaces_credential(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        client, store, cfg = self._capture_client(storage, oidc_config)
+        self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "t", "refresh_token": "rt-old"},
+            state="s1",
+        )
+        self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "t", "refresh_token": "rt-new"},
+            state="s2",
+        )
+        assert store is not None
+        plain = store.get_oidc_credential("test-admin", cfg.issuer)
+        assert plain is not None
+        assert plain["refresh_token"] == "rt-new"
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_no_refresh_token_logs_and_login_succeeds(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        client, store, cfg = self._capture_client(storage, oidc_config)
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "fake.jwt.token", "access_token": "at"},
+        )
+        assert resp.status_code == 302
+        assert "oidc_success=1" in resp.headers["location"]
+        assert store is not None
+        assert store.get_oidc_credential("test-admin", cfg.issuer) is None
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_capture_disabled_persists_nothing(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        client, store, cfg = self._capture_client(storage, oidc_config, capture=False)
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "t", "refresh_token": "rt-present"},
+        )
+        assert resp.status_code == 302
+        assert store is not None
+        assert store.get_oidc_credential("test-admin", cfg.issuer) is None
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_missing_store_login_still_succeeds(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        client, _store, _cfg = self._capture_client(storage, oidc_config, with_store=False)
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "t", "refresh_token": "rt-1"},
+        )
+        assert resp.status_code == 302
+        assert "oidc_success=1" in resp.headers["location"]
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_store_failure_does_not_block_login(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        client, store, _cfg = self._capture_client(storage, oidc_config)
+        assert store is not None
+        with patch.object(store, "upsert_oidc_credential", side_effect=RuntimeError("boom")):
+            resp = self._login(
+                client,
+                storage,
+                mock_exchange,
+                mock_validate,
+                mock_provision,
+                tokens={"id_token": "t", "refresh_token": "rt-1"},
+            )
+        assert resp.status_code == 302
+        assert "oidc_success=1" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
 # Admin OIDC identity endpoint tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -1001,6 +1001,67 @@ class TestAdminOIDCIdentities:
         # Verify it's gone
         assert storage.get_oidc_identity("https://idp.example.com", "sub-456") is None
 
+    def test_delete_identity_revokes_credential_and_purges_obo_cache(
+        self, storage: SQLiteBackend
+    ) -> None:
+        """#551 follow-up: unlinking an identity must revoke the captured
+        credential AND purge the user's already-minted oauth_obo cache rows —
+        deleting only the credential leaves live cached bearers authorizing
+        dispatch until TTL. The response/audit report what was actually cut."""
+        from tests.conftest import make_mcp_token_cipher
+        from turnstone.core.mcp_crypto import MCPTokenStore
+
+        issuer = "https://idp.example.com"
+        store = MCPTokenStore(storage, make_mcp_token_cipher(), node_id="test")
+        app = Starlette(
+            routes=[
+                Mount(
+                    "/v1",
+                    routes=[
+                        Route(
+                            "/api/admin/oidc-identities",
+                            admin_delete_oidc_identity,
+                            methods=["DELETE"],
+                        )
+                    ],
+                )
+            ],
+            middleware=[Middleware(_InjectAuthMiddleware)],
+        )
+        app.state.auth_storage = storage
+        app.state.mcp_token_store = store
+        client = TestClient(app, raise_server_exceptions=False)
+
+        storage.create_oidc_identity(issuer, "sub-1", "user-x", "x@example.com")
+        store.upsert_oidc_credential("user-x", issuer, refresh_token="rt-live")
+        storage.create_mcp_server(
+            server_id="srv-obo",
+            name="obo-srv",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        store.create_user_token(
+            "user-x",
+            "obo-srv",
+            access_token="minted-at",
+            refresh_token=None,
+            expires_at="2026-12-31T00:00:00",
+            scopes=None,
+            as_issuer=issuer,
+            audience="api://mcp-a",
+        )
+
+        resp = client.delete(f"/v1/api/admin/oidc-identities?issuer={issuer}&subject=sub-1")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["obo_credential_revoked"] is True
+        assert body["obo_cache_rows_purged"] == 1
+        # Credential gone → no future mints; cache row gone → no live cached bearer.
+        assert store.get_oidc_credential("user-x", issuer) is None
+        assert storage.get_mcp_user_token("user-x", "obo-srv") is None
+
     def test_delete_nonexistent_returns_404(self, admin_client: TestClient) -> None:
         resp = admin_client.delete(
             "/v1/api/admin/oidc-identities?issuer=https://no.such&subject=nope",

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -190,6 +190,23 @@ class TestOIDCAuthorize:
         resp = client.get("/v1/api/auth/oidc/authorize")
         assert resp.status_code == 404
 
+    def test_disabled_retryable_triggers_login_self_heal(self, storage: SQLiteBackend) -> None:
+        """Review finding: the LOGIN path must trigger runtime rediscovery too,
+        not just the obo mint path — otherwise a single-node install whose node
+        booted during a transient IdP outage stays login-dark forever. A
+        disabled+retryable config makes authorize call maybe_rediscover_oidc."""
+        from unittest.mock import AsyncMock, patch
+
+        app = Starlette(
+            routes=[Mount("/v1", routes=[Route("/api/auth/oidc/authorize", _oidc_authorize)])]
+        )
+        app.state.oidc_config = _make_oidc_config(enabled=False, discovery_retryable=True)
+        app.state.auth_storage = storage
+        client = TestClient(app, raise_server_exceptions=False)
+        with patch("turnstone.core.auth.maybe_rediscover_oidc", new=AsyncMock()) as heal:
+            client.get("/v1/api/auth/oidc/authorize")
+        heal.assert_awaited_once()
+
     def test_no_storage_returns_503(self) -> None:
         app = Starlette(
             routes=[Mount("/v1", routes=[Route("/api/auth/oidc/authorize", _oidc_authorize)])]

--- a/tests/test_server_lifespan_mcp_crypto.py
+++ b/tests/test_server_lifespan_mcp_crypto.py
@@ -111,3 +111,52 @@ class TestInitializeMcpCryptoState:
         ):
             initialize_mcp_crypto_state(state, node_id="n1")
         assert exc_info.value.code == 1
+
+    def test_capture_key_guard_fires_even_when_oidc_discovery_failed(
+        self, backend, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Review finding: the capture-credential key guard must NOT depend on
+        oidc_config.enabled. A node that boots while the IdP is unreachable comes
+        up enabled=False (discovery_retryable=True); gating the guard on enabled
+        would silently skip the loud boot-time failure exactly then, and runtime
+        rediscovery later re-enables OIDC so the first login persists a refresh
+        token with no key. capture_user_credential=True + no key must SystemExit
+        regardless of the (transient) discovery state — no oauth_obo rows exist,
+        so only the capture guard can catch this."""
+        _patch_security(monkeypatch, {})  # no encryption key
+        # enabled=False models a boot-time discovery failure; capture opt-in on.
+        state = types.SimpleNamespace(
+            oidc_config=types.SimpleNamespace(
+                enabled=False,
+                issuer="https://idp.example.com",
+                capture_user_credential=True,
+                discovery_retryable=True,
+            )
+        )
+        with (
+            caplog.at_level("ERROR", logger="turnstone.core.mcp_crypto"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            initialize_mcp_crypto_state(state, node_id="n1")
+        assert exc_info.value.code == 1
+        messages = " ".join(record.message for record in caplog.records)
+        assert "capture_user_credential" in messages
+
+    def test_capture_with_key_starts_even_when_oidc_disabled(
+        self, backend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The converse: capture opt-in WITH a key installed boots cleanly even
+        while discovery is down — the cipher/store land so a later rediscovery's
+        first capture has somewhere encrypted to persist."""
+        _patch_security(monkeypatch, {"mcp_token_encryption_key": Fernet.generate_key().decode()})
+        state = types.SimpleNamespace(
+            oidc_config=types.SimpleNamespace(
+                enabled=False,
+                issuer="https://idp.example.com",
+                capture_user_credential=True,
+                discovery_retryable=True,
+            )
+        )
+        initialize_mcp_crypto_state(state, node_id="n1")
+        assert isinstance(state.mcp_token_cipher, MCPTokenCipher)
+        assert isinstance(state.mcp_token_store, MCPTokenStore)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9742,6 +9742,39 @@ def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse |
     return None
 
 
+def _enforce_oauth_obo_requirements(
+    request: Request, auth_type: str, *, audience: str | None
+) -> JSONResponse | None:
+    """Write-time validation for ``oauth_obo`` rows (issue #551).
+
+    Rejects at the write choke point what would otherwise fail per-dispatch at
+    runtime (or worse, at the next boot):
+
+    - **No token-encryption key** → 503. An oauth_obo row persists encrypted
+      per-user mint-cache rows AND makes ``initialize_mcp_crypto_state``
+      ``SystemExit(1)`` at the next restart, so accepting one keyless plants a
+      deferred whole-cluster boot failure.
+    - **No ``oauth_audience``** → 400. The mint engine hard-requires the
+      downstream audience; without it every tool call fails transient and logs
+      ``obo_misconfigured``. Reject here, exactly as bad URL schemes are.
+    """
+    if auth_type != "oauth_obo":
+        return None
+    if getattr(request.app.state, "mcp_token_store", None) is None:
+        return JSONResponse({"error": _OAUTH_TOKEN_STORE_503_MSG}, status_code=503)
+    if not (audience or "").strip():
+        return JSONResponse(
+            {
+                "error": (
+                    "auth_type=oauth_obo requires oauth_audience "
+                    "(the downstream resource the access token is minted for)"
+                )
+            },
+            status_code=400,
+        )
+    return None
+
+
 def _get_mcp_max_servers(request: Request) -> int:
     """Read cluster.mcp_max_servers via ConfigStore (validated + cached)."""
     config_store = getattr(request.app.state, "config_store", None)
@@ -10111,8 +10144,15 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     # Helper returns None when key is absent — fall back to the default.
     auth_type = auth_type_value if auth_type_value is not None else "static"
 
-    # sec-1: oauth_user must use https:// (loopback http allowed for dev).
+    # sec-1: oauth_user/oauth_obo must use https:// (loopback http allowed for dev).
     err_resp = _enforce_oauth_user_https(auth_type, str(body.get("url", "")).strip())
+    if err_resp is not None:
+        return err_resp
+
+    # #551: oauth_obo needs an encryption key + an audience at write time.
+    err_resp = _enforce_oauth_obo_requirements(
+        request, auth_type, audience=_clean_oauth_text(body.get("oauth_audience"), max_length=2048)
+    )
     if err_resp is not None:
         return err_resp
 
@@ -10315,33 +10355,17 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         if _oauth_url_key in body:
             updates[_oauth_url_key] = _clean_oauth_text(body[_oauth_url_key], max_length=2048)
 
-    # When auth_type is changed away from oauth_user, clear the OAuth
-    # columns so a stale client_id / audience can't leak back if the
-    # row is later flipped to a different oauth_user provider.
-    # ``oauth_client_secret_ct`` is owned by a dedicated write path
-    # (not the generic update); the matching clear-on-transition is
-    # applied below via ``token_store.set_oauth_client_secret(..., None)``
-    # (or a direct storage call when no encryption key is configured).
-    transitioning_away_from_oauth_user = (
-        updates.get("auth_type") in {"static", "none"} and existing.get("auth_type") == "oauth_user"
-    )
-    # Renaming an oauth_user row needs the same per-user-token purge as
-    # delete: the tokens are keyed on the OLD ``server_name`` and a row
-    # later created with that old name (with attacker-controlled URL)
-    # would otherwise silently rebind them.
-    name_changing = "name" in updates and existing.get("name", "") != updates["name"]
-    # URL change on an oauth_user row needs the same purge: bearer tokens
-    # are bound (via OAuth resource / audience) to the URL active at
-    # consent time, so sending them to a new URL is a token-binding
-    # violation. A compromised admin who flips the URL to an attacker
-    # endpoint would otherwise replay every user's bearer there silently.
-    # Re-consent forces fresh token issuance bound to the new resource.
-    url_changing = (
-        existing.get("auth_type") == "oauth_user"
-        and "url" in updates
-        and existing.get("url", "") != updates["url"]
-    )
-    if updates.get("auth_type") and updates["auth_type"] != "oauth_user":
+    from turnstone.core.mcp_oauth import is_user_scoped_auth
+
+    old_auth = existing.get("auth_type")
+    new_auth = updates.get("auth_type")
+    # Clear the OAuth columns the target auth_type does NOT use, so a stale
+    # client_id / audience can't leak back on a later flip. static/none use
+    # none; oauth_obo uses oauth_audience (+ oauth_scopes) but none of the
+    # oauth_user-only columns; oauth_user uses them all.
+    # ``oauth_client_secret_ct`` is owned by a dedicated write path (see below).
+    if new_auth and not is_user_scoped_auth(new_auth):
+        # → static/none: clear every OAuth column.
         updates.update(
             {
                 "oauth_client_id": None,
@@ -10352,6 +10376,46 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
                 "oauth_as_issuer_cached": None,
             }
         )
+    elif new_auth == "oauth_obo":
+        # obo keeps audience/scopes (it needs them); clear oauth_user-only cols.
+        updates.update(
+            {
+                "oauth_client_id": None,
+                "oauth_registration_mode": None,
+                "oauth_authorization_server_url": None,
+                "oauth_as_issuer_cached": None,
+            }
+        )
+    # Renaming a pool-backed row needs the same per-user-token purge as
+    # delete: the tokens are keyed on the OLD ``server_name`` and a row
+    # later created with that old name (with attacker-controlled URL)
+    # would otherwise silently rebind them.
+    name_changing = "name" in updates and existing.get("name", "") != updates["name"]
+    # Any auth_type transition touching a pool-backed type (oauth_user or
+    # oauth_obo) purges the per-user rows: leaving to static/none orphans them;
+    # oauth_user↔oauth_obo mixes semantically different rows (per-server-AS
+    # refresh tokens vs minted cache) and would otherwise leave a live grant at
+    # the old AS unrevoked and refresh-bearing rows in the mint cache.
+    auth_type_purge = (
+        new_auth is not None
+        and new_auth != old_auth
+        and (is_user_scoped_auth(old_auth) or is_user_scoped_auth(new_auth))
+    )
+    # URL change on a pool-backed row needs the same purge: bearer tokens
+    # are bound (via OAuth resource / audience) to the URL active at
+    # mint/consent time, so sending them to a new URL is a token-binding
+    # violation. A compromised admin who flips the URL to an attacker
+    # endpoint would otherwise replay every user's bearer there silently.
+    url_changing = (
+        is_user_scoped_auth(old_auth)
+        and "url" in updates
+        and existing.get("url", "") != updates["url"]
+    )
+    # Leaving oauth_user (to static/none OR to oauth_obo, which doesn't use the
+    # per-server client secret) clears the encrypted secret column below.
+    leaving_oauth_user = (
+        old_auth == "oauth_user" and new_auth is not None and new_auth != "oauth_user"
+    )
 
     # bug-2 / sec-1: validate token-store availability and JSON shape BEFORE
     # ``storage.update_mcp_server`` so a missing key doesn't leave partial
@@ -10368,18 +10432,24 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     if err_resp is not None:
         return err_resp
 
+    # #551: an oauth_obo row (whether newly flipped or edited) needs an
+    # encryption key + an audience — validated against the post-update value.
+    audience_now = updates.get("oauth_audience", existing.get("oauth_audience"))
+    err_resp = _enforce_oauth_obo_requirements(request, auth_type_now, audience=audience_now)
+    if err_resp is not None:
+        return err_resp
+
     if updates:
         storage.update_mcp_server(server_id, **updates)
 
     audit_uid, ip = _audit_context(request)
 
-    # Purge per-user tokens + pending OAuth states keyed on the OLD
-    # name on rename, on ``oauth_user → static/none`` transition, or
-    # on URL change for an oauth_user row. All three cases would
-    # otherwise leave tokens orphaned-and-rebindable because the OAuth
-    # tables key on the mutable ``server_name`` and tokens are bound
-    # to the URL active at consent time.
-    if name_changing or transitioning_away_from_oauth_user or url_changing:
+    # Purge per-user tokens + pending OAuth states keyed on the OLD name on
+    # rename, on any pool-backed auth_type transition, or on URL change for a
+    # pool-backed row. All cases would otherwise leave tokens
+    # orphaned-and-rebindable (the OAuth tables key on the mutable
+    # ``server_name`` and tokens are bound to the URL active at mint/consent time).
+    if name_changing or auth_type_purge or url_changing:
         purge_target = existing.get("name", "")
         if purge_target:
             try:
@@ -10391,11 +10461,11 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
                     exc_info=True,
                 )
 
-    # sec-2: when the row is leaving ``oauth_user``, also clear the encrypted
-    # client secret column.  Operators expect "disable OAuth" to revoke
-    # credentials; leaving stale ciphertext that resurfaces if the row is
-    # flipped back is surprising and a footgun.
-    if transitioning_away_from_oauth_user:
+    # sec-2: when the row is leaving ``oauth_user`` (to static/none or to
+    # oauth_obo), also clear the encrypted client secret column.  Operators
+    # expect "disable OAuth" to revoke credentials; leaving stale ciphertext
+    # that resurfaces if the row is flipped back is surprising and a footgun.
+    if leaving_oauth_user:
         token_store = getattr(request.app.state, "mcp_token_store", None)
         if token_store is not None:
             token_store.set_oauth_client_secret(server_id, None)
@@ -10699,12 +10769,18 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
     if not name or "__" in name:
         return JSONResponse({"error": "invalid server name"}, status_code=400)
 
+    from turnstone.core.mcp_oauth import is_user_scoped_auth
+
     existing = storage.get_mcp_server_by_name(name)
     if existing is None:
         return JSONResponse({"error": "No such server"}, status_code=404)
-    if existing.get("auth_type") != "oauth_user":
+    # Both pool-backed types populate mcp_user_tokens (oauth_user: consent
+    # tokens; oauth_obo: minted cache rows), so bulk-revoke serves both — it is
+    # the documented remediation for the stale rows an oauth_user→oauth_obo flip
+    # leaves behind.
+    if not is_user_scoped_auth(existing.get("auth_type")):
         return JSONResponse(
-            {"error": "bulk-revoke is only valid for auth_type=oauth_user servers"},
+            {"error": "bulk-revoke is only valid for oauth_user or oauth_obo servers"},
             status_code=400,
         )
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9842,9 +9842,26 @@ def _oauth_columns_to_clear(auth_type: str | None) -> dict[str, None]:
 
 
 def _enforce_oauth_obo_requirements(
-    request: Request, auth_type: str, *, audience: str | None, scopes: str | None
+    request: Request,
+    auth_type: str,
+    *,
+    audience: str | None,
+    scopes: str | None,
+    check_oidc_deployment: bool = True,
 ) -> JSONResponse | None:
     """Write-time validation for ``oauth_obo`` rows (issue #551).
+
+    ``check_oidc_deployment`` splits the checks by what they guard. The
+    DEPLOYMENT-level checks (token-encryption key, OIDC configured/enabled,
+    capture opt-in, valid grant profile) reject configuring a NEW obo mint that
+    could never work — they run on create and on a flip INTO obo. They are
+    SKIPPED for a same-type edit of an existing obo server (``False``): OIDC
+    being operator-disabled is a deployment state, not a per-server one, so
+    blocking every edit — including the natural remedy of setting
+    ``enabled=false`` — would only lock the operator out (the row can still be
+    DELETEd, but not disabled). The PER-SERVER validity checks (audience
+    required; ``oauth_scopes`` rejected under the entra profile) always run so a
+    same-type edit can't leave the row itself invalid.
 
     Rejects at the write choke point what would otherwise fail per-dispatch at
     runtime (or worse, at the next boot):
@@ -9872,61 +9889,60 @@ def _enforce_oauth_obo_requirements(
     """
     if auth_type != "oauth_obo":
         return None
-    if getattr(request.app.state, "mcp_token_store", None) is None:
-        return JSONResponse({"error": _OAUTH_TOKEN_STORE_503_MSG}, status_code=503)
-    oidc_config = getattr(request.app.state, "oidc_config", None)
-    # Accept a config that is enabled OR merely transiently un-discovered
-    # (``discovery_retryable`` — the IdP was unreachable at this process's boot).
-    # OIDC is still CONFIGURED there (issuer set); rejecting it would make every
-    # oauth_obo server un-editable/un-disable-able on the console — which never
-    # runs the runtime rediscovery that heals server nodes — until a manual
-    # restart. Reject only a genuinely absent / operator-disabled OIDC (neither
-    # flag set: no issuer configured).
-    oidc_configured = oidc_config is not None and (
-        getattr(oidc_config, "enabled", False) or getattr(oidc_config, "discovery_retryable", False)
-    )
-    if not oidc_configured:
-        return JSONResponse(
-            {
-                "error": (
-                    "auth_type=oauth_obo requires OIDC sign-in to be configured and "
-                    "enabled (it mints per-server tokens from each user's Turnstone "
-                    "sign-in). Configure [oidc] and capture_user_credential, or use "
-                    "auth_type=oauth_user for per-server consent."
-                )
-            },
-            status_code=400,
-        )
-    if not getattr(oidc_config, "capture_user_credential", False):
-        # The mint redeems the user's CAPTURED IdP refresh token; with capture
-        # off, login persists nothing, so every dispatch returns kind="missing"
-        # and the "sign in again" remedy can never succeed — a permanent
-        # misconfig this choke point exists to reject. (Enabling capture also
-        # requires the encryption key, checked at boot.)
-        return JSONResponse(
-            {
-                "error": (
-                    "auth_type=oauth_obo requires [oidc] capture_user_credential=true "
-                    "so each user's sign-in credential is captured for minting; it is "
-                    "currently disabled, so this server could never obtain a token."
-                )
-            },
-            status_code=400,
-        )
     profile = _obo_profile(request)
-    from turnstone.core.mcp_oauth import OBO_GRANT_PROFILES
-
-    if profile not in OBO_GRANT_PROFILES:
-        return JSONResponse(
-            {
-                "error": (
-                    f"[oidc] obo_grant_profile={profile!r} is not a valid grant profile "
-                    f"({', '.join(sorted(OBO_GRANT_PROFILES))}); fix the deployment "
-                    "config before configuring oauth_obo servers"
-                )
-            },
-            status_code=400,
+    if check_oidc_deployment:
+        if getattr(request.app.state, "mcp_token_store", None) is None:
+            return JSONResponse({"error": _OAUTH_TOKEN_STORE_503_MSG}, status_code=503)
+        oidc_config = getattr(request.app.state, "oidc_config", None)
+        # Accept a config that is enabled OR merely transiently un-discovered
+        # (``discovery_retryable`` — the IdP was unreachable at this process's
+        # boot). OIDC is still CONFIGURED there (issuer set); reject only a
+        # genuinely absent / operator-disabled OIDC (neither flag set).
+        oidc_configured = oidc_config is not None and (
+            getattr(oidc_config, "enabled", False)
+            or getattr(oidc_config, "discovery_retryable", False)
         )
+        if not oidc_configured:
+            return JSONResponse(
+                {
+                    "error": (
+                        "auth_type=oauth_obo requires OIDC sign-in to be configured and "
+                        "enabled (it mints per-server tokens from each user's Turnstone "
+                        "sign-in). Configure [oidc] and capture_user_credential, or use "
+                        "auth_type=oauth_user for per-server consent."
+                    )
+                },
+                status_code=400,
+            )
+        if not getattr(oidc_config, "capture_user_credential", False):
+            # The mint redeems the user's CAPTURED IdP refresh token; with capture
+            # off, login persists nothing, so every dispatch returns kind="missing"
+            # and the "sign in again" remedy can never succeed — a permanent
+            # misconfig this choke point exists to reject. (Enabling capture also
+            # requires the encryption key, checked at boot.)
+            return JSONResponse(
+                {
+                    "error": (
+                        "auth_type=oauth_obo requires [oidc] capture_user_credential=true "
+                        "so each user's sign-in credential is captured for minting; it is "
+                        "currently disabled, so this server could never obtain a token."
+                    )
+                },
+                status_code=400,
+            )
+        from turnstone.core.mcp_oauth import OBO_GRANT_PROFILES
+
+        if profile not in OBO_GRANT_PROFILES:
+            return JSONResponse(
+                {
+                    "error": (
+                        f"[oidc] obo_grant_profile={profile!r} is not a valid grant profile "
+                        f"({', '.join(sorted(OBO_GRANT_PROFILES))}); fix the deployment "
+                        "config before configuring oauth_obo servers"
+                    )
+                },
+                status_code=400,
+            )
     if not (audience or "").strip():
         return JSONResponse(
             {
@@ -10637,12 +10653,11 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # minted obo bearers (and oauth_user tokens) are audience-scoped, so cached
     # rows for the OLD audience must be purged or a privilege reduction silently
     # doesn't take effect until they expire. (auth_type flips already purge, so
-    # only guard the same-type edit here.)
+    # only guard the same-type edit here.) Like ``scopes_changing`` below, the
+    # same-type no-op normalization above already dropped an equal re-sent value
+    # from ``updates``, so "in updates" already means a genuine change.
     audience_changing = (
-        is_user_scoped_auth(old_auth)
-        and not is_flip
-        and "oauth_audience" in updates
-        and (existing.get("oauth_audience") or "") != (updates["oauth_audience"] or "")
+        is_user_scoped_auth(old_auth) and not is_flip and "oauth_audience" in updates
     )
     # Changing oauth_scopes on an oauth_obo row is the same token-binding
     # change under the rfc8693 profile: the exchange scope shapes the minted
@@ -10686,8 +10701,16 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # pre-filled field, so every unrelated save would 400.
     audience_now = updates.get("oauth_audience", existing.get("oauth_audience"))
     scopes_being_set = updates.get("oauth_scopes") if "oauth_scopes" in updates else None
+    # Run the DEPLOYMENT-level OIDC checks only when this write is a NEW obo
+    # enablement (a flip INTO obo); a same-type edit of an existing obo server
+    # keeps only the per-server validity checks, so an operator can still
+    # disable / edit an obo server after OIDC was operator-disabled.
     err_resp = _enforce_oauth_obo_requirements(
-        request, auth_type_now, audience=audience_now, scopes=scopes_being_set
+        request,
+        auth_type_now,
+        audience=audience_now,
+        scopes=scopes_being_set,
+        check_oidc_deployment=is_flip,
     )
     if err_resp is not None:
         return err_resp

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6002,6 +6002,25 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
 
     storage.delete_oidc_identity(issuer, subject)
 
+    # #551: unlinking the identity must also revoke the captured IdP refresh
+    # credential (keyed on (user_id, issuer)) — otherwise a deprovisioned user's
+    # scheduled/autonomous runs keep minting oauth_obo access tokens
+    # indefinitely (rotation write-back keeps the RT alive). Best-effort: a
+    # failure here must not leave the identity un-deleted.
+    credential_revoked = False
+    token_store = getattr(request.app.state, "mcp_token_store", None)
+    if token_store is not None:
+        try:
+            credential_revoked = bool(
+                token_store.delete_oidc_credential(identity["user_id"], issuer)
+            )
+        except Exception:
+            log.warning(
+                "admin.oidc_identity.credential_revoke_failed user=%s",
+                identity["user_id"],
+                exc_info=True,
+            )
+
     audit_uid, ip = _audit_context(request)
     record_audit(
         storage,
@@ -6009,7 +6028,7 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
         "oidc_identity.delete",
         "oidc_identity",
         f"{issuer}:{subject}",
-        {"user_id": identity["user_id"]},
+        {"user_id": identity["user_id"], "obo_credential_revoked": credential_revoked},
         ip,
     )
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9875,7 +9875,17 @@ def _enforce_oauth_obo_requirements(
     if getattr(request.app.state, "mcp_token_store", None) is None:
         return JSONResponse({"error": _OAUTH_TOKEN_STORE_503_MSG}, status_code=503)
     oidc_config = getattr(request.app.state, "oidc_config", None)
-    if oidc_config is None or not getattr(oidc_config, "enabled", False):
+    # Accept a config that is enabled OR merely transiently un-discovered
+    # (``discovery_retryable`` — the IdP was unreachable at this process's boot).
+    # OIDC is still CONFIGURED there (issuer set); rejecting it would make every
+    # oauth_obo server un-editable/un-disable-able on the console — which never
+    # runs the runtime rediscovery that heals server nodes — until a manual
+    # restart. Reject only a genuinely absent / operator-disabled OIDC (neither
+    # flag set: no issuer configured).
+    oidc_configured = oidc_config is not None and (
+        getattr(oidc_config, "enabled", False) or getattr(oidc_config, "discovery_retryable", False)
+    )
+    if not oidc_configured:
         return JSONResponse(
             {
                 "error": (
@@ -10315,6 +10325,12 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     # Helper returns None when key is absent — fall back to the default.
     auth_type = auth_type_value if auth_type_value is not None else "static"
 
+    # Clean the OAuth text fields ONCE — reused by both the write-time validator
+    # and the persisted ``oauth_cols`` below, so the validated and persisted
+    # values (and the 2048 max_length) can't silently diverge.
+    clean_audience = _clean_oauth_text(body.get("oauth_audience"), max_length=2048)
+    clean_scopes = _clean_oauth_text(body.get("oauth_scopes"))
+
     # sec-1: oauth_user/oauth_obo must use https:// (loopback http allowed for dev).
     err_resp = _enforce_oauth_user_https(auth_type, str(body.get("url", "")).strip())
     if err_resp is not None:
@@ -10324,8 +10340,8 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     err_resp = _enforce_oauth_obo_requirements(
         request,
         auth_type,
-        audience=_clean_oauth_text(body.get("oauth_audience"), max_length=2048),
-        scopes=_clean_oauth_text(body.get("oauth_scopes")),
+        audience=clean_audience,
+        scopes=clean_scopes,
     )
     if err_resp is not None:
         return err_resp
@@ -10363,19 +10379,19 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     # handler applies on a flip: persist only the OAuth columns the target
     # auth_type actually uses, so a row created as oauth_obo can't carry a
     # client_id / registration_mode / AS-URL straight into a later oauth_user
-    # flip. (``oauth_as_issuer_cached`` is discovery-owned and not a create
-    # parameter, so it is dropped from the cleared set here.)
+    # flip. ``oauth_as_issuer_cached`` (nulled by the cleared set for a
+    # non-oauth_user type) IS a valid create parameter, so it passes through
+    # to ``create_mcp_server`` as its default None.
     oauth_cols: dict[str, Any] = {
         "oauth_client_id": _clean_oauth_text(body.get("oauth_client_id")),
-        "oauth_scopes": _clean_oauth_text(body.get("oauth_scopes")),
-        "oauth_audience": _clean_oauth_text(body.get("oauth_audience"), max_length=2048),
+        "oauth_scopes": clean_scopes,
+        "oauth_audience": clean_audience,
         "oauth_registration_mode": _clean_oauth_text(body.get("oauth_registration_mode")),
         "oauth_authorization_server_url": _clean_oauth_text(
             body.get("oauth_authorization_server_url"), max_length=2048
         ),
     }
     oauth_cols.update(_oauth_columns_to_clear(auth_type))
-    oauth_cols.pop("oauth_as_issuer_cached", None)
 
     storage.create_mcp_server(
         server_id=server_id,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -10454,6 +10454,11 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
         ip,
     )
 
+    # Auto-reload nodes so the new server reaches them (and per-user pools
+    # re-prime for active sessions) without a separate /reload — mirrors the
+    # registry-install path.
+    await _notify_nodes_mcp_reload(request)
+
     server = storage.get_mcp_server(server_id)
     return JSONResponse(_mcp_server_to_detail(_mask_mcp_secrets(server or {})))
 
@@ -10801,6 +10806,10 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         ip,
     )
 
+    # Auto-reload nodes so the edit (incl. a pool auth_type flip) reaches them
+    # and active sessions re-prime, without a separate /reload.
+    await _notify_nodes_mcp_reload(request)
+
     server = storage.get_mcp_server(server_id)
     return JSONResponse(_mcp_server_to_detail(_mask_mcp_secrets(server or {})))
 
@@ -10854,14 +10863,25 @@ async def admin_delete_mcp_server(request: Request) -> JSONResponse:
         ip,
     )
 
+    # Auto-reload nodes so they drop the removed server without a separate
+    # /reload.
+    await _notify_nodes_mcp_reload(request)
+
     return JSONResponse({"status": "ok"})
 
 
 async def _notify_nodes_mcp_reload(request: Request) -> dict[str, Any]:
-    """Tell all nodes to re-read the mcp_servers DB table and reconcile."""
-    collector: ClusterCollector = request.app.state.collector
+    """Tell all nodes to re-read the mcp_servers DB table and reconcile.
+
+    Best-effort: if the cluster fan-out infra isn't present (e.g. a minimal
+    test app), the DB write has already landed and nodes pick the change up on
+    their next reconcile — so skip rather than 500 the caller.
+    """
+    collector: ClusterCollector | None = getattr(request.app.state, "collector", None)
+    client: httpx.AsyncClient | None = getattr(request.app.state, "proxy_client", None)
+    if collector is None or client is None:
+        return {}
     nodes = collector.get_all_nodes()
-    client: httpx.AsyncClient = request.app.state.proxy_client
     headers = _proxy_auth_headers(request)
     sem = asyncio.Semaphore(_get_fan_out_limit(request))
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6026,13 +6026,24 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
                 for row in storage.list_mcp_servers()
                 if row.get("auth_type") == "oauth_obo"
             ]
-            for server_name in obo_servers:
+        except Exception:
+            obo_servers = []
+            log.warning(
+                "admin.oidc_identity.obo_server_list_failed user=%s", user_id, exc_info=True
+            )
+        for server_name in obo_servers:
+            # Per-server try/except: a failure on one server must not leave the
+            # remaining servers' cached bearers un-purged for a deprovisioned user.
+            try:
                 if token_store.delete_user_token(user_id, server_name):
                     obo_cache_purged += 1
-        except Exception:
-            log.warning(
-                "admin.oidc_identity.obo_cache_purge_failed user=%s", user_id, exc_info=True
-            )
+            except Exception:
+                log.warning(
+                    "admin.oidc_identity.obo_cache_purge_failed user=%s server=%s",
+                    user_id,
+                    server_name,
+                    exc_info=True,
+                )
 
     audit_uid, ip = _audit_context(request)
     record_audit(
@@ -10081,13 +10092,19 @@ async def admin_list_mcp_servers(request: Request) -> JSONResponse:
     # stack the DB latency on top of the fan-out latency.  Skipped
     # entirely when no row is oauth_user so static-only installs
     # exercise zero new storage queries.
-    has_oauth_user = any(s.get("auth_type") == "oauth_user" for s in servers)
+    from turnstone.core.mcp_oauth import is_user_scoped_auth
+
+    # Both pool-backed types populate mcp_user_tokens (oauth_user: consents;
+    # oauth_obo: minted cache), so run the count for either — it drives the
+    # per-row pill: oauth_user's consented-users count and oauth_obo's
+    # flush-cache action (gated on count>0 in the UI).
+    has_user_scoped = any(is_user_scoped_auth(s.get("auth_type")) for s in servers)
     status_task: asyncio.Task[dict[str, dict[str, dict[str, Any]]]] = asyncio.create_task(
         _collect_mcp_status(request)
     )
     count_task: asyncio.Task[dict[str, int]] | None = (
         asyncio.create_task(asyncio.to_thread(storage.count_mcp_consented_users_grouped_by_server))
-        if has_oauth_user
+        if has_user_scoped
         else None
     )
 
@@ -10109,11 +10126,11 @@ async def admin_list_mcp_servers(request: Request) -> JSONResponse:
             status = node_servers.get(s["name"])
             if status:
                 per_node[node_id] = status
-        # Phase 9: surface the consented-users-count pill for
-        # oauth_user rows.  Aggregate was pre-computed above with a
+        # Surface the count for both pool-backed types (oauth_user consents /
+        # oauth_obo minted-token cache). Aggregate was pre-computed above with a
         # single bulk GROUP BY query; we just look up here.
         consent_count: int | None = None
-        if s.get("auth_type") == "oauth_user":
+        if is_user_scoped_auth(s.get("auth_type")):
             consent_count = consent_counts.get(s["name"], 0)
         s = _mask_mcp_secrets(s, reveal)
         result.append(_mcp_server_to_detail(s, per_node, consent_count))
@@ -10459,11 +10476,17 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         )
         # A FLIP into obo from oauth_user carries oauth_user's AS-consent scopes,
         # which the rfc8693 mint leg would send verbatim as the exchange scope →
-        # invalid_scope → a permanent-failure loop with no operator-fixable
-        # remedy in the error. Clear stale scopes on the flip unless this same
-        # request supplies obo scopes explicitly.
-        if old_auth != "oauth_obo" and "oauth_scopes" not in body:
-            updates["oauth_scopes"] = None
+        # invalid_scope → a permanent-failure loop. Clear the carried-over scopes
+        # on the flip. Robust to the admin form re-submitting the pre-filled old
+        # value: clear UNLESS the operator supplied a genuinely NEW value in this
+        # request (different from the existing row's scopes) — an equal value is
+        # the stale carry-over, not an intentional obo scope.
+        if old_auth != "oauth_obo":
+            body_scopes = (
+                _clean_oauth_text(body["oauth_scopes"]) if "oauth_scopes" in body else None
+            )
+            if body_scopes is None or body_scopes == (existing.get("oauth_scopes") or None):
+                updates["oauth_scopes"] = None
     # Renaming a pool-backed row needs the same per-user-token purge as
     # delete: the tokens are keyed on the OLD ``server_name`` and a row
     # later created with that old name (with attacker-controlled URL)
@@ -10522,11 +10545,16 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         return err_resp
 
     # #551: an oauth_obo row (whether newly flipped or edited) needs an
-    # encryption key + an audience — validated against the post-update value.
+    # encryption key + an audience — validated against the merged post-update
+    # audience. The entra-scope reject, though, must fire ONLY when this request
+    # actually SETS scopes ("oauth_scopes" in updates — from the body or the
+    # flip-clear above), not on the carried-over existing value: otherwise a
+    # pre-existing scoped row under the entra profile becomes un-editable (every
+    # maintenance PUT that doesn't clear scopes would 400).
     audience_now = updates.get("oauth_audience", existing.get("oauth_audience"))
-    scopes_now = updates.get("oauth_scopes", existing.get("oauth_scopes"))
+    scopes_being_set = updates.get("oauth_scopes") if "oauth_scopes" in updates else None
     err_resp = _enforce_oauth_obo_requirements(
-        request, auth_type_now, audience=audience_now, scopes=scopes_now
+        request, auth_type_now, audience=audience_now, scopes=scopes_being_set
     )
     if err_resp is not None:
         return err_resp

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9726,11 +9726,13 @@ async def admin_registry_install(request: Request) -> JSONResponse:
         ip,
     )
 
-    # Auto-reload nodes for one-click UX
-    await _notify_nodes_mcp_reload(request)
-
     server_row = storage.get_mcp_server(server_id)
-    return JSONResponse(_mcp_server_to_detail(_mask_mcp_secrets(server_row or {})))
+    # Auto-reload nodes for one-click UX — scheduled after the response so the
+    # install isn't blocked on cluster fan-out (see _schedule_mcp_reload).
+    return JSONResponse(
+        _mcp_server_to_detail(_mask_mcp_secrets(server_row or {})),
+        background=_schedule_mcp_reload(request),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -10454,13 +10456,14 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
         ip,
     )
 
-    # Auto-reload nodes so the new server reaches them (and per-user pools
-    # re-prime for active sessions) without a separate /reload — mirrors the
-    # registry-install path.
-    await _notify_nodes_mcp_reload(request)
-
     server = storage.get_mcp_server(server_id)
-    return JSONResponse(_mcp_server_to_detail(_mask_mcp_secrets(server or {})))
+    # Auto-reload nodes so the new server reaches them (and per-user pools
+    # re-prime for active sessions) without a separate /reload — scheduled after
+    # the response so the write isn't blocked on cluster fan-out.
+    return JSONResponse(
+        _mcp_server_to_detail(_mask_mcp_secrets(server or {})),
+        background=_schedule_mcp_reload(request),
+    )
 
 
 async def admin_get_mcp_server(request: Request) -> JSONResponse:
@@ -10806,12 +10809,14 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         ip,
     )
 
-    # Auto-reload nodes so the edit (incl. a pool auth_type flip) reaches them
-    # and active sessions re-prime, without a separate /reload.
-    await _notify_nodes_mcp_reload(request)
-
     server = storage.get_mcp_server(server_id)
-    return JSONResponse(_mcp_server_to_detail(_mask_mcp_secrets(server or {})))
+    # Auto-reload nodes so the edit (incl. a pool auth_type flip) reaches them
+    # and active sessions re-prime — scheduled after the response so the write
+    # isn't blocked on cluster fan-out.
+    return JSONResponse(
+        _mcp_server_to_detail(_mask_mcp_secrets(server or {})),
+        background=_schedule_mcp_reload(request),
+    )
 
 
 async def admin_delete_mcp_server(request: Request) -> JSONResponse:
@@ -10863,25 +10868,23 @@ async def admin_delete_mcp_server(request: Request) -> JSONResponse:
         ip,
     )
 
-    # Auto-reload nodes so they drop the removed server without a separate
-    # /reload.
-    await _notify_nodes_mcp_reload(request)
-
-    return JSONResponse({"status": "ok"})
+    # Auto-reload nodes so they drop the removed server — scheduled after the
+    # response so the delete isn't blocked on cluster fan-out.
+    return JSONResponse({"status": "ok"}, background=_schedule_mcp_reload(request))
 
 
 async def _notify_nodes_mcp_reload(request: Request) -> dict[str, Any]:
     """Tell all nodes to re-read the mcp_servers DB table and reconcile.
 
-    Best-effort: if the cluster fan-out infra isn't present (e.g. a minimal
-    test app), the DB write has already landed and nodes pick the change up on
-    their next reconcile — so skip rather than 500 the caller.
+    Drain-style: awaited inline only by the operator-triggered ``POST /reload``,
+    which reports the per-node results and must fail loudly if the fan-out infra
+    is absent. Admin *writes* (create/update/delete/registry-install) never await
+    this — they schedule it best-effort via ``_schedule_mcp_reload`` so a write's
+    response isn't blocked on (nor failed by) cluster reachability.
     """
-    collector: ClusterCollector | None = getattr(request.app.state, "collector", None)
-    client: httpx.AsyncClient | None = getattr(request.app.state, "proxy_client", None)
-    if collector is None or client is None:
-        return {}
+    collector: ClusterCollector = request.app.state.collector
     nodes = collector.get_all_nodes()
+    client: httpx.AsyncClient = request.app.state.proxy_client
     headers = _proxy_auth_headers(request)
     sem = asyncio.Semaphore(_get_fan_out_limit(request))
 
@@ -10897,6 +10900,9 @@ async def _notify_nodes_mcp_reload(request: Request) -> dict[str, Any]:
                     headers=headers,
                     timeout=30,
                 )
+                # A non-2xx reply is a failed reload, not a reached node (httpx
+                # does not raise on status); surface it as an error so _run warns.
+                resp.raise_for_status()
                 return node_id, resp.json()
             except Exception as exc:
                 log.debug("Failed to notify node %s for MCP reload", node_id, exc_info=True)
@@ -10904,6 +10910,49 @@ async def _notify_nodes_mcp_reload(request: Request) -> dict[str, Any]:
 
     results = await asyncio.gather(*[_notify(n) for n in nodes])
     return {nid: data for nid, data in results if data is not None}
+
+
+def _schedule_mcp_reload(request: Request) -> BackgroundTask:
+    """Best-effort node-reload fan-out to run AFTER an admin MCP write's 200.
+
+    Returned as a ``BackgroundTask`` — the "trigger, not drain" contract also
+    used by ``_cascade_cancel_to_children``: the admin write's response is never
+    blocked on the per-node fan-out (each node POST can hit a 30s timeout under
+    the fan-out semaphore), so a fan-out failure can't fail a write that already
+    committed.
+
+    There is no periodic node→DB reconcile — a node that misses this reload
+    keeps serving a stale MCP catalog until the next ``POST /reload`` (or a node
+    restart). So ``_run`` does NOT swallow failures: any unreached node (or a
+    systemic fan-out fault) is logged at WARNING (visible at the default INFO
+    level), and the per-node status view surfaces the divergence. Only
+    ``POST /reload`` awaits the fan-out inline, where draining and reporting
+    per-node results to the operator is the point.
+    """
+
+    async def _run() -> None:
+        try:
+            results = await _notify_nodes_mcp_reload(request)
+        except Exception:
+            log.warning(
+                "auto mcp-reload fan-out failed after admin write; nodes may serve a "
+                "stale MCP catalog until the next POST /reload",
+                exc_info=True,
+            )
+            return
+        unreached = sorted(
+            nid for nid, data in results.items() if isinstance(data, dict) and "error" in data
+        )
+        if unreached:
+            log.warning(
+                "auto mcp-reload did not reach %d of %d node(s) after admin write "
+                "(stale MCP catalog until next reload): %s",
+                len(unreached),
+                len(results),
+                ", ".join(unreached),
+            )
+
+    return BackgroundTask(_run)
 
 
 async def _notify_nodes_mcp_action(request: Request, action: str, name: str) -> dict[str, Any]:
@@ -10932,6 +10981,9 @@ async def _notify_nodes_mcp_action(request: Request, action: str, name: str) -> 
                     headers=headers,
                     timeout=30,
                 )
+                # A non-2xx reply is a failed action, not a reached node (httpx
+                # does not raise on status); surface it as an error to the operator.
+                resp.raise_for_status()
                 return node_id, resp.json()
             except Exception as exc:
                 log.debug(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9682,7 +9682,7 @@ async def admin_registry_install(request: Request) -> JSONResponse:
 
 _MCP_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _MCP_MAX_SERVERS = 200  # fallback; prefer cluster.mcp_max_servers from storage
-_MCP_AUTH_TYPES = frozenset({"none", "static", "oauth_user"})
+_MCP_AUTH_TYPES = frozenset({"none", "static", "oauth_user", "oauth_obo"})
 
 
 def _clean_oauth_text(value: Any, *, max_length: int = 512) -> str | None:
@@ -9714,20 +9714,22 @@ def _parse_auth_type(body: dict[str, Any]) -> tuple[str | None, JSONResponse | N
     auth_type = str(body["auth_type"]).strip()
     if auth_type not in _MCP_AUTH_TYPES:
         return None, JSONResponse(
-            {"error": "auth_type must be 'none', 'static', or 'oauth_user'"},
+            {"error": "auth_type must be 'none', 'static', 'oauth_user', or 'oauth_obo'"},
             status_code=400,
         )
     return auth_type, None
 
 
 def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse | None:
-    """Reject oauth_user MCP server URLs that aren't https (or loopback http).
+    """Reject per-user-auth MCP server URLs that aren't https (or loopback http).
 
-    Belt-and-braces with :func:`turnstone.core.mcp_client._validate_oauth_user_url`
+    Applies to both pool-backed types — ``oauth_user`` and ``oauth_obo`` —
+    since both transmit per-user bearers to the server URL. Belt-and-braces
+    with :func:`turnstone.core.mcp_client._validate_oauth_user_url`
     so a misconfigured row never persists. Returns the error response or
     ``None`` when the input is acceptable.
     """
-    if auth_type != "oauth_user":
+    if auth_type not in ("oauth_user", "oauth_obo"):
         return None
     if not url:
         return None  # presence checked elsewhere; this helper only checks scheme

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9889,6 +9889,22 @@ def _enforce_oauth_obo_requirements(
             },
             status_code=400,
         )
+    if not getattr(oidc_config, "capture_user_credential", False):
+        # The mint redeems the user's CAPTURED IdP refresh token; with capture
+        # off, login persists nothing, so every dispatch returns kind="missing"
+        # and the "sign in again" remedy can never succeed — a permanent
+        # misconfig this choke point exists to reject. (Enabling capture also
+        # requires the encryption key, checked at boot.)
+        return JSONResponse(
+            {
+                "error": (
+                    "auth_type=oauth_obo requires [oidc] capture_user_credential=true "
+                    "so each user's sign-in credential is captured for minting; it is "
+                    "currently disabled, so this server could never obtain a token."
+                )
+            },
+            status_code=400,
+        )
     profile = _obo_profile(request)
     from turnstone.core.mcp_oauth import OBO_GRANT_PROFILES
 
@@ -10551,22 +10567,36 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
             ):
                 del updates[_noop_key]
 
-    # Clear the OAuth columns the target auth_type does NOT use (shared
-    # ``_oauth_columns_to_clear`` policy). ``oauth_client_secret_ct`` is owned by
-    # a dedicated write path (see below).
-    if is_flip:
-        target_auth = new_auth  # non-None: is_flip requires new_auth is not None
-        if is_user_scoped_auth(target_auth):
-            # FLIP into a user-scoped type: recompute the semantic columns from
-            # the body — present → that value, absent → NULL — so neither the
-            # old audience nor the old scopes can leak across the semantic
-            # boundary. The top-of-handler loop already copied any body value
-            # into ``updates``; forcing the key present here NULLs it when the
-            # body omitted it (e.g. an API PUT of just {"auth_type": ...}, or the
-            # console form clearing the field on the auth-type switch).
-            updates["oauth_audience"] = updates.get("oauth_audience")
-            updates["oauth_scopes"] = updates.get("oauth_scopes")
-        updates.update(_oauth_columns_to_clear(target_auth))
+    # Scrub the OAuth columns the target auth_type does NOT use — on EVERY write,
+    # not just a flip. This is a SECURITY invariant, not a flip nicety: a
+    # same-type edit can still inject a column the type doesn't use (e.g. an API
+    # PUT of {"auth_type":"static","oauth_authorization_server_url":"…attacker…"}
+    # onto a static row), which — because oauth_user legitimately USES that
+    # column — would then survive a later flip to oauth_user and redirect every
+    # consenting user's OAuth traffic. The persisted OAuth columns must be a pure
+    # function of the target auth_type (the create handler enforces the same via
+    # ``_oauth_columns_to_clear``). ``oauth_client_secret_ct`` is owned by a
+    # dedicated write path (see below).
+    target_auth = new_auth if new_auth is not None else old_auth
+    if is_flip and new_auth is not None and is_user_scoped_auth(new_auth):
+        # FLIP into a user-scoped type: the columns whose MEANING differs across
+        # oauth_user↔oauth_obo must be recomputed from the body — present → that
+        # value, absent → NULL — never inherited from the old model's row. For
+        # oauth_audience/oauth_scopes this is the semantic-boundary rule; for a
+        # flip INTO oauth_user the oauth_user-only columns (client_id /
+        # registration / AS-URL) are also recomputed, so a stale/injected value
+        # left on the pre-flip static/none/obo row cannot carry in (those models
+        # don't use these columns, so the operator supplies them fresh here).
+        updates["oauth_audience"] = updates.get("oauth_audience")
+        updates["oauth_scopes"] = updates.get("oauth_scopes")
+        if new_auth == "oauth_user":
+            for _user_col in (
+                "oauth_client_id",
+                "oauth_registration_mode",
+                "oauth_authorization_server_url",
+            ):
+                updates[_user_col] = updates.get(_user_col)
+    updates.update(_oauth_columns_to_clear(target_auth))
     # Renaming a pool-backed row needs the same per-user-token purge as
     # delete: the tokens are keyed on the OLD ``server_name`` and a row
     # later created with that old name (with attacker-controlled URL)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9802,6 +9802,47 @@ def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse |
     return None
 
 
+def _obo_profile(request: Request) -> str:
+    """Deployment-level ``[oidc] obo_grant_profile`` (``""`` when OIDC absent).
+
+    One reader for the profile so the create handler, the update handler, and
+    the write-time enforcement never diverge on how they resolve it.
+    """
+    oidc_config = getattr(request.app.state, "oidc_config", None)
+    return str(getattr(oidc_config, "obo_grant_profile", "") or "")
+
+
+def _oauth_columns_to_clear(auth_type: str | None) -> dict[str, None]:
+    """OAuth columns to force-NULL for a row of *auth_type* (shared write policy).
+
+    Single source of the "which OAuth columns does this auth model use" policy,
+    consumed by both the create and update handlers so they cannot drift.
+    ``oauth_user`` uses every column (nothing cleared); ``oauth_obo`` uses
+    ``oauth_audience`` (+ ``oauth_scopes`` under rfc8693) but none of the
+    oauth_user-only columns; ``static``/``none`` use no OAuth columns at all.
+    ``oauth_client_secret_ct`` is owned by a dedicated write path and is not
+    included here. Callers that cannot persist ``oauth_as_issuer_cached`` (the
+    create path) drop that key.
+    """
+    if auth_type == "oauth_user":
+        return {}
+    if auth_type == "oauth_obo":
+        return {
+            "oauth_client_id": None,
+            "oauth_registration_mode": None,
+            "oauth_authorization_server_url": None,
+            "oauth_as_issuer_cached": None,
+        }
+    return {  # static / none
+        "oauth_client_id": None,
+        "oauth_scopes": None,
+        "oauth_audience": None,
+        "oauth_registration_mode": None,
+        "oauth_authorization_server_url": None,
+        "oauth_as_issuer_cached": None,
+    }
+
+
 def _enforce_oauth_obo_requirements(
     request: Request, auth_type: str, *, audience: str | None, scopes: str | None
 ) -> JSONResponse | None:
@@ -9814,6 +9855,14 @@ def _enforce_oauth_obo_requirements(
       per-user mint-cache rows AND makes ``initialize_mcp_crypto_state``
       ``SystemExit(1)`` at the next restart, so accepting one keyless plants a
       deferred whole-cluster boot failure.
+    - **OIDC not enabled / no captured-credential source** → 400. The mint
+      redeems the user's captured IdP credential, so an install with no
+      ``[oidc]`` issuer (or OIDC operator-disabled) can NEVER mint — every tool
+      call would return ``mcp_refresh_unavailable`` ("please retry") forever, a
+      permanent misconfig dressed as a transient. Reject at write time.
+    - **Invalid ``obo_grant_profile``** → 400. A typo'd deployment profile
+      leaves the mint leg unresolved (``obo_misconfigured`` per dispatch), so
+      surface it here rather than as a runtime transient that never heals.
     - **No ``oauth_audience``** → 400. The mint engine hard-requires the
       downstream audience; without it every tool call fails transient and logs
       ``obo_misconfigured``. Reject here, exactly as bad URL schemes are.
@@ -9827,6 +9876,33 @@ def _enforce_oauth_obo_requirements(
         return None
     if getattr(request.app.state, "mcp_token_store", None) is None:
         return JSONResponse({"error": _OAUTH_TOKEN_STORE_503_MSG}, status_code=503)
+    oidc_config = getattr(request.app.state, "oidc_config", None)
+    if oidc_config is None or not getattr(oidc_config, "enabled", False):
+        return JSONResponse(
+            {
+                "error": (
+                    "auth_type=oauth_obo requires OIDC sign-in to be configured and "
+                    "enabled (it mints per-server tokens from each user's Turnstone "
+                    "sign-in). Configure [oidc] and capture_user_credential, or use "
+                    "auth_type=oauth_user for per-server consent."
+                )
+            },
+            status_code=400,
+        )
+    profile = _obo_profile(request)
+    from turnstone.core.mcp_oauth import OBO_GRANT_PROFILES
+
+    if profile not in OBO_GRANT_PROFILES:
+        return JSONResponse(
+            {
+                "error": (
+                    f"[oidc] obo_grant_profile={profile!r} is not a valid grant profile "
+                    f"({', '.join(sorted(OBO_GRANT_PROFILES))}); fix the deployment "
+                    "config before configuring oauth_obo servers"
+                )
+            },
+            status_code=400,
+        )
     if not (audience or "").strip():
         return JSONResponse(
             {
@@ -9837,20 +9913,17 @@ def _enforce_oauth_obo_requirements(
             },
             status_code=400,
         )
-    if (scopes or "").strip():
-        oidc_config = getattr(request.app.state, "oidc_config", None)
-        profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
-        if profile == "entra":
-            return JSONResponse(
-                {
-                    "error": (
-                        "oauth_scopes is not used by the entra grant profile "
-                        "(it mints <audience>/.default); leave it empty or switch "
-                        "the deployment to the rfc8693 profile"
-                    )
-                },
-                status_code=400,
-            )
+    if (scopes or "").strip() and profile == "entra":
+        return JSONResponse(
+            {
+                "error": (
+                    "oauth_scopes is not used by the entra grant profile "
+                    "(it mints <audience>/.default); leave it empty or switch "
+                    "the deployment to the rfc8693 profile"
+                )
+            },
+            status_code=400,
+        )
     return None
 
 
@@ -10272,30 +10345,23 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     headers_dict = body.get("headers", {})
     env_dict = body.get("env", {})
 
-    # Column policy — mirror of the update handler's clearing rules: persist
-    # only the OAuth columns the target auth_type actually uses, so a later
-    # auth_type flip can't resurrect values the operator never intended for
-    # the new mode (the update path clears on TRANSITION; without the same
-    # policy here, a row CREATED as oauth_obo could carry a client_id /
-    # registration_mode / AS-URL straight into a later oauth_user flip).
-    oauth_client_id = _clean_oauth_text(body.get("oauth_client_id"))
-    oauth_scopes = _clean_oauth_text(body.get("oauth_scopes"))
-    oauth_audience = _clean_oauth_text(body.get("oauth_audience"), max_length=2048)
-    oauth_registration_mode = _clean_oauth_text(body.get("oauth_registration_mode"))
-    oauth_as_url = _clean_oauth_text(body.get("oauth_authorization_server_url"), max_length=2048)
-    if auth_type == "oauth_obo":
-        # obo uses audience (+ scopes under rfc8693) but none of the
-        # oauth_user-only columns.
-        oauth_client_id = None
-        oauth_registration_mode = None
-        oauth_as_url = None
-    elif auth_type != "oauth_user":
-        # static/none use no OAuth columns at all.
-        oauth_client_id = None
-        oauth_scopes = None
-        oauth_audience = None
-        oauth_registration_mode = None
-        oauth_as_url = None
+    # Column policy — the SAME ``_oauth_columns_to_clear`` rule the update
+    # handler applies on a flip: persist only the OAuth columns the target
+    # auth_type actually uses, so a row created as oauth_obo can't carry a
+    # client_id / registration_mode / AS-URL straight into a later oauth_user
+    # flip. (``oauth_as_issuer_cached`` is discovery-owned and not a create
+    # parameter, so it is dropped from the cleared set here.)
+    oauth_cols: dict[str, Any] = {
+        "oauth_client_id": _clean_oauth_text(body.get("oauth_client_id")),
+        "oauth_scopes": _clean_oauth_text(body.get("oauth_scopes")),
+        "oauth_audience": _clean_oauth_text(body.get("oauth_audience"), max_length=2048),
+        "oauth_registration_mode": _clean_oauth_text(body.get("oauth_registration_mode")),
+        "oauth_authorization_server_url": _clean_oauth_text(
+            body.get("oauth_authorization_server_url"), max_length=2048
+        ),
+    }
+    oauth_cols.update(_oauth_columns_to_clear(auth_type))
+    oauth_cols.pop("oauth_as_issuer_cached", None)
 
     storage.create_mcp_server(
         server_id=server_id,
@@ -10310,11 +10376,7 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
         enabled=bool(body.get("enabled", True)),
         created_by=audit_uid,
         auth_type=auth_type,
-        oauth_client_id=oauth_client_id,
-        oauth_scopes=oauth_scopes,
-        oauth_audience=oauth_audience,
-        oauth_registration_mode=oauth_registration_mode,
-        oauth_authorization_server_url=oauth_as_url,
+        **oauth_cols,
     )
 
     # Encrypt + persist the operator-supplied client secret via the dedicated
@@ -10467,87 +10529,44 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
 
     old_auth = existing.get("auth_type")
     new_auth = updates.get("auth_type")
+    # A flip is any auth_type transition. ``oauth_audience`` and ``oauth_scopes``
+    # keep their meaning only WITHIN an auth type — across oauth_user↔oauth_obo
+    # the audience is a resource indicator vs. an IdP-side app identifier, and
+    # the scopes are AS-consent scopes vs. an rfc8693 exchange scope — so on a
+    # flip they must NEVER carry from the old row; they are recomputed from the
+    # request body (or NULLed) for the target type below.
+    is_flip = new_auth is not None and new_auth != old_auth
 
-    # A request that re-sends oauth_scopes / oauth_audience equal to the row's
-    # current value is a no-op — drop it from ``updates``. The admin form
-    # pre-fills both fields and submits them on every save, and three rules
-    # below key on "this request SETS the column": the entra-profile scope
-    # rejection (without this, a pre-existing scoped row under the entra
-    # profile is un-editable — every unrelated save 400s), the mint-cache
-    # purge triggers (a no-op re-send must not flush every user's cache), and
-    # the flip-into-oauth_user clearing of obo-era values (a re-sent stale
-    # pre-fill must not masquerade as an explicit set).
-    for _noop_key in ("oauth_scopes", "oauth_audience"):
-        if _noop_key in updates and (updates[_noop_key] or None) == (
-            existing.get(_noop_key) or None
-        ):
-            del updates[_noop_key]
+    if not is_flip:
+        # SAME-TYPE edit: a re-send of oauth_scopes / oauth_audience equal to the
+        # row's current value is a genuine no-op — drop it from ``updates`` so the
+        # admin form's unconditional re-send of pre-filled fields doesn't (a)
+        # trip the mint-cache purge triggers or (b) trip the entra scope
+        # rejection that would otherwise make a legacy-scoped row un-editable.
+        # (On a flip this comparison is meaningless — the old value is in the
+        # other auth model's semantics — so it is skipped.)
+        for _noop_key in ("oauth_scopes", "oauth_audience"):
+            if _noop_key in updates and (updates[_noop_key] or None) == (
+                existing.get(_noop_key) or None
+            ):
+                del updates[_noop_key]
 
-    # Clear the OAuth columns the target auth_type does NOT use, so a stale
-    # client_id / audience can't leak back on a later flip. static/none use
-    # none; oauth_obo uses oauth_audience (+ oauth_scopes) but none of the
-    # oauth_user-only columns; oauth_user uses client_id / registration /
-    # AS-URL / scopes plus an audience with DIFFERENT semantics (RFC 8707
-    # resource indicator, not the obo IdP-side app identifier).
-    # ``oauth_client_secret_ct`` is owned by a dedicated write path (see below).
-    if new_auth and not is_user_scoped_auth(new_auth):
-        # → static/none: clear every OAuth column.
-        updates.update(
-            {
-                "oauth_client_id": None,
-                "oauth_scopes": None,
-                "oauth_audience": None,
-                "oauth_registration_mode": None,
-                "oauth_authorization_server_url": None,
-                "oauth_as_issuer_cached": None,
-            }
-        )
-    elif new_auth == "oauth_obo":
-        # obo keeps audience (it needs it); clear the oauth_user-only columns.
-        updates.update(
-            {
-                "oauth_client_id": None,
-                "oauth_registration_mode": None,
-                "oauth_authorization_server_url": None,
-                "oauth_as_issuer_cached": None,
-            }
-        )
-        # A FLIP into obo carries oauth_user's AS-consent scopes, which mean
-        # something different in each grant profile:
-        #   entra   — scopes are never used (the leg pins <audience>/.default),
-        #             so clear the carry-over unless this request typed a
-        #             genuinely NEW value (which the enforce step below then
-        #             rejects loudly rather than silently discarding);
-        #   rfc8693 — scopes ARE the token-exchange scope, so honor the
-        #             request verbatim: a value equal to the old consent
-        #             scopes is a deliberate keep (the operator sees the
-        #             field on the flip form), and only an OMITTED field
-        #             clears the oauth_user consent scopes (different
-        #             semantics under the new auth model).
-        if old_auth != "oauth_obo":
-            profile = str(
-                getattr(getattr(request.app.state, "oidc_config", None), "obo_grant_profile", "")
-                or ""
-            )
-            if profile == "entra":
-                if "oauth_scopes" not in updates:
-                    updates["oauth_scopes"] = None
-            elif "oauth_scopes" not in body:
-                updates["oauth_scopes"] = None
-    elif new_auth == "oauth_user" and old_auth != "oauth_user":
-        # Flipping INTO oauth_user: the obo-era oauth_audience is an IdP-side
-        # app identifier (api://<guid> on Entra, a client id on Keycloak), NOT
-        # the RFC 8707 resource indicator oauth_user passes to its per-server
-        # AS — carried over, build_authorize_url requests (and the token
-        # validator accepts) a wrong-resource token that 401s on every
-        # dispatch with no visible cause. Same for rfc8693 exchange scopes
-        # leaking into consent scopes. Clear both unless this request
-        # explicitly sets them. (On main this was structurally impossible —
-        # any non-oauth_user row had every OAuth column nulled.)
-        if "oauth_audience" not in updates:
-            updates["oauth_audience"] = None
-        if "oauth_scopes" not in updates and "oauth_scopes" not in body:
-            updates["oauth_scopes"] = None
+    # Clear the OAuth columns the target auth_type does NOT use (shared
+    # ``_oauth_columns_to_clear`` policy). ``oauth_client_secret_ct`` is owned by
+    # a dedicated write path (see below).
+    if is_flip:
+        target_auth = new_auth  # non-None: is_flip requires new_auth is not None
+        if is_user_scoped_auth(target_auth):
+            # FLIP into a user-scoped type: recompute the semantic columns from
+            # the body — present → that value, absent → NULL — so neither the
+            # old audience nor the old scopes can leak across the semantic
+            # boundary. The top-of-handler loop already copied any body value
+            # into ``updates``; forcing the key present here NULLs it when the
+            # body omitted it (e.g. an API PUT of just {"auth_type": ...}, or the
+            # console form clearing the field on the auth-type switch).
+            updates["oauth_audience"] = updates.get("oauth_audience")
+            updates["oauth_scopes"] = updates.get("oauth_scopes")
+        updates.update(_oauth_columns_to_clear(target_auth))
     # Renaming a pool-backed row needs the same per-user-token purge as
     # delete: the tokens are keyed on the OLD ``server_name`` and a row
     # later created with that old name (with attacker-controlled URL)

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6002,23 +6002,36 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
 
     storage.delete_oidc_identity(issuer, subject)
 
-    # #551: unlinking the identity must also revoke the captured IdP refresh
-    # credential (keyed on (user_id, issuer)) — otherwise a deprovisioned user's
-    # scheduled/autonomous runs keep minting oauth_obo access tokens
-    # indefinitely (rotation write-back keeps the RT alive). Best-effort: a
-    # failure here must not leave the identity un-deleted.
+    # #551: unlinking the identity must revoke the captured IdP refresh
+    # credential (keyed on (user_id, issuer)) AND purge the already-minted
+    # oauth_obo access-token cache rows — otherwise a deprovisioned user's
+    # scheduled/autonomous runs keep executing MCP tool calls with the still-fresh
+    # cached bearer until it expires (deleting only the credential stops FUTURE
+    # mints but not the live cache). Best-effort: a failure must not leave the
+    # identity un-deleted.
+    user_id = identity["user_id"]
     credential_revoked = False
+    obo_cache_purged = 0
     token_store = getattr(request.app.state, "mcp_token_store", None)
     if token_store is not None:
         try:
-            credential_revoked = bool(
-                token_store.delete_oidc_credential(identity["user_id"], issuer)
-            )
+            credential_revoked = bool(token_store.delete_oidc_credential(user_id, issuer))
         except Exception:
             log.warning(
-                "admin.oidc_identity.credential_revoke_failed user=%s",
-                identity["user_id"],
-                exc_info=True,
+                "admin.oidc_identity.credential_revoke_failed user=%s", user_id, exc_info=True
+            )
+        try:
+            obo_servers = [
+                row["name"]
+                for row in storage.list_mcp_servers()
+                if row.get("auth_type") == "oauth_obo"
+            ]
+            for server_name in obo_servers:
+                if token_store.delete_user_token(user_id, server_name):
+                    obo_cache_purged += 1
+        except Exception:
+            log.warning(
+                "admin.oidc_identity.obo_cache_purge_failed user=%s", user_id, exc_info=True
             )
 
     audit_uid, ip = _audit_context(request)
@@ -6028,11 +6041,26 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
         "oidc_identity.delete",
         "oidc_identity",
         f"{issuer}:{subject}",
-        {"user_id": identity["user_id"], "obo_credential_revoked": credential_revoked},
+        {
+            "user_id": user_id,
+            "obo_credential_revoked": credential_revoked,
+            "obo_cache_rows_purged": obo_cache_purged,
+        },
         ip,
     )
 
-    return JSONResponse({"status": "ok"})
+    # Note: warmed per-user pool sessions on server nodes hold the bearer
+    # in-memory and self-clear at token TTL / idle eviction; the console has no
+    # per-user cross-node eviction primitive. Credential + cache purge stop all
+    # FUTURE dispatch (next call re-reads the now-empty cache → mint → missing
+    # credential → re-login), bounding residual access to the current token TTL.
+    return JSONResponse(
+        {
+            "status": "ok",
+            "obo_credential_revoked": credential_revoked,
+            "obo_cache_rows_purged": obo_cache_purged,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -9748,7 +9776,9 @@ def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse |
     so a misconfigured row never persists. Returns the error response or
     ``None`` when the input is acceptable.
     """
-    if auth_type not in ("oauth_user", "oauth_obo"):
+    from turnstone.core.mcp_oauth import is_user_scoped_auth
+
+    if not is_user_scoped_auth(auth_type):
         return None
     if not url:
         return None  # presence checked elsewhere; this helper only checks scheme
@@ -9762,7 +9792,7 @@ def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse |
 
 
 def _enforce_oauth_obo_requirements(
-    request: Request, auth_type: str, *, audience: str | None
+    request: Request, auth_type: str, *, audience: str | None, scopes: str | None
 ) -> JSONResponse | None:
     """Write-time validation for ``oauth_obo`` rows (issue #551).
 
@@ -9776,6 +9806,11 @@ def _enforce_oauth_obo_requirements(
     - **No ``oauth_audience``** → 400. The mint engine hard-requires the
       downstream audience; without it every tool call fails transient and logs
       ``obo_misconfigured``. Reject here, exactly as bad URL schemes are.
+    - **``oauth_scopes`` under the entra grant profile** → 400. Entra's ``scope``
+      is its only audience carrier (the leg pins ``<audience>/.default``), so a
+      per-server scope list is silently ignored at mint time — reject it at the
+      form instead of letting the operator believe it took effect. (The rfc8693
+      profile does use ``oauth_scopes``, so it is allowed there.)
     """
     if auth_type != "oauth_obo":
         return None
@@ -9791,6 +9826,20 @@ def _enforce_oauth_obo_requirements(
             },
             status_code=400,
         )
+    if (scopes or "").strip():
+        oidc_config = getattr(request.app.state, "oidc_config", None)
+        profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
+        if profile == "entra":
+            return JSONResponse(
+                {
+                    "error": (
+                        "oauth_scopes is not used by the entra grant profile "
+                        "(it mints <audience>/.default); leave it empty or switch "
+                        "the deployment to the rfc8693 profile"
+                    )
+                },
+                status_code=400,
+            )
     return None
 
 
@@ -10170,7 +10219,10 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
 
     # #551: oauth_obo needs an encryption key + an audience at write time.
     err_resp = _enforce_oauth_obo_requirements(
-        request, auth_type, audience=_clean_oauth_text(body.get("oauth_audience"), max_length=2048)
+        request,
+        auth_type,
+        audience=_clean_oauth_text(body.get("oauth_audience"), max_length=2048),
+        scopes=_clean_oauth_text(body.get("oauth_scopes")),
     )
     if err_resp is not None:
         return err_resp
@@ -10396,7 +10448,7 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
             }
         )
     elif new_auth == "oauth_obo":
-        # obo keeps audience/scopes (it needs them); clear oauth_user-only cols.
+        # obo keeps audience (it needs it); clear the oauth_user-only columns.
         updates.update(
             {
                 "oauth_client_id": None,
@@ -10405,6 +10457,13 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
                 "oauth_as_issuer_cached": None,
             }
         )
+        # A FLIP into obo from oauth_user carries oauth_user's AS-consent scopes,
+        # which the rfc8693 mint leg would send verbatim as the exchange scope →
+        # invalid_scope → a permanent-failure loop with no operator-fixable
+        # remedy in the error. Clear stale scopes on the flip unless this same
+        # request supplies obo scopes explicitly.
+        if old_auth != "oauth_obo" and "oauth_scopes" not in body:
+            updates["oauth_scopes"] = None
     # Renaming a pool-backed row needs the same per-user-token purge as
     # delete: the tokens are keyed on the OLD ``server_name`` and a row
     # later created with that old name (with attacker-controlled URL)
@@ -10430,6 +10489,17 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         and "url" in updates
         and existing.get("url", "") != updates["url"]
     )
+    # Changing oauth_audience on a pool-backed row is a token-binding change too:
+    # minted obo bearers (and oauth_user tokens) are audience-scoped, so cached
+    # rows for the OLD audience must be purged or a privilege reduction silently
+    # doesn't take effect until they expire. (auth_type flips already purge, so
+    # only guard the same-type edit here.)
+    audience_changing = (
+        is_user_scoped_auth(old_auth)
+        and (new_auth is None or new_auth == old_auth)
+        and "oauth_audience" in updates
+        and (existing.get("oauth_audience") or "") != (updates["oauth_audience"] or "")
+    )
     # Leaving oauth_user (to static/none OR to oauth_obo, which doesn't use the
     # per-server client secret) clears the encrypted secret column below.
     leaving_oauth_user = (
@@ -10454,7 +10524,10 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # #551: an oauth_obo row (whether newly flipped or edited) needs an
     # encryption key + an audience — validated against the post-update value.
     audience_now = updates.get("oauth_audience", existing.get("oauth_audience"))
-    err_resp = _enforce_oauth_obo_requirements(request, auth_type_now, audience=audience_now)
+    scopes_now = updates.get("oauth_scopes", existing.get("oauth_scopes"))
+    err_resp = _enforce_oauth_obo_requirements(
+        request, auth_type_now, audience=audience_now, scopes=scopes_now
+    )
     if err_resp is not None:
         return err_resp
 
@@ -10464,11 +10537,12 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     audit_uid, ip = _audit_context(request)
 
     # Purge per-user tokens + pending OAuth states keyed on the OLD name on
-    # rename, on any pool-backed auth_type transition, or on URL change for a
-    # pool-backed row. All cases would otherwise leave tokens
-    # orphaned-and-rebindable (the OAuth tables key on the mutable
-    # ``server_name`` and tokens are bound to the URL active at mint/consent time).
-    if name_changing or auth_type_purge or url_changing:
+    # rename, on any pool-backed auth_type transition, on URL change, or on
+    # audience change for a pool-backed row. All cases would otherwise leave
+    # tokens orphaned-and-rebindable or bound to a superseded URL/audience (the
+    # OAuth tables key on the mutable ``server_name`` and tokens are bound to the
+    # URL + audience active at mint/consent time).
+    if name_changing or auth_type_purge or url_changing or audience_changing:
         purge_target = existing.get("name", "")
         if purge_target:
             try:
@@ -10793,10 +10867,16 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
     existing = storage.get_mcp_server_by_name(name)
     if existing is None:
         return JSONResponse({"error": "No such server"}, status_code=404)
-    # Both pool-backed types populate mcp_user_tokens (oauth_user: consent
-    # tokens; oauth_obo: minted cache rows), so bulk-revoke serves both — it is
-    # the documented remediation for the stale rows an oauth_user→oauth_obo flip
-    # leaves behind.
+    # Both pool-backed types populate mcp_user_tokens, but the semantics differ
+    # and must be honest (issue #551): for oauth_user, deleting the rows is a
+    # durable REVOCATION — users lose access until they re-consent. For
+    # oauth_obo, the per-server rows are a mint CACHE; the shared per-user
+    # credential survives (it is issuer-scoped, not per-server, and IdP-governed),
+    # so the next dispatch simply re-mints. Bulk-revoke on an obo server is
+    # therefore a cache FLUSH (force re-mint, e.g. after narrowing the audience),
+    # NOT a consent revocation — surfaced via a distinct audit event + response
+    # ``effect`` so an operator is never told access was cut when it re-mints.
+    is_obo = existing.get("auth_type") == "oauth_obo"
     if not is_user_scoped_auth(existing.get("auth_type")):
         return JSONResponse(
             {"error": "bulk-revoke is only valid for oauth_user or oauth_obo servers"},
@@ -10816,7 +10896,7 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
     record_audit(
         storage,
         audit_uid,
-        "mcp_server.oauth.bulk_revoked",
+        "mcp_server.oauth.obo_cache_flushed" if is_obo else "mcp_server.oauth.bulk_revoked",
         "mcp_server",
         target_id,
         {
@@ -10824,6 +10904,7 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
             "rows_deleted": deleted,
             "consented_users_before": consented_before,
             "upstream_revoke_outcome": "bulk_admin_no_upstream",
+            "effect": "cache_flush_remints" if is_obo else "revoked_until_reconsent",
         },
         ip,
     )
@@ -10833,6 +10914,9 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
             "status": "ok",
             "rows_deleted": deleted,
             "consented_users_before": consented_before,
+            # Honest semantics: obo re-mints on next use (revoke at the IdP or
+            # unlink the identity to cut a user off); oauth_user needs re-consent.
+            "effect": "cache_flush_remints" if is_obo else "revoked_until_reconsent",
         }
     )
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -57,6 +57,7 @@ from turnstone.core.auth import (
     require_permission,
 )
 from turnstone.core.deadline import DeadlineExceededError, run_with_deadline
+from turnstone.core.mcp_crypto import is_user_scoped_auth
 from turnstone.core.memory import get_workstream_display_names
 from turnstone.core.rendezvous import NoAvailableNodeError
 from turnstone.core.session_replay import session_replay_preamble
@@ -9787,7 +9788,6 @@ def _enforce_oauth_user_https(auth_type: str, url: str | None) -> JSONResponse |
     so a misconfigured row never persists. Returns the error response or
     ``None`` when the input is acceptable.
     """
-    from turnstone.core.mcp_oauth import is_user_scoped_auth
 
     if not is_user_scoped_auth(auth_type):
         return None
@@ -10092,7 +10092,6 @@ async def admin_list_mcp_servers(request: Request) -> JSONResponse:
     # stack the DB latency on top of the fan-out latency.  Skipped
     # entirely when no row is oauth_user so static-only installs
     # exercise zero new storage queries.
-    from turnstone.core.mcp_oauth import is_user_scoped_auth
 
     # Both pool-backed types populate mcp_user_tokens (oauth_user: consents;
     # oauth_obo: minted cache), so run the count for either — it drives the
@@ -10273,6 +10272,31 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
     headers_dict = body.get("headers", {})
     env_dict = body.get("env", {})
 
+    # Column policy — mirror of the update handler's clearing rules: persist
+    # only the OAuth columns the target auth_type actually uses, so a later
+    # auth_type flip can't resurrect values the operator never intended for
+    # the new mode (the update path clears on TRANSITION; without the same
+    # policy here, a row CREATED as oauth_obo could carry a client_id /
+    # registration_mode / AS-URL straight into a later oauth_user flip).
+    oauth_client_id = _clean_oauth_text(body.get("oauth_client_id"))
+    oauth_scopes = _clean_oauth_text(body.get("oauth_scopes"))
+    oauth_audience = _clean_oauth_text(body.get("oauth_audience"), max_length=2048)
+    oauth_registration_mode = _clean_oauth_text(body.get("oauth_registration_mode"))
+    oauth_as_url = _clean_oauth_text(body.get("oauth_authorization_server_url"), max_length=2048)
+    if auth_type == "oauth_obo":
+        # obo uses audience (+ scopes under rfc8693) but none of the
+        # oauth_user-only columns.
+        oauth_client_id = None
+        oauth_registration_mode = None
+        oauth_as_url = None
+    elif auth_type != "oauth_user":
+        # static/none use no OAuth columns at all.
+        oauth_client_id = None
+        oauth_scopes = None
+        oauth_audience = None
+        oauth_registration_mode = None
+        oauth_as_url = None
+
     storage.create_mcp_server(
         server_id=server_id,
         name=name,
@@ -10286,13 +10310,11 @@ async def admin_create_mcp_server(request: Request) -> JSONResponse:
         enabled=bool(body.get("enabled", True)),
         created_by=audit_uid,
         auth_type=auth_type,
-        oauth_client_id=_clean_oauth_text(body.get("oauth_client_id")),
-        oauth_scopes=_clean_oauth_text(body.get("oauth_scopes")),
-        oauth_audience=_clean_oauth_text(body.get("oauth_audience"), max_length=2048),
-        oauth_registration_mode=_clean_oauth_text(body.get("oauth_registration_mode")),
-        oauth_authorization_server_url=_clean_oauth_text(
-            body.get("oauth_authorization_server_url"), max_length=2048
-        ),
+        oauth_client_id=oauth_client_id,
+        oauth_scopes=oauth_scopes,
+        oauth_audience=oauth_audience,
+        oauth_registration_mode=oauth_registration_mode,
+        oauth_authorization_server_url=oauth_as_url,
     )
 
     # Encrypt + persist the operator-supplied client secret via the dedicated
@@ -10443,14 +10465,30 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         if _oauth_url_key in body:
             updates[_oauth_url_key] = _clean_oauth_text(body[_oauth_url_key], max_length=2048)
 
-    from turnstone.core.mcp_oauth import is_user_scoped_auth
-
     old_auth = existing.get("auth_type")
     new_auth = updates.get("auth_type")
+
+    # A request that re-sends oauth_scopes / oauth_audience equal to the row's
+    # current value is a no-op — drop it from ``updates``. The admin form
+    # pre-fills both fields and submits them on every save, and three rules
+    # below key on "this request SETS the column": the entra-profile scope
+    # rejection (without this, a pre-existing scoped row under the entra
+    # profile is un-editable — every unrelated save 400s), the mint-cache
+    # purge triggers (a no-op re-send must not flush every user's cache), and
+    # the flip-into-oauth_user clearing of obo-era values (a re-sent stale
+    # pre-fill must not masquerade as an explicit set).
+    for _noop_key in ("oauth_scopes", "oauth_audience"):
+        if _noop_key in updates and (updates[_noop_key] or None) == (
+            existing.get(_noop_key) or None
+        ):
+            del updates[_noop_key]
+
     # Clear the OAuth columns the target auth_type does NOT use, so a stale
     # client_id / audience can't leak back on a later flip. static/none use
     # none; oauth_obo uses oauth_audience (+ oauth_scopes) but none of the
-    # oauth_user-only columns; oauth_user uses them all.
+    # oauth_user-only columns; oauth_user uses client_id / registration /
+    # AS-URL / scopes plus an audience with DIFFERENT semantics (RFC 8707
+    # resource indicator, not the obo IdP-side app identifier).
     # ``oauth_client_secret_ct`` is owned by a dedicated write path (see below).
     if new_auth and not is_user_scoped_auth(new_auth):
         # → static/none: clear every OAuth column.
@@ -10474,19 +10512,42 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
                 "oauth_as_issuer_cached": None,
             }
         )
-        # A FLIP into obo from oauth_user carries oauth_user's AS-consent scopes,
-        # which the rfc8693 mint leg would send verbatim as the exchange scope →
-        # invalid_scope → a permanent-failure loop. Clear the carried-over scopes
-        # on the flip. Robust to the admin form re-submitting the pre-filled old
-        # value: clear UNLESS the operator supplied a genuinely NEW value in this
-        # request (different from the existing row's scopes) — an equal value is
-        # the stale carry-over, not an intentional obo scope.
+        # A FLIP into obo carries oauth_user's AS-consent scopes, which mean
+        # something different in each grant profile:
+        #   entra   — scopes are never used (the leg pins <audience>/.default),
+        #             so clear the carry-over unless this request typed a
+        #             genuinely NEW value (which the enforce step below then
+        #             rejects loudly rather than silently discarding);
+        #   rfc8693 — scopes ARE the token-exchange scope, so honor the
+        #             request verbatim: a value equal to the old consent
+        #             scopes is a deliberate keep (the operator sees the
+        #             field on the flip form), and only an OMITTED field
+        #             clears the oauth_user consent scopes (different
+        #             semantics under the new auth model).
         if old_auth != "oauth_obo":
-            body_scopes = (
-                _clean_oauth_text(body["oauth_scopes"]) if "oauth_scopes" in body else None
+            profile = str(
+                getattr(getattr(request.app.state, "oidc_config", None), "obo_grant_profile", "")
+                or ""
             )
-            if body_scopes is None or body_scopes == (existing.get("oauth_scopes") or None):
+            if profile == "entra":
+                if "oauth_scopes" not in updates:
+                    updates["oauth_scopes"] = None
+            elif "oauth_scopes" not in body:
                 updates["oauth_scopes"] = None
+    elif new_auth == "oauth_user" and old_auth != "oauth_user":
+        # Flipping INTO oauth_user: the obo-era oauth_audience is an IdP-side
+        # app identifier (api://<guid> on Entra, a client id on Keycloak), NOT
+        # the RFC 8707 resource indicator oauth_user passes to its per-server
+        # AS — carried over, build_authorize_url requests (and the token
+        # validator accepts) a wrong-resource token that 401s on every
+        # dispatch with no visible cause. Same for rfc8693 exchange scopes
+        # leaking into consent scopes. Clear both unless this request
+        # explicitly sets them. (On main this was structurally impossible —
+        # any non-oauth_user row had every OAuth column nulled.)
+        if "oauth_audience" not in updates:
+            updates["oauth_audience"] = None
+        if "oauth_scopes" not in updates and "oauth_scopes" not in body:
+            updates["oauth_scopes"] = None
     # Renaming a pool-backed row needs the same per-user-token purge as
     # delete: the tokens are keyed on the OLD ``server_name`` and a row
     # later created with that old name (with attacker-controlled URL)
@@ -10523,6 +10584,19 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
         and "oauth_audience" in updates
         and (existing.get("oauth_audience") or "") != (updates["oauth_audience"] or "")
     )
+    # Changing oauth_scopes on an oauth_obo row is the same token-binding
+    # change under the rfc8693 profile: the exchange scope shapes the minted
+    # bearer's privileges, so cached rows minted with the OLD scopes must be
+    # purged or a scope narrowing silently doesn't take effect until token
+    # TTL — inconsistent with the audience purge above. oauth_user scope
+    # edits deliberately do NOT purge (consent scopes bind per-grant at the
+    # AS; step-up re-consent handles widening). The no-op normalization
+    # above guarantees "in updates" here means a genuine change.
+    scopes_changing = (
+        old_auth == "oauth_obo"
+        and (new_auth is None or new_auth == old_auth)
+        and "oauth_scopes" in updates
+    )
     # Leaving oauth_user (to static/none OR to oauth_obo, which doesn't use the
     # per-server client secret) clears the encrypted secret column below.
     leaving_oauth_user = (
@@ -10546,11 +10620,12 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
 
     # #551: an oauth_obo row (whether newly flipped or edited) needs an
     # encryption key + an audience — validated against the merged post-update
-    # audience. The entra-scope reject, though, must fire ONLY when this request
-    # actually SETS scopes ("oauth_scopes" in updates — from the body or the
-    # flip-clear above), not on the carried-over existing value: otherwise a
-    # pre-existing scoped row under the entra profile becomes un-editable (every
-    # maintenance PUT that doesn't clear scopes would 400).
+    # audience. The entra-scope reject fires ONLY when this request actually
+    # CHANGES scopes ("oauth_scopes" in updates — the no-op normalization
+    # above already dropped a re-sent equal value), never on the carried-over
+    # existing value: otherwise a pre-existing scoped row under the entra
+    # profile becomes un-editable — the admin form always re-submits the
+    # pre-filled field, so every unrelated save would 400.
     audience_now = updates.get("oauth_audience", existing.get("oauth_audience"))
     scopes_being_set = updates.get("oauth_scopes") if "oauth_scopes" in updates else None
     err_resp = _enforce_oauth_obo_requirements(
@@ -10565,12 +10640,13 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     audit_uid, ip = _audit_context(request)
 
     # Purge per-user tokens + pending OAuth states keyed on the OLD name on
-    # rename, on any pool-backed auth_type transition, on URL change, or on
-    # audience change for a pool-backed row. All cases would otherwise leave
-    # tokens orphaned-and-rebindable or bound to a superseded URL/audience (the
-    # OAuth tables key on the mutable ``server_name`` and tokens are bound to the
-    # URL + audience active at mint/consent time).
-    if name_changing or auth_type_purge or url_changing or audience_changing:
+    # rename, on any pool-backed auth_type transition, on URL change, or on an
+    # audience / obo-scope change for a pool-backed row. All cases would
+    # otherwise leave tokens orphaned-and-rebindable or bound to a superseded
+    # URL/audience/scope set (the OAuth tables key on the mutable
+    # ``server_name`` and tokens are bound to the URL + audience + scopes
+    # active at mint/consent time).
+    if name_changing or auth_type_purge or url_changing or audience_changing or scopes_changing:
         purge_target = existing.get("name", "")
         if purge_target:
             try:
@@ -10889,8 +10965,6 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
     name = request.path_params.get("name", "").strip()
     if not name or "__" in name:
         return JSONResponse({"error": "invalid server name"}, status_code=400)
-
-    from turnstone.core.mcp_oauth import is_user_scoped_auth
 
     existing = storage.get_mcp_server_by_name(name)
     if existing is None:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6022,11 +6022,9 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
                 "admin.oidc_identity.credential_revoke_failed user=%s", user_id, exc_info=True
             )
         try:
-            obo_servers = [
-                row["name"]
-                for row in storage.list_mcp_servers()
-                if row.get("auth_type") == "oauth_obo"
-            ]
+            from turnstone.core.mcp_oauth import obo_server_names
+
+            obo_servers = sorted(obo_server_names(storage))
         except Exception:
             obo_servers = []
             log.warning(
@@ -10576,8 +10574,9 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # consenting user's OAuth traffic. The persisted OAuth columns must be a pure
     # function of the target auth_type (the create handler enforces the same via
     # ``_oauth_columns_to_clear``). ``oauth_client_secret_ct`` is owned by a
-    # dedicated write path (see below).
-    target_auth = new_auth if new_auth is not None else old_auth
+    # dedicated write path (see below). ``target_auth`` is the effective
+    # post-update auth type — reused below by the write-time validators.
+    target_auth = new_auth if new_auth is not None else (old_auth or "static")
     if is_flip and new_auth is not None and is_user_scoped_auth(new_auth):
         # FLIP into a user-scoped type: the columns whose MEANING differs across
         # oauth_user↔oauth_obo must be recomputed from the body — present → that
@@ -10607,11 +10606,7 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # oauth_user↔oauth_obo mixes semantically different rows (per-server-AS
     # refresh tokens vs minted cache) and would otherwise leave a live grant at
     # the old AS unrevoked and refresh-bearing rows in the mint cache.
-    auth_type_purge = (
-        new_auth is not None
-        and new_auth != old_auth
-        and (is_user_scoped_auth(old_auth) or is_user_scoped_auth(new_auth))
-    )
+    auth_type_purge = is_flip and (is_user_scoped_auth(old_auth) or is_user_scoped_auth(new_auth))
     # URL change on a pool-backed row needs the same purge: bearer tokens
     # are bound (via OAuth resource / audience) to the URL active at
     # mint/consent time, so sending them to a new URL is a token-binding
@@ -10629,7 +10624,7 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # only guard the same-type edit here.)
     audience_changing = (
         is_user_scoped_auth(old_auth)
-        and (new_auth is None or new_auth == old_auth)
+        and not is_flip
         and "oauth_audience" in updates
         and (existing.get("oauth_audience") or "") != (updates["oauth_audience"] or "")
     )
@@ -10641,11 +10636,7 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
     # edits deliberately do NOT purge (consent scopes bind per-grant at the
     # AS; step-up re-consent handles widening). The no-op normalization
     # above guarantees "in updates" here means a genuine change.
-    scopes_changing = (
-        old_auth == "oauth_obo"
-        and (new_auth is None or new_auth == old_auth)
-        and "oauth_scopes" in updates
-    )
+    scopes_changing = old_auth == "oauth_obo" and not is_flip and "oauth_scopes" in updates
     # Leaving oauth_user (to static/none OR to oauth_obo, which doesn't use the
     # per-server client secret) clears the encrypted secret column below.
     leaving_oauth_user = (
@@ -10654,8 +10645,10 @@ async def admin_update_mcp_server(request: Request) -> JSONResponse:
 
     # bug-2 / sec-1: validate token-store availability and JSON shape BEFORE
     # ``storage.update_mcp_server`` so a missing key doesn't leave partial
-    # column changes persisted.
-    auth_type_now = updates.get("auth_type", existing.get("auth_type", "static"))
+    # column changes persisted. ``target_auth`` (above) is the effective
+    # post-update auth type — one derivation feeds both the column scrub and
+    # these validators so they can't disagree on the row's type.
+    auth_type_now = target_auth
     err_resp = _require_token_store_for_oauth_secret(request, body, auth_type=auth_type_now)
     if err_resp is not None:
         return err_resp

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -4781,7 +4781,11 @@ function _renderMcpServers(items) {
       : 'data-mcp-detail="' + escapeHtml(s.server_id) + '"';
     // Phase 9: surface the connect/bulk-revoke affordances only for
     // user-OAuth servers, and bulk-revoke only once a user has consented.
+    // oauth_obo has NO per-server connect (it uses the org sign-in); its
+    // "flush cache" drops minted tokens so users re-mint (honest label — it is
+    // not a durable revoke; that is governed by the identity provider).
     const isOauth = s.auth_type === "oauth_user";
+    const isObo = s.auth_type === "oauth_obo";
     const consentCount =
       typeof s.consented_users_count === "number" ? s.consented_users_count : 0;
     const actions = _kebabMenu([
@@ -4798,6 +4802,20 @@ function _renderMcpServers(items) {
               "Drop all " + consentCount + " user consents for this server",
             attrs: {
               "data-mcp-bulk-revoke": s.name,
+              "data-mcp-consent-count": consentCount,
+            },
+          }
+        : null,
+      isObo && consentCount > 0
+        ? {
+            label: "flush cache (" + consentCount + ")",
+            kind: "danger",
+            title:
+              "Drop " +
+              consentCount +
+              " users' minted tokens; they re-mint on next use unless access is removed at your identity provider",
+            attrs: {
+              "data-mcp-cache-flush": s.name,
               "data-mcp-consent-count": consentCount,
             },
           }
@@ -4964,6 +4982,42 @@ function _renderMcpServers(items) {
       );
     });
   });
+  el.querySelectorAll("[data-mcp-cache-flush]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      const name = this.getAttribute("data-mcp-cache-flush");
+      const count = this.getAttribute("data-mcp-consent-count") || "?";
+      showConfirmModal(
+        "Flush minted tokens",
+        "Drop " +
+          count +
+          ' users’ minted tokens for server "' +
+          name +
+          '"? This forces a fresh mint on next use (e.g. after changing the audience). It does NOT cut off access — users re-mint from their org sign-in; to revoke a user, remove their access at your identity provider or unlink their identity.',
+        "Flush cache",
+        function () {
+          authFetch(
+            "/v1/api/admin/mcp-servers/" +
+              encodeURIComponent(name) +
+              "/bulk-revoke",
+            { method: "POST" },
+          )
+            .then(function (r) {
+              if (!r.ok) throw new Error();
+              return r.json();
+            })
+            .then(function (j) {
+              showToast(
+                "Flushed " + (j.rows_deleted || 0) + " token(s) for " + name,
+              );
+              loadAdminMcp();
+            })
+            .catch(function () {
+              showToast("Failed to flush cache for " + name);
+            });
+        },
+      );
+    });
+  });
   el.querySelectorAll("[data-mcp-delete]").forEach(function (btn) {
     btn.addEventListener("click", function () {
       const sid = this.getAttribute("data-mcp-delete");
@@ -5011,13 +5065,31 @@ function _selectedMcpAuthType() {
 
 function toggleMcpAuthFields() {
   const authType = _selectedMcpAuthType();
+  const isOauthUser = authType === "oauth_user";
+  const isObo = authType === "oauth_obo";
+  // The OAuth fields block is shared by oauth_user and oauth_obo; obo shows
+  // only the audience (+ scopes for the rfc8693 profile), hiding the
+  // oauth_user-only client/registration inputs it does not use.
   const oauthDiv = document.getElementById("mcp-oauth-fields");
-  if (oauthDiv) {
-    oauthDiv.hidden = authType !== "oauth_user";
-  }
+  if (oauthDiv) oauthDiv.hidden = !(isOauthUser || isObo);
+  const userOnly = document.getElementById("mcp-oauth-user-only");
+  if (userOnly) userOnly.hidden = !isOauthUser;
+  const oboNote = document.getElementById("mcp-obo-note");
+  if (oboNote) oboNote.hidden = !isObo;
+  // For obo the audience is required (the mint engine hard-requires it) and
+  // scopes apply only under the rfc8693 grant profile; retitle the hints so
+  // the operator isn't misled (no impl vocabulary in the copy).
+  const audHint = document.getElementById("mcp-oauth-audience-hint");
+  if (audHint)
+    audHint.textContent = isObo ? "required" : "auto-populated from URL";
+  const scopesHint = document.getElementById("mcp-oauth-scopes-hint");
+  if (scopesHint)
+    scopesHint.textContent = isObo
+      ? "only used by the rfc8693 sign-in profile"
+      : "space-separated";
   // The "Headers" textarea (inside mcp-http-fields) is only meaningful
-  // for static auth; hide it for 'none' / 'oauth_user' so operators
-  // don't accidentally configure stale credentials.
+  // for static auth; hide it for 'none' / 'oauth_user' / 'oauth_obo' so
+  // operators don't accidentally configure stale credentials.
   const headersInput = document.getElementById("mcp-headers");
   if (headersInput) {
     const headersLabel = document.querySelector('label[for="mcp-headers"]');
@@ -5079,6 +5151,7 @@ function _mcpResetForm() {
   document.getElementById("mcp-auth-static").checked = true;
   document.getElementById("mcp-auth-none").checked = false;
   document.getElementById("mcp-auth-oauth").checked = false;
+  document.getElementById("mcp-auth-obo").checked = false;
   document.getElementById("mcp-oauth-as-url").value = "";
   document.getElementById("mcp-oauth-registration").value = "preregistered";
   document.getElementById("mcp-oauth-client-id").value = "";
@@ -5146,6 +5219,8 @@ function showEditMcpModal(serverId) {
         authType === "static";
       document.getElementById("mcp-auth-oauth").checked =
         authType === "oauth_user";
+      document.getElementById("mcp-auth-obo").checked =
+        authType === "oauth_obo";
       document.getElementById("mcp-oauth-as-url").value =
         s.oauth_authorization_server_url || "";
       document.getElementById("mcp-oauth-registration").value =
@@ -5224,7 +5299,7 @@ function _parseMcpForm() {
       }
       payload.headers = hdrObj;
     } else {
-      // 'none' / 'oauth_user' — clear server-side static headers state.
+      // 'none' / 'oauth_user' / 'oauth_obo' — clear static headers state.
       payload.headers = {};
     }
   }
@@ -5248,6 +5323,18 @@ function _parseMcpForm() {
     const secret = document.getElementById("mcp-oauth-client-secret").value;
     // Submit only when the operator typed a value; redacted in audit log.
     if (secret) payload.oauth_client_secret = secret;
+  } else if (authType === "oauth_obo") {
+    // Sign-in passthrough uses only the audience (+ optional rfc8693 scopes);
+    // the client/registration/secret columns are oauth_user-only and cleared
+    // server-side. Audience is required — catch it here for an inline error
+    // rather than a round-trip 400.
+    const audience = document.getElementById("mcp-oauth-audience").value.trim();
+    if (!audience)
+      return { error: "Audience is required for sign-in passthrough servers" };
+    payload.oauth_audience = audience;
+    payload.oauth_scopes = document
+      .getElementById("mcp-oauth-scopes")
+      .value.trim();
   }
 
   return payload;

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -4738,6 +4738,10 @@ function _renderMcpServers(items) {
     let dotClass = "mcp-status-dot disabled";
     let rowClass = "mcp-row-disabled";
     let statusText = "disabled";
+    // Pool-backed (oauth_user/oauth_obo) servers hold NO cluster-level session —
+    // they connect per-user on demand — so "connecting"/"idle" reads as broken
+    // when the resting state (zero warm users) is normal.
+    const isPool = s.auth_type === "oauth_user" || s.auth_type === "oauth_obo";
     if (!s.enabled) {
       statusText = "disabled";
     } else if (anyConnected) {
@@ -4748,6 +4752,10 @@ function _renderMcpServers(items) {
       dotClass = "mcp-status-dot error";
       rowClass = "mcp-row-error";
       statusText = "error";
+    } else if (isPool) {
+      dotClass = "mcp-status-dot disabled";
+      rowClass = "mcp-row-disabled";
+      statusText = "per-user";
     } else if (s.enabled && s.source !== "config" && nodeIds.length === 0) {
       dotClass = "mcp-status-dot connecting";
       rowClass = "mcp-row-disabled";

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -4652,6 +4652,43 @@ function loadAdminMcp() {
     });
 }
 
+function _wireMcpTokenDropButtons(el, attr, opts) {
+  // Shared binder for the two per-server token-drop list actions —
+  // "Bulk-revoke" (oauth_user consents) and "Flush cache" (oauth_obo minted
+  // tokens). Both post to the same bulk-revoke endpoint; only the operator-
+  // facing copy differs, so the confirm/fetch/toast/reload flow lives once.
+  el.querySelectorAll("[" + attr + "]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      const name = this.getAttribute(attr);
+      const count = this.getAttribute("data-mcp-consent-count") || "?";
+      showConfirmModal(
+        opts.title,
+        opts.message(name, count),
+        opts.confirmLabel,
+        function () {
+          authFetch(
+            "/v1/api/admin/mcp-servers/" +
+              encodeURIComponent(name) +
+              "/bulk-revoke",
+            { method: "POST" },
+          )
+            .then(function (r) {
+              if (!r.ok) throw new Error();
+              return r.json();
+            })
+            .then(function (j) {
+              showToast(opts.successToast(name, j.rows_deleted || 0));
+              loadAdminMcp();
+            })
+            .catch(function () {
+              showToast(opts.failToast(name));
+            });
+        },
+      );
+    });
+  });
+}
+
 function _renderMcpServers(items) {
   const el = document.getElementById("admin-mcp-table");
   if (!items.length) {
@@ -4946,77 +4983,43 @@ function _renderMcpServers(items) {
       window.open(url, "_blank", "noopener");
     });
   });
-  el.querySelectorAll("[data-mcp-bulk-revoke]").forEach(function (btn) {
-    btn.addEventListener("click", function () {
-      const name = this.getAttribute("data-mcp-bulk-revoke");
-      const count = this.getAttribute("data-mcp-consent-count") || "?";
-      showConfirmModal(
-        "Bulk-revoke MCP consents",
+  _wireMcpTokenDropButtons(el, "data-mcp-bulk-revoke", {
+    title: "Bulk-revoke MCP consents",
+    message: function (name, count) {
+      return (
         "Drop all " +
-          count +
-          ' user consents for server "' +
-          name +
-          '"? Users will need to re-consent on next use. Upstream revoke is not attempted in bulk; tokens at the authorization server will expire naturally.',
-        "Bulk-revoke",
-        function () {
-          authFetch(
-            "/v1/api/admin/mcp-servers/" +
-              encodeURIComponent(name) +
-              "/bulk-revoke",
-            { method: "POST" },
-          )
-            .then(function (r) {
-              if (!r.ok) throw new Error();
-              return r.json();
-            })
-            .then(function (j) {
-              showToast(
-                "Bulk-revoked " + (j.rows_deleted || 0) + " row(s) for " + name,
-              );
-              loadAdminMcp();
-            })
-            .catch(function () {
-              showToast("Failed to bulk-revoke " + name);
-            });
-        },
+        count +
+        ' user consents for server "' +
+        name +
+        '"? Users will need to re-consent on next use. Upstream revoke is not attempted in bulk; tokens at the authorization server will expire naturally.'
       );
-    });
+    },
+    confirmLabel: "Bulk-revoke",
+    successToast: function (name, n) {
+      return "Bulk-revoked " + n + " row(s) for " + name;
+    },
+    failToast: function (name) {
+      return "Failed to bulk-revoke " + name;
+    },
   });
-  el.querySelectorAll("[data-mcp-cache-flush]").forEach(function (btn) {
-    btn.addEventListener("click", function () {
-      const name = this.getAttribute("data-mcp-cache-flush");
-      const count = this.getAttribute("data-mcp-consent-count") || "?";
-      showConfirmModal(
-        "Flush minted tokens",
+  _wireMcpTokenDropButtons(el, "data-mcp-cache-flush", {
+    title: "Flush minted tokens",
+    message: function (name, count) {
+      return (
         "Drop " +
-          count +
-          ' users’ minted tokens for server "' +
-          name +
-          '"? This forces a fresh mint on next use (e.g. after changing the audience). It does NOT cut off access — users re-mint from their org sign-in; to revoke a user, remove their access at your identity provider or unlink their identity.',
-        "Flush cache",
-        function () {
-          authFetch(
-            "/v1/api/admin/mcp-servers/" +
-              encodeURIComponent(name) +
-              "/bulk-revoke",
-            { method: "POST" },
-          )
-            .then(function (r) {
-              if (!r.ok) throw new Error();
-              return r.json();
-            })
-            .then(function (j) {
-              showToast(
-                "Flushed " + (j.rows_deleted || 0) + " token(s) for " + name,
-              );
-              loadAdminMcp();
-            })
-            .catch(function () {
-              showToast("Failed to flush cache for " + name);
-            });
-        },
+        count +
+        ' users’ minted tokens for server "' +
+        name +
+        '"? This forces a fresh mint on next use (e.g. after changing the audience). It does NOT cut off access — users re-mint from their org sign-in; to revoke a user, remove their access at your identity provider or unlink their identity.'
       );
-    });
+    },
+    confirmLabel: "Flush cache",
+    successToast: function (name, n) {
+      return "Flushed " + n + " token(s) for " + name;
+    },
+    failToast: function (name) {
+      return "Failed to flush cache for " + name;
+    },
   });
   el.querySelectorAll("[data-mcp-delete]").forEach(function (btn) {
     btn.addEventListener("click", function () {
@@ -5105,9 +5108,29 @@ function _wireMcpAudienceAutofill() {
   if (!urlInput || urlInput.dataset.audAutofill === "1") return;
   urlInput.dataset.audAutofill = "1";
   urlInput.addEventListener("blur", function () {
+    // oauth_user only: there the audience IS the server URL (resource
+    // indicator). For sign-in passthrough the audience is the identity-
+    // provider-side application identifier — prefilling the MCP URL there
+    // passes every validation layer and then fails every token mint, so
+    // the autofill stays off.
+    if (_selectedMcpAuthType() === "oauth_obo") return;
     const aud = document.getElementById("mcp-oauth-audience");
     if (aud && !aud.value.trim()) aud.value = urlInput.value.trim();
   });
+}
+
+function _onMcpAuthTypeChange() {
+  // Switching INTO sign-in passthrough: if the audience field still holds
+  // the URL-autofill artifact (operator typed the URL first, then picked
+  // this mode), blank it so the required-field check asks for a real
+  // identity-provider application identifier instead of silently
+  // persisting the MCP URL as the audience.
+  if (_selectedMcpAuthType() === "oauth_obo") {
+    const aud = document.getElementById("mcp-oauth-audience");
+    const urlVal = document.getElementById("mcp-url").value.trim();
+    if (aud && urlVal && aud.value.trim() === urlVal) aud.value = "";
+  }
+  toggleMcpAuthFields();
 }
 
 function _mcpWire() {
@@ -5118,7 +5141,7 @@ function _mcpWire() {
     .addEventListener("change", toggleMcpTransport);
   const authRadios = document.getElementsByName("mcp-auth-type");
   for (let i = 0; i < authRadios.length; i++) {
-    authRadios[i].addEventListener("change", toggleMcpAuthFields);
+    authRadios[i].addEventListener("change", _onMcpAuthTypeChange);
   }
   document
     .getElementById("mcp-create-submit")
@@ -5156,7 +5179,11 @@ function _mcpResetForm() {
   document.getElementById("mcp-oauth-registration").value = "preregistered";
   document.getElementById("mcp-oauth-client-id").value = "";
   document.getElementById("mcp-oauth-client-secret").value = "";
-  document.getElementById("mcp-oauth-scopes").value = "";
+  const scopesReset = document.getElementById("mcp-oauth-scopes");
+  scopesReset.value = "";
+  // Create flow has no loaded row — the marker's absence tells
+  // _parseMcpForm to always include the field.
+  delete scopesReset.dataset.loaded;
   document.getElementById("mcp-oauth-audience").value = "";
   document.getElementById("mcp-create-error").classList.remove("is-visible");
   toggleMcpTransport();
@@ -5229,7 +5256,12 @@ function showEditMcpModal(serverId) {
         s.oauth_client_id || "";
       // Secret field always blank — write-only, never read back.
       document.getElementById("mcp-oauth-client-secret").value = "";
-      document.getElementById("mcp-oauth-scopes").value = s.oauth_scopes || "";
+      const scopesInput = document.getElementById("mcp-oauth-scopes");
+      scopesInput.value = s.oauth_scopes || "";
+      // Remember the loaded value so _parseMcpForm can omit an untouched
+      // pre-fill from the payload (the server treats a present field as an
+      // operator-set value).
+      scopesInput.dataset.loaded = s.oauth_scopes || "";
       document.getElementById("mcp-oauth-audience").value =
         s.oauth_audience || "";
       toggleMcpTransport();
@@ -5332,9 +5364,18 @@ function _parseMcpForm() {
     if (!audience)
       return { error: "Audience is required for sign-in passthrough servers" };
     payload.oauth_audience = audience;
-    payload.oauth_scopes = document
-      .getElementById("mcp-oauth-scopes")
-      .value.trim();
+    // Include scopes only when the operator changed them from the loaded row
+    // value (or on create, where no loaded marker exists): the server treats
+    // a present field as an operator-set value, and re-submitting the
+    // untouched pre-fill on every save must not read as one.
+    const scopesInput = document.getElementById("mcp-oauth-scopes");
+    const scopesVal = scopesInput.value.trim();
+    if (
+      scopesInput.dataset.loaded === undefined ||
+      scopesVal !== scopesInput.dataset.loaded.trim()
+    ) {
+      payload.oauth_scopes = scopesVal;
+    }
   }
 
   return payload;

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -5120,16 +5120,17 @@ function _wireMcpAudienceAutofill() {
 }
 
 function _onMcpAuthTypeChange() {
-  // Switching INTO sign-in passthrough: if the audience field still holds
-  // the URL-autofill artifact (operator typed the URL first, then picked
-  // this mode), blank it so the required-field check asks for a real
-  // identity-provider application identifier instead of silently
-  // persisting the MCP URL as the audience.
-  if (_selectedMcpAuthType() === "oauth_obo") {
-    const aud = document.getElementById("mcp-oauth-audience");
-    const urlVal = document.getElementById("mcp-url").value.trim();
-    if (aud && urlVal && aud.value.trim() === urlVal) aud.value = "";
-  }
+  // Audience and Scopes are auth-type-specific: for oauth_user the audience is
+  // an RFC 8707 resource indicator (~ the MCP URL) and scopes are AS-consent
+  // scopes; for sign-in passthrough the audience is the identity-provider-side
+  // application identifier and scopes (rfc8693 only) are the token-exchange
+  // scope. Carrying one type's value into the other passes validation and then
+  // fails every mint/consent, so clear both when the auth type changes — the
+  // operator re-enters the correct values for the new mode (the backend
+  // likewise refuses to carry these columns across a flip). A same-type edit
+  // never fires this (the radio didn't change), so pre-filled values are kept.
+  document.getElementById("mcp-oauth-audience").value = "";
+  document.getElementById("mcp-oauth-scopes").value = "";
   toggleMcpAuthFields();
 }
 
@@ -5179,11 +5180,7 @@ function _mcpResetForm() {
   document.getElementById("mcp-oauth-registration").value = "preregistered";
   document.getElementById("mcp-oauth-client-id").value = "";
   document.getElementById("mcp-oauth-client-secret").value = "";
-  const scopesReset = document.getElementById("mcp-oauth-scopes");
-  scopesReset.value = "";
-  // Create flow has no loaded row — the marker's absence tells
-  // _parseMcpForm to always include the field.
-  delete scopesReset.dataset.loaded;
+  document.getElementById("mcp-oauth-scopes").value = "";
   document.getElementById("mcp-oauth-audience").value = "";
   document.getElementById("mcp-create-error").classList.remove("is-visible");
   toggleMcpTransport();
@@ -5256,12 +5253,7 @@ function showEditMcpModal(serverId) {
         s.oauth_client_id || "";
       // Secret field always blank — write-only, never read back.
       document.getElementById("mcp-oauth-client-secret").value = "";
-      const scopesInput = document.getElementById("mcp-oauth-scopes");
-      scopesInput.value = s.oauth_scopes || "";
-      // Remember the loaded value so _parseMcpForm can omit an untouched
-      // pre-fill from the payload (the server treats a present field as an
-      // operator-set value).
-      scopesInput.dataset.loaded = s.oauth_scopes || "";
+      document.getElementById("mcp-oauth-scopes").value = s.oauth_scopes || "";
       document.getElementById("mcp-oauth-audience").value =
         s.oauth_audience || "";
       toggleMcpTransport();
@@ -5364,18 +5356,13 @@ function _parseMcpForm() {
     if (!audience)
       return { error: "Audience is required for sign-in passthrough servers" };
     payload.oauth_audience = audience;
-    // Include scopes only when the operator changed them from the loaded row
-    // value (or on create, where no loaded marker exists): the server treats
-    // a present field as an operator-set value, and re-submitting the
-    // untouched pre-fill on every save must not read as one.
-    const scopesInput = document.getElementById("mcp-oauth-scopes");
-    const scopesVal = scopesInput.value.trim();
-    if (
-      scopesInput.dataset.loaded === undefined ||
-      scopesVal !== scopesInput.dataset.loaded.trim()
-    ) {
-      payload.oauth_scopes = scopesVal;
-    }
+    // Always send the visible Scopes value — the backend distinguishes a
+    // same-type no-op re-send (dropped) from a genuine change / flip on its
+    // side, so the form doesn't need omit-when-unchanged logic (which used to
+    // collide with the backend's flip handling and silently drop scopes).
+    payload.oauth_scopes = document
+      .getElementById("mcp-oauth-scopes")
+      .value.trim();
   }
 
   return payload;

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -2457,47 +2457,77 @@
                     <span class="segmented-hint">recommended</span></span
                   >
                 </label>
+                <label class="segmented-option">
+                  <input
+                    type="radio"
+                    name="mcp-auth-type"
+                    id="mcp-auth-obo"
+                    value="oauth_obo"
+                  />
+                  <span class="segmented-indicator" aria-hidden="true"></span>
+                  <span class="segmented-text"
+                    >Sign-in passthrough
+                    <span class="segmented-hint"
+                      >uses your org login — no separate connect</span
+                    ></span
+                  >
+                </label>
               </div>
               <div id="mcp-oauth-fields" hidden>
-                <label for="mcp-oauth-as-url"
-                  >Authorization server URL
-                  <span class="label-hint"
-                    >optional — override discovery when the MCP server URL is
-                    not the OAuth issuer</span
-                  ></label
-                >
-                <input
-                  type="text"
-                  id="mcp-oauth-as-url"
-                  class="sh-mono"
-                  placeholder="https://auth.example.com"
-                />
-                <label for="mcp-oauth-registration">Client registration</label>
-                <select id="mcp-oauth-registration">
-                  <option value="preregistered">preregistered</option>
-                  <option value="dcr">dcr (Dynamic Client Registration)</option>
-                </select>
-                <label for="mcp-oauth-client-id">Client ID</label>
-                <input
-                  type="text"
-                  id="mcp-oauth-client-id"
-                  class="sh-mono"
-                  placeholder="(operator-issued client_id)"
-                />
-                <label for="mcp-oauth-client-secret"
-                  >Client secret
-                  <span class="label-hint"
-                    >write-only, never displayed</span
-                  ></label
-                >
-                <input
-                  type="password"
-                  id="mcp-oauth-client-secret"
-                  placeholder="***"
-                  autocomplete="off"
-                />
+                <p id="mcp-obo-note" class="label-hint" hidden>
+                  Each user's org sign-in mints an access token for this server
+                  on demand — no per-user connect step. Requires the audience
+                  below and matching delegated permissions in your identity
+                  provider.
+                </p>
+                <div id="mcp-oauth-user-only">
+                  <label for="mcp-oauth-as-url"
+                    >Authorization server URL
+                    <span class="label-hint"
+                      >optional — override discovery when the MCP server URL is
+                      not the OAuth issuer</span
+                    ></label
+                  >
+                  <input
+                    type="text"
+                    id="mcp-oauth-as-url"
+                    class="sh-mono"
+                    placeholder="https://auth.example.com"
+                  />
+                  <label for="mcp-oauth-registration"
+                    >Client registration</label
+                  >
+                  <select id="mcp-oauth-registration">
+                    <option value="preregistered">preregistered</option>
+                    <option value="dcr">
+                      dcr (Dynamic Client Registration)
+                    </option>
+                  </select>
+                  <label for="mcp-oauth-client-id">Client ID</label>
+                  <input
+                    type="text"
+                    id="mcp-oauth-client-id"
+                    class="sh-mono"
+                    placeholder="(operator-issued client_id)"
+                  />
+                  <label for="mcp-oauth-client-secret"
+                    >Client secret
+                    <span class="label-hint"
+                      >write-only, never displayed</span
+                    ></label
+                  >
+                  <input
+                    type="password"
+                    id="mcp-oauth-client-secret"
+                    placeholder="***"
+                    autocomplete="off"
+                  />
+                </div>
                 <label for="mcp-oauth-scopes"
-                  >Scopes <span class="label-hint">space-separated</span></label
+                  >Scopes
+                  <span class="label-hint" id="mcp-oauth-scopes-hint"
+                    >space-separated</span
+                  ></label
                 >
                 <input
                   type="text"
@@ -2507,7 +2537,9 @@
                 />
                 <label for="mcp-oauth-audience"
                   >Audience
-                  <span class="label-hint">auto-populated from URL</span></label
+                  <span class="label-hint" id="mcp-oauth-audience-hint"
+                    >auto-populated from URL</span
+                  ></label
                 >
                 <input
                   type="text"

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -2109,6 +2109,35 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
         _record_oidc_failure()
         return RedirectResponse("/?oidc_error=Authentication+failed", status_code=302)
 
+    # Capture the IdP refresh token as the user's single OBO credential
+    # (issue #551).  Best-effort: capture failure must not block login —
+    # the mint path surfaces a missing credential on the reconnect rail.
+    if oidc_config.capture_user_credential:
+        idp_refresh_token = tokens.get("refresh_token")
+        token_store = getattr(request.app.state, "mcp_token_store", None)
+        if not isinstance(idp_refresh_token, str) or not idp_refresh_token:
+            log.info(
+                "oidc.capture: no refresh_token in token response (user=%s) — "
+                "check the IdP allows offline_access for this client",
+                user["user_id"],
+            )
+        elif token_store is None:
+            log.warning(
+                "oidc.capture: enabled but no token encryption key configured — "
+                "credential NOT captured (user=%s)",
+                user["user_id"],
+            )
+        else:
+            try:
+                await asyncio.to_thread(
+                    token_store.upsert_oidc_credential,
+                    user["user_id"],
+                    oidc_config.issuer,
+                    refresh_token=idp_refresh_token,
+                )
+            except Exception:
+                log.exception("oidc.capture: failed to persist credential")
+
     # Load permissions and issue Turnstone JWT
     perms = await asyncio.to_thread(_load_user_permissions, storage, user["user_id"])
     scopes = _permissions_to_scopes(perms)

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -44,6 +44,7 @@ from turnstone.core.oidc import (
     exchange_code,
     fetch_jwks,
     generate_pkce_verifier,
+    maybe_rediscover_oidc,
     provision_oidc_user,
     validate_id_token,
 )
@@ -1898,6 +1899,14 @@ async def handle_oidc_authorize(request: Request, audience: str) -> Response:
     from starlette.responses import JSONResponse, RedirectResponse
 
     oidc_config = getattr(request.app.state, "oidc_config", None)
+    if oidc_config is not None and not oidc_config.enabled:
+        # Self-heal a transient boot-time discovery outage: the LOGIN path is a
+        # rediscovery trigger too, not just the obo mint path. Without this, a
+        # single-node install (or one where every node booted during the outage)
+        # would keep login dark until an operator restart — the exact symptom
+        # maybe_rediscover_oidc exists to fix. No-op unless discovery_retryable.
+        await maybe_rediscover_oidc(request.app.state)
+        oidc_config = getattr(request.app.state, "oidc_config", None)
     if not oidc_config or not oidc_config.enabled:
         return JSONResponse({"error": "OIDC not configured"}, status_code=404)
 
@@ -1988,6 +1997,12 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
     from starlette.responses import JSONResponse, RedirectResponse
 
     oidc_config = getattr(request.app.state, "oidc_config", None)
+    if oidc_config is not None and not oidc_config.enabled:
+        # Self-heal a transient boot-time discovery outage on the login path too
+        # (see handle_oidc_authorize). A user mid-flow whose authorize landed on
+        # a recovered node can still complete the callback here.
+        await maybe_rediscover_oidc(request.app.state)
+        oidc_config = getattr(request.app.state, "oidc_config", None)
     if not oidc_config or not oidc_config.enabled:
         return JSONResponse({"error": "OIDC not configured"}, status_code=404)
 

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -7339,10 +7339,14 @@ def _pool_lookup_error(
         )
     # kind == "token"
     if not (lookup.token or ""):
+        # A classified lookup returns kind=="token" only with a real token, so
+        # this empty-token fallback is barely reachable — but keep it
+        # auth-model-aware like the sibling ``missing`` branch above, so an obo
+        # row never shows per-server-consent copy + a null consent_url.
         return _structured_error(
             code="mcp_consent_required",
             server=server_name,
-            detail="No token for user. Consent flow required.",
+            detail=_consent_missing_detail(server_row),
             consent_url=_build_consent_url(server_row),
         )
     return None

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2535,8 +2535,8 @@ class MCPClientManager:
         """
         if not user_id or self._loop is None:
             return
-        if not self._pool_server_names:
-            return
+        if not self._oauth_user_server_names and not self._obo_server_names:
+            return  # no pool-backed servers — nothing to prime (no set allocation)
         if self._app_state is None or self._storage is None:
             return
         # run_coroutine_threadsafe keeps the task referenced by the loop while
@@ -5705,6 +5705,14 @@ class MCPClientManager:
         an obo pending row — written when the credential was missing — would
         persist forever after the user re-logs in.
 
+        Deliberately NOT gated to oauth_obo: for oauth_user it also clears the
+        dispatch-time transient badges written by
+        :meth:`_record_pending_consent_best_effort` (non-interactive runs), which
+        the sweep's ``_token_sweep_warned``-keyed clear never touches for a pair
+        it didn't proactively warn. The TTL map below bounds the cost to one
+        DELETE per pair per window, so the extra oauth_user coverage is close to
+        free rather than redundant.
+
         Deduped via the ``_pending_consent_cleared`` TTL map so it is NOT an
         unconditional per-call SQL write: after a DB-confirmed DELETE the pair
         is skipped for ``_PENDING_CONSENT_CLEAR_TTL_SECONDS``, then the DELETE
@@ -5755,13 +5763,17 @@ class MCPClientManager:
         """
         if len(self._pending_consent_cleared) < _PENDING_CONSENT_CLEARED_MAX:
             return
-        entries = list(self._pending_consent_cleared.items())
-        expired = [k for k, t in entries if now - t >= _PENDING_CONSENT_CLEAR_TTL_SECONDS]
-        for k in expired:
-            self._pending_consent_cleared.pop(k, None)
+        # Pass 1: drop expired entries (snapshot the items so concurrent mutation
+        # can't raise mid-iteration; ``pop`` tolerates an already-removed key).
+        for k, t in list(self._pending_consent_cleared.items()):
+            if now - t >= _PENDING_CONSENT_CLEAR_TTL_SECONDS:
+                self._pending_consent_cleared.pop(k, None)
+        # Pass 2: only if still over the cap, drop the oldest half of what
+        # REMAINS. Re-reading the map here means we sort just the live survivors
+        # — never re-targeting keys pass 1 already removed.
         if len(self._pending_consent_cleared) >= _PENDING_CONSENT_CLEARED_MAX:
-            by_age = sorted(entries, key=lambda kv: kv[1])
-            for k, _ in by_age[: len(by_age) // 2]:
+            survivors = sorted(self._pending_consent_cleared.items(), key=lambda kv: kv[1])
+            for k, _ in survivors[: len(survivors) // 2]:
                 self._pending_consent_cleared.pop(k, None)
 
     def _dispatch_pool_sync(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -5609,6 +5609,29 @@ class MCPClientManager:
                 exc_info=True,
             )
 
+    def _clear_pending_consent_sync(self, user_id: str, server_name: str) -> None:
+        """Best-effort synchronous clear of a deferred-consent row on dispatch success.
+
+        Called from the sync dispatchers when a dispatch SUCCEEDS, so a stale
+        badge self-heals. This is the only clear path that covers oauth_obo: the
+        oauth_user clears live in the token sweep (which skips obo) and the
+        consent callback (which obo never runs), so without a success-side clear
+        an obo pending row — written when the credential was missing — would
+        persist forever after the user re-logs in. Delete is a no-op when no row
+        exists, so this is safe to call on every successful dispatch.
+        """
+        if self._storage is None:
+            return
+        try:
+            self._storage.delete_mcp_pending_consent(user_id, server_name)
+        except Exception:
+            log.debug(
+                "mcp_pool.pending_consent_clear_failed user=%s server=%s",
+                user_id,
+                server_name,
+                exc_info=True,
+            )
+
     def _dispatch_pool_sync(
         self,
         *,
@@ -5696,6 +5719,8 @@ class MCPClientManager:
                     user_id=user_id, server_name=server_name, result=result
                 )
             raise RuntimeError(result)
+        # Success clears any stale pending-consent badge (the obo self-heal path).
+        self._clear_pending_consent_sync(user_id, server_name)
         return result
 
     def _run_pool_dispatch_attempt(
@@ -5799,6 +5824,7 @@ class MCPClientManager:
                     user_id=user_id, server_name=server_name, result=result
                 )
             raise RuntimeError(result)
+        self._clear_pending_consent_sync(user_id, server_name)
         return result
 
     def _run_pool_dispatch_resource_attempt(
@@ -5890,6 +5916,7 @@ class MCPClientManager:
                     user_id=user_id, server_name=server_name, result=result
                 )
             raise RuntimeError(result)
+        self._clear_pending_consent_sync(user_id, server_name)
         return result
 
     def _run_pool_dispatch_prompt_attempt(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -778,7 +778,15 @@ class MCPClientManager:
         # row. The dispatch-success clear consults it so the common (no pending
         # row) path never issues an SQL DELETE — a per-node hint, not
         # authoritative: cross-node the sweep / next same-node success reconciles.
-        self._pending_consent_written: set[tuple[str, str]] = set()
+        # (user, server) pairs this node believes have NO pending-consent row —
+        # either cleared here, or never seen to fail here. The dispatch-success
+        # clear does its SQL DELETE only the FIRST time a pair reaches success
+        # since its last failure, then records it here so subsequent successes
+        # skip the SQL (keeps the hot path write-free). Crucially this is NOT
+        # gated on "we wrote the row": a fresh node / a node that didn't write
+        # the row still clears on its first success, so a badge written on
+        # another node self-heals cross-node. A write resets the pair (below).
+        self._pending_consent_cleared: set[tuple[str, str]] = set()
 
         # Idle-eviction task handle. Scheduled lazily on the mcp-loop the
         # first time a pool entry is created (start() runs before pool
@@ -2592,6 +2600,12 @@ class MCPClientManager:
                                 user_id=user_id,
                                 server_name=server_name,
                                 server_row=server_row,
+                                # Same as the oauth_user priming call below: a
+                                # sustained-UNCLASSIFIABLE IdP failure during a
+                                # bulk session-start prime must NOT escalate-revoke
+                                # (drop the cache row + arm cooldown) across every
+                                # user — defer that to the user's real dispatch.
+                                revoke_ambiguous_escalation=False,
                             )
                         else:
                             lookup = await get_user_access_token_classified(
@@ -2834,9 +2848,9 @@ class MCPClientManager:
             scopes_required=scopes_required,
             now_iso=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"),
         )
-        # Remember we wrote a row so the dispatch-success clear can skip its SQL
-        # DELETE on the common (no-pending) path.
-        self._pending_consent_written.add((user_id, server_name))
+        # A fresh pending row exists again → un-mark the pair so the next
+        # successful dispatch (on any node) clears it.
+        self._pending_consent_cleared.discard((user_id, server_name))
 
     async def _persist_pending_consent_best_effort(self, user_id: str, server_name: str) -> bool:
         """Raise the dashboard pending-consent badge for a proactively-detected
@@ -2878,7 +2892,7 @@ class MCPClientManager:
             return
         try:
             await asyncio.to_thread(self._storage.delete_mcp_pending_consent, user_id, server_name)
-            self._pending_consent_written.discard((user_id, server_name))
+            self._pending_consent_cleared.add((user_id, server_name))
         except Exception:
             log.debug(
                 "MCP token sweep: pending-consent clear failed user=%s server=%s",
@@ -5640,19 +5654,23 @@ class MCPClientManager:
         an obo pending row — written when the credential was missing — would
         persist forever after the user re-logs in.
 
-        Gated on this node's ``_pending_consent_written`` hint so the common case
-        (no pending row was ever written for this pair) issues ZERO SQL — the
-        DELETE runs only when we actually recorded a row, keeping the hot dispatch
-        path free of an unconditional per-call write.
+        Deduped via ``_pending_consent_cleared`` so it is NOT an unconditional
+        per-call SQL write: the DELETE runs only the first time a pair reaches
+        success since its last failure, then the pair is recorded and subsequent
+        successes skip it — keeping the hot dispatch path free of per-call SQL.
+        Unlike a "we wrote the row" gate, this fires on ANY node's first success
+        (a fresh node's cleared-set is empty), so a badge written on another node
+        self-heals cross-node; a node restart also re-clears once. A new failure
+        removes the pair (``_write_pending_consent``) so the badge re-clears.
         """
         key = (user_id, server_name)
-        if key not in self._pending_consent_written:
-            return
+        if key in self._pending_consent_cleared:
+            return  # already cleared on this node since the last failure — no SQL
         if self._storage is None:
             return
         try:
             self._storage.delete_mcp_pending_consent(user_id, server_name)
-            self._pending_consent_written.discard(key)
+            self._pending_consent_cleared.add(key)
         except Exception:
             log.debug(
                 "mcp_pool.pending_consent_clear_failed user=%s server=%s",

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -7279,7 +7279,14 @@ def _pool_error_detail(server_row: dict[str, Any], situation: str, *, kind: str 
     card; everything else is treated as ``oauth_user``.
     """
     model = "oauth_obo" if server_row.get("auth_type") == "oauth_obo" else "oauth_user"
-    return _POOL_ERROR_DETAIL[(model, situation)].format(kind=kind, kind_cap=kind.capitalize())
+    template = _POOL_ERROR_DETAIL[(model, situation)]
+    # Only the insufficient_scope rows carry {kind}/{kind_cap}; the rest are
+    # plain strings. Format ONLY when a kind is supplied so a future message
+    # containing a literal brace (a scope/JSON example) can't raise inside this
+    # error-rendering path and turn a clean structured error into a 500.
+    if kind:
+        return template.format(kind=kind, kind_cap=kind.capitalize())
+    return template
 
 
 def _consent_missing_detail(server_row: dict[str, Any]) -> str:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -6579,7 +6579,7 @@ class MCPClientManager:
             return _structured_error(
                 code="mcp_insufficient_scope",
                 server=server_name,
-                detail=_insufficient_scope_detail(server_row, kind),
+                detail=_pool_error_detail(server_row, "insufficient_scope", kind=kind),
                 scopes_required=list(scopes),
                 consent_url=_build_consent_url(server_row, scopes_required=list(scopes)),
             )
@@ -7290,22 +7290,19 @@ def _pool_error_detail(server_row: dict[str, Any], situation: str, *, kind: str 
 
 
 def _consent_missing_detail(server_row: dict[str, Any]) -> str:
-    """Detail for a ``missing`` token lookup (see :func:`_pool_error_detail`)."""
+    """Detail for a ``missing`` token lookup (see :func:`_pool_error_detail`).
+
+    Kept as a named wrapper (unlike the single-use situations, which call
+    :func:`_pool_error_detail` directly) because it has multiple callers.
+    """
     return _pool_error_detail(server_row, "missing")
 
 
-def _refresh_failed_detail(server_row: dict[str, Any]) -> str:
-    """Detail for a permanent ``refresh_failed`` lookup (see :func:`_pool_error_detail`)."""
-    return _pool_error_detail(server_row, "refresh_failed")
-
-
-def _insufficient_scope_detail(server_row: dict[str, Any], kind: str) -> str:
-    """Detail for a 403 insufficient_scope (see :func:`_pool_error_detail`)."""
-    return _pool_error_detail(server_row, "insufficient_scope", kind=kind)
-
-
 def _token_rejected_detail(server_row: dict[str, Any]) -> str:
-    """Detail for a 401 that survived one forced refresh (see :func:`_pool_error_detail`)."""
+    """Detail for a 401 that survived one forced refresh (see :func:`_pool_error_detail`).
+
+    Named wrapper because the three sync dispatchers each surface it.
+    """
     return _pool_error_detail(server_row, "token_rejected")
 
 
@@ -7349,7 +7346,7 @@ def _pool_lookup_error(
         return _structured_error(
             code="mcp_consent_required",
             server=server_name,
-            detail=_refresh_failed_detail(server_row),
+            detail=_pool_error_detail(server_row, "refresh_failed"),
             consent_url=_build_consent_url(server_row),
         )
     # kind == "token"

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -4706,6 +4706,12 @@ class MCPClientManager:
             log.warning("reconcile_sync: failed to read mcp_servers table", exc_info=True)
             return {"added": [], "removed": [], "updated": []}
 
+        # Pool-backed (oauth_user / oauth_obo) names known BEFORE this
+        # reconcile — diffed against the refreshed sets below to spot servers
+        # that appeared since active sessions last primed (see the re-prime
+        # self-heal near the end of this method).
+        prev_pool_names = self._oauth_user_server_names | self._obo_server_names
+
         # Refresh the in-memory oauth_user name cache from the rows we
         # just read — feeds :meth:`server_auth_type` so callers (e.g.
         # ``web_search.resolve_web_search_client``) avoid a per-turn SQL
@@ -4716,6 +4722,9 @@ class MCPClientManager:
         self._obo_server_names = {
             row["name"] for row in rows if row.get("auth_type") == "oauth_obo"
         }
+        newly_added_pool = (
+            self._oauth_user_server_names | self._obo_server_names
+        ) - prev_pool_names
 
         desired = _db_servers_to_config(rows)
         desired_names = set(desired)
@@ -4767,7 +4776,41 @@ class MCPClientManager:
                 len(removed),
                 len(updated),
             )
+
+        # Self-heal: a pool-backed (oauth_user / oauth_obo) server registered
+        # while a user's ChatSession was already open would otherwise never
+        # reach that session — ``prime_user_pools`` runs once at session start,
+        # and for oauth_obo priming is the ONLY path tools take into the
+        # catalog (there is no consent flow to warm it later). Re-prime every
+        # active session's user so a mid-session registration surfaces its
+        # tools automatically — no reconnect or fresh workstream needed.
+        if newly_added_pool:
+            self._reprime_active_users(newly_added_pool)
+
         return {"added": added, "removed": removed, "updated": updated}
+
+    def _reprime_active_users(self, new_servers: set[str]) -> None:
+        """Re-warm active sessions' pools after new pool-backed servers appear.
+
+        Called from :meth:`reconcile_sync` when a reconcile reveals an
+        oauth_user / oauth_obo server that active sessions never primed. Active
+        users come from the tool-listener registry (each open ChatSession
+        registers ``(user_id, callback)`` via :meth:`add_listener`); the
+        ``user_id=None`` global/admin listener is skipped. ``prime_user_pools``
+        is idempotent and fire-and-forget, so re-priming an already-warm pool
+        is a cheap skip and re-priming a user without the stored token /
+        captured credential is a no-op.
+        """
+        with self._listeners_lock:
+            user_ids = {uid for uid, _cb in self._listeners if uid}
+        for user_id in user_ids:
+            self.prime_user_pools(user_id)
+        if user_ids:
+            log.info(
+                "MCP reconcile: re-primed %d active user(s) after %d new pool server(s) appeared",
+                len(user_ids),
+                len(new_servers),
+            )
 
     # -- query methods -------------------------------------------------------
 

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2616,6 +2616,11 @@ class MCPClientManager:
                                 # (drop the cache row + arm cooldown) across every
                                 # user — defer that to the user's real dispatch.
                                 revoke_ambiguous_escalation=False,
+                                # The credential-presence gate above already
+                                # confirmed the captured credential exists for this
+                                # user (one read for ALL their obo servers), so skip
+                                # the per-server pre-lock existence re-read.
+                                credential_present=True,
                             )
                         else:
                             lookup = await get_user_access_token_classified(
@@ -2926,9 +2931,10 @@ class MCPClientManager:
             return
         try:
             await asyncio.to_thread(self._storage.delete_mcp_pending_consent, user_id, server_name)
-            now = time.monotonic()
-            self._prune_pending_consent_cleared(now)
-            self._pending_consent_cleared[(user_id, server_name)] = now
+            # Route through the shared helper (not an inline prune+stamp) so the
+            # two DB-confirmed clear sites can't drift — see
+            # _mark_pending_consent_cleared, which names this method as a caller.
+            self._mark_pending_consent_cleared((user_id, server_name), time.monotonic())
         except Exception:
             log.debug(
                 "MCP token sweep: pending-consent clear failed user=%s server=%s",

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -774,6 +774,11 @@ class MCPClientManager:
         # credential, so the priming / keep-alive-sweep / consent sites that
         # iterate ``_oauth_user_server_names`` deliberately exclude these.
         self._obo_server_names: set[str] = set()
+        # (user, server) pairs for which THIS node has written a pending-consent
+        # row. The dispatch-success clear consults it so the common (no pending
+        # row) path never issues an SQL DELETE — a per-node hint, not
+        # authoritative: cross-node the sweep / next same-node success reconciles.
+        self._pending_consent_written: set[tuple[str, str]] = set()
 
         # Idle-eviction task handle. Scheduled lazily on the mcp-loop the
         # first time a pool entry is created (start() runs before pool
@@ -2525,12 +2530,14 @@ class MCPClientManager:
             log.debug("mcp pool prime skipped: loop closed user=%s", user_id)
 
     async def _prime_user_pools(self, user_id: str) -> None:
-        """Warm THIS user's consented ``oauth_user`` pools (runs on the mcp-loop).
+        """Warm THIS user's pool-backed servers — oauth_user AND oauth_obo (runs on the mcp-loop).
 
         Best-effort and transient-safe: each token is resolved via the SAME
-        guarded refresh state machine the lazy-dispatch path uses
-        (:func:`get_user_access_token_classified`). That refreshes an expired /
-        near-expiry access token and persists it, but a TRANSIENT AS/network
+        guarded state machine the lazy-dispatch path uses — for oauth_user
+        :func:`get_user_access_token_classified` (refresh grant), for oauth_obo
+        :func:`get_obo_access_token_classified` (mint from the captured
+        credential). That refreshes/mints an expired / near-expiry access token
+        and persists it, but a TRANSIENT AS/network
         failure keeps the token (``kind=refresh_failed_transient``, no revoke)
         and is simply skipped here — only a genuinely PERMANENT rejection (the
         user must re-consent anyway) clears it. This closes the chicken-and-egg
@@ -2559,23 +2566,27 @@ class MCPClientManager:
             try:
                 async with sem:
                     try:
-                        server_row = await asyncio.to_thread(
-                            self._storage.get_mcp_server_by_name, server_name
-                        )
-                        if not server_row:
-                            return
+                        # Branch on the in-memory obo registry (no SQL) to pick the
+                        # lookup path. For oauth_obo we need the row up front (mint
+                        # takes server_row + it feeds cfg); for oauth_user we defer
+                        # the row fetch until AFTER a successful lookup so a user
+                        # with no token pays no SELECT (the pre-obo behaviour).
                         # Resolve via the same guarded state machine lazy dispatch
-                        # uses. For oauth_obo this MINTS from the user's captured
-                        # credential (missing credential → kind="missing", skipped,
-                        # the re-login rail handles it on real dispatch). For
-                        # oauth_user, revoke_ambiguous_escalation=False: a
-                        # genuinely-dead grant is still revoked so the catalog
-                        # isn't left cold behind a phantom "consented" token, but a
-                        # sustained-UNCLASSIFIABLE rejection is deferred to lazy
-                        # dispatch — priming runs for every server, so an AS hiccup
-                        # we can't classify must not revoke a server the user may
-                        # not be using this session. Only kind == "token" warms it.
-                        if str(server_row.get("auth_type") or "") == "oauth_obo":
+                        # uses. For oauth_obo this MINTS from the captured credential
+                        # (missing credential → kind="missing", skipped — the
+                        # re-login rail handles it on real dispatch). For oauth_user,
+                        # revoke_ambiguous_escalation=False: a genuinely-dead grant is
+                        # still revoked so the catalog isn't left cold behind a
+                        # phantom "consented" token, but a sustained-UNCLASSIFIABLE
+                        # rejection is deferred to lazy dispatch. Only kind=="token"
+                        # warms the pool.
+                        server_row: dict[str, Any] | None = None
+                        if server_name in self._obo_server_names:
+                            server_row = await asyncio.to_thread(
+                                self._storage.get_mcp_server_by_name, server_name
+                            )
+                            if not server_row:
+                                return
                             lookup = await get_obo_access_token_classified(
                                 app_state=self._app_state,
                                 user_id=user_id,
@@ -2591,6 +2602,12 @@ class MCPClientManager:
                             )
                         if lookup.kind != "token" or not lookup.token:
                             return  # not consented / no credential / refresh failed — lazy paths handle it
+                        if server_row is None:
+                            server_row = await asyncio.to_thread(
+                                self._storage.get_mcp_server_by_name, server_name
+                            )
+                            if not server_row:
+                                return
                         cfg = _pool_cfg_from_row(server_row)
                         await self._prime_user_server(key, cfg, lookup.token)
                         log.info(
@@ -2817,6 +2834,9 @@ class MCPClientManager:
             scopes_required=scopes_required,
             now_iso=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"),
         )
+        # Remember we wrote a row so the dispatch-success clear can skip its SQL
+        # DELETE on the common (no-pending) path.
+        self._pending_consent_written.add((user_id, server_name))
 
     async def _persist_pending_consent_best_effort(self, user_id: str, server_name: str) -> bool:
         """Raise the dashboard pending-consent badge for a proactively-detected
@@ -2858,6 +2878,7 @@ class MCPClientManager:
             return
         try:
             await asyncio.to_thread(self._storage.delete_mcp_pending_consent, user_id, server_name)
+            self._pending_consent_written.discard((user_id, server_name))
         except Exception:
             log.debug(
                 "MCP token sweep: pending-consent clear failed user=%s server=%s",
@@ -5617,13 +5638,21 @@ class MCPClientManager:
         oauth_user clears live in the token sweep (which skips obo) and the
         consent callback (which obo never runs), so without a success-side clear
         an obo pending row — written when the credential was missing — would
-        persist forever after the user re-logs in. Delete is a no-op when no row
-        exists, so this is safe to call on every successful dispatch.
+        persist forever after the user re-logs in.
+
+        Gated on this node's ``_pending_consent_written`` hint so the common case
+        (no pending row was ever written for this pair) issues ZERO SQL — the
+        DELETE runs only when we actually recorded a row, keeping the hot dispatch
+        path free of an unconditional per-call write.
         """
+        key = (user_id, server_name)
+        if key not in self._pending_consent_written:
+            return
         if self._storage is None:
             return
         try:
             self._storage.delete_mcp_pending_consent(user_id, server_name)
+            self._pending_consent_written.discard(key)
         except Exception:
             log.debug(
                 "mcp_pool.pending_consent_clear_failed user=%s server=%s",

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -5469,6 +5469,7 @@ class MCPClientManager:
                 user_id=user_id,
                 server_name=server_name,
                 force_refresh=force_refresh,
+                server_row=server_row,
             )
         return await get_user_access_token_classified(
             app_state=self._app_state,
@@ -5990,7 +5991,7 @@ class MCPClientManager:
             return _structured_error(
                 code="mcp_consent_required",
                 server=server_name,
-                detail="Refresh token rejected. Re-consent required.",
+                detail=_refresh_failed_detail(server_row),
                 consent_url=_build_consent_url(server_row),
             )
         # kind == "token"
@@ -6169,7 +6170,7 @@ class MCPClientManager:
             return _structured_error(
                 code="mcp_consent_required",
                 server=server_name,
-                detail="Refresh token rejected. Re-consent required.",
+                detail=_refresh_failed_detail(server_row),
                 consent_url=_build_consent_url(server_row),
             )
         access_token = lookup.token or ""
@@ -6325,7 +6326,7 @@ class MCPClientManager:
             return _structured_error(
                 code="mcp_consent_required",
                 server=server_name,
-                detail="Refresh token rejected. Re-consent required.",
+                detail=_refresh_failed_detail(server_row),
                 consent_url=_build_consent_url(server_row),
             )
         access_token = lookup.token or ""
@@ -7179,6 +7180,22 @@ def _consent_missing_detail(server_row: dict[str, Any]) -> str:
     if server_row.get("auth_type") == "oauth_obo":
         return "No sign-in credential for this account. Sign in to Turnstone again to reconnect."
     return "No token for user. Consent flow required."
+
+
+def _refresh_failed_detail(server_row: dict[str, Any]) -> str:
+    """User-facing detail for a ``refresh_failed`` (permanent) lookup, per auth model.
+
+    For ``oauth_obo`` there is no per-server consent to redo and
+    ``_build_consent_url`` returns None, so "re-consent required" is a dead end —
+    the remedy is an admin tenant-grant fix or a re-login. Point the user there
+    instead of at a consent flow that does not exist for this auth type.
+    """
+    if server_row.get("auth_type") == "oauth_obo":
+        return (
+            "Sign-in credential was rejected for this server. Sign in to Turnstone "
+            "again; if it keeps failing, your administrator may need to grant access."
+        )
+    return "Refresh token rejected. Re-consent required."
 
 
 def _pool_cfg_from_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -55,7 +55,9 @@ from turnstone.core.mcp_http_parsers import (
 from turnstone.core.mcp_oauth import (
     TokenLookupResult,
     emit_oauth_failure_audit,
+    get_obo_access_token_classified,
     get_user_access_token_classified,
+    is_user_scoped_auth,
 )
 
 if TYPE_CHECKING:
@@ -766,6 +768,12 @@ class MCPClientManager:
         # backend resolution) can answer "is this server pool-backed?"
         # without a SQL roundtrip.
         self._oauth_user_server_names: set[str] = set()
+        # Sibling registry for auth_type='oauth_obo' servers (issue #551):
+        # also pool-backed (per-user sessions), but with NO per-server
+        # consent flow — tokens mint from the user's single captured
+        # credential, so the priming / keep-alive-sweep / consent sites that
+        # iterate ``_oauth_user_server_names`` deliberately exclude these.
+        self._obo_server_names: set[str] = set()
 
         # Idle-eviction task handle. Scheduled lazily on the mcp-loop the
         # first time a pool entry is created (start() runs before pool
@@ -4470,12 +4478,13 @@ class MCPClientManager:
         :meth:`_oauth_user_server_status`). Both are ignored for static servers,
         whose session is process-global.
         """
-        # auth_type='oauth_user' servers hold NO process-global session — they
-        # are warmed per-user into the pool — so the static-session check below
-        # would always report them "connecting". Derive their status from the
-        # REQUESTING user's warm pool entry instead, so the console pill reflects
-        # that user's real reachability once their pool is primed.
-        if name in self._oauth_user_server_names:
+        # Pool-backed servers (oauth_user / oauth_obo) hold NO process-global
+        # session — they are warmed per-user into the pool — so the
+        # static-session check below would always report them "connecting".
+        # Derive their status from the REQUESTING user's warm pool entry
+        # instead, so the console pill reflects that user's real reachability
+        # once their pool is primed.
+        if self._is_pool_server(name):
             return self._oauth_user_server_status(name, user_id, aggregate=aggregate)
         state = self._static_servers.get(name)
         connected = state is not None and state.session is not None
@@ -4560,7 +4569,7 @@ class MCPClientManager:
             "url": "",
             "circuit_open": cb_open,
             "consecutive_failures": self._consecutive_failures.get(name, 0),
-            "auth_type": "oauth_user",
+            "auth_type": self.server_auth_type(name) or "oauth_user",
             "user_pools": len(warm),
             "last_refresh_at": last_refresh[0] if last_refresh is not None else None,
             "last_refresh_outcome": last_refresh[1] if last_refresh is not None else None,
@@ -4580,7 +4589,7 @@ class MCPClientManager:
         result: dict[str, dict[str, Any]] = {}
         for name in list(self._server_configs):
             result[name] = self.get_server_status(name, user_id, aggregate=aggregate)
-        for name in list(self._oauth_user_server_names):
+        for name in list(self._oauth_user_server_names | self._obo_server_names):
             if name not in result:
                 result[name] = self.get_server_status(name, user_id, aggregate=aggregate)
         return result
@@ -4611,6 +4620,9 @@ class MCPClientManager:
         # roundtrip.
         self._oauth_user_server_names = {
             row["name"] for row in rows if row.get("auth_type") == "oauth_user"
+        }
+        self._obo_server_names = {
+            row["name"] for row in rows if row.get("auth_type") == "oauth_obo"
         }
 
         desired = _db_servers_to_config(rows)
@@ -4811,18 +4823,27 @@ class MCPClientManager:
         return user_map is not None and name in user_map
 
     def server_auth_type(self, server_name: str) -> str | None:
-        """Return ``'oauth_user'`` for pool-backed servers, else ``None``.
+        """Return the pool-backed auth type (``'oauth_user'`` / ``'oauth_obo'``), else ``None``.
 
         In-memory accessor for the per-turn callers that need to
         distinguish pool-backed servers from static-path ones without a
         SQL roundtrip. ``None`` means "either static-path or unknown" —
         the boot-time / per-node web_search resolver only uses this as
-        a defence-in-depth gate, so a missing-cache miss is safe (the
-        outer ``is_mcp_tool`` check already proves the server is in
-        ``_tool_map``, which by construction excludes oauth_user).
+        a defence-in-depth gate (via :func:`is_user_scoped_auth`), so a
+        missing-cache miss is safe (the outer ``is_mcp_tool`` check
+        already proves the server is in ``_tool_map``, which by
+        construction excludes pool-backed servers).
         Populated by ``reconcile_sync`` and ``create_mcp_client``.
         """
-        return "oauth_user" if server_name in self._oauth_user_server_names else None
+        if server_name in self._oauth_user_server_names:
+            return "oauth_user"
+        if server_name in self._obo_server_names:
+            return "oauth_obo"
+        return None
+
+    def _is_pool_server(self, server_name: str) -> bool:
+        """True when *server_name* uses per-user pool sessions (no static session)."""
+        return server_name in self._oauth_user_server_names or server_name in self._obo_server_names
 
     @property
     def server_count(self) -> int:
@@ -4962,7 +4983,7 @@ class MCPClientManager:
             # Per-user pools are managed separately; ``__`` names can never
             # connect (``_connect_one``'s reserved-delimiter guard), so retrying
             # them forever would only spam ``log.error`` every interval.
-            if name not in self._oauth_user_server_names and "__" not in name
+            if not self._is_pool_server(name) and "__" not in name
         ]
         if not names:
             return self._static_health_check_s
@@ -5422,9 +5443,39 @@ class MCPClientManager:
         if not server_name or not original:
             return None
         row = self._lookup_server_row(server_name)
-        if row is None or row.get("auth_type") != "oauth_user":
+        if row is None or not is_user_scoped_auth(row.get("auth_type")):
             return None
         return server_name, original, row
+
+    async def _pool_token_lookup(
+        self,
+        server_row: dict[str, Any],
+        user_id: str,
+        server_name: str,
+        *,
+        force_refresh: bool,
+    ) -> TokenLookupResult:
+        """Classified token lookup routed by the server's auth model.
+
+        ``oauth_obo`` servers mint from the user's single captured
+        credential (:func:`get_obo_access_token_classified`); everything
+        else keeps the per-(user, server) refresh-grant path. Both share
+        the ``TokenLookupResult`` vocabulary, so the dispatcher's error
+        mapping below is auth-model-agnostic.
+        """
+        if str(server_row.get("auth_type") or "") == "oauth_obo":
+            return await get_obo_access_token_classified(
+                app_state=self._app_state,
+                user_id=user_id,
+                server_name=server_name,
+                force_refresh=force_refresh,
+            )
+        return await get_user_access_token_classified(
+            app_state=self._app_state,
+            user_id=user_id,
+            server_name=server_name,
+            force_refresh=force_refresh,
+        )
 
     def _lookup_server_row(self, server_name: str) -> dict[str, Any] | None:
         """Return the ``mcp_servers`` row for *server_name*, or None."""
@@ -5470,7 +5521,7 @@ class MCPClientManager:
         else:
             server_name = mapping[0]
         row = self._lookup_server_row(server_name)
-        if row is None or row.get("auth_type") != "oauth_user":
+        if row is None or not is_user_scoped_auth(row.get("auth_type")):
             return None
         return server_name, uri, row
 
@@ -5496,7 +5547,7 @@ class MCPClientManager:
         if not server_name or not original:
             return None
         row = self._lookup_server_row(server_name)
-        if row is None or row.get("auth_type") != "oauth_user":
+        if row is None or not is_user_scoped_auth(row.get("auth_type")):
             return None
         return server_name, original, row
 
@@ -5905,17 +5956,14 @@ class MCPClientManager:
         # this retry; the local cached token is the one the AS just
         # rejected, so reading it back without ``force_refresh=True``
         # would re-attempt with the same (rejected) bearer.
-        lookup: TokenLookupResult = await get_user_access_token_classified(
-            app_state=self._app_state,
-            user_id=user_id,
-            server_name=server_name,
-            force_refresh=retry_count > 0,
+        lookup: TokenLookupResult = await self._pool_token_lookup(
+            server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         if lookup.kind == "missing":
             return _structured_error(
                 code="mcp_consent_required",
                 server=server_name,
-                detail="No token for user. Consent flow required.",
+                detail=_consent_missing_detail(server_row),
                 consent_url=_build_consent_url(server_row),
             )
         if lookup.kind == "decrypt_failure":
@@ -6090,17 +6138,14 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
-        lookup: TokenLookupResult = await get_user_access_token_classified(
-            app_state=self._app_state,
-            user_id=user_id,
-            server_name=server_name,
-            force_refresh=retry_count > 0,
+        lookup: TokenLookupResult = await self._pool_token_lookup(
+            server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         if lookup.kind == "missing":
             return _structured_error(
                 code="mcp_consent_required",
                 server=server_name,
-                detail="No token for user. Consent flow required.",
+                detail=_consent_missing_detail(server_row),
                 consent_url=_build_consent_url(server_row),
             )
         if lookup.kind == "decrypt_failure":
@@ -6249,17 +6294,14 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
-        lookup: TokenLookupResult = await get_user_access_token_classified(
-            app_state=self._app_state,
-            user_id=user_id,
-            server_name=server_name,
-            force_refresh=retry_count > 0,
+        lookup: TokenLookupResult = await self._pool_token_lookup(
+            server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         if lookup.kind == "missing":
             return _structured_error(
                 code="mcp_consent_required",
                 server=server_name,
-                detail="No token for user. Consent flow required.",
+                detail=_consent_missing_detail(server_row),
                 consent_url=_build_consent_url(server_row),
             )
         if lookup.kind == "decrypt_failure":
@@ -7126,6 +7168,19 @@ def _build_consent_url(
     return f"/v1/api/mcp/oauth/start?{qs}"
 
 
+def _consent_missing_detail(server_row: dict[str, Any]) -> str:
+    """User-facing detail for a ``missing`` token lookup, per auth model.
+
+    ``oauth_obo`` has no per-server consent flow — the missing thing is the
+    user's captured sign-in credential, so the affordance is a re-login
+    (``_build_consent_url`` already returns None for these servers, so no
+    per-server Connect button is advertised).
+    """
+    if server_row.get("auth_type") == "oauth_obo":
+        return "No sign-in credential for this account. Sign in to Turnstone again to reconnect."
+    return "No token for user. Consent flow required."
+
+
 def _pool_cfg_from_row(row: dict[str, Any]) -> dict[str, Any]:
     """Build a streamable-http MCP-client cfg from an ``mcp_servers`` row.
 
@@ -7164,15 +7219,15 @@ def _pool_cfg_from_row(row: dict[str, Any]) -> dict[str, Any]:
 def _db_servers_to_config(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """Convert mcp_servers DB rows to the config dict format.
 
-    Skips ``auth_type='oauth_user'`` rows: they need per-user bearer
-    tokens fetched at dispatch time via the OAuth flow, so auto-connecting
-    them at startup with empty headers fails handshake and trips the
-    circuit breaker. The upcoming per-user pool integration brings them
-    online lazily once a user has consented.
+    Skips pool-backed rows (``auth_type='oauth_user'`` / ``'oauth_obo'``):
+    they need per-user bearer tokens fetched at dispatch time, so
+    auto-connecting them at startup with empty headers fails handshake and
+    trips the circuit breaker. The per-user pool brings them online lazily —
+    on consent for oauth_user, on first dispatch for oauth_obo.
     """
     result: dict[str, dict[str, Any]] = {}
     for row in rows:
-        if row.get("auth_type") == "oauth_user":
+        if is_user_scoped_auth(row.get("auth_type")):
             continue
         name = row["name"]
         cfg: dict[str, Any] = {"type": row["transport"]}
@@ -7264,14 +7319,16 @@ def create_mcp_client(
     # Check DB first to know which servers are DB-managed
     db_names: set[str] = set()
     oauth_user_names: set[str] = set()
+    obo_names: set[str] = set()
     if storage is not None:
         try:
             rows = storage.list_mcp_servers(enabled_only=True)
             if rows:
                 db_names = {r["name"] for r in rows}
-                # Cache oauth_user names so per-turn callers (web_search
+                # Cache pool-backed names so per-turn callers (web_search
                 # backend resolution) can answer auth_type without SQL.
                 oauth_user_names = {r["name"] for r in rows if r.get("auth_type") == "oauth_user"}
+                obo_names = {r["name"] for r in rows if r.get("auth_type") == "oauth_obo"}
         except Exception:
             log.warning("Failed to load DB-managed MCP servers", exc_info=True)
 
@@ -7283,5 +7340,6 @@ def create_mcp_client(
     # Mark DB-sourced servers so reconcile_sync won't remove config-file servers
     mgr._db_managed = {name for name in servers if name in db_names}
     mgr._oauth_user_server_names = oauth_user_names
+    mgr._obo_server_names = obo_names
     mgr.start()
     return mgr

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -4706,11 +4706,14 @@ class MCPClientManager:
             log.warning("reconcile_sync: failed to read mcp_servers table", exc_info=True)
             return {"added": [], "removed": [], "updated": []}
 
-        # Pool-backed (oauth_user / oauth_obo) names known BEFORE this
-        # reconcile — diffed against the refreshed sets below to spot servers
-        # that appeared since active sessions last primed (see the re-prime
-        # self-heal near the end of this method).
-        prev_pool_names = self._oauth_user_server_names | self._obo_server_names
+        # Prior (name -> pool auth_type) view, reconstructed from the tracked
+        # pool-name sets. Diffing auth_type — not just names — below catches a
+        # server MIGRATED in place between the two pool auth types
+        # (oauth_user <-> oauth_obo, the flip the OBO feature enables): a
+        # name-only diff sees the same name on both sides and misses it.
+        # Mirrors the explicit two-type split of the set rebuilds just below.
+        prev_pool_auth = {n: "oauth_user" for n in self._oauth_user_server_names}
+        prev_pool_auth.update(dict.fromkeys(self._obo_server_names, "oauth_obo"))
 
         # Refresh the in-memory oauth_user name cache from the rows we
         # just read — feeds :meth:`server_auth_type` so callers (e.g.
@@ -4722,9 +4725,13 @@ class MCPClientManager:
         self._obo_server_names = {
             row["name"] for row in rows if row.get("auth_type") == "oauth_obo"
         }
-        newly_added_pool = (
-            self._oauth_user_server_names | self._obo_server_names
-        ) - prev_pool_names
+        new_pool_auth = {n: "oauth_user" for n in self._oauth_user_server_names}
+        new_pool_auth.update(dict.fromkeys(self._obo_server_names, "oauth_obo"))
+        # Pool servers newly registered OR migrated between pool auth types
+        # since active sessions last primed.
+        newly_added_pool = {
+            name for name, at in new_pool_auth.items() if prev_pool_auth.get(name) != at
+        }
 
         desired = _db_servers_to_config(rows)
         desired_names = set(desired)
@@ -4785,31 +4792,48 @@ class MCPClientManager:
         # active session's user so a mid-session registration surfaces its
         # tools automatically — no reconnect or fresh workstream needed.
         if newly_added_pool:
-            self._reprime_active_users(newly_added_pool)
+            self._reprime_active_users(len(newly_added_pool))
 
         return {"added": added, "removed": removed, "updated": updated}
 
-    def _reprime_active_users(self, new_servers: set[str]) -> None:
-        """Re-warm active sessions' pools after new pool-backed servers appear.
+    def _reprime_active_users(self, changed_count: int) -> None:
+        """Schedule a pool re-warm for every active session's user after
+        *changed_count* pool-backed servers were newly registered or migrated
+        between pool auth types this reconcile (see :meth:`reconcile_sync`).
 
-        Called from :meth:`reconcile_sync` when a reconcile reveals an
-        oauth_user / oauth_obo server that active sessions never primed. Active
-        users come from the tool-listener registry (each open ChatSession
+        Active users come from the tool-listener registry (each open ChatSession
         registers ``(user_id, callback)`` via :meth:`add_listener`); the
         ``user_id=None`` global/admin listener is skipped. ``prime_user_pools``
-        is idempotent and fire-and-forget, so re-priming an already-warm pool
-        is a cheap skip and re-priming a user without the stored token /
-        captured credential is a no-op.
+        is fire-and-forget — it SCHEDULES the mint/connect onto the mcp-loop and
+        returns, no-opping for an already-warm pool, a user without a captured
+        credential, or a down loop — so the log below reports what was
+        SCHEDULED, not what completed. The call is guarded per-user (mirroring
+        the session.py call sites) so one user's scheduling failure can't abort
+        the loop or 500 the reload endpoint.
+
+        Fan-out note: only the infrequent, operator-driven reload path reaches
+        here and each user's mint concurrency is already capped
+        (``_PRIME_MAX_CONCURRENCY``); a shared cross-user mint cap is left as a
+        follow-up if IdP rate-limiting is ever observed under a large active-user
+        count.
         """
         with self._listeners_lock:
             user_ids = {uid for uid, _cb in self._listeners if uid}
         for user_id in user_ids:
-            self.prime_user_pools(user_id)
+            try:
+                self.prime_user_pools(user_id)
+            except Exception:
+                log.debug(
+                    "mcp reconcile re-prime scheduling failed user=%s",
+                    user_id,
+                    exc_info=True,
+                )
         if user_ids:
             log.info(
-                "MCP reconcile: re-primed %d active user(s) after %d new pool server(s) appeared",
+                "MCP reconcile: scheduled pool re-prime for %d active session "
+                "user(s) after %d pool server change(s)",
                 len(user_ids),
-                len(new_servers),
+                changed_count,
             )
 
     # -- query methods -------------------------------------------------------

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2498,17 +2498,21 @@ class MCPClientManager:
             )
 
     def prime_user_pools(self, user_id: str) -> None:
-        """Fire-and-forget: warm THIS user's consented ``oauth_user`` pools.
+        """Fire-and-forget: warm THIS user's pool-backed servers (oauth_user + oauth_obo).
 
-        Called at ChatSession start so a per-user OAuth server's tools are
-        present automatically — no manual reconnect after a reboot/upgrade, and
-        no chicken-and-egg (the model can't dispatch a tool it can't see). Only
-        touches servers the user already has a stored token for; skips servers
-        already connected. Non-blocking: schedules onto the mcp-loop and returns
-        immediately. The per-user tool listeners (registered by ChatSession)
-        deliver the catalog to the live session when each prime completes.
+        Called at ChatSession start so a per-user server's tools are present
+        automatically — no manual reconnect after a reboot/upgrade, and no
+        chicken-and-egg (the model can't dispatch a tool it can't see). For
+        oauth_obo this is the ONLY way tools reach the catalog: there is no
+        consent flow, so nothing else would warm the pool and the documented
+        "mint on first dispatch" could never fire (the model would never see the
+        tool to dispatch it). Only touches servers the user already has a stored
+        token / captured credential for; skips servers already connected.
+        Non-blocking: schedules onto the mcp-loop and returns immediately.
         """
-        if not user_id or self._loop is None or not self._oauth_user_server_names:
+        if not user_id or self._loop is None:
+            return
+        if not (self._oauth_user_server_names or self._obo_server_names):
             return
         if self._app_state is None or self._storage is None:
             return
@@ -2555,28 +2559,38 @@ class MCPClientManager:
             try:
                 async with sem:
                     try:
-                        # Resolve via the guarded refresh state machine, but with
-                        # revoke_ambiguous_escalation=False: a genuinely-dead grant
-                        # (permanent AS rejection / expired-no-refresh) is still
-                        # revoked so the catalog isn't left cold behind a phantom
-                        # "consented" token, but a sustained-UNCLASSIFIABLE rejection
-                        # is deferred to lazy dispatch — priming runs for every
-                        # consented server, so an AS hiccup we can't classify must
-                        # not revoke consent for one the user may not be using this
-                        # session. Only kind == "token" warms the pool.
-                        lookup = await get_user_access_token_classified(
-                            app_state=self._app_state,
-                            user_id=user_id,
-                            server_name=server_name,
-                            revoke_ambiguous_escalation=False,
-                        )
-                        if lookup.kind != "token" or not lookup.token:
-                            return  # not consented / undecryptable / refresh failed — lazy paths handle it
                         server_row = await asyncio.to_thread(
                             self._storage.get_mcp_server_by_name, server_name
                         )
                         if not server_row:
                             return
+                        # Resolve via the same guarded state machine lazy dispatch
+                        # uses. For oauth_obo this MINTS from the user's captured
+                        # credential (missing credential → kind="missing", skipped,
+                        # the re-login rail handles it on real dispatch). For
+                        # oauth_user, revoke_ambiguous_escalation=False: a
+                        # genuinely-dead grant is still revoked so the catalog
+                        # isn't left cold behind a phantom "consented" token, but a
+                        # sustained-UNCLASSIFIABLE rejection is deferred to lazy
+                        # dispatch — priming runs for every server, so an AS hiccup
+                        # we can't classify must not revoke a server the user may
+                        # not be using this session. Only kind == "token" warms it.
+                        if str(server_row.get("auth_type") or "") == "oauth_obo":
+                            lookup = await get_obo_access_token_classified(
+                                app_state=self._app_state,
+                                user_id=user_id,
+                                server_name=server_name,
+                                server_row=server_row,
+                            )
+                        else:
+                            lookup = await get_user_access_token_classified(
+                                app_state=self._app_state,
+                                user_id=user_id,
+                                server_name=server_name,
+                                revoke_ambiguous_escalation=False,
+                            )
+                        if lookup.kind != "token" or not lookup.token:
+                            return  # not consented / no credential / refresh failed — lazy paths handle it
                         cfg = _pool_cfg_from_row(server_row)
                         await self._prime_user_server(key, cfg, lookup.token)
                         log.info(
@@ -2594,7 +2608,8 @@ class MCPClientManager:
             finally:
                 self._priming_keys.discard(key)
 
-        await asyncio.gather(*(_prime_one(s) for s in list(self._oauth_user_server_names)))
+        prime_names = self._oauth_user_server_names | self._obo_server_names
+        await asyncio.gather(*(_prime_one(s) for s in list(prime_names)))
 
     # -- background token-freshness sweep (oauth_user grants) -----------------
 

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2535,7 +2535,7 @@ class MCPClientManager:
         """
         if not user_id or self._loop is None:
             return
-        if not (self._oauth_user_server_names or self._obo_server_names):
+        if not self._pool_server_names:
             return
         if self._app_state is None or self._storage is None:
             return
@@ -2649,7 +2649,7 @@ class MCPClientManager:
             finally:
                 self._priming_keys.discard(key)
 
-        prime_names = self._oauth_user_server_names | self._obo_server_names
+        prime_names = self._pool_server_names
         if self._obo_server_names:
             # One raw existence SELECT (no decrypt) decides ALL obo servers for
             # this user: a user with no captured credential — a local-auth
@@ -4675,7 +4675,7 @@ class MCPClientManager:
         result: dict[str, dict[str, Any]] = {}
         for name in list(self._server_configs):
             result[name] = self.get_server_status(name, user_id, aggregate=aggregate)
-        for name in list(self._oauth_user_server_names | self._obo_server_names):
+        for name in list(self._pool_server_names):
             if name not in result:
                 result[name] = self.get_server_status(name, user_id, aggregate=aggregate)
         return result
@@ -4934,6 +4934,17 @@ class MCPClientManager:
         one definition over the two per-auth-type registries.
         """
         return self.server_auth_type(server_name) is not None
+
+    @property
+    def _pool_server_names(self) -> set[str]:
+        """Union of the per-auth-type pool registries (oauth_user + oauth_obo).
+
+        The set-level counterpart to :meth:`_is_pool_server`, so the iteration
+        sites (priming, keep-hot sweep, status) share ONE definition of "which
+        servers are pool-backed" — a future third pool-backed auth type is added
+        in one place instead of being missed at an ad-hoc inline union.
+        """
+        return self._oauth_user_server_names | self._obo_server_names
 
     @property
     def server_count(self) -> int:
@@ -7221,77 +7232,74 @@ def _build_consent_url(
     return f"/v1/api/mcp/oauth/start?{qs}"
 
 
-def _consent_missing_detail(server_row: dict[str, Any]) -> str:
-    """User-facing detail for a ``missing`` token lookup, per auth model.
+# User-facing remediation copy for every (auth model, failure situation) a
+# pool-backed dispatch can surface. Consolidated into ONE table so the
+# oauth_user-vs-oauth_obo split lives in a single place instead of a branch
+# fanned across four helpers: a lookup situation that must show obo re-login /
+# admin guidance can't silently keep oauth_user's "re-consent at a per-server
+# flow that doesn't exist for obo" copy — the exact wrong-remediation bug this
+# feature's review caught repeatedly. ``{kind}`` / ``{kind_cap}`` are filled per
+# call (only the insufficient_scope rows use them; other rows ignore them).
+_POOL_ERROR_DETAIL: dict[tuple[str, str], str] = {
+    ("oauth_user", "missing"): "No token for user. Consent flow required.",
+    ("oauth_obo", "missing"): (
+        "No sign-in credential for this account. Sign in to Turnstone again to reconnect."
+    ),
+    ("oauth_user", "refresh_failed"): "Refresh token rejected. Re-consent required.",
+    ("oauth_obo", "refresh_failed"): (
+        "Sign-in credential was rejected for this server. Sign in to Turnstone "
+        "again; if it keeps failing, your administrator may need to grant access."
+    ),
+    ("oauth_user", "insufficient_scope"): (
+        "{kind_cap} requires elevated scopes. Re-consent flow with new scopes required."
+    ),
+    ("oauth_obo", "insufficient_scope"): (
+        "This {kind} needs additional permissions your sign-in token does not "
+        "carry. Ask your administrator to grant the required access (add the "
+        "scope to the server, or widen your delegated permissions at the "
+        "identity provider)."
+    ),
+    ("oauth_user", "token_rejected"): "Refreshed token still rejected. Re-consent required.",
+    ("oauth_obo", "token_rejected"): (
+        "Server rejected a freshly issued sign-in token. This usually means the "
+        "server's audience setting doesn't match what the server expects — ask "
+        "your administrator to check it."
+    ),
+}
 
-    ``oauth_obo`` has no per-server consent flow — the missing thing is the
-    user's captured sign-in credential, so the affordance is a re-login
-    (``_build_consent_url`` already returns None for these servers, so no
-    per-server Connect button is advertised).
+
+def _pool_error_detail(server_row: dict[str, Any], situation: str, *, kind: str = "") -> str:
+    """Remediation copy for *situation* on *server_row*, chosen by auth model.
+
+    Single lookup into :data:`_POOL_ERROR_DETAIL` — the ONE place the
+    oauth_user-vs-oauth_obo decision is made — so no dispatch site can pair a
+    situation with the wrong auth model's copy. ``oauth_obo`` rows never have a
+    per-server consent flow (``_build_consent_url`` returns None), so their copy
+    points at a re-login / administrator remedy rather than a dead-end consent
+    card; everything else is treated as ``oauth_user``.
     """
-    if server_row.get("auth_type") == "oauth_obo":
-        return "No sign-in credential for this account. Sign in to Turnstone again to reconnect."
-    return "No token for user. Consent flow required."
+    model = "oauth_obo" if server_row.get("auth_type") == "oauth_obo" else "oauth_user"
+    return _POOL_ERROR_DETAIL[(model, situation)].format(kind=kind, kind_cap=kind.capitalize())
+
+
+def _consent_missing_detail(server_row: dict[str, Any]) -> str:
+    """Detail for a ``missing`` token lookup (see :func:`_pool_error_detail`)."""
+    return _pool_error_detail(server_row, "missing")
 
 
 def _refresh_failed_detail(server_row: dict[str, Any]) -> str:
-    """User-facing detail for a ``refresh_failed`` (permanent) lookup, per auth model.
-
-    For ``oauth_obo`` there is no per-server consent to redo and
-    ``_build_consent_url`` returns None, so "re-consent required" is a dead end —
-    the remedy is an admin tenant-grant fix or a re-login. Point the user there
-    instead of at a consent flow that does not exist for this auth type.
-    """
-    if server_row.get("auth_type") == "oauth_obo":
-        return (
-            "Sign-in credential was rejected for this server. Sign in to Turnstone "
-            "again; if it keeps failing, your administrator may need to grant access."
-        )
-    return "Refresh token rejected. Re-consent required."
+    """Detail for a permanent ``refresh_failed`` lookup (see :func:`_pool_error_detail`)."""
+    return _pool_error_detail(server_row, "refresh_failed")
 
 
 def _insufficient_scope_detail(server_row: dict[str, Any], kind: str) -> str:
-    """User-facing detail for a 403 insufficient_scope, per auth model.
-
-    ``oauth_user``: a per-server step-up re-consent with the widened scope set
-    is the remedy (``_build_consent_url`` attaches the affordance). ``oauth_obo``:
-    there is no per-server consent flow — the minted token's scopes come from
-    the user's captured sign-in (entra: the app's delegated permissions;
-    rfc8693: the server's configured ``oauth_scopes``), so a user-driven
-    step-up is impossible (``_build_consent_url`` returns None). Point at the
-    real fix — an administrator widening access — instead of a dead-end
-    re-consent card.
-    """
-    if server_row.get("auth_type") == "oauth_obo":
-        return (
-            f"This {kind} needs additional permissions your sign-in token does not "
-            "carry. Ask your administrator to grant the required access (add the "
-            "scope to the server, or widen your delegated permissions at the "
-            "identity provider)."
-        )
-    return (
-        f"{kind.capitalize()} requires elevated scopes. Re-consent flow with new scopes required."
-    )
+    """Detail for a 403 insufficient_scope (see :func:`_pool_error_detail`)."""
+    return _pool_error_detail(server_row, "insufficient_scope", kind=kind)
 
 
 def _token_rejected_detail(server_row: dict[str, Any]) -> str:
-    """User-facing detail for a 401 that survived one forced refresh (retry ceiling).
-
-    ``oauth_user``: the freshly refreshed bearer was rejected — per-server
-    re-consent is the actionable remedy (``_build_consent_url`` attaches the
-    Connect affordance). ``oauth_obo``: the bearer was JUST minted from the
-    captured credential and there is no per-server consent flow
-    (``_build_consent_url`` returns None), so "re-consent required" is a dead
-    end — the realistic causes are server-side (audience mismatch, upstream
-    auth misconfig, clock skew), so point at the administrator instead.
-    """
-    if server_row.get("auth_type") == "oauth_obo":
-        return (
-            "Server rejected a freshly issued sign-in token. This usually means the "
-            "server's audience setting doesn't match what the server expects — ask "
-            "your administrator to check it."
-        )
-    return "Refreshed token still rejected. Re-consent required."
+    """Detail for a 401 that survived one forced refresh (see :func:`_pool_error_detail`)."""
+    return _pool_error_detail(server_row, "token_rejected")
 
 
 def _pool_lookup_error(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -5713,8 +5713,7 @@ class MCPClientManager:
             return
         try:
             self._storage.delete_mcp_pending_consent(user_id, server_name)
-            self._prune_pending_consent_cleared(now)
-            self._pending_consent_cleared[key] = now
+            self._mark_pending_consent_cleared(key, now)
         except Exception:
             log.debug(
                 "mcp_pool.pending_consent_clear_failed user=%s server=%s",
@@ -5722,6 +5721,17 @@ class MCPClientManager:
                 server_name,
                 exc_info=True,
             )
+
+    def _mark_pending_consent_cleared(self, key: tuple[str, str], now: float) -> None:
+        """Record a DB-confirmed pending-consent DELETE in the TTL map.
+
+        The single "prune-then-stamp" step shared by the two DB-confirmed clear
+        sites (:meth:`_clear_pending_consent_sync` on the hot dispatch path and
+        :meth:`_clear_pending_consent_best_effort` from the sweep) so the
+        bookkeeping order can't drift between them.
+        """
+        self._prune_pending_consent_cleared(now)
+        self._pending_consent_cleared[key] = now
 
     def _prune_pending_consent_cleared(self, now: float) -> None:
         """Drop aged entries when the TTL map grows large (memory hygiene).
@@ -6558,10 +6568,7 @@ class MCPClientManager:
             return _structured_error(
                 code="mcp_insufficient_scope",
                 server=server_name,
-                detail=(
-                    f"{kind.capitalize()} requires elevated scopes. "
-                    "Re-consent flow with new scopes required."
-                ),
+                detail=_insufficient_scope_detail(server_row, kind),
                 scopes_required=list(scopes),
                 consent_url=_build_consent_url(server_row, scopes_required=list(scopes)),
             )
@@ -7241,6 +7248,30 @@ def _refresh_failed_detail(server_row: dict[str, Any]) -> str:
             "again; if it keeps failing, your administrator may need to grant access."
         )
     return "Refresh token rejected. Re-consent required."
+
+
+def _insufficient_scope_detail(server_row: dict[str, Any], kind: str) -> str:
+    """User-facing detail for a 403 insufficient_scope, per auth model.
+
+    ``oauth_user``: a per-server step-up re-consent with the widened scope set
+    is the remedy (``_build_consent_url`` attaches the affordance). ``oauth_obo``:
+    there is no per-server consent flow — the minted token's scopes come from
+    the user's captured sign-in (entra: the app's delegated permissions;
+    rfc8693: the server's configured ``oauth_scopes``), so a user-driven
+    step-up is impossible (``_build_consent_url`` returns None). Point at the
+    real fix — an administrator widening access — instead of a dead-end
+    re-consent card.
+    """
+    if server_row.get("auth_type") == "oauth_obo":
+        return (
+            f"This {kind} needs additional permissions your sign-in token does not "
+            "carry. Ask your administrator to grant the required access (add the "
+            "scope to the server, or widen your delegated permissions at the "
+            "identity provider)."
+        )
+    return (
+        f"{kind.capitalize()} requires elevated scopes. Re-consent flow with new scopes required."
+    )
 
 
 def _token_rejected_detail(server_row: dict[str, Any]) -> str:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -148,6 +148,17 @@ _MAX_PROMPTS_PER_SERVER = 1000
 # thundering herd of connects on every session start.
 _PRIME_MAX_CONCURRENCY = 4
 
+# How long a node trusts its own pending-consent DELETE before re-running it on
+# the next dispatch success. Bounds two things at once: the hot-path SQL rate
+# (at most one DELETE per (user, server) per window) and the staleness of a
+# consent badge written by ANOTHER node after this node's last clear.
+_PENDING_CONSENT_CLEAR_TTL_SECONDS = 300.0
+
+# Size threshold that triggers opportunistic pruning of the cleared-pairs TTL
+# map. Purely memory hygiene — a pruned pair costs one extra SQL DELETE on its
+# next success, never a correctness change.
+_PENDING_CONSENT_CLEARED_MAX = 4096
+
 
 # ``mcp.client.streamable_http._send_session_terminated_error`` synthesizes this
 # (non-standard, POSITIVE) JSON-RPC code *client-side* when a held
@@ -774,19 +785,18 @@ class MCPClientManager:
         # credential, so the priming / keep-alive-sweep / consent sites that
         # iterate ``_oauth_user_server_names`` deliberately exclude these.
         self._obo_server_names: set[str] = set()
-        # (user, server) pairs for which THIS node has written a pending-consent
-        # row. The dispatch-success clear consults it so the common (no pending
-        # row) path never issues an SQL DELETE — a per-node hint, not
-        # authoritative: cross-node the sweep / next same-node success reconciles.
-        # (user, server) pairs this node believes have NO pending-consent row —
-        # either cleared here, or never seen to fail here. The dispatch-success
-        # clear does its SQL DELETE only the FIRST time a pair reaches success
-        # since its last failure, then records it here so subsequent successes
-        # skip the SQL (keeps the hot path write-free). Crucially this is NOT
-        # gated on "we wrote the row": a fresh node / a node that didn't write
-        # the row still clears on its first success, so a badge written on
-        # another node self-heals cross-node. A write resets the pair (below).
-        self._pending_consent_cleared: set[tuple[str, str]] = set()
+        # (user, server) → monotonic time of this node's last DB-confirmed
+        # pending-consent DELETE. The dispatch-success clear skips its SQL
+        # DELETE while the entry is younger than the TTL (keeps the hot path
+        # write-free) and re-runs it once the entry ages out — so a
+        # pending-consent row written by ANOTHER node after this node's last
+        # clear still self-heals within one TTL window of active dispatching.
+        # (A pure cleared-once set suppressed the clear forever: node A's
+        # entry never invalidated when node B wrote a fresh row.) A failure
+        # observed on THIS node re-arms the pair immediately
+        # (_write_pending_consent pops it). Entries are pruned
+        # opportunistically on insert — memory hygiene, not correctness.
+        self._pending_consent_cleared: dict[tuple[str, str], float] = {}
 
         # Idle-eviction task handle. Scheduled lazily on the mcp-loop the
         # first time a pool entry is created (start() runs before pool
@@ -2640,6 +2650,29 @@ class MCPClientManager:
                 self._priming_keys.discard(key)
 
         prime_names = self._oauth_user_server_names | self._obo_server_names
+        if self._obo_server_names:
+            # One raw existence SELECT (no decrypt) decides ALL obo servers for
+            # this user: a user with no captured credential — a local-auth
+            # account, or capture disabled when they last logged in — would
+            # otherwise pay three SQL reads per obo server per session start
+            # (server row + cache row + credential) just to learn
+            # kind="missing". The oauth_user branch keeps its own deferred-row
+            # optimisation. On any read hiccup, fail open and let the
+            # per-server mint path classify it.
+            issuer = str(getattr(getattr(self._app_state, "oidc_config", None), "issuer", "") or "")
+            has_credential = False
+            if issuer:
+                try:
+                    has_credential = (
+                        await asyncio.to_thread(
+                            self._storage.get_oidc_user_credential, user_id, issuer
+                        )
+                        is not None
+                    )
+                except Exception:
+                    has_credential = True
+            if not has_credential:
+                prime_names -= self._obo_server_names
         await asyncio.gather(*(_prime_one(s) for s in list(prime_names)))
 
     # -- background token-freshness sweep (oauth_user grants) -----------------
@@ -2849,8 +2882,9 @@ class MCPClientManager:
             now_iso=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S"),
         )
         # A fresh pending row exists again → un-mark the pair so the next
-        # successful dispatch (on any node) clears it.
-        self._pending_consent_cleared.discard((user_id, server_name))
+        # successful dispatch on this node clears it without waiting out the
+        # TTL (other nodes converge via their own TTL expiry).
+        self._pending_consent_cleared.pop((user_id, server_name), None)
 
     async def _persist_pending_consent_best_effort(self, user_id: str, server_name: str) -> bool:
         """Raise the dashboard pending-consent badge for a proactively-detected
@@ -2892,7 +2926,9 @@ class MCPClientManager:
             return
         try:
             await asyncio.to_thread(self._storage.delete_mcp_pending_consent, user_id, server_name)
-            self._pending_consent_cleared.add((user_id, server_name))
+            now = time.monotonic()
+            self._prune_pending_consent_cleared(now)
+            self._pending_consent_cleared[(user_id, server_name)] = now
         except Exception:
             log.debug(
                 "MCP token sweep: pending-consent clear failed user=%s server=%s",
@@ -4892,8 +4928,12 @@ class MCPClientManager:
         return None
 
     def _is_pool_server(self, server_name: str) -> bool:
-        """True when *server_name* uses per-user pool sessions (no static session)."""
-        return server_name in self._oauth_user_server_names or server_name in self._obo_server_names
+        """True when *server_name* uses per-user pool sessions (no static session).
+
+        Derived from :meth:`server_auth_type` so pool membership has exactly
+        one definition over the two per-auth-type registries.
+        """
+        return self.server_auth_type(server_name) is not None
 
     @property
     def server_count(self) -> int:
@@ -5654,23 +5694,27 @@ class MCPClientManager:
         an obo pending row — written when the credential was missing — would
         persist forever after the user re-logs in.
 
-        Deduped via ``_pending_consent_cleared`` so it is NOT an unconditional
-        per-call SQL write: the DELETE runs only the first time a pair reaches
-        success since its last failure, then the pair is recorded and subsequent
-        successes skip it — keeping the hot dispatch path free of per-call SQL.
-        Unlike a "we wrote the row" gate, this fires on ANY node's first success
-        (a fresh node's cleared-set is empty), so a badge written on another node
-        self-heals cross-node; a node restart also re-clears once. A new failure
-        removes the pair (``_write_pending_consent``) so the badge re-clears.
+        Deduped via the ``_pending_consent_cleared`` TTL map so it is NOT an
+        unconditional per-call SQL write: after a DB-confirmed DELETE the pair
+        is skipped for ``_PENDING_CONSENT_CLEAR_TTL_SECONDS``, then the DELETE
+        re-runs on the next success — bounding both the hot-path SQL rate (one
+        DELETE per pair per TTL) and the staleness of a badge written by
+        ANOTHER node after this node's last clear (a permanent cleared-set
+        suppressed that clear forever). A failure observed on this node
+        re-arms the pair immediately (``_write_pending_consent``); a node
+        restart clears once on first success.
         """
         key = (user_id, server_name)
-        if key in self._pending_consent_cleared:
-            return  # already cleared on this node since the last failure — no SQL
+        now = time.monotonic()
+        cleared_at = self._pending_consent_cleared.get(key)
+        if cleared_at is not None and now - cleared_at < _PENDING_CONSENT_CLEAR_TTL_SECONDS:
+            return  # cleared recently on this node — no SQL
         if self._storage is None:
             return
         try:
             self._storage.delete_mcp_pending_consent(user_id, server_name)
-            self._pending_consent_cleared.add(key)
+            self._prune_pending_consent_cleared(now)
+            self._pending_consent_cleared[key] = now
         except Exception:
             log.debug(
                 "mcp_pool.pending_consent_clear_failed user=%s server=%s",
@@ -5678,6 +5722,26 @@ class MCPClientManager:
                 server_name,
                 exc_info=True,
             )
+
+    def _prune_pending_consent_cleared(self, now: float) -> None:
+        """Drop aged entries when the TTL map grows large (memory hygiene).
+
+        Runs from dispatch threads, so it snapshots ``items()`` and removes
+        via ``pop`` — tolerant of concurrent same-map mutation (worst case a
+        minor over/under-prune, never an exception). Correctness never
+        depends on an entry being present: a dropped pair just re-runs one
+        SQL DELETE on its next success.
+        """
+        if len(self._pending_consent_cleared) < _PENDING_CONSENT_CLEARED_MAX:
+            return
+        entries = list(self._pending_consent_cleared.items())
+        expired = [k for k, t in entries if now - t >= _PENDING_CONSENT_CLEAR_TTL_SECONDS]
+        for k in expired:
+            self._pending_consent_cleared.pop(k, None)
+        if len(self._pending_consent_cleared) >= _PENDING_CONSENT_CLEARED_MAX:
+            by_age = sorted(entries, key=lambda kv: kv[1])
+            for k, _ in by_age[: len(by_age) // 2]:
+                self._pending_consent_cleared.pop(k, None)
 
     def _dispatch_pool_sync(
         self,
@@ -6018,7 +6082,8 @@ class MCPClientManager:
         JSON string when token state precludes dispatch. ``server_row``
         is supplied by ``_resolve_pool_target`` so this path doesn't
         re-issue the ``mcp_servers`` lookup; it's also pre-validated to
-        have ``auth_type='oauth_user'``.
+        be a pool-backed user-scoped auth type — ``oauth_user`` OR
+        ``oauth_obo`` (``_pool_token_lookup`` below branches on it).
 
         ``retry_count`` is supplied by :meth:`_dispatch_pool_sync` and
         bounds the auth_401 refresh-and-retry to one re-issue. The first
@@ -6049,49 +6114,10 @@ class MCPClientManager:
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        if lookup.kind == "missing":
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail=_consent_missing_detail(server_row),
-                consent_url=_build_consent_url(server_row),
-            )
-        if lookup.kind == "decrypt_failure":
-            return _structured_error(
-                code="mcp_token_undecryptable_key_unknown",
-                server=server_name,
-                detail=(
-                    "Stored token cannot be decrypted by any installed encryption key. "
-                    "Operator action required."
-                ),
-            )
-        if lookup.kind == "refresh_failed_transient":
-            # Transient refresh failure (AS/network blip) — the token was kept;
-            # a retry may succeed once the AS recovers. Retryable, NOT re-consent.
-            return _structured_error(
-                code="mcp_refresh_unavailable",
-                server=server_name,
-                detail="Token refresh temporarily failed; please retry.",
-            )
-        if lookup.kind == "refresh_failed":
-            # ``mcp_server.oauth.token_revoked`` audit was already emitted
-            # by ``get_user_access_token_classified`` when it deleted the
-            # row; no second audit needed here.
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail=_refresh_failed_detail(server_row),
-                consent_url=_build_consent_url(server_row),
-            )
-        # kind == "token"
+        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        if lookup_error is not None:
+            return lookup_error
         access_token = lookup.token or ""
-        if not access_token:
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail="No token for user. Consent flow required.",
-                consent_url=_build_consent_url(server_row),
-            )
 
         # URL hygiene — pool dispatch transmits the per-user bearer; reject
         # plaintext schemes before they reach _connect_one_pool.
@@ -6172,7 +6198,7 @@ class MCPClientManager:
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
-                    detail="Refreshed token still rejected. Re-consent required.",
+                    detail=_token_rejected_detail(server_row),
                     consent_url=_build_consent_url(server_row),
                 )
             if classification == "auth_403":
@@ -6231,45 +6257,10 @@ class MCPClientManager:
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        if lookup.kind == "missing":
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail=_consent_missing_detail(server_row),
-                consent_url=_build_consent_url(server_row),
-            )
-        if lookup.kind == "decrypt_failure":
-            return _structured_error(
-                code="mcp_token_undecryptable_key_unknown",
-                server=server_name,
-                detail=(
-                    "Stored token cannot be decrypted by any installed encryption key. "
-                    "Operator action required."
-                ),
-            )
-        if lookup.kind == "refresh_failed_transient":
-            # Transient refresh failure (AS/network blip) — the token was kept;
-            # a retry may succeed once the AS recovers. Retryable, NOT re-consent.
-            return _structured_error(
-                code="mcp_refresh_unavailable",
-                server=server_name,
-                detail="Token refresh temporarily failed; please retry.",
-            )
-        if lookup.kind == "refresh_failed":
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail=_refresh_failed_detail(server_row),
-                consent_url=_build_consent_url(server_row),
-            )
+        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        if lookup_error is not None:
+            return lookup_error
         access_token = lookup.token or ""
-        if not access_token:
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail="No token for user. Consent flow required.",
-                consent_url=_build_consent_url(server_row),
-            )
 
         url = str(server_row.get("url") or "")
         try:
@@ -6321,7 +6312,7 @@ class MCPClientManager:
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
-                    detail="Refreshed token still rejected. Re-consent required.",
+                    detail=_token_rejected_detail(server_row),
                     consent_url=_build_consent_url(server_row),
                 )
             if classification == "auth_403":
@@ -6387,45 +6378,10 @@ class MCPClientManager:
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        if lookup.kind == "missing":
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail=_consent_missing_detail(server_row),
-                consent_url=_build_consent_url(server_row),
-            )
-        if lookup.kind == "decrypt_failure":
-            return _structured_error(
-                code="mcp_token_undecryptable_key_unknown",
-                server=server_name,
-                detail=(
-                    "Stored token cannot be decrypted by any installed encryption key. "
-                    "Operator action required."
-                ),
-            )
-        if lookup.kind == "refresh_failed_transient":
-            # Transient refresh failure (AS/network blip) — the token was kept;
-            # a retry may succeed once the AS recovers. Retryable, NOT re-consent.
-            return _structured_error(
-                code="mcp_refresh_unavailable",
-                server=server_name,
-                detail="Token refresh temporarily failed; please retry.",
-            )
-        if lookup.kind == "refresh_failed":
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail=_refresh_failed_detail(server_row),
-                consent_url=_build_consent_url(server_row),
-            )
+        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        if lookup_error is not None:
+            return lookup_error
         access_token = lookup.token or ""
-        if not access_token:
-            return _structured_error(
-                code="mcp_consent_required",
-                server=server_name,
-                detail="No token for user. Consent flow required.",
-                consent_url=_build_consent_url(server_row),
-            )
 
         url = str(server_row.get("url") or "")
         try:
@@ -6477,7 +6433,7 @@ class MCPClientManager:
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
-                    detail="Refreshed token still rejected. Re-consent required.",
+                    detail=_token_rejected_detail(server_row),
                     consent_url=_build_consent_url(server_row),
                 )
             if classification == "auth_403":
@@ -7285,6 +7241,80 @@ def _refresh_failed_detail(server_row: dict[str, Any]) -> str:
             "again; if it keeps failing, your administrator may need to grant access."
         )
     return "Refresh token rejected. Re-consent required."
+
+
+def _token_rejected_detail(server_row: dict[str, Any]) -> str:
+    """User-facing detail for a 401 that survived one forced refresh (retry ceiling).
+
+    ``oauth_user``: the freshly refreshed bearer was rejected — per-server
+    re-consent is the actionable remedy (``_build_consent_url`` attaches the
+    Connect affordance). ``oauth_obo``: the bearer was JUST minted from the
+    captured credential and there is no per-server consent flow
+    (``_build_consent_url`` returns None), so "re-consent required" is a dead
+    end — the realistic causes are server-side (audience mismatch, upstream
+    auth misconfig, clock skew), so point at the administrator instead.
+    """
+    if server_row.get("auth_type") == "oauth_obo":
+        return (
+            "Server rejected a freshly issued sign-in token. This usually means the "
+            "server's audience setting doesn't match what the server expects — ask "
+            "your administrator to check it."
+        )
+    return "Refreshed token still rejected. Re-consent required."
+
+
+def _pool_lookup_error(
+    lookup: TokenLookupResult, server_name: str, server_row: dict[str, Any]
+) -> str | None:
+    """Map a failed pool token lookup to its structured error; ``None`` on success.
+
+    Single copy of the lookup-kind → structured-error mapping shared by the
+    tool / resource / prompt dispatchers — previously three hand-synced
+    copies that every auth-model change had to edit in lockstep. Returns
+    ``None`` exactly when *lookup* carries a non-empty bearer.
+    """
+    if lookup.kind == "missing":
+        return _structured_error(
+            code="mcp_consent_required",
+            server=server_name,
+            detail=_consent_missing_detail(server_row),
+            consent_url=_build_consent_url(server_row),
+        )
+    if lookup.kind == "decrypt_failure":
+        return _structured_error(
+            code="mcp_token_undecryptable_key_unknown",
+            server=server_name,
+            detail=(
+                "Stored token cannot be decrypted by any installed encryption key. "
+                "Operator action required."
+            ),
+        )
+    if lookup.kind == "refresh_failed_transient":
+        # Transient refresh failure (AS/network blip) — the token was kept;
+        # a retry may succeed once the AS recovers. Retryable, NOT re-consent.
+        return _structured_error(
+            code="mcp_refresh_unavailable",
+            server=server_name,
+            detail="Token refresh temporarily failed; please retry.",
+        )
+    if lookup.kind == "refresh_failed":
+        # The ``mcp_server.oauth.token_revoked`` audit was already emitted by
+        # the classified lookup when it deleted the row; no second audit here.
+        return _structured_error(
+            code="mcp_consent_required",
+            server=server_name,
+            detail=_refresh_failed_detail(server_row),
+            consent_url=_build_consent_url(server_row),
+        )
+    # kind == "token"
+    if not (lookup.token or ""):
+        return _structured_error(
+            code="mcp_consent_required",
+            server=server_name,
+            detail="No token for user. Consent flow required.",
+            consent_url=_build_consent_url(server_row),
+        )
+    return None
 
 
 def _pool_cfg_from_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -596,13 +596,14 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
     1. ``load_mcp_token_cipher_config()`` — wrapped in try/except. Raises
        :class:`SystemExit(1)` on :class:`MCPTokenKeyConfigError` after
        logging.
-    2. Counts ``mcp_servers`` rows with ``auth_type='oauth_user'``. If
+    2. Counts ``mcp_servers`` rows with a user-scoped ``auth_type``
+       (``oauth_user`` or ``oauth_obo``; see ``is_user_scoped_auth``). If
        any exist AND no key is configured, raises ``SystemExit(1)``.
        Same enforcement when ``[oidc] capture_user_credential`` is
        enabled (the captured IdP credential must be encrypted at rest).
     3. On success, sets ``app_state.mcp_token_cipher`` and
        ``app_state.mcp_token_store`` (both possibly ``None`` when no
-       key + no oauth_user rows).
+       key + no user-scoped rows).
 
     The helper is shared by ``turnstone/server.py:_lifespan`` and
     ``turnstone/console/server.py:_lifespan``.  A separate

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -553,6 +553,8 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
        logging.
     2. Counts ``mcp_servers`` rows with ``auth_type='oauth_user'``. If
        any exist AND no key is configured, raises ``SystemExit(1)``.
+       Same enforcement when ``[oidc] capture_user_credential`` is
+       enabled (the captured IdP credential must be encrypted at rest).
     3. On success, sets ``app_state.mcp_token_cipher`` and
        ``app_state.mcp_token_store`` (both possibly ``None`` when no
        key + no oauth_user rows).
@@ -584,6 +586,26 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
             "print(Fernet.generate_key().decode())' "
             "and add it to your config.toml.",
             oauth_user_count,
+        )
+        raise SystemExit(1)
+
+    # Same enforcement for single-credential capture (issue #551): the
+    # captured IdP refresh token must never be persisted unencrypted.
+    # Runs after OIDC init (see docstring), so app_state.oidc_config is set.
+    oidc_config = getattr(app_state, "oidc_config", None)
+    if (
+        oidc_config is not None
+        and getattr(oidc_config, "enabled", False)
+        and getattr(oidc_config, "capture_user_credential", False)
+        and cipher_cfg is None
+    ):
+        log.error(
+            "oidc.capture: [oidc] capture_user_credential is enabled but no "
+            "[security] mcp_token_encryption_keys (rotation list) or "
+            "mcp_token_encryption_key (single) in config.toml. Generate a key with: "
+            "python -c 'from cryptography.fernet import Fernet; "
+            "print(Fernet.generate_key().decode())' "
+            "and add it to your config.toml."
         )
         raise SystemExit(1)
 

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -619,12 +619,22 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
         raise SystemExit(1)
 
     # Same enforcement for single-credential capture (issue #551): the
-    # captured IdP refresh token must never be persisted unencrypted.
-    # Runs after OIDC init (see docstring), so app_state.oidc_config is set.
+    # captured IdP refresh token must never be persisted unencrypted. This is
+    # gated ONLY on the operator's ``capture_user_credential`` opt-in — NOT on
+    # ``oidc_config.enabled``. Enabled reflects whether OIDC *discovery*
+    # succeeded, which is transient: a node that boots while the IdP is briefly
+    # unreachable comes up enabled=False (discovery_retryable=True), and
+    # runtime rediscovery re-enables OIDC later — at which point the very first
+    # login's capture step would persist a refresh token. Gating the key
+    # requirement on ``enabled`` would silently skip the loud boot-time failure
+    # exactly when the IdP is down at boot, then quietly no-op capture forever
+    # once OIDC heals. The opt-in flag is a static config value (preserved
+    # across the discovery-failure ``dataclasses.replace``), so keying on it
+    # makes the requirement independent of discovery state. Runs after OIDC
+    # init (see docstring), so app_state.oidc_config is set.
     oidc_config = getattr(app_state, "oidc_config", None)
     if (
         oidc_config is not None
-        and getattr(oidc_config, "enabled", False)
         and getattr(oidc_config, "capture_user_credential", False)
         and cipher_cfg is None
     ):

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -90,6 +90,21 @@ class MCPUserTokenPlain(TypedDict):
     last_refreshed: str | None
 
 
+class OIDCCredentialPlain(TypedDict):
+    """Plaintext shape returned by ``MCPTokenStore.get_oidc_credential``.
+
+    Mirrors ``OIDCUserCredential`` (storage row shape) with the refresh
+    token decrypted — the per-(user, issuer) credential that
+    ``auth_type='oauth_obo'`` servers redeem on demand (issue #551).
+    """
+
+    user_id: str
+    issuer: str
+    refresh_token: str
+    created: str
+    last_refreshed: str
+
+
 class MCPUserTokenMetadata(TypedDict):
     """Non-secret subset of ``MCPUserToken`` for the settings UI.
 
@@ -377,6 +392,54 @@ class MCPTokenStore:
     def delete_user_token(self, user_id: str, server_name: str) -> bool:
         """Delete the user-token row. Returns True if existed."""
         return self._storage.delete_mcp_user_token(user_id, server_name)
+
+    # -- OIDC user credential (single-credential MCP minting, #551) -------------
+    #
+    # Same cipher envelope as the per-(user, server) tokens above; lives on
+    # this store so there is exactly one owner of the encryption keys.
+
+    def upsert_oidc_credential(self, user_id: str, issuer: str, *, refresh_token: str) -> None:
+        """Encrypt and create-or-replace the user's captured IdP refresh token."""
+        refresh_ct = self._cipher.encrypt(refresh_token.encode("utf-8"))
+        self._storage.upsert_oidc_user_credential(user_id, issuer, refresh_token_ct=refresh_ct)
+
+    def get_oidc_credential(self, user_id: str, issuer: str) -> OIDCCredentialPlain | None:
+        """Returns plaintext dict or None.
+
+        Raises ``MCPTokenDecryptError`` on key mismatch — caller MUST NOT
+        auto-delete the row (same contract as ``get_user_token``).
+        """
+        row = self._storage.get_oidc_user_credential(user_id, issuer)
+        if row is None:
+            return None
+        try:
+            refresh_pt = self._cipher.decrypt(row["refresh_token_ct"]).decode("utf-8")
+        except MCPTokenDecryptError as exc:
+            self._audit_decrypt_failure(f"oidc:{issuer}", exc.key_fingerprints_attempted)
+            raise
+        return OIDCCredentialPlain(
+            user_id=row["user_id"],
+            issuer=row["issuer"],
+            refresh_token=refresh_pt,
+            created=row["created"],
+            last_refreshed=row["last_refreshed"],
+        )
+
+    def update_oidc_credential_after_redeem(
+        self, user_id: str, issuer: str, *, refresh_token: str
+    ) -> bool:
+        """Rotation write-back: persist the newest refresh token after a
+        redemption returned one (both verified grant legs rotate).
+        Returns True when a row was updated.
+        """
+        refresh_ct = self._cipher.encrypt(refresh_token.encode("utf-8"))
+        return self._storage.update_oidc_user_credential_refresh(
+            user_id, issuer, refresh_token_ct=refresh_ct
+        )
+
+    def delete_oidc_credential(self, user_id: str, issuer: str) -> bool:
+        """Remove the captured credential (logout-all / admin revoke)."""
+        return self._storage.delete_oidc_user_credential(user_id, issuer)
 
     def list_user_token_metadata(self, user_id: str) -> list[MCPUserTokenMetadata]:
         """Return non-secret metadata for every token row owned by ``user_id``.

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -573,13 +573,19 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
         raise SystemExit(1) from exc
 
     storage = get_storage()
+    # Both pool-backed types persist encrypted per-user rows (oauth_user:
+    # tokens + refresh; oauth_obo: minted-token cache), so both force the
+    # key requirement.  Literal tuple rather than mcp_oauth's
+    # USER_SCOPED_AUTH_TYPES: importing mcp_oauth here would be a cycle.
     oauth_user_count = sum(
-        1 for row in storage.list_mcp_servers() if row.get("auth_type") == "oauth_user"
+        1
+        for row in storage.list_mcp_servers()
+        if row.get("auth_type") in ("oauth_user", "oauth_obo")
     )
 
     if oauth_user_count > 0 and cipher_cfg is None:
         log.error(
-            "mcp.oauth: %d server(s) configured with auth_type='oauth_user' but no "
+            "mcp.oauth: %d server(s) configured with auth_type='oauth_user'/'oauth_obo' but no "
             "[security] mcp_token_encryption_keys (rotation list) or "
             "mcp_token_encryption_key (single) in config.toml. Generate a key with: "
             "python -c 'from cryptography.fernet import Fernet; "

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -22,6 +22,12 @@ from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 from turnstone.core.audit import record_audit
 from turnstone.core.log import get_logger
 
+# USER_SCOPED_AUTH_TYPES lives in storage._protocol — the bottom of the import
+# graph — so the backend SQL predicates (any_user_scoped_mcp_servers) share the
+# SAME object as the application layer; this module re-exports it (mcp_oauth
+# re-exports in turn).
+from turnstone.core.storage._protocol import USER_SCOPED_AUTH_TYPES as USER_SCOPED_AUTH_TYPES
+
 if TYPE_CHECKING:
     from turnstone.core.storage._protocol import StorageBackend
 
@@ -31,16 +37,13 @@ log = get_logger(__name__)
 _KEY_BYTES = 32  # Fernet requires 32 bytes
 _KEY_FINGERPRINT_BYTES = 8  # short hex prefix for audit/error fields
 
+
 # MCP auth types whose connections and per-user rows are keyed per-(user, server):
 # oauth_user (per-server browser consent + refresh token) and oauth_obo (minted
-# on demand from the user's single captured credential, issue #551). Defined
-# here — the leaf module both mcp_oauth and console import — so there is ONE
-# source of truth; mcp_oauth re-exports it. Both persist encrypted per-user rows,
-# so both force the token-encryption-key requirement at startup (see
-# initialize_mcp_crypto_state).
-USER_SCOPED_AUTH_TYPES: frozenset[str] = frozenset({"oauth_user", "oauth_obo"})
-
-
+# on demand from the user's single captured credential, issue #551) — the
+# USER_SCOPED_AUTH_TYPES set imported above. Both types persist encrypted
+# per-user rows, so both force the token-encryption-key requirement at startup
+# (see initialize_mcp_crypto_state).
 def is_user_scoped_auth(auth_type: str | None) -> bool:
     """True when *auth_type* uses per-(user, server) connections and tokens."""
     return auth_type in USER_SCOPED_AUTH_TYPES
@@ -50,6 +53,17 @@ def is_user_scoped_auth(auth_type: str | None) -> bool:
 _KEY_GEN_HINT = (
     "regenerate with: python -c 'from cryptography.fernet import Fernet; "
     "print(Fernet.generate_key().decode())'"
+)
+
+# Operator-facing tail for the two startup key-requirement SystemExit logs
+# (user-scoped servers / credential capture) — one copy so the guidance
+# can't drift between them.
+_STARTUP_KEY_REQUIRED_HINT = (
+    "no [security] mcp_token_encryption_keys (rotation list) or "
+    "mcp_token_encryption_key (single) in config.toml. Generate a key with: "
+    "python -c 'from cryptography.fernet import Fernet; "
+    "print(Fernet.generate_key().decode())' "
+    "and add it to your config.toml."
 )
 
 
@@ -598,13 +612,9 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
 
     if user_scoped_count > 0 and cipher_cfg is None:
         log.error(
-            "mcp.oauth: %d server(s) configured with auth_type='oauth_user'/'oauth_obo' but no "
-            "[security] mcp_token_encryption_keys (rotation list) or "
-            "mcp_token_encryption_key (single) in config.toml. Generate a key with: "
-            "python -c 'from cryptography.fernet import Fernet; "
-            "print(Fernet.generate_key().decode())' "
-            "and add it to your config.toml.",
+            "mcp.oauth: %d server(s) configured with auth_type='oauth_user'/'oauth_obo' but %s",
             user_scoped_count,
+            _STARTUP_KEY_REQUIRED_HINT,
         )
         raise SystemExit(1)
 
@@ -619,12 +629,8 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
         and cipher_cfg is None
     ):
         log.error(
-            "oidc.capture: [oidc] capture_user_credential is enabled but no "
-            "[security] mcp_token_encryption_keys (rotation list) or "
-            "mcp_token_encryption_key (single) in config.toml. Generate a key with: "
-            "python -c 'from cryptography.fernet import Fernet; "
-            "print(Fernet.generate_key().decode())' "
-            "and add it to your config.toml."
+            "oidc.capture: [oidc] capture_user_credential is enabled but %s",
+            _STARTUP_KEY_REQUIRED_HINT,
         )
         raise SystemExit(1)
 

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -31,6 +31,21 @@ log = get_logger(__name__)
 _KEY_BYTES = 32  # Fernet requires 32 bytes
 _KEY_FINGERPRINT_BYTES = 8  # short hex prefix for audit/error fields
 
+# MCP auth types whose connections and per-user rows are keyed per-(user, server):
+# oauth_user (per-server browser consent + refresh token) and oauth_obo (minted
+# on demand from the user's single captured credential, issue #551). Defined
+# here — the leaf module both mcp_oauth and console import — so there is ONE
+# source of truth; mcp_oauth re-exports it. Both persist encrypted per-user rows,
+# so both force the token-encryption-key requirement at startup (see
+# initialize_mcp_crypto_state).
+USER_SCOPED_AUTH_TYPES: frozenset[str] = frozenset({"oauth_user", "oauth_obo"})
+
+
+def is_user_scoped_auth(auth_type: str | None) -> bool:
+    """True when *auth_type* uses per-(user, server) connections and tokens."""
+    return auth_type in USER_SCOPED_AUTH_TYPES
+
+
 # Operator-facing hint for malformed/missing keys.
 _KEY_GEN_HINT = (
     "regenerate with: python -c 'from cryptography.fernet import Fernet; "
@@ -575,15 +590,13 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
     storage = get_storage()
     # Both pool-backed types persist encrypted per-user rows (oauth_user:
     # tokens + refresh; oauth_obo: minted-token cache), so both force the
-    # key requirement.  Literal tuple rather than mcp_oauth's
-    # USER_SCOPED_AUTH_TYPES: importing mcp_oauth here would be a cycle.
-    oauth_user_count = sum(
-        1
-        for row in storage.list_mcp_servers()
-        if row.get("auth_type") in ("oauth_user", "oauth_obo")
+    # key requirement — USER_SCOPED_AUTH_TYPES is the single source of truth
+    # (defined above in this leaf module; mcp_oauth re-exports it).
+    user_scoped_count = sum(
+        1 for row in storage.list_mcp_servers() if is_user_scoped_auth(row.get("auth_type"))
     )
 
-    if oauth_user_count > 0 and cipher_cfg is None:
+    if user_scoped_count > 0 and cipher_cfg is None:
         log.error(
             "mcp.oauth: %d server(s) configured with auth_type='oauth_user'/'oauth_obo' but no "
             "[security] mcp_token_encryption_keys (rotation list) or "
@@ -591,7 +604,7 @@ def initialize_mcp_crypto_state(app_state: object, *, node_id: str = "") -> None
             "python -c 'from cryptography.fernet import Fernet; "
             "print(Fernet.generate_key().decode())' "
             "and add it to your config.toml.",
-            oauth_user_count,
+            user_scoped_count,
         )
         raise SystemExit(1)
 

--- a/turnstone/core/mcp_crypto.py
+++ b/turnstone/core/mcp_crypto.py
@@ -455,12 +455,28 @@ class MCPTokenStore:
         )
 
     def update_oidc_credential_after_redeem(
-        self, user_id: str, issuer: str, *, refresh_token: str
+        self, user_id: str, issuer: str, *, refresh_token: str, expected_current: str
     ) -> bool:
         """Rotation write-back: persist the newest refresh token after a
         redemption returned one (both verified grant legs rotate).
-        Returns True when a row was updated.
+        Returns True when the row was updated.
+
+        Value compare-and-swap on *expected_current* (the refresh token the mint
+        read before redeeming): the write only lands when the STORED credential
+        still decrypts to that value. This stops a rotation from clobbering a
+        credential a concurrent LOGIN capture just refreshed — the capture writes
+        the freshest token during the mint's in-flight redemption POST, so by the
+        time this write-back runs the stored value already differs from
+        ``expected_current`` and the stale rotated token is dropped instead of
+        overwriting the fresh login one. (The compare can't be done on ciphertext
+        — Fernet is non-deterministic — so it decrypts the current row. The mint
+        holds the per-issuer credential lock, so the only racer is the unlocked
+        capture, narrowing the residual window to this method's own read→write
+        gap; a capture landing there self-heals on the user's next login.)
         """
+        current = self.get_oidc_credential(user_id, issuer)
+        if current is None or current["refresh_token"] != expected_current:
+            return False
         refresh_ct = self._cipher.encrypt(refresh_token.encode("utf-8"))
         return self._storage.update_oidc_user_credential_refresh(
             user_id, issuer, refresh_token_ct=refresh_ct

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1798,6 +1798,436 @@ async def get_user_access_token_classified(
         return _token_result(app_state, user_id, server_name, new_access)
 
 
+# ---------------------------------------------------------------------------
+# Single-credential on-behalf-of minting (auth_type='oauth_obo', issue #551)
+#
+# Servers with auth_type='oauth_obo' never run the per-server browser consent
+# flow.  Instead the user's single captured IdP refresh token (see
+# `[oidc] capture_user_credential`) is redeemed on demand for a short-lived
+# server-audience access token via the deployment's grant leg:
+#
+#   entra    — one refresh-token grant with scope=<audience>/.default
+#              (Entra RTs are client-bound, not resource-bound — verified)
+#   rfc8693  — refresh grant for a subject token, then a standard
+#              token-exchange with audience=<server client id> (verified on
+#              Keycloak 26.3; per-server oauth_scopes activates optional
+#              audience scopes)
+#
+# The minted token is cached in the existing per-(user, server)
+# mcp_user_tokens row with refresh_token_ct=NULL — cache, not custody.  A
+# permanent mint failure drops ONLY that cache row (re-consent UX for that
+# server); the shared credential is NEVER auto-deleted here — a missing
+# tenant grant for one server (AADSTS65001, verified) must not lock the user
+# out of every other OBO server.  Credential lifecycle (logout/admin revoke)
+# is handled elsewhere.
+# ---------------------------------------------------------------------------
+
+#: Auth types whose connections and tokens are per-(user, server).  The MCP
+#: client keys its connection pool and per-user tool catalogs on this class.
+USER_SCOPED_AUTH_TYPES: frozenset[str] = frozenset({"oauth_user", "oauth_obo"})
+
+#: Grant legs a deployment may select via ``[oidc] obo_grant_profile``.
+OBO_GRANT_PROFILES: frozenset[str] = frozenset({"entra", "rfc8693"})
+
+
+def is_user_scoped_auth(auth_type: str | None) -> bool:
+    """True when *auth_type* uses per-(user, server) connections and tokens."""
+    return auth_type in USER_SCOPED_AUTH_TYPES
+
+
+async def _obo_token_post(
+    *,
+    token_endpoint: str,
+    data: dict[str, str],
+    http_client: httpx.AsyncClient | None,
+    leg: str,
+) -> dict[str, Any]:
+    """POST one OBO grant-leg request; classify failures like a refresh.
+
+    Mirrors :func:`refresh_token`'s hardening (body size cap, JSON-object
+    validation) and raises :class:`MCPOAuthRefreshFailed` with the same
+    conservative :func:`_classify_refresh_failure` mapping, so the OBO state
+    machine reacts to AS rejections exactly like the oauth_user one — a
+    verified AADSTS65001 (missing tenant grant) classifies PERMANENT via
+    ``invalid_grant``.
+    """
+    try:
+        if http_client is not None:
+            resp = await http_client.post(token_endpoint, data=data, timeout=_DEFAULT_HTTP_TIMEOUT)
+        else:
+            async with httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT) as transient:
+                resp = await transient.post(token_endpoint, data=data)
+    except httpx.HTTPError as exc:
+        raise MCPOAuthRefreshFailed(f"obo {leg} request failed: {exc}") from exc
+
+    if len(resp.content) > _MAX_TOKEN_BODY_BYTES:
+        raise MCPOAuthRefreshFailed(f"obo {leg} response body exceeds size limit")
+
+    if resp.status_code != 200:
+        raise MCPOAuthRefreshFailed(
+            f"obo {leg} returned HTTP {resp.status_code}: {_format_as_error(resp)}",
+            failure_class=_classify_refresh_failure(resp),
+        )
+
+    try:
+        doc = resp.json()
+    except ValueError as exc:
+        raise MCPOAuthRefreshFailed(f"obo {leg} body is not valid JSON: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise MCPOAuthRefreshFailed(f"obo {leg} body is not a JSON object")
+    typed: dict[str, Any] = doc
+    return typed
+
+
+async def _obo_mint_entra(
+    *,
+    oidc_config: Any,
+    credential_refresh_token: str,
+    audience: str,
+    scopes: str,
+    http_client: httpx.AsyncClient | None,
+) -> dict[str, Any]:
+    """Entra leg: redeem the client-bound RT directly for the audience.
+
+    Wire shape verified against a real tenant (docs/design/obo-spike):
+    ``grant_type=refresh_token`` + ``scope=<audience>/.default`` returns an
+    audience-scoped access token and (usually) a rotated refresh token.
+    """
+    return await _obo_token_post(
+        token_endpoint=oidc_config.token_endpoint,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": credential_refresh_token,
+            "client_id": oidc_config.client_id,
+            "client_secret": oidc_config.client_secret,
+            "scope": scopes or f"{audience}/.default",
+        },
+        http_client=http_client,
+        leg="entra-redemption",
+    )
+
+
+async def _obo_mint_rfc8693(
+    *,
+    oidc_config: Any,
+    credential_refresh_token: str,
+    audience: str,
+    scopes: str,
+    http_client: httpx.AsyncClient | None,
+) -> dict[str, Any]:
+    """RFC 8693 leg: refresh grant for a subject token, then token exchange.
+
+    Chain verified on Keycloak 26.3 standard token exchange
+    (docs/design/obo-spike).  The refresh leg may rotate the credential —
+    the rotated value is propagated in the merged response so the caller's
+    write-back persists it; the exchanged token itself carries no RT.
+    """
+    subject = await _obo_token_post(
+        token_endpoint=oidc_config.token_endpoint,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": credential_refresh_token,
+            "client_id": oidc_config.client_id,
+            "client_secret": oidc_config.client_secret,
+        },
+        http_client=http_client,
+        leg="rfc8693-refresh",
+    )
+    subject_at = subject.get("access_token")
+    if not isinstance(subject_at, str) or not subject_at:
+        raise MCPOAuthRefreshFailed("obo rfc8693-refresh response missing access_token")
+
+    exchange_data: dict[str, str] = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "client_id": oidc_config.client_id,
+        "client_secret": oidc_config.client_secret,
+        "subject_token": subject_at,
+        "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        "audience": audience,
+    }
+    if scopes:
+        # e.g. Keycloak optional audience scopes must be requested explicitly
+        # or the exchange fails "Requested audience not available" (verified).
+        exchange_data["scope"] = scopes
+    exchanged = await _obo_token_post(
+        token_endpoint=oidc_config.token_endpoint,
+        data=exchange_data,
+        http_client=http_client,
+        leg="rfc8693-exchange",
+    )
+    rotated = subject.get("refresh_token")
+    if isinstance(rotated, str) and rotated:
+        exchanged = {**exchanged, "refresh_token": rotated}
+    return exchanged
+
+
+_OBO_MINT_LEGS = {
+    "entra": _obo_mint_entra,
+    "rfc8693": _obo_mint_rfc8693,
+}
+
+
+async def _persist_obo_cache_row(
+    token_store: MCPTokenStore,
+    user_id: str,
+    server_name: str,
+    *,
+    access_token: str,
+    expires_at: str | None,
+    scopes: str,
+    issuer: str,
+    audience: str,
+) -> None:
+    """Create-or-update the per-(user, server) cache row (refresh_token=NULL)."""
+    updated = await asyncio.to_thread(
+        token_store.update_user_token_after_refresh,
+        user_id,
+        server_name,
+        access_token=access_token,
+        refresh_token=None,
+        expires_at=expires_at,
+    )
+    if not updated:
+        await asyncio.to_thread(
+            token_store.create_user_token,
+            user_id,
+            server_name,
+            access_token=access_token,
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=scopes or None,
+            as_issuer=issuer,
+            audience=audience,
+        )
+
+
+async def get_obo_access_token_classified(
+    *,
+    app_state: Any,
+    user_id: str,
+    server_name: str,
+    force_refresh: bool = False,
+) -> TokenLookupResult:
+    """Tagged token lookup for ``auth_type='oauth_obo'`` servers.
+
+    Sibling of :func:`get_user_access_token_classified` sharing its result
+    vocabulary, cache table, locks, and backoff — but "refresh" here is a
+    mint from the user's single captured credential, so:
+
+    - a MISSING cache row is normal (first use mints; no consent
+      prerequisite);
+    - ``kind="missing"`` means the *credential* is absent → the dispatcher's
+      consent path prompts a re-login rather than a per-server consent;
+    - a PERMANENT mint rejection (dead grant / missing tenant grant /
+      Conditional Access challenge) drops only the cache row via
+      :func:`_revoke_after_refresh_failure` — the shared credential is never
+      auto-deleted, so one mis-granted server can't lock the user out of the
+      rest.
+
+    Locking: outer per-(user, server) asyncio lock (same map as oauth_user),
+    then a per-(user, issuer) asyncio + cluster advisory lock pair keyed
+    ``__obo__:<issuer>`` — the credential is the shared mutable resource
+    (rotation write-back), so concurrent mints for DIFFERENT servers
+    serialize cluster-wide on the credential, single-flighting redemptions
+    even where the IdP rotates strictly.  Order is always server → credential
+    and nothing acquires the reverse, so the pair cannot deadlock.
+    """
+    token_store: MCPTokenStore | None = getattr(app_state, "mcp_token_store", None)
+    if token_store is None:
+        log.debug("mcp_server.oauth.token_store_unconfigured")
+        return TokenLookupResult(kind="missing")
+
+    t_lock_request_started = datetime.now(UTC).replace(microsecond=0)
+
+    try:
+        plain = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
+    except MCPTokenDecryptError as exc:
+        log.warning(
+            "mcp_server.oauth.obo_cache_decrypt_failed",
+            user_id=user_id,
+            server_name=server_name,
+            exc_info=True,
+        )
+        return _no_token_result(
+            app_state,
+            user_id,
+            server_name,
+            TokenLookupResult(
+                kind="decrypt_failure",
+                decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
+            ),
+        )
+    if plain is not None and not force_refresh and not _token_needs_refresh(plain["expires_at"]):
+        return _token_result(app_state, user_id, server_name, plain["access_token"])
+
+    if _refresh_in_cooldown(app_state, user_id, server_name):
+        return TokenLookupResult(kind="refresh_failed_transient")
+
+    storage = _get_storage(app_state)
+    if storage is None:
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+    server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
+    if server_row is None:
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+    server_id_for_audit = str(server_row.get("server_id") or "")
+
+    oidc_config = getattr(app_state, "oidc_config", None)
+    profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
+    audience = str(server_row.get("oauth_audience") or "")
+    scopes = str(server_row.get("oauth_scopes") or "")
+    mint = _OBO_MINT_LEGS.get(profile)
+    if (
+        oidc_config is None
+        or not getattr(oidc_config, "enabled", False)
+        or not getattr(oidc_config, "token_endpoint", "")
+        or mint is None
+        or not audience
+    ):
+        # Operator-fixable configuration problem — loud log, no revoke, and a
+        # retryable classification so fixing the config heals without a
+        # re-consent round.
+        log.error(
+            "mcp_server.oauth.obo_misconfigured",
+            server_name=server_name,
+            oidc_enabled=bool(oidc_config is not None and getattr(oidc_config, "enabled", False)),
+            grant_profile=profile or "<unset>",
+            has_audience=bool(audience),
+        )
+        return TokenLookupResult(kind="refresh_failed_transient")
+    issuer = str(getattr(oidc_config, "issuer", ""))
+
+    credential = await asyncio.to_thread(token_store.get_oidc_credential, user_id, issuer)
+    if credential is None:
+        # No captured credential → the consent affordance is a re-login.
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+
+    lock = _refresh_lock_for(app_state, user_id, server_name)
+    credential_key = f"__obo__:{issuer}"
+    credential_lock = _refresh_lock_for(app_state, user_id, credential_key)
+    pg_lock = await _acquire_pg_refresh_lock(storage, user_id, credential_key)
+    async with lock, credential_lock, pg_lock:
+        # Race check: another caller may have minted for this server while we
+        # waited (same two-condition reuse rule as the oauth_user path).
+        try:
+            plain2 = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
+        except MCPTokenDecryptError as exc:
+            return _no_token_result(
+                app_state,
+                user_id,
+                server_name,
+                TokenLookupResult(
+                    kind="decrypt_failure",
+                    decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
+                ),
+            )
+        if plain2 is not None and not _token_needs_refresh(plain2["expires_at"]):
+            if not force_refresh:
+                return _token_result(app_state, user_id, server_name, plain2["access_token"])
+            last_refreshed = _parse_iso_to_utc(plain2.get("last_refreshed") or "")
+            if last_refreshed is not None and last_refreshed >= t_lock_request_started:
+                return _token_result(app_state, user_id, server_name, plain2["access_token"])
+
+        # Re-read the credential under the lock — a concurrent mint for a
+        # different server may have rotated it; always redeem the newest.
+        credential2 = await asyncio.to_thread(token_store.get_oidc_credential, user_id, issuer)
+        if credential2 is None:
+            return _no_token_result(
+                app_state, user_id, server_name, TokenLookupResult(kind="missing")
+            )
+
+        http_client = getattr(app_state, "oidc_http_client", None)
+        try:
+            tokens = await mint(
+                oidc_config=oidc_config,
+                credential_refresh_token=credential2["refresh_token"],
+                audience=audience,
+                scopes=scopes,
+                http_client=http_client,
+            )
+        except MCPOAuthRefreshFailed as exc:
+            if exc.failure_class is _RefreshFailureClass.PERMANENT:
+                log.warning(
+                    "mcp_server.oauth.obo_mint_rejected",
+                    user_id=user_id,
+                    server_name=server_name,
+                    error=str(exc),
+                )
+                # Drops ONLY the per-server cache row; the credential stays.
+                return await _revoke_after_refresh_failure(
+                    app_state,
+                    token_store,
+                    user_id,
+                    server_name,
+                    server_id_for_audit,
+                    reason="obo_mint_rejected",
+                )
+            backoff = _refresh_backoff_state(app_state, user_id, server_name)
+            backoff.last_failure_monotonic = time.monotonic()
+            if exc.failure_class is _RefreshFailureClass.AMBIGUOUS:
+                backoff.ambiguous_streak += 1
+                if backoff.ambiguous_streak >= _AMBIGUOUS_ESCALATION_THRESHOLD:
+                    log.warning(
+                        "mcp_server.oauth.obo_mint_ambiguous_escalated",
+                        user_id=user_id,
+                        server_name=server_name,
+                        streak=backoff.ambiguous_streak,
+                        error=str(exc),
+                    )
+                    return await _revoke_after_refresh_failure(
+                        app_state,
+                        token_store,
+                        user_id,
+                        server_name,
+                        server_id_for_audit,
+                        reason="obo_mint_ambiguous_escalated",
+                    )
+            else:
+                backoff.ambiguous_streak = 0
+            log.warning(
+                "mcp_server.oauth.obo_mint_transient_failure",
+                user_id=user_id,
+                server_name=server_name,
+                failure_class=exc.failure_class.value,
+                error=str(exc),
+            )
+            return TokenLookupResult(kind="refresh_failed_transient")
+
+        access_token = tokens.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            backoff = _refresh_backoff_state(app_state, user_id, server_name)
+            backoff.last_failure_monotonic = time.monotonic()
+            log.warning(
+                "mcp_server.oauth.obo_mint_missing_access_token",
+                user_id=user_id,
+                server_name=server_name,
+            )
+            return TokenLookupResult(kind="refresh_failed_transient")
+
+        # Rotation write-back BEFORE the cache write: if the process dies
+        # between the two, a stale credential is the failure that strands
+        # users (verified: both legs rotate), a stale cache row just re-mints.
+        rotated = tokens.get("refresh_token")
+        if isinstance(rotated, str) and rotated and rotated != credential2["refresh_token"]:
+            await asyncio.to_thread(
+                token_store.update_oidc_credential_after_redeem,
+                user_id,
+                issuer,
+                refresh_token=rotated,
+            )
+
+        await _persist_obo_cache_row(
+            token_store,
+            user_id,
+            server_name,
+            access_token=access_token,
+            expires_at=_expires_at_from_response(tokens),
+            scopes=scopes,
+            issuer=issuer,
+            audience=audience,
+        )
+        return _token_result(app_state, user_id, server_name, access_token)
+
+
 def _token_needs_refresh(expires_at: str | None) -> bool:
     """Return True when *expires_at* is missing, malformed, or within the skew window."""
     if not expires_at:
@@ -3252,12 +3682,15 @@ __all__ = [
     "MCPOAuthRefreshFailed",
     "MCP_OAUTH_DISCOVERY_CACHE_TTL_SECONDS",
     "MCP_OAUTH_STATE_TTL_SECONDS",
+    "OBO_GRANT_PROFILES",
     "TokenLookupResult",
+    "USER_SCOPED_AUTH_TYPES",
     "build_authorize_url",
     "close_mcp_oauth_state",
     "create_pending_state",
     "discover_authorization_server",
     "generate_pkce_pair",
+    "get_obo_access_token_classified",
     "get_user_access_token",
     "get_user_access_token_classified",
     "handle_mcp_oauth_authorize",
@@ -3268,6 +3701,7 @@ __all__ = [
     "handle_mcp_oauth_list_pending",
     "handle_mcp_oauth_revoke_connection",
     "initialize_mcp_oauth_state",
+    "is_user_scoped_auth",
     "pop_pending_state",
     "revoke_token_at_as",
 ]

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -2451,9 +2451,12 @@ async def get_obo_access_token_classified(
         from turnstone.core.oidc import maybe_rediscover_oidc
 
         await maybe_rediscover_oidc(app_state)
+        # Re-read only the DISCOVERY-derived state (enabled / token_endpoint) that
+        # rediscovery can change. ``obo_grant_profile`` is a static config field
+        # rediscovery never touches, so ``profile`` / ``mint`` computed above still
+        # hold — recomputing them would be dead work implying the profile can
+        # change across a heal (it cannot).
         oidc_config = getattr(app_state, "oidc_config", None)
-        profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
-        mint = _OBO_MINT_LEGS.get(profile)
     if (
         oidc_config is None
         or not getattr(oidc_config, "enabled", False)

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -898,7 +898,7 @@ async def _hardened_token_post(
     *,
     token_endpoint: str,
     data: dict[str, str],
-    http_client: httpx.AsyncClient | None,
+    http_client: httpx.AsyncClient,
     request_label: str,
     endpoint_label: str,
     classify_oversized_by_status: bool = False,
@@ -916,10 +916,10 @@ async def _hardened_token_post(
 
     The two labels preserve each caller's historical error text verbatim
     (``refresh request failed`` vs ``refresh endpoint returned HTTP …``);
-    the OBO wrapper passes one string for both. When *http_client* is
-    ``None`` a transient per-request client is used — the OBO mint path runs
-    on the MCP loop and deliberately passes ``None`` (see
-    :func:`get_obo_access_token_classified`).
+    the OBO wrapper passes one string for both. Callers always supply
+    *http_client* — the oauth_user path its long-lived client, the OBO path a
+    single per-mint client opened in :func:`get_obo_access_token_classified` so
+    the rfc8693 legs reuse one connection.
 
     ``classify_oversized_by_status`` controls how an OVER-sized error body is
     classified. The oauth_user refresh path keeps the default (``False`` →
@@ -930,11 +930,7 @@ async def _hardened_token_post(
     to the honest re-login/admin remedy instead of looping "please retry".
     """
     try:
-        if http_client is not None:
-            resp = await http_client.post(token_endpoint, data=data, timeout=_DEFAULT_HTTP_TIMEOUT)
-        else:
-            async with httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT) as transient:
-                resp = await transient.post(token_endpoint, data=data)
+        resp = await http_client.post(token_endpoint, data=data, timeout=_DEFAULT_HTTP_TIMEOUT)
     except httpx.HTTPError as exc:
         raise MCPOAuthRefreshFailed(f"{request_label} request failed: {exc}") from exc
 
@@ -2063,7 +2059,7 @@ async def _obo_token_post(
     *,
     token_endpoint: str,
     data: dict[str, str],
-    http_client: httpx.AsyncClient | None,
+    http_client: httpx.AsyncClient,
     leg: str,
 ) -> dict[str, Any]:
     """POST one OBO grant-leg request; classify failures like a refresh.
@@ -2119,7 +2115,7 @@ async def _obo_mint_entra(
     credential_refresh_token: str,
     audience: str,
     scopes: str,
-    http_client: httpx.AsyncClient | None,
+    http_client: httpx.AsyncClient,
     persist_rotation: Callable[[str], Awaitable[None]],
 ) -> dict[str, Any]:
     """Entra leg: redeem the client-bound RT directly for the audience.
@@ -2173,7 +2169,7 @@ async def _obo_mint_rfc8693(
     credential_refresh_token: str,
     audience: str,
     scopes: str,
-    http_client: httpx.AsyncClient | None,
+    http_client: httpx.AsyncClient,
     persist_rotation: Callable[[str], Awaitable[None]],
 ) -> dict[str, Any]:
     """RFC 8693 leg: refresh grant for a subject token, then token exchange.
@@ -2397,6 +2393,16 @@ async def get_obo_access_token_classified(
     profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
     audience = str(server_row.get("oauth_audience") or "")
     scopes = str(server_row.get("oauth_scopes") or "")
+    # Scope the freshness gate + cache row to what the leg ACTUALLY mints, not to
+    # the configured column: the entra leg pins ``<audience>/.default`` and
+    # ignores oauth_scopes (an inert leftover after an rfc8693→entra profile
+    # switch). Recording the configured "Files.Read" there would make
+    # _is_fresh_obo_cache_row keep serving the broad ``.default`` bearer while
+    # believing it is narrow. rfc8693 DOES apply the scope, so there the two are
+    # the same. The RAW ``scopes`` is still passed to the mint below so the entra
+    # leg's once-per-audience "oauth_scopes ignored" warning still surfaces the
+    # misconfigured leftover to operators.
+    effective_scopes = "" if profile == "entra" else scopes
     mint = _OBO_MINT_LEGS.get(profile)
 
     try:
@@ -2413,7 +2419,7 @@ async def get_obo_access_token_classified(
     # refresh-less row (see _is_fresh_obo_cache_row). A stale-audience/-scopes or
     # refresh-bearing row falls through to a fresh mint (which overwrites it via
     # _persist_obo_cache_row).
-    fresh = _is_fresh_obo_cache_row(plain, audience, scopes)
+    fresh = _is_fresh_obo_cache_row(plain, audience, effective_scopes)
     if fresh and not force_refresh and plain is not None:
         return _token_result(app_state, user_id, server_name, plain["access_token"])
 
@@ -2499,7 +2505,7 @@ async def get_obo_access_token_classified(
             return _decrypt_failure_result(app_state, user_id, server_name, exc, event=None)
         # Same servability gate as the pre-lock read (refresh-less, right-audience,
         # right-scopes, not-expired) — a stale row falls through and re-mints.
-        if _is_fresh_obo_cache_row(plain2, audience, scopes) and plain2 is not None:
+        if _is_fresh_obo_cache_row(plain2, audience, effective_scopes) and plain2 is not None:
             if not force_refresh:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
             # force_refresh means the caller's bearer was rejected; serialized
@@ -2563,11 +2569,11 @@ async def get_obo_access_token_classified(
         # client object and a pooled connection is bound to the loop that
         # created it, so sharing the login client here collides routinely —
         # the login exchange and the first mint hit the same IdP origin
-        # seconds apart by design. No long-lived mint client is kept:
-        # _obo_token_post uses a transient per-request client when this is
-        # None (mints are ~hourly per (user, server), not hot-path).
-        # ``obo_http_client`` is an injection seam for tests / e2e harnesses.
-        injected_client = getattr(app_state, "obo_http_client", None)
+        # seconds apart by design. No long-lived mint client is kept: a fresh
+        # one is opened per mint below (mints are ~hourly per (user, server),
+        # not hot-path). ``obo_http_client`` is an injection seam for tests /
+        # e2e harnesses; when unset a per-mint client is created here.
+        injected_client: httpx.AsyncClient | None = getattr(app_state, "obo_http_client", None)
         # One client for the whole mint: the rfc8693 leg makes TWO POSTs to the
         # same token endpoint, so a per-request transient would pay two TLS
         # handshakes. When no client is injected (production), open a single
@@ -2575,8 +2581,10 @@ async def get_obo_access_token_classified(
         # the refresh leg's pooled connection.
         try:
             async with contextlib.AsyncExitStack() as mint_stack:
-                mint_client = injected_client
-                if mint_client is None:
+                mint_client: httpx.AsyncClient
+                if injected_client is not None:
+                    mint_client = injected_client
+                else:
                     mint_client = await mint_stack.enter_async_context(
                         httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT)
                     )
@@ -2641,7 +2649,10 @@ async def get_obo_access_token_classified(
                 expires_at=_expires_at_from_response(
                     tokens, default_ttl_seconds=_OBO_DEFAULT_TTL_SECONDS
                 ),
-                scopes=scopes,
+                # Record the EFFECTIVE scope the leg minted (see effective_scopes),
+                # so the freshness gate compares like-for-like and never serves a
+                # broad entra .default token believing it is a narrow configured one.
+                scopes=effective_scopes,
                 issuer=issuer,
                 audience=audience,
             )

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -76,6 +76,14 @@ MCP_OAUTH_DISCOVERY_CACHE_TTL_SECONDS = 86400
 _DEFAULT_HTTP_TIMEOUT = 10.0
 _ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
 _PENDING_CLEANUP_INTERVAL_S = 60.0
+# Fallback lifetime for a minted obo cache row when the IdP omits the
+# RFC 8693-optional ``expires_in``. Unlike oauth_user tokens (a missing expiry
+# means an opaque token cached until a 401), an obo minted access token is
+# always short-lived, so a NULL expiry must NOT read as "never expires" in the
+# freshness gate. Conservative so the row re-mints soon rather than being served
+# long past its real lifetime (which would also defeat audience/scope narrowing
+# that relies on TTL turnover).
+_OBO_DEFAULT_TTL_SECONDS = 300
 
 # Limits on PRM/AS body sizes — defensive against runaway responses.
 _MAX_DISCOVERY_BODY_BYTES = 256 * 1024
@@ -2512,13 +2520,19 @@ async def get_obo_access_token_classified(
             return TokenLookupResult(kind="refresh_failed_transient")
 
         # Credential rotation was already persisted by the mint leg (see
-        # _persist_rotation); the cache write is the only remaining step.
+        # _persist_rotation); the cache write is the only remaining step. The
+        # expiry is never NULL for an obo row (see _OBO_DEFAULT_TTL_SECONDS): a
+        # missing expires_in falls back to a conservative default so the
+        # freshness gate can never serve a short-lived minted token forever.
+        obo_expires_at = _expires_at_from_response(tokens) or (
+            datetime.now(UTC) + timedelta(seconds=_OBO_DEFAULT_TTL_SECONDS)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
         await _persist_obo_cache_row(
             token_store,
             user_id,
             server_name,
             access_token=access_token,
-            expires_at=_expires_at_from_response(tokens),
+            expires_at=obo_expires_at,
             scopes=scopes,
             issuer=issuer,
             audience=audience,

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -3668,7 +3668,7 @@ async def _install_gate_passes(app_state: Any, storage: Any) -> bool:
         cached_value, cached_at = cached
         if (now - cached_at) < _INSTALL_GATE_CACHE_TTL_S:
             return bool(cached_value)
-    value = bool(await asyncio.to_thread(storage.any_oauth_user_mcp_servers))
+    value = bool(await asyncio.to_thread(storage.any_user_scoped_mcp_servers))
     app_state._mcp_install_gate_cache = (value, now)
     return value
 

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -901,6 +901,7 @@ async def _hardened_token_post(
     http_client: httpx.AsyncClient | None,
     request_label: str,
     endpoint_label: str,
+    classify_oversized_by_status: bool = False,
 ) -> dict[str, Any]:
     """POST one token-grant request with the shared hardening skeleton.
 
@@ -919,6 +920,14 @@ async def _hardened_token_post(
     ``None`` a transient per-request client is used — the OBO mint path runs
     on the MCP loop and deliberately passes ``None`` (see
     :func:`get_obo_access_token_classified`).
+
+    ``classify_oversized_by_status`` controls how an OVER-sized error body is
+    classified. The oauth_user refresh path keeps the default (``False`` →
+    TRANSIENT), byte-identical to the pre-refactor behavior, so a large upstream
+    error can never escalate a pre-existing consent to re-consent. The OBO legs
+    pass ``True`` so an over-sized client-error body is AMBIGUOUS (it can't read
+    the body to pin PERMANENT without defeating the guard) and still escalates
+    to the honest re-login/admin remedy instead of looping "please retry".
     """
     try:
         if http_client is not None:
@@ -930,15 +939,9 @@ async def _hardened_token_post(
         raise MCPOAuthRefreshFailed(f"{request_label} request failed: {exc}") from exc
 
     if len(resp.content) > _MAX_TOKEN_BODY_BYTES:
-        # Classify by STATUS without reading the over-sized body (reading it to
-        # pin PERMANENT would defeat the guard). A client-error status — a likely
-        # dead grant — becomes AMBIGUOUS so it still escalates to re-consent after
-        # a streak, rather than the default TRANSIENT that would loop "please
-        # retry" forever on a permanently-dead grant whose error body happened to
-        # exceed the cap.
         oversized_class = (
             _RefreshFailureClass.AMBIGUOUS
-            if resp.status_code in (400, 401, 403)
+            if classify_oversized_by_status and resp.status_code in (400, 401, 403)
             else _RefreshFailureClass.TRANSIENT
         )
         raise MCPOAuthRefreshFailed(
@@ -1544,6 +1547,7 @@ async def _revoke_after_refresh_failure(
     server_id_for_audit: str,
     *,
     reason: str,
+    audit_when_absent: bool = True,
 ) -> TokenLookupResult:
     """Delete the stored token, emit a ``token_revoked`` audit, and drop locks.
 
@@ -1553,19 +1557,24 @@ async def _revoke_after_refresh_failure(
     entry exists — and returns ``refresh_failed`` so the dispatcher surfaces
     re-consent.
 
-    The ``token_revoked`` audit is emitted ONLY when a row was actually deleted.
-    This matters for oauth_obo: its shared credential survives a per-server
-    revoke, so after the first permanent rejection deletes the cache row, every
-    later dispatch/prime past the cooldown re-runs the doomed redemption and
-    lands here again with nothing to delete — auditing unconditionally would
-    append a fresh "token_revoked" row for a token that no longer exists on
-    every cycle, forever (misleading forensics + alert fatigue for operators
-    who alert on token_revoked). oauth_user cannot hit the empty-delete case (a
-    revoke there also removes the only refresh source, so no recurrence), so
-    this gate is a no-op for it.
+    ``audit_when_absent`` controls the audit when ``delete_user_token`` finds no
+    row:
+
+    - oauth_user (default ``True``): reaching a refresh-grant failure means a
+      grant EXISTED (you cannot refresh without a token), so a real grant died —
+      audit it even if a concurrent admin/user revoke deleted the row first, so
+      an operator's SIEM never misses the AS-rejected-the-grant signal. This is
+      the pre-refactor behavior (the audit was unconditional on main).
+    - oauth_obo (``False``): a mint needs no pre-existing cache row, so a
+      permanent rejection on a server the user never successfully minted for
+      lands here with nothing to delete; its shared credential also survives, so
+      every later dispatch/prime past the cooldown re-runs the doomed redemption
+      and returns here again. Auditing those would append a "token_revoked" row
+      for a token that never existed, forever — so obo audits only a real
+      deletion.
     """
     deleted = await asyncio.to_thread(token_store.delete_user_token, user_id, server_name)
-    if deleted:
+    if deleted or audit_when_absent:
         await _audit_event(
             app_state,
             server_id=server_id_for_audit,
@@ -1728,6 +1737,11 @@ async def _handle_refresh_failure(
             server_name,
             server_id_for_audit,
             reason=permanent_reason,
+            # ``arm_cooldown_on_permanent`` marks the obo path (shared credential
+            # survives the revoke); there, audit only a real deletion to avoid
+            # revocation rows for tokens that never existed. oauth_user audits
+            # unconditionally (a refresh failure means a grant existed).
+            audit_when_absent=not arm_cooldown_on_permanent,
         )
         if arm_cooldown_on_permanent:
             # _revoke_after_refresh_failure cleared the backoff; re-arm the
@@ -1763,6 +1777,7 @@ async def _handle_refresh_failure(
                     server_name,
                     server_id_for_audit,
                     reason=escalation_reason,
+                    audit_when_absent=not arm_cooldown_on_permanent,
                 )
                 if arm_cooldown_on_permanent:
                     # Same shared-credential backstop as the PERMANENT branch: an
@@ -2067,6 +2082,10 @@ async def _obo_token_post(
         http_client=http_client,
         request_label=label,
         endpoint_label=label,
+        # OBO: an over-sized client-error body escalates (AMBIGUOUS) rather than
+        # looping "please retry" — see _hardened_token_post. (oauth_user keeps
+        # the TRANSIENT default.)
+        classify_oversized_by_status=True,
     )
 
 

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -2609,15 +2609,14 @@ async def get_obo_access_token_classified(
         # expiry is never NULL for an obo row (see _OBO_DEFAULT_TTL_SECONDS): a
         # missing expires_in falls back to a conservative default so the
         # freshness gate can never serve a short-lived minted token forever.
-        obo_expires_at = _expires_at_from_response(tokens) or (
-            datetime.now(UTC) + timedelta(seconds=_OBO_DEFAULT_TTL_SECONDS)
-        ).strftime("%Y-%m-%dT%H:%M:%S")
         await _persist_obo_cache_row(
             token_store,
             user_id,
             server_name,
             access_token=access_token,
-            expires_at=obo_expires_at,
+            expires_at=_expires_at_from_response(
+                tokens, default_ttl_seconds=_OBO_DEFAULT_TTL_SECONDS
+            ),
             scopes=scopes,
             issuer=issuer,
             audience=audience,
@@ -2763,20 +2762,26 @@ async def _refresh_and_persist(
     return new_access, rotated_refresh, new_expires_at
 
 
-def _expires_at_from_response(tokens: dict[str, Any]) -> str | None:
+def _expires_at_from_response(
+    tokens: dict[str, Any], *, default_ttl_seconds: int | None = None
+) -> str | None:
     """Convert an AS ``expires_in`` to an ISO timestamp.
 
     Accepts int, float, or string-serialised numerics — some real ASes
     return ``"3600"`` (string), some return ``3600.0`` (float). Returns
-    ``None`` when the field is missing, malformed, or non-positive.
+    ``None`` when the field is missing, malformed, or non-positive — UNLESS
+    *default_ttl_seconds* is given, in which case that fallback lifetime is
+    used (the obo mint path passes ``_OBO_DEFAULT_TTL_SECONDS`` so a minted
+    row is never cached with a NULL, read-as-never-expiring expiry). One owner
+    of the stored-expiry timestamp format.
     """
     expires_in = tokens.get("expires_in")
-    seconds: int
+    seconds: int | None
     if isinstance(expires_in, bool):
         # ``bool`` is a subclass of ``int`` — reject explicitly so True
         # doesn't silently parse as 1 second.
-        return None
-    if isinstance(expires_in, int):
+        seconds = None
+    elif isinstance(expires_in, int):
         seconds = expires_in
     elif isinstance(expires_in, float):
         seconds = int(expires_in)
@@ -2784,11 +2789,13 @@ def _expires_at_from_response(tokens: dict[str, Any]) -> str | None:
         try:
             seconds = int(float(expires_in))
         except (TypeError, ValueError):
-            return None
+            seconds = None
     else:
-        return None
-    if seconds <= 0:
-        return None
+        seconds = None
+    if seconds is None or seconds <= 0:
+        if default_ttl_seconds is None:
+            return None
+        seconds = default_ttl_seconds
     return (datetime.now(UTC) + timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%S")
 
 

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
     from starlette.responses import Response
 
-    from turnstone.core.mcp_crypto import MCPTokenStore
+    from turnstone.core.mcp_crypto import MCPTokenStore, MCPUserTokenPlain
     from turnstone.core.storage._protocol import StorageBackend
 
 log = get_logger(__name__)
@@ -1993,6 +1993,11 @@ async def _maybe_persist_rotation(
         await persist_rotation(rotated)
 
 
+#: Audiences already warned about ignored entra scopes — dedupes the warning to
+#: once per audience per process (see _obo_mint_entra).
+_ENTRA_SCOPE_IGNORED_WARNED: set[str] = set()
+
+
 async def _obo_mint_entra(
     *,
     oidc_config: Any,
@@ -2014,13 +2019,19 @@ async def _obo_mint_entra(
     list would drop the audience and yield a wrong-audience token); they are a
     ``rfc8693``-only knob.
     """
-    if scopes:
-        # The admin write path rejects scopes-with-entra (console
-        # _enforce_oauth_obo_requirements), so reaching here is a pre-existing
-        # row or a direct-API write — debug, not a per-mint warning flood.
-        log.debug(
-            "obo: oauth_scopes ignored for the entra grant leg (audience=%s uses "
-            "<audience>/.default); scopes apply only to rfc8693",
+    if scopes and audience not in _ENTRA_SCOPE_IGNORED_WARNED:
+        # Entra ignores oauth_scopes (it pins <audience>/.default), so a
+        # configured scope restriction silently does not apply on this
+        # credential-minting path. The admin write path rejects NEW
+        # scopes-with-entra, but a deployment-level profile switch
+        # (rfc8693→entra) leaves pre-existing scoped rows — surface that ONCE
+        # per audience per process (not per mint) so it's visible at default log
+        # levels without flooding.
+        _ENTRA_SCOPE_IGNORED_WARNED.add(audience)
+        log.warning(
+            "obo: oauth_scopes is IGNORED for the entra grant leg (audience=%s mints "
+            "<audience>/.default) — a configured scope restriction is not applied; "
+            "clear oauth_scopes or use the rfc8693 profile",
             audience,
         )
     resp = await _obo_token_post(
@@ -2119,27 +2130,30 @@ async def _persist_obo_cache_row(
     issuer: str,
     audience: str,
 ) -> None:
-    """Create-or-update the per-(user, server) cache row (refresh_token=NULL)."""
-    updated = await asyncio.to_thread(
-        token_store.update_user_token_after_refresh,
+    """Write the per-(user, server) mint-cache row (refresh_token=NULL).
+
+    Delete-then-create rather than update-in-place: the row is pure cache (no
+    refresh token to preserve), and — crucially — a plain update would keep the
+    OLD ``audience`` / ``as_issuer`` / ``scopes`` columns
+    (``update_user_token_after_refresh`` rewrites only the token + expiry), so a
+    re-mint after an audience change would store the new token under the stale
+    audience and the read-side audience guard would re-mint on every dispatch
+    forever. Deleting first guarantees the row's audience matches what was minted.
+    Runs under the per-(user, server) lock, so the delete/create can't race a
+    concurrent mint for this pair.
+    """
+    await asyncio.to_thread(token_store.delete_user_token, user_id, server_name)
+    await asyncio.to_thread(
+        token_store.create_user_token,
         user_id,
         server_name,
         access_token=access_token,
         refresh_token=None,
         expires_at=expires_at,
+        scopes=scopes or None,
+        as_issuer=issuer,
+        audience=audience,
     )
-    if not updated:
-        await asyncio.to_thread(
-            token_store.create_user_token,
-            user_id,
-            server_name,
-            access_token=access_token,
-            refresh_token=None,
-            expires_at=expires_at,
-            scopes=scopes or None,
-            as_issuer=issuer,
-            audience=audience,
-        )
 
 
 async def _read_obo_credential(
@@ -2182,12 +2196,36 @@ async def _read_obo_credential(
     return credential
 
 
+def _is_fresh_obo_cache_row(plain: MCPUserTokenPlain | None, current_audience: str) -> bool:
+    """True when a cache row may be served as a minted obo access token.
+
+    Three conditions, all required (single source of truth for the pre-lock read
+    AND the post-lock re-read so they can't drift):
+
+    - refresh_token is NULL — minted rows carry no refresh token; a
+      refresh-bearing row is a stale oauth_user leftover (an in-flight refresh
+      that landed after an auth_type-flip purge) and must never be served;
+    - the row's audience equals the server's CURRENT audience — a token minted
+      for a since-narrowed audience must NOT be served, so an operator's
+      privilege reduction takes effect immediately rather than at token TTL
+      (the audience-change purge is best-effort; this is the authoritative gate);
+    - not at/near expiry.
+    """
+    return (
+        plain is not None
+        and plain["refresh_token"] is None
+        and (plain.get("audience") or "") == current_audience
+        and not _token_needs_refresh(plain["expires_at"])
+    )
+
+
 async def get_obo_access_token_classified(
     *,
     app_state: Any,
     user_id: str,
     server_name: str,
     force_refresh: bool = False,
+    revoke_ambiguous_escalation: bool = True,
     server_row: dict[str, Any] | None = None,
 ) -> TokenLookupResult:
     """Tagged token lookup for ``auth_type='oauth_obo'`` servers.
@@ -2225,6 +2263,25 @@ async def get_obo_access_token_classified(
 
     t_lock_request_started = datetime.now(UTC).replace(microsecond=0)
 
+    # Resolve the server row + audience FIRST (callers on the dispatch/priming
+    # path pass server_row, so this is normally no SQL) — the fast-path cache
+    # serve must validate the row's audience against the CURRENT one, so it can't
+    # run before the audience is known.
+    storage = _get_storage(app_state)
+    if storage is None:
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+    if server_row is None:
+        server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
+    if server_row is None:
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+    server_id_for_audit = str(server_row.get("server_id") or "")
+
+    oidc_config = getattr(app_state, "oidc_config", None)
+    profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
+    audience = str(server_row.get("oauth_audience") or "")
+    scopes = str(server_row.get("oauth_scopes") or "")
+    mint = _OBO_MINT_LEGS.get(profile)
+
     try:
         plain = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
     except MCPTokenDecryptError as exc:
@@ -2243,41 +2300,19 @@ async def get_obo_access_token_classified(
                 decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
             ),
         )
-    # A cache row carrying a refresh token is NOT a valid obo mint-cache row
-    # (minted rows have refresh_token NULL) — it's a stale oauth_user leftover
-    # from an in-flight refresh that landed after an auth_type-flip purge, or a
-    # bad transition. Never serve it as a minted token; treat it as needing a
-    # fresh mint (which then overwrites it via _persist_obo_cache_row).
-    fresh_obo_row = (
-        plain is not None
-        and plain["refresh_token"] is None
-        and not _token_needs_refresh(plain["expires_at"])
-    )
-    if plain is not None and fresh_obo_row and not force_refresh:
+    # Serve the cache only when it is a fresh, right-audience, refresh-less row
+    # (see _is_fresh_obo_cache_row). A stale-audience or refresh-bearing row
+    # falls through to a fresh mint (which overwrites it via _persist_obo_cache_row).
+    if _is_fresh_obo_cache_row(plain, audience) and not force_refresh and plain is not None:
         return _token_result(app_state, user_id, server_name, plain["access_token"])
 
     # Gate the cooldown short-circuit on actually needing a mint (cache absent or
     # stale), mirroring the oauth_user path: a force_refresh 401-retry on a
     # still-fresh cache must fall through to the locked re-read so it can pick up
     # a token a cluster-mate just minted, rather than fail transient in-cooldown.
-    needs_mint = not fresh_obo_row
+    needs_mint = not _is_fresh_obo_cache_row(plain, audience)
     if needs_mint and _refresh_in_cooldown(app_state, user_id, server_name):
         return TokenLookupResult(kind="refresh_failed_transient")
-
-    storage = _get_storage(app_state)
-    if storage is None:
-        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
-    if server_row is None:
-        server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
-    if server_row is None:
-        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
-    server_id_for_audit = str(server_row.get("server_id") or "")
-
-    oidc_config = getattr(app_state, "oidc_config", None)
-    profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
-    audience = str(server_row.get("oauth_audience") or "")
-    scopes = str(server_row.get("oauth_scopes") or "")
-    mint = _OBO_MINT_LEGS.get(profile)
     if (
         oidc_config is None
         or not getattr(oidc_config, "enabled", False)
@@ -2332,13 +2367,10 @@ async def get_obo_access_token_classified(
                     decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
                 ),
             )
-        # Same stale-row guard as the pre-lock read: a refresh-bearing row is an
-        # oauth_user leftover, not a mint-cache hit — fall through and re-mint.
-        if (
-            plain2 is not None
-            and plain2["refresh_token"] is None
-            and not _token_needs_refresh(plain2["expires_at"])
-        ):
+        # Same servability gate as the pre-lock read (refresh-less, right-audience,
+        # not-expired) — a stale-audience or refresh-bearing row falls through and
+        # re-mints.
+        if _is_fresh_obo_cache_row(plain2, audience) and plain2 is not None:
             if not force_refresh:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
             last_refreshed = _parse_iso_to_utc(plain2.get("last_refreshed") or "")
@@ -2384,7 +2416,7 @@ async def get_obo_access_token_classified(
                 server_id_for_audit=server_id_for_audit,
                 token_store=token_store,
                 revoke_on_failure=True,
-                revoke_ambiguous_escalation=True,
+                revoke_ambiguous_escalation=revoke_ambiguous_escalation,
                 events=_OBO_MINT_FAILURE_EVENTS,
                 permanent_reason="obo_mint_rejected",
                 escalation_reason="obo_mint_ambiguous_escalated",

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -2342,6 +2342,7 @@ async def get_obo_access_token_classified(
     force_refresh: bool = False,
     revoke_ambiguous_escalation: bool = True,
     server_row: dict[str, Any] | None = None,
+    credential_present: bool | None = None,
 ) -> TokenLookupResult:
     """Tagged token lookup for ``auth_type='oauth_obo'`` servers.
 
@@ -2483,10 +2484,16 @@ async def get_obo_access_token_classified(
     # to short-circuit the common "no captured credential" case before taking
     # the pg advisory lock. The authoritative decrypt happens exactly once under
     # the lock (credential2 below), where decrypt_failure is already classified —
-    # so the refresh token is never Fernet-decrypted twice per mint (which, at
-    # session-start priming across N obo servers, was N redundant decrypts per
-    # user). Mirrors the raw existence guard the priming path already uses.
-    if await asyncio.to_thread(storage.get_oidc_user_credential, user_id, issuer) is None:
+    # so the refresh token is never Fernet-decrypted twice per mint. When the
+    # caller already established presence for this issuer (``credential_present``
+    # — the priming path does one existence read for ALL of a user's obo servers)
+    # this per-server read is skipped, so session-start priming doesn't re-read
+    # the credential N times.
+    if credential_present is None:
+        credential_present = (
+            await asyncio.to_thread(storage.get_oidc_user_credential, user_id, issuer) is not None
+        )
+    if not credential_present:
         # No captured credential → the consent affordance is a re-login.
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
 

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -38,7 +38,12 @@ import httpx
 
 from turnstone.core.audit import record_audit
 from turnstone.core.log import get_logger
-from turnstone.core.mcp_crypto import MCPTokenDecryptError
+from turnstone.core.mcp_crypto import (
+    USER_SCOPED_AUTH_TYPES,
+    MCPTokenDecryptError,
+    OIDCCredentialPlain,
+    is_user_scoped_auth,
+)
 from turnstone.core.mcp_http_parsers import (
     MAX_INSUFFICIENT_SCOPE_REPORTED,
     is_valid_scope_token,
@@ -1499,6 +1504,133 @@ async def get_user_access_token(*, app_state: Any, user_id: str, server_name: st
     return None
 
 
+async def _handle_refresh_failure(
+    exc: MCPOAuthRefreshFailed,
+    *,
+    app_state: Any,
+    user_id: str,
+    server_name: str,
+    server_id_for_audit: str,
+    token_store: MCPTokenStore,
+    revoke_on_failure: bool,
+    revoke_ambiguous_escalation: bool,
+    event_prefix: str,
+    permanent_reason: str,
+    escalation_reason: str,
+    arm_cooldown_on_permanent: bool = False,
+) -> TokenLookupResult:
+    """Shared failure classifier for the refresh-grant (oauth_user) and mint
+    (oauth_obo) token-lookup state machines.
+
+    Extracted so the two pool auth types can never drift on
+    revoke/backoff/escalation semantics — a change to escalation policy applies
+    to both. Behaviour for ``oauth_user`` is byte-identical to the previous
+    inline block (``event_prefix='refresh'``, ``arm_cooldown_on_permanent=False``).
+
+    ``arm_cooldown_on_permanent`` is the one divergence the two callers need:
+    oauth_user's post-revoke lookup short-circuits to ``missing`` (its token row
+    was deleted, so no AS call recurs), but oauth_obo's shared credential
+    survives a per-server revoke by design — so without arming the cooldown here
+    every subsequent dispatch would re-run the doomed IdP redemption and emit
+    another ``token_revoked`` audit row. Arming it gives the permanent-rejection
+    arm a terminal backstop (one redemption per cooldown window).
+    """
+    if not revoke_on_failure:
+        # Observe-only (background sweep): never revoke, never mutate the
+        # shared streak / cooldown. A permanent rejection surfaces as a
+        # dead grant to badge; anything else is a retryable transient the
+        # next tick (or a real dispatch) re-attempts. The 240s sweep
+        # cadence is its own rate limit, so skipping the cooldown here
+        # cannot hammer the AS.
+        if exc.failure_class is _RefreshFailureClass.PERMANENT:
+            return TokenLookupResult(kind="refresh_failed")
+        return TokenLookupResult(kind="refresh_failed_transient")
+    if exc.failure_class is _RefreshFailureClass.PERMANENT:
+        # The AS rejected the grant as dead (invalid_grant / invalid_scope
+        # / an OIDC interaction-required code): a reliable dead-grant
+        # signal (RFC 6749 §5.2), so revoke unconditionally — even under
+        # background priming. Deferring it would strand the catalog cold
+        # with the token still reading "consented" and no re-consent path.
+        result = await _revoke_after_refresh_failure(
+            app_state,
+            token_store,
+            user_id,
+            server_name,
+            server_id_for_audit,
+            reason=permanent_reason,
+        )
+        if arm_cooldown_on_permanent:
+            # _revoke_after_refresh_failure cleared the backoff; re-arm the
+            # cooldown as the terminal backstop for the surviving credential.
+            _refresh_backoff_state(
+                app_state, user_id, server_name
+            ).last_failure_monotonic = time.monotonic()
+        return result
+    # Transient or ambiguous: keep the token (a blip must never revoke a
+    # user's consent) and arm the cooldown so a down AS isn't hit on
+    # every later dispatch.
+    backoff = _refresh_backoff_state(app_state, user_id, server_name)
+    backoff.last_failure_monotonic = time.monotonic()
+    if exc.failure_class is _RefreshFailureClass.AMBIGUOUS:
+        backoff.ambiguous_streak += 1
+        if backoff.ambiguous_streak >= _AMBIGUOUS_ESCALATION_THRESHOLD:
+            # A persistent 400/401 rejection we can't map to a standard
+            # code most likely IS a dead grant the AS reports in a
+            # non-standard shape. Escalate to re-consent so the user
+            # isn't stranded on a retryable error forever. (Infra
+            # transients never reach here, so an outage can't escalate.)
+            if revoke_ambiguous_escalation:
+                log.warning(
+                    f"mcp_server.oauth.{event_prefix}_ambiguous_escalated",
+                    user_id=user_id,
+                    server_name=server_name,
+                    streak=backoff.ambiguous_streak,
+                    error=str(exc),
+                )
+                return await _revoke_after_refresh_failure(
+                    app_state,
+                    token_store,
+                    user_id,
+                    server_name,
+                    server_id_for_audit,
+                    reason=escalation_reason,
+                )
+            # Background priming: an UNCLASSIFIABLE sustained rejection is
+            # exactly where a bulk prime of servers the user may not be
+            # using must not revoke consent. Defer the escalation-revoke to
+            # lazy dispatch — the streak + armed cooldown persist, so it
+            # escalates on the user's next real call. Falls through to the
+            # transient return below (token kept, lock retained).
+            log.warning(
+                f"mcp_server.oauth.{event_prefix}_ambiguous_escalation_deferred",
+                user_id=user_id,
+                server_name=server_name,
+                streak=backoff.ambiguous_streak,
+                error=str(exc),
+            )
+    else:
+        # A clean infra/operator-fixable transient breaks any ambiguous
+        # run — only an uninterrupted streak escalates.
+        backoff.ambiguous_streak = 0
+    log.warning(
+        f"mcp_server.oauth.{event_prefix}_transient_failure",
+        user_id=user_id,
+        server_name=server_name,
+        failure_class=exc.failure_class.value,
+        ambiguous_streak=backoff.ambiguous_streak,
+        error=str(exc),
+    )
+    # Do NOT drop the refresh lock here: the token is kept, so the
+    # per-key asyncio.Lock must stay registered to keep serializing
+    # concurrent refreshes. Dropping it would let a second concurrent
+    # caller mint a fresh lock and refresh the same token in parallel —
+    # with refresh-token rotation that races to invalid_grant and a
+    # spurious revoke (the exact bug this path prevents). The async-with
+    # still releases the lock on return; the entry is pruned when the
+    # token is later refreshed or revoked.
+    return TokenLookupResult(kind="refresh_failed_transient")
+
+
 async def get_user_access_token_classified(
     *,
     app_state: Any,
@@ -1708,93 +1840,19 @@ async def get_user_access_token_classified(
                 existing_scopes=plain2.get("scopes") or "",
             )
         except MCPOAuthRefreshFailed as exc:
-            if not revoke_on_failure:
-                # Observe-only (background sweep): never revoke, never mutate the
-                # shared streak / cooldown. A permanent rejection surfaces as a
-                # dead grant to badge; anything else is a retryable transient the
-                # next tick (or a real dispatch) re-attempts. The 240s sweep
-                # cadence is its own rate limit, so skipping the cooldown here
-                # cannot hammer the AS.
-                if exc.failure_class is _RefreshFailureClass.PERMANENT:
-                    return TokenLookupResult(kind="refresh_failed")
-                return TokenLookupResult(kind="refresh_failed_transient")
-            if exc.failure_class is _RefreshFailureClass.PERMANENT:
-                # The AS rejected the grant as dead (invalid_grant / invalid_scope
-                # / an OIDC interaction-required code): a reliable dead-grant
-                # signal (RFC 6749 §5.2), so revoke unconditionally — even under
-                # background priming. Deferring it would strand the catalog cold
-                # with the token still reading "consented" and no re-consent path.
-                return await _revoke_after_refresh_failure(
-                    app_state,
-                    token_store,
-                    user_id,
-                    server_name,
-                    server_id_for_audit,
-                    reason="refresh_failed",
-                )
-            # Transient or ambiguous: keep the token (a blip must never revoke a
-            # user's consent) and arm the cooldown so a down AS isn't hit on
-            # every later dispatch.
-            backoff = _refresh_backoff_state(app_state, user_id, server_name)
-            backoff.last_failure_monotonic = time.monotonic()
-            if exc.failure_class is _RefreshFailureClass.AMBIGUOUS:
-                backoff.ambiguous_streak += 1
-                if backoff.ambiguous_streak >= _AMBIGUOUS_ESCALATION_THRESHOLD:
-                    # A persistent 400/401 rejection we can't map to a standard
-                    # code most likely IS a dead grant the AS reports in a
-                    # non-standard shape. Escalate to re-consent so the user
-                    # isn't stranded on a retryable error forever. (Infra
-                    # transients never reach here, so an outage can't escalate.)
-                    if revoke_ambiguous_escalation:
-                        log.warning(
-                            "mcp_server.oauth.refresh_ambiguous_escalated",
-                            user_id=user_id,
-                            server_name=server_name,
-                            streak=backoff.ambiguous_streak,
-                            error=str(exc),
-                        )
-                        return await _revoke_after_refresh_failure(
-                            app_state,
-                            token_store,
-                            user_id,
-                            server_name,
-                            server_id_for_audit,
-                            reason="refresh_failed_ambiguous_escalated",
-                        )
-                    # Background priming: an UNCLASSIFIABLE sustained rejection is
-                    # exactly where a bulk prime of servers the user may not be
-                    # using must not revoke consent. Defer the escalation-revoke to
-                    # lazy dispatch — the streak + armed cooldown persist, so it
-                    # escalates on the user's next real call. Falls through to the
-                    # transient return below (token kept, lock retained).
-                    log.warning(
-                        "mcp_server.oauth.refresh_ambiguous_escalation_deferred",
-                        user_id=user_id,
-                        server_name=server_name,
-                        streak=backoff.ambiguous_streak,
-                        error=str(exc),
-                    )
-            else:
-                # A clean infra/operator-fixable transient breaks any ambiguous
-                # run — only an uninterrupted streak escalates.
-                backoff.ambiguous_streak = 0
-            log.warning(
-                "mcp_server.oauth.refresh_transient_failure",
+            return await _handle_refresh_failure(
+                exc,
+                app_state=app_state,
                 user_id=user_id,
                 server_name=server_name,
-                failure_class=exc.failure_class.value,
-                ambiguous_streak=backoff.ambiguous_streak,
-                error=str(exc),
+                server_id_for_audit=server_id_for_audit,
+                token_store=token_store,
+                revoke_on_failure=revoke_on_failure,
+                revoke_ambiguous_escalation=revoke_ambiguous_escalation,
+                event_prefix="refresh",
+                permanent_reason="refresh_failed",
+                escalation_reason="refresh_failed_ambiguous_escalated",
             )
-            # Do NOT drop the refresh lock here: the token is kept, so the
-            # per-key asyncio.Lock must stay registered to keep serializing
-            # concurrent refreshes. Dropping it would let a second concurrent
-            # caller mint a fresh lock and refresh the same token in parallel —
-            # with refresh-token rotation that races to invalid_grant and a
-            # spurious revoke (the exact bug this path prevents). The async-with
-            # still releases the lock on return; the entry is pruned when the
-            # token is later refreshed or revoked.
-            return TokenLookupResult(kind="refresh_failed_transient")
         return _token_result(app_state, user_id, server_name, new_access)
 
 
@@ -1822,17 +1880,10 @@ async def get_user_access_token_classified(
 # is handled elsewhere.
 # ---------------------------------------------------------------------------
 
-#: Auth types whose connections and tokens are per-(user, server).  The MCP
-#: client keys its connection pool and per-user tool catalogs on this class.
-USER_SCOPED_AUTH_TYPES: frozenset[str] = frozenset({"oauth_user", "oauth_obo"})
-
-#: Grant legs a deployment may select via ``[oidc] obo_grant_profile``.
-OBO_GRANT_PROFILES: frozenset[str] = frozenset({"entra", "rfc8693"})
-
-
-def is_user_scoped_auth(auth_type: str | None) -> bool:
-    """True when *auth_type* uses per-(user, server) connections and tokens."""
-    return auth_type in USER_SCOPED_AUTH_TYPES
+#: Auth types whose connections and tokens are per-(user, server). Re-exported
+#: from :mod:`mcp_crypto` (the leaf module) so there is one source of truth; the
+#: MCP client keys its connection pool and per-user tool catalogs on this class.
+#: ``OBO_GRANT_PROFILES`` is derived from ``_OBO_MINT_LEGS`` below.
 
 
 async def _obo_token_post(
@@ -1879,6 +1930,25 @@ async def _obo_token_post(
     return typed
 
 
+# A leg persists a rotated CREDENTIAL refresh token the instant it obtains one,
+# via a caller-supplied ``persist_rotation`` callback bound to the credential
+# under the held lock. It is the ONLY channel by which a mint updates the stored
+# credential — the returned access-token dict's own ``refresh_token`` (if any) is
+# never written back to the credential, so an audience-scoped exchange RT (RFC
+# 8693 §2.2.1) cannot poison it.
+
+
+async def _maybe_persist_rotation(
+    resp: dict[str, Any],
+    credential_refresh_token: str,
+    persist_rotation: Any,
+) -> None:
+    """Persist a rotated credential RT from *resp* when it differs from the current one."""
+    rotated = resp.get("refresh_token")
+    if isinstance(rotated, str) and rotated and rotated != credential_refresh_token:
+        await persist_rotation(rotated)
+
+
 async def _obo_mint_entra(
     *,
     oidc_config: Any,
@@ -1886,25 +1956,40 @@ async def _obo_mint_entra(
     audience: str,
     scopes: str,
     http_client: httpx.AsyncClient | None,
+    persist_rotation: Any,
 ) -> dict[str, Any]:
     """Entra leg: redeem the client-bound RT directly for the audience.
 
     Wire shape verified against a real tenant (docs/design/obo-spike):
     ``grant_type=refresh_token`` + ``scope=<audience>/.default`` returns an
     audience-scoped access token and (usually) a rotated refresh token.
+
+    ``scope`` is Entra's ONLY audience carrier, so it always pins
+    ``<audience>/.default`` — the pre-consented-delegated-permissions model the
+    feature targets. Per-server ``oauth_scopes`` do NOT apply here (a bare scope
+    list would drop the audience and yield a wrong-audience token); they are a
+    ``rfc8693``-only knob.
     """
-    return await _obo_token_post(
+    if scopes:
+        log.warning(
+            "obo: oauth_scopes is ignored for the entra grant leg (audience=%s uses "
+            "<audience>/.default); set scopes only on rfc8693 servers",
+            audience,
+        )
+    resp = await _obo_token_post(
         token_endpoint=oidc_config.token_endpoint,
         data={
             "grant_type": "refresh_token",
             "refresh_token": credential_refresh_token,
             "client_id": oidc_config.client_id,
             "client_secret": oidc_config.client_secret,
-            "scope": scopes or f"{audience}/.default",
+            "scope": f"{audience}/.default",
         },
         http_client=http_client,
         leg="entra-redemption",
     )
+    await _maybe_persist_rotation(resp, credential_refresh_token, persist_rotation)
+    return resp
 
 
 async def _obo_mint_rfc8693(
@@ -1914,13 +1999,18 @@ async def _obo_mint_rfc8693(
     audience: str,
     scopes: str,
     http_client: httpx.AsyncClient | None,
+    persist_rotation: Any,
 ) -> dict[str, Any]:
     """RFC 8693 leg: refresh grant for a subject token, then token exchange.
 
     Chain verified on Keycloak 26.3 standard token exchange
-    (docs/design/obo-spike).  The refresh leg may rotate the credential —
-    the rotated value is propagated in the merged response so the caller's
-    write-back persists it; the exchanged token itself carries no RT.
+    (docs/design/obo-spike). Rotation ordering is correctness-critical: the
+    refresh leg may consume-and-rotate the credential RT, so its rotated value
+    is persisted IMMEDIATELY (before the exchange leg) — if the exchange then
+    fails, the stored credential already holds the live rotated RT rather than a
+    consumed one (else the next mint for every obo server would fail and lock the
+    user out). The exchange response's own ``refresh_token`` (RFC 8693 §2.2.1
+    permits one, audience-scoped) is deliberately NOT persisted to the credential.
     """
     subject = await _obo_token_post(
         token_endpoint=oidc_config.token_endpoint,
@@ -1933,6 +2023,9 @@ async def _obo_mint_rfc8693(
         http_client=http_client,
         leg="rfc8693-refresh",
     )
+    # Persist the credential rotation BEFORE the exchange call can fail.
+    await _maybe_persist_rotation(subject, credential_refresh_token, persist_rotation)
+
     subject_at = subject.get("access_token")
     if not isinstance(subject_at, str) or not subject_at:
         raise MCPOAuthRefreshFailed("obo rfc8693-refresh response missing access_token")
@@ -1949,22 +2042,23 @@ async def _obo_mint_rfc8693(
         # e.g. Keycloak optional audience scopes must be requested explicitly
         # or the exchange fails "Requested audience not available" (verified).
         exchange_data["scope"] = scopes
-    exchanged = await _obo_token_post(
+    return await _obo_token_post(
         token_endpoint=oidc_config.token_endpoint,
         data=exchange_data,
         http_client=http_client,
         leg="rfc8693-exchange",
     )
-    rotated = subject.get("refresh_token")
-    if isinstance(rotated, str) and rotated:
-        exchanged = {**exchanged, "refresh_token": rotated}
-    return exchanged
 
 
 _OBO_MINT_LEGS = {
     "entra": _obo_mint_entra,
     "rfc8693": _obo_mint_rfc8693,
 }
+
+#: Grant legs a deployment may select via ``[oidc] obo_grant_profile`` — derived
+#: from the operative registry so the two never drift (used by oidc config
+#: validation; there is no second hand-written copy).
+OBO_GRANT_PROFILES: frozenset[str] = frozenset(_OBO_MINT_LEGS)
 
 
 async def _persist_obo_cache_row(
@@ -2001,14 +2095,59 @@ async def _persist_obo_cache_row(
         )
 
 
+async def _read_obo_credential(
+    app_state: Any,
+    token_store: MCPTokenStore,
+    user_id: str,
+    server_name: str,
+    issuer: str,
+) -> TokenLookupResult | OIDCCredentialPlain:
+    """Read the captured IdP credential, classifying absence and undecryptability.
+
+    Returns the plaintext credential dict, or a ``TokenLookupResult`` when it is
+    ``missing`` (no credential → the dispatcher surfaces a re-login) or
+    ``decrypt_failure`` (key rotated away → operator action). The bare
+    ``get_oidc_credential`` raises ``MCPTokenDecryptError``; catching it here
+    keeps the mint path's classified-result contract intact (a raw exception
+    would escape ``_dispatch_pool`` into the session's generic error path).
+    """
+    try:
+        credential = await asyncio.to_thread(token_store.get_oidc_credential, user_id, issuer)
+    except MCPTokenDecryptError as exc:
+        log.warning(
+            "mcp_server.oauth.obo_credential_decrypt_failed",
+            user_id=user_id,
+            server_name=server_name,
+            exc_info=True,
+        )
+        return _no_token_result(
+            app_state,
+            user_id,
+            server_name,
+            TokenLookupResult(
+                kind="decrypt_failure",
+                decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
+            ),
+        )
+    if credential is None:
+        # No captured credential → the consent affordance is a re-login.
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+    return credential
+
+
 async def get_obo_access_token_classified(
     *,
     app_state: Any,
     user_id: str,
     server_name: str,
     force_refresh: bool = False,
+    server_row: dict[str, Any] | None = None,
 ) -> TokenLookupResult:
     """Tagged token lookup for ``auth_type='oauth_obo'`` servers.
+
+    ``server_row`` may be passed by a caller that already holds the
+    ``mcp_servers`` row (the dispatch path does) to save a per-call SQL
+    round-trip on this per-LLM-turn hot path; it is loaded lazily otherwise.
 
     Sibling of :func:`get_user_access_token_classified` sharing its result
     vocabulary, cache table, locks, and backoff — but "refresh" here is a
@@ -2060,13 +2199,19 @@ async def get_obo_access_token_classified(
     if plain is not None and not force_refresh and not _token_needs_refresh(plain["expires_at"]):
         return _token_result(app_state, user_id, server_name, plain["access_token"])
 
-    if _refresh_in_cooldown(app_state, user_id, server_name):
+    # Gate the cooldown short-circuit on actually needing a mint (cache absent or
+    # stale), mirroring the oauth_user path: a force_refresh 401-retry on a
+    # still-fresh cache must fall through to the locked re-read so it can pick up
+    # a token a cluster-mate just minted, rather than fail transient in-cooldown.
+    needs_mint = plain is None or _token_needs_refresh(plain["expires_at"])
+    if needs_mint and _refresh_in_cooldown(app_state, user_id, server_name):
         return TokenLookupResult(kind="refresh_failed_transient")
 
     storage = _get_storage(app_state)
     if storage is None:
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
-    server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
+    if server_row is None:
+        server_row = await asyncio.to_thread(storage.get_mcp_server_by_name, server_name)
     if server_row is None:
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
     server_id_for_audit = str(server_row.get("server_id") or "")
@@ -2085,7 +2230,15 @@ async def get_obo_access_token_classified(
     ):
         # Operator-fixable configuration problem — loud log, no revoke, and a
         # retryable classification so fixing the config heals without a
-        # re-consent round.
+        # re-consent round. Arm the cooldown so a misconfigured server on a busy
+        # deployment doesn't emit an error line + SQL per dispatch: the check is
+        # loud once per 30s window per (user, server), and a fixed config heals
+        # on the next tick after the window lapses. (The write path also rejects
+        # audience-less oauth_obo rows, so this branch is normally a typo'd
+        # grant profile, not a common state.)
+        _refresh_backoff_state(
+            app_state, user_id, server_name
+        ).last_failure_monotonic = time.monotonic()
         log.error(
             "mcp_server.oauth.obo_misconfigured",
             server_name=server_name,
@@ -2096,10 +2249,12 @@ async def get_obo_access_token_classified(
         return TokenLookupResult(kind="refresh_failed_transient")
     issuer = str(getattr(oidc_config, "issuer", ""))
 
-    credential = await asyncio.to_thread(token_store.get_oidc_credential, user_id, issuer)
-    if credential is None:
-        # No captured credential → the consent affordance is a re-login.
-        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
+    credential_result = await _read_obo_credential(
+        app_state, token_store, user_id, server_name, issuer
+    )
+    if isinstance(credential_result, TokenLookupResult):
+        return credential_result  # missing or decrypt_failure
+    # credential present (unlocked pre-check; re-read authoritatively under lock)
 
     lock = _refresh_lock_for(app_state, user_id, server_name)
     credential_key = f"__obo__:{issuer}"
@@ -2129,10 +2284,22 @@ async def get_obo_access_token_classified(
 
         # Re-read the credential under the lock — a concurrent mint for a
         # different server may have rotated it; always redeem the newest.
-        credential2 = await asyncio.to_thread(token_store.get_oidc_credential, user_id, issuer)
-        if credential2 is None:
-            return _no_token_result(
-                app_state, user_id, server_name, TokenLookupResult(kind="missing")
+        credential2 = await _read_obo_credential(
+            app_state, token_store, user_id, server_name, issuer
+        )
+        if isinstance(credential2, TokenLookupResult):
+            return credential2  # missing or decrypt_failure
+
+        # The mint leg persists any credential-RT rotation the instant it obtains
+        # one, via this callback under the held credential lock — so on rfc8693 a
+        # rotation from the refresh leg survives an exchange-leg failure, and an
+        # audience-scoped exchange RT never reaches the credential.
+        async def _persist_rotation(new_credential_rt: str) -> None:
+            await asyncio.to_thread(
+                token_store.update_oidc_credential_after_redeem,
+                user_id,
+                issuer,
+                refresh_token=new_credential_rt,
             )
 
         http_client = getattr(app_state, "oidc_http_client", None)
@@ -2143,59 +2310,34 @@ async def get_obo_access_token_classified(
                 audience=audience,
                 scopes=scopes,
                 http_client=http_client,
+                persist_rotation=_persist_rotation,
             )
         except MCPOAuthRefreshFailed as exc:
-            if exc.failure_class is _RefreshFailureClass.PERMANENT:
-                log.warning(
-                    "mcp_server.oauth.obo_mint_rejected",
-                    user_id=user_id,
-                    server_name=server_name,
-                    error=str(exc),
-                )
-                # Drops ONLY the per-server cache row; the credential stays.
-                return await _revoke_after_refresh_failure(
-                    app_state,
-                    token_store,
-                    user_id,
-                    server_name,
-                    server_id_for_audit,
-                    reason="obo_mint_rejected",
-                )
-            backoff = _refresh_backoff_state(app_state, user_id, server_name)
-            backoff.last_failure_monotonic = time.monotonic()
-            if exc.failure_class is _RefreshFailureClass.AMBIGUOUS:
-                backoff.ambiguous_streak += 1
-                if backoff.ambiguous_streak >= _AMBIGUOUS_ESCALATION_THRESHOLD:
-                    log.warning(
-                        "mcp_server.oauth.obo_mint_ambiguous_escalated",
-                        user_id=user_id,
-                        server_name=server_name,
-                        streak=backoff.ambiguous_streak,
-                        error=str(exc),
-                    )
-                    return await _revoke_after_refresh_failure(
-                        app_state,
-                        token_store,
-                        user_id,
-                        server_name,
-                        server_id_for_audit,
-                        reason="obo_mint_ambiguous_escalated",
-                    )
-            else:
-                backoff.ambiguous_streak = 0
-            log.warning(
-                "mcp_server.oauth.obo_mint_transient_failure",
+            return await _handle_refresh_failure(
+                exc,
+                app_state=app_state,
                 user_id=user_id,
                 server_name=server_name,
-                failure_class=exc.failure_class.value,
-                error=str(exc),
+                server_id_for_audit=server_id_for_audit,
+                token_store=token_store,
+                revoke_on_failure=True,
+                revoke_ambiguous_escalation=True,
+                event_prefix="obo_mint",
+                permanent_reason="obo_mint_rejected",
+                escalation_reason="obo_mint_ambiguous_escalated",
+                # The shared credential survives a per-server revoke, so arm the
+                # cooldown as the terminal backstop (else every re-dispatch would
+                # re-run the doomed redemption + emit another token_revoked row).
+                arm_cooldown_on_permanent=True,
             )
-            return TokenLookupResult(kind="refresh_failed_transient")
 
         access_token = tokens.get("access_token")
         if not isinstance(access_token, str) or not access_token:
             backoff = _refresh_backoff_state(app_state, user_id, server_name)
             backoff.last_failure_monotonic = time.monotonic()
+            # A malformed 200 is a clean transient (not a dead grant): reset the
+            # ambiguous streak, matching the sibling's _refresh_and_persist path.
+            backoff.ambiguous_streak = 0
             log.warning(
                 "mcp_server.oauth.obo_mint_missing_access_token",
                 user_id=user_id,
@@ -2203,18 +2345,8 @@ async def get_obo_access_token_classified(
             )
             return TokenLookupResult(kind="refresh_failed_transient")
 
-        # Rotation write-back BEFORE the cache write: if the process dies
-        # between the two, a stale credential is the failure that strands
-        # users (verified: both legs rotate), a stale cache row just re-mints.
-        rotated = tokens.get("refresh_token")
-        if isinstance(rotated, str) and rotated and rotated != credential2["refresh_token"]:
-            await asyncio.to_thread(
-                token_store.update_oidc_credential_after_redeem,
-                user_id,
-                issuer,
-                refresh_token=rotated,
-            )
-
+        # Credential rotation was already persisted by the mint leg (see
+        # _persist_rotation); the cache write is the only remaining step.
         await _persist_obo_cache_row(
             token_store,
             user_id,

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1435,6 +1435,21 @@ def _refresh_backoff_state(app_state: Any, user_id: str, server_name: str) -> _R
     return state
 
 
+def _arm_cooldown(app_state: Any, user_id: str, server_name: str) -> _RefreshBackoffState:
+    """Stamp the per-(user, server) transient-failure cooldown clock to now.
+
+    Single definition of the "back off this pair" operation (previously written
+    inline at every failure site) so a change to how the cooldown is armed —
+    jitter, a min-interval, a second timestamp — is one edit, not four, and a
+    missed site can't silently keep hammering the AS/IdP on that path. Returns
+    the backoff state so a caller that also mutates the ambiguous streak reuses
+    the same object instead of re-fetching it.
+    """
+    state = _refresh_backoff_state(app_state, user_id, server_name)
+    state.last_failure_monotonic = time.monotonic()
+    return state
+
+
 def _clear_refresh_backoff(app_state: Any, user_id: str, server_name: str) -> None:
     """Drop the backoff state for ``(user_id, server_name)``.
 
@@ -1687,15 +1702,12 @@ async def _handle_refresh_failure(
         if arm_cooldown_on_permanent:
             # _revoke_after_refresh_failure cleared the backoff; re-arm the
             # cooldown as the terminal backstop for the surviving credential.
-            _refresh_backoff_state(
-                app_state, user_id, server_name
-            ).last_failure_monotonic = time.monotonic()
+            _arm_cooldown(app_state, user_id, server_name)
         return result
     # Transient or ambiguous: keep the token (a blip must never revoke a
     # user's consent) and arm the cooldown so a down AS isn't hit on
     # every later dispatch.
-    backoff = _refresh_backoff_state(app_state, user_id, server_name)
-    backoff.last_failure_monotonic = time.monotonic()
+    backoff = _arm_cooldown(app_state, user_id, server_name)
     if exc.failure_class is _RefreshFailureClass.AMBIGUOUS:
         backoff.ambiguous_streak += 1
         if backoff.ambiguous_streak >= _AMBIGUOUS_ESCALATION_THRESHOLD:
@@ -2383,9 +2395,7 @@ async def get_obo_access_token_classified(
         # on the next tick after the window lapses. (The write path also rejects
         # audience-less oauth_obo rows, so this branch is normally a typo'd
         # grant profile, not a common state.)
-        _refresh_backoff_state(
-            app_state, user_id, server_name
-        ).last_failure_monotonic = time.monotonic()
+        _arm_cooldown(app_state, user_id, server_name)
         log.error(
             "mcp_server.oauth.obo_misconfigured",
             server_name=server_name,
@@ -2396,12 +2406,16 @@ async def get_obo_access_token_classified(
         return TokenLookupResult(kind="refresh_failed_transient")
     issuer = str(getattr(oidc_config, "issuer", ""))
 
-    credential_result = await _read_obo_credential(
-        app_state, token_store, user_id, server_name, issuer
-    )
-    if isinstance(credential_result, TokenLookupResult):
-        return credential_result  # missing or decrypt_failure
-    # credential present (unlocked pre-check; re-read authoritatively under lock)
+    # Cheap pre-lock presence check: a raw existence read (NO decrypt) is enough
+    # to short-circuit the common "no captured credential" case before taking
+    # the pg advisory lock. The authoritative decrypt happens exactly once under
+    # the lock (credential2 below), where decrypt_failure is already classified —
+    # so the refresh token is never Fernet-decrypted twice per mint (which, at
+    # session-start priming across N obo servers, was N redundant decrypts per
+    # user). Mirrors the raw existence guard the priming path already uses.
+    if await asyncio.to_thread(storage.get_oidc_user_credential, user_id, issuer) is None:
+        # No captured credential → the consent affordance is a re-login.
+        return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
 
     lock = _refresh_lock_for(app_state, user_id, server_name)
     credential_key = f"__obo__:{issuer}"
@@ -2507,8 +2521,7 @@ async def get_obo_access_token_classified(
 
         access_token = tokens.get("access_token")
         if not isinstance(access_token, str) or not access_token:
-            backoff = _refresh_backoff_state(app_state, user_id, server_name)
-            backoff.last_failure_monotonic = time.monotonic()
+            backoff = _arm_cooldown(app_state, user_id, server_name)
             # A malformed 200 is a clean transient (not a dead grant): reset the
             # ambiguous streak, matching the sibling's _refresh_and_persist path.
             backoff.ambiguous_streak = 0

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -32,7 +32,7 @@ import time
 import urllib.parse
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import httpx
 
@@ -57,6 +57,8 @@ from turnstone.core.oauth_ssrf import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from starlette.requests import Request
     from starlette.responses import Response
 
@@ -1504,6 +1506,36 @@ async def get_user_access_token(*, app_state: Any, user_id: str, server_name: st
     return None
 
 
+class _FailureEvents(NamedTuple):
+    """Structured-log event names for :func:`_handle_refresh_failure`.
+
+    Passed as whole literals (not composed from a prefix) so every emitted
+    event name appears verbatim in source — operators' alerting greps for
+    e.g. ``mcp_server.oauth.refresh_transient_failure`` and must find it here.
+    ``permanent`` logs the IdP error text on a PERMANENT rejection before the
+    revoke; ``None`` suppresses it (preserves oauth_user's exact prior output).
+    """
+
+    transient: str
+    escalated: str
+    deferred: str
+    permanent: str | None
+
+
+_REFRESH_FAILURE_EVENTS = _FailureEvents(
+    transient="mcp_server.oauth.refresh_transient_failure",
+    escalated="mcp_server.oauth.refresh_ambiguous_escalated",
+    deferred="mcp_server.oauth.refresh_ambiguous_escalation_deferred",
+    permanent=None,  # oauth_user's permanent path logged no error-text line
+)
+_OBO_MINT_FAILURE_EVENTS = _FailureEvents(
+    transient="mcp_server.oauth.obo_mint_transient_failure",
+    escalated="mcp_server.oauth.obo_mint_ambiguous_escalated",
+    deferred="mcp_server.oauth.obo_mint_ambiguous_escalation_deferred",
+    permanent="mcp_server.oauth.obo_mint_rejected",  # carries the AS error body
+)
+
+
 async def _handle_refresh_failure(
     exc: MCPOAuthRefreshFailed,
     *,
@@ -1514,7 +1546,7 @@ async def _handle_refresh_failure(
     token_store: MCPTokenStore,
     revoke_on_failure: bool,
     revoke_ambiguous_escalation: bool,
-    event_prefix: str,
+    events: _FailureEvents,
     permanent_reason: str,
     escalation_reason: str,
     arm_cooldown_on_permanent: bool = False,
@@ -1525,7 +1557,7 @@ async def _handle_refresh_failure(
     Extracted so the two pool auth types can never drift on
     revoke/backoff/escalation semantics — a change to escalation policy applies
     to both. Behaviour for ``oauth_user`` is byte-identical to the previous
-    inline block (``event_prefix='refresh'``, ``arm_cooldown_on_permanent=False``).
+    inline block (``events=_REFRESH_FAILURE_EVENTS``, ``arm_cooldown_on_permanent=False``).
 
     ``arm_cooldown_on_permanent`` is the one divergence the two callers need:
     oauth_user's post-revoke lookup short-circuits to ``missing`` (its token row
@@ -1551,6 +1583,18 @@ async def _handle_refresh_failure(
         # signal (RFC 6749 §5.2), so revoke unconditionally — even under
         # background priming. Deferring it would strand the catalog cold
         # with the token still reading "consented" and no re-consent path.
+        if events.permanent is not None:
+            # Record the IdP error body BEFORE the revoke: it is the only place
+            # the AS's actual message survives (the token_revoked audit row
+            # carries just a reason code), and it is what lets an operator tell a
+            # missing tenant-grant / Conditional-Access challenge from a dead
+            # credential without wire-level capture.
+            log.warning(
+                events.permanent,
+                user_id=user_id,
+                server_name=server_name,
+                error=str(exc),
+            )
         result = await _revoke_after_refresh_failure(
             app_state,
             token_store,
@@ -1581,7 +1625,7 @@ async def _handle_refresh_failure(
             # transients never reach here, so an outage can't escalate.)
             if revoke_ambiguous_escalation:
                 log.warning(
-                    f"mcp_server.oauth.{event_prefix}_ambiguous_escalated",
+                    events.escalated,
                     user_id=user_id,
                     server_name=server_name,
                     streak=backoff.ambiguous_streak,
@@ -1602,7 +1646,7 @@ async def _handle_refresh_failure(
             # escalates on the user's next real call. Falls through to the
             # transient return below (token kept, lock retained).
             log.warning(
-                f"mcp_server.oauth.{event_prefix}_ambiguous_escalation_deferred",
+                events.deferred,
                 user_id=user_id,
                 server_name=server_name,
                 streak=backoff.ambiguous_streak,
@@ -1613,7 +1657,7 @@ async def _handle_refresh_failure(
         # run — only an uninterrupted streak escalates.
         backoff.ambiguous_streak = 0
     log.warning(
-        f"mcp_server.oauth.{event_prefix}_transient_failure",
+        events.transient,
         user_id=user_id,
         server_name=server_name,
         failure_class=exc.failure_class.value,
@@ -1849,7 +1893,7 @@ async def get_user_access_token_classified(
                 token_store=token_store,
                 revoke_on_failure=revoke_on_failure,
                 revoke_ambiguous_escalation=revoke_ambiguous_escalation,
-                event_prefix="refresh",
+                events=_REFRESH_FAILURE_EVENTS,
                 permanent_reason="refresh_failed",
                 escalation_reason="refresh_failed_ambiguous_escalated",
             )
@@ -1941,7 +1985,7 @@ async def _obo_token_post(
 async def _maybe_persist_rotation(
     resp: dict[str, Any],
     credential_refresh_token: str,
-    persist_rotation: Any,
+    persist_rotation: Callable[[str], Awaitable[None]],
 ) -> None:
     """Persist a rotated credential RT from *resp* when it differs from the current one."""
     rotated = resp.get("refresh_token")
@@ -1956,7 +2000,7 @@ async def _obo_mint_entra(
     audience: str,
     scopes: str,
     http_client: httpx.AsyncClient | None,
-    persist_rotation: Any,
+    persist_rotation: Callable[[str], Awaitable[None]],
 ) -> dict[str, Any]:
     """Entra leg: redeem the client-bound RT directly for the audience.
 
@@ -1971,9 +2015,12 @@ async def _obo_mint_entra(
     ``rfc8693``-only knob.
     """
     if scopes:
-        log.warning(
-            "obo: oauth_scopes is ignored for the entra grant leg (audience=%s uses "
-            "<audience>/.default); set scopes only on rfc8693 servers",
+        # The admin write path rejects scopes-with-entra (console
+        # _enforce_oauth_obo_requirements), so reaching here is a pre-existing
+        # row or a direct-API write — debug, not a per-mint warning flood.
+        log.debug(
+            "obo: oauth_scopes ignored for the entra grant leg (audience=%s uses "
+            "<audience>/.default); scopes apply only to rfc8693",
             audience,
         )
     resp = await _obo_token_post(
@@ -1999,7 +2046,7 @@ async def _obo_mint_rfc8693(
     audience: str,
     scopes: str,
     http_client: httpx.AsyncClient | None,
-    persist_rotation: Any,
+    persist_rotation: Callable[[str], Awaitable[None]],
 ) -> dict[str, Any]:
     """RFC 8693 leg: refresh grant for a subject token, then token exchange.
 
@@ -2196,14 +2243,24 @@ async def get_obo_access_token_classified(
                 decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
             ),
         )
-    if plain is not None and not force_refresh and not _token_needs_refresh(plain["expires_at"]):
+    # A cache row carrying a refresh token is NOT a valid obo mint-cache row
+    # (minted rows have refresh_token NULL) — it's a stale oauth_user leftover
+    # from an in-flight refresh that landed after an auth_type-flip purge, or a
+    # bad transition. Never serve it as a minted token; treat it as needing a
+    # fresh mint (which then overwrites it via _persist_obo_cache_row).
+    fresh_obo_row = (
+        plain is not None
+        and plain["refresh_token"] is None
+        and not _token_needs_refresh(plain["expires_at"])
+    )
+    if plain is not None and fresh_obo_row and not force_refresh:
         return _token_result(app_state, user_id, server_name, plain["access_token"])
 
     # Gate the cooldown short-circuit on actually needing a mint (cache absent or
     # stale), mirroring the oauth_user path: a force_refresh 401-retry on a
     # still-fresh cache must fall through to the locked re-read so it can pick up
     # a token a cluster-mate just minted, rather than fail transient in-cooldown.
-    needs_mint = plain is None or _token_needs_refresh(plain["expires_at"])
+    needs_mint = not fresh_obo_row
     if needs_mint and _refresh_in_cooldown(app_state, user_id, server_name):
         return TokenLookupResult(kind="refresh_failed_transient")
 
@@ -2275,7 +2332,13 @@ async def get_obo_access_token_classified(
                     decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
                 ),
             )
-        if plain2 is not None and not _token_needs_refresh(plain2["expires_at"]):
+        # Same stale-row guard as the pre-lock read: a refresh-bearing row is an
+        # oauth_user leftover, not a mint-cache hit — fall through and re-mint.
+        if (
+            plain2 is not None
+            and plain2["refresh_token"] is None
+            and not _token_needs_refresh(plain2["expires_at"])
+        ):
             if not force_refresh:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
             last_refreshed = _parse_iso_to_utc(plain2.get("last_refreshed") or "")
@@ -2322,7 +2385,7 @@ async def get_obo_access_token_classified(
                 token_store=token_store,
                 revoke_on_failure=True,
                 revoke_ambiguous_escalation=True,
-                event_prefix="obo_mint",
+                events=_OBO_MINT_FAILURE_EVENTS,
                 permanent_reason="obo_mint_rejected",
                 escalation_reason="obo_mint_ambiguous_escalated",
                 # The shared credential survives a per-server revoke, so arm the

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -2544,6 +2544,11 @@ async def get_obo_access_token_classified(
                     user_id,
                     issuer,
                     refresh_token=new_credential_rt,
+                    # Value CAS against the RT this mint read: skips the write if
+                    # a concurrent login capture already refreshed the credential
+                    # (see update_oidc_credential_after_redeem), so a rotation
+                    # can't clobber a fresh login token.
+                    expected_current=credential2["refresh_token"],
                 )
             except Exception:
                 log.error(
@@ -2562,16 +2567,27 @@ async def get_obo_access_token_classified(
         # _obo_token_post uses a transient per-request client when this is
         # None (mints are ~hourly per (user, server), not hot-path).
         # ``obo_http_client`` is an injection seam for tests / e2e harnesses.
-        http_client = getattr(app_state, "obo_http_client", None)
+        injected_client = getattr(app_state, "obo_http_client", None)
+        # One client for the whole mint: the rfc8693 leg makes TWO POSTs to the
+        # same token endpoint, so a per-request transient would pay two TLS
+        # handshakes. When no client is injected (production), open a single
+        # transient here and thread it into both legs so the exchange leg reuses
+        # the refresh leg's pooled connection.
         try:
-            tokens = await mint(
-                oidc_config=oidc_config,
-                credential_refresh_token=credential2["refresh_token"],
-                audience=audience,
-                scopes=scopes,
-                http_client=http_client,
-                persist_rotation=_persist_rotation,
-            )
+            async with contextlib.AsyncExitStack() as mint_stack:
+                mint_client = injected_client
+                if mint_client is None:
+                    mint_client = await mint_stack.enter_async_context(
+                        httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT)
+                    )
+                tokens = await mint(
+                    oidc_config=oidc_config,
+                    credential_refresh_token=credential2["refresh_token"],
+                    audience=audience,
+                    scopes=scopes,
+                    http_client=mint_client,
+                    persist_rotation=_persist_rotation,
+                )
         except MCPOAuthRefreshFailed as exc:
             return await _handle_refresh_failure(
                 exc,
@@ -2609,18 +2625,33 @@ async def get_obo_access_token_classified(
         # expiry is never NULL for an obo row (see _OBO_DEFAULT_TTL_SECONDS): a
         # missing expires_in falls back to a conservative default so the
         # freshness gate can never serve a short-lived minted token forever.
-        await _persist_obo_cache_row(
-            token_store,
-            user_id,
-            server_name,
-            access_token=access_token,
-            expires_at=_expires_at_from_response(
-                tokens, default_ttl_seconds=_OBO_DEFAULT_TTL_SECONDS
-            ),
-            scopes=scopes,
-            issuer=issuer,
-            audience=audience,
-        )
+        #
+        # Best-effort: the mint already SUCCEEDED and ``access_token`` is a
+        # working bearer for THIS dispatch. A transient storage error on the
+        # cache write (delete+create) must not discard that token or escape the
+        # classified-result contract as a raw exception — return the token and
+        # let the next dispatch re-mint (the un-written cache row just means one
+        # extra mint, not a failed tool call).
+        try:
+            await _persist_obo_cache_row(
+                token_store,
+                user_id,
+                server_name,
+                access_token=access_token,
+                expires_at=_expires_at_from_response(
+                    tokens, default_ttl_seconds=_OBO_DEFAULT_TTL_SECONDS
+                ),
+                scopes=scopes,
+                issuer=issuer,
+                audience=audience,
+            )
+        except Exception:
+            log.warning(
+                "mcp_server.oauth.obo_cache_persist_failed",
+                user_id=user_id,
+                server_name=server_name,
+                exc_info=True,
+            )
         return _token_result(app_state, user_id, server_name, access_token)
 
 

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -887,6 +887,60 @@ async def exchange_code(
     return doc
 
 
+async def _hardened_token_post(
+    *,
+    token_endpoint: str,
+    data: dict[str, str],
+    http_client: httpx.AsyncClient | None,
+    request_label: str,
+    endpoint_label: str,
+) -> dict[str, Any]:
+    """POST one token-grant request with the shared hardening skeleton.
+
+    Single implementation of the POST → body-size cap →
+    :func:`_classify_refresh_failure` → JSON-object-validation chain used by
+    both the oauth_user refresh and the OBO mint legs, so the two grant
+    paths cannot drift. Raises :class:`MCPOAuthRefreshFailed` on any
+    failure; a non-200 carries the conservative classification — an explicit
+    dead-grant / re-consent code revokes consent; infra (5xx/429) and
+    operator-fixable codes keep the token; an unrecognised 400/401 is
+    ambiguous and the caller escalates only after a sustained run.
+
+    The two labels preserve each caller's historical error text verbatim
+    (``refresh request failed`` vs ``refresh endpoint returned HTTP …``);
+    the OBO wrapper passes one string for both. When *http_client* is
+    ``None`` a transient per-request client is used — the OBO mint path runs
+    on the MCP loop and deliberately passes ``None`` (see
+    :func:`get_obo_access_token_classified`).
+    """
+    try:
+        if http_client is not None:
+            resp = await http_client.post(token_endpoint, data=data, timeout=_DEFAULT_HTTP_TIMEOUT)
+        else:
+            async with httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT) as transient:
+                resp = await transient.post(token_endpoint, data=data)
+    except httpx.HTTPError as exc:
+        raise MCPOAuthRefreshFailed(f"{request_label} request failed: {exc}") from exc
+
+    if len(resp.content) > _MAX_TOKEN_BODY_BYTES:
+        raise MCPOAuthRefreshFailed(f"{endpoint_label} response body exceeds size limit")
+
+    if resp.status_code != 200:
+        raise MCPOAuthRefreshFailed(
+            f"{endpoint_label} returned HTTP {resp.status_code}: {_format_as_error(resp)}",
+            failure_class=_classify_refresh_failure(resp),
+        )
+
+    try:
+        doc = resp.json()
+    except ValueError as exc:
+        raise MCPOAuthRefreshFailed(f"{request_label} body is not valid JSON: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise MCPOAuthRefreshFailed(f"{request_label} body is not a JSON object")
+    typed: dict[str, Any] = doc
+    return typed
+
+
 async def refresh_token(
     *,
     as_metadata: ASMetadata,
@@ -914,36 +968,13 @@ async def refresh_token(
     if scopes:
         data["scope"] = scopes
 
-    try:
-        resp = await http_client.post(
-            as_metadata.token_endpoint,
-            data=data,
-            timeout=_DEFAULT_HTTP_TIMEOUT,
-        )
-    except httpx.HTTPError as exc:
-        raise MCPOAuthRefreshFailed(f"refresh request failed: {exc}") from exc
-
-    if len(resp.content) > _MAX_TOKEN_BODY_BYTES:
-        raise MCPOAuthRefreshFailed("refresh endpoint response body exceeds size limit")
-
-    if resp.status_code != 200:
-        # Classify the rejection (see _classify_refresh_failure): an explicit
-        # dead-grant / re-consent code revokes consent; infra (5xx/429) and
-        # operator-fixable codes keep the token; an unrecognised 400/401 is
-        # ambiguous and the caller escalates only after a sustained run.
-        raise MCPOAuthRefreshFailed(
-            f"refresh endpoint returned HTTP {resp.status_code}: {_format_as_error(resp)}",
-            failure_class=_classify_refresh_failure(resp),
-        )
-
-    try:
-        doc = resp.json()
-    except ValueError as exc:
-        raise MCPOAuthRefreshFailed(f"refresh body is not valid JSON: {exc}") from exc
-
-    if not isinstance(doc, dict):
-        raise MCPOAuthRefreshFailed("refresh body is not a JSON object")
-    return doc
+    return await _hardened_token_post(
+        token_endpoint=as_metadata.token_endpoint,
+        data=data,
+        http_client=http_client,
+        request_label="refresh",
+        endpoint_label="refresh endpoint",
+    )
 
 
 async def revoke_token_at_as(
@@ -1924,11 +1955,6 @@ async def get_user_access_token_classified(
 # is handled elsewhere.
 # ---------------------------------------------------------------------------
 
-#: Auth types whose connections and tokens are per-(user, server). Re-exported
-#: from :mod:`mcp_crypto` (the leaf module) so there is one source of truth; the
-#: MCP client keys its connection pool and per-user tool catalogs on this class.
-#: ``OBO_GRANT_PROFILES`` is derived from ``_OBO_MINT_LEGS`` below.
-
 
 async def _obo_token_post(
     *,
@@ -1939,39 +1965,21 @@ async def _obo_token_post(
 ) -> dict[str, Any]:
     """POST one OBO grant-leg request; classify failures like a refresh.
 
-    Mirrors :func:`refresh_token`'s hardening (body size cap, JSON-object
-    validation) and raises :class:`MCPOAuthRefreshFailed` with the same
-    conservative :func:`_classify_refresh_failure` mapping, so the OBO state
-    machine reacts to AS rejections exactly like the oauth_user one — a
-    verified AADSTS65001 (missing tenant grant) classifies PERMANENT via
+    Label-binding wrapper over :func:`_hardened_token_post` (the shared
+    body-size-cap / JSON-object-validation / conservative
+    :func:`_classify_refresh_failure` skeleton), so the OBO state machine
+    reacts to AS rejections exactly like the oauth_user one — a verified
+    AADSTS65001 (missing tenant grant) classifies PERMANENT via
     ``invalid_grant``.
     """
-    try:
-        if http_client is not None:
-            resp = await http_client.post(token_endpoint, data=data, timeout=_DEFAULT_HTTP_TIMEOUT)
-        else:
-            async with httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT) as transient:
-                resp = await transient.post(token_endpoint, data=data)
-    except httpx.HTTPError as exc:
-        raise MCPOAuthRefreshFailed(f"obo {leg} request failed: {exc}") from exc
-
-    if len(resp.content) > _MAX_TOKEN_BODY_BYTES:
-        raise MCPOAuthRefreshFailed(f"obo {leg} response body exceeds size limit")
-
-    if resp.status_code != 200:
-        raise MCPOAuthRefreshFailed(
-            f"obo {leg} returned HTTP {resp.status_code}: {_format_as_error(resp)}",
-            failure_class=_classify_refresh_failure(resp),
-        )
-
-    try:
-        doc = resp.json()
-    except ValueError as exc:
-        raise MCPOAuthRefreshFailed(f"obo {leg} body is not valid JSON: {exc}") from exc
-    if not isinstance(doc, dict):
-        raise MCPOAuthRefreshFailed(f"obo {leg} body is not a JSON object")
-    typed: dict[str, Any] = doc
-    return typed
+    label = f"obo {leg}"
+    return await _hardened_token_post(
+        token_endpoint=token_endpoint,
+        data=data,
+        http_client=http_client,
+        request_label=label,
+        endpoint_label=label,
+    )
 
 
 # A leg persists a rotated CREDENTIAL refresh token the instant it obtains one,
@@ -2029,10 +2037,12 @@ async def _obo_mint_entra(
         # levels without flooding.
         _ENTRA_SCOPE_IGNORED_WARNED.add(audience)
         log.warning(
-            "obo: oauth_scopes is IGNORED for the entra grant leg (audience=%s mints "
-            "<audience>/.default) — a configured scope restriction is not applied; "
-            "clear oauth_scopes or use the rfc8693 profile",
-            audience,
+            "mcp_server.oauth.obo_entra_scopes_ignored",
+            audience=audience,
+            hint=(
+                "oauth_scopes is not applied on the entra grant leg (it mints "
+                "<audience>/.default); clear oauth_scopes or use the rfc8693 profile"
+            ),
         )
     resp = await _obo_token_post(
         token_endpoint=oidc_config.token_endpoint,
@@ -2303,16 +2313,32 @@ async def get_obo_access_token_classified(
     # Serve the cache only when it is a fresh, right-audience, refresh-less row
     # (see _is_fresh_obo_cache_row). A stale-audience or refresh-bearing row
     # falls through to a fresh mint (which overwrites it via _persist_obo_cache_row).
-    if _is_fresh_obo_cache_row(plain, audience) and not force_refresh and plain is not None:
+    fresh = _is_fresh_obo_cache_row(plain, audience)
+    if fresh and not force_refresh and plain is not None:
         return _token_result(app_state, user_id, server_name, plain["access_token"])
 
     # Gate the cooldown short-circuit on actually needing a mint (cache absent or
     # stale), mirroring the oauth_user path: a force_refresh 401-retry on a
     # still-fresh cache must fall through to the locked re-read so it can pick up
     # a token a cluster-mate just minted, rather than fail transient in-cooldown.
-    needs_mint = not _is_fresh_obo_cache_row(plain, audience)
-    if needs_mint and _refresh_in_cooldown(app_state, user_id, server_name):
+    if not fresh and _refresh_in_cooldown(app_state, user_id, server_name):
         return TokenLookupResult(kind="refresh_failed_transient")
+    if oidc_config is not None and not getattr(oidc_config, "enabled", False):
+        # A node that booted during a transient IdP outage carries
+        # enabled=False with discovery_retryable=True; without a runtime
+        # retry, every obo mint on this node would fail "transient" until an
+        # operator restarts it (the login path's lazy retry covers only JWKS,
+        # not discovery). Cooldown-gated and single-flight; a no-op when OIDC
+        # is operator-disabled or the boot failure was a config rejection.
+        # Lazy import: oidc.load_oidc_config imports OBO_GRANT_PROFILES from
+        # this module (also lazily), so neither module may import the other
+        # at module level.
+        from turnstone.core.oidc import maybe_rediscover_oidc
+
+        await maybe_rediscover_oidc(app_state)
+        oidc_config = getattr(app_state, "oidc_config", None)
+        profile = str(getattr(oidc_config, "obo_grant_profile", "") or "")
+        mint = _OBO_MINT_LEGS.get(profile)
     if (
         oidc_config is None
         or not getattr(oidc_config, "enabled", False)
@@ -2373,8 +2399,13 @@ async def get_obo_access_token_classified(
         if _is_fresh_obo_cache_row(plain2, audience) and plain2 is not None:
             if not force_refresh:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
-            last_refreshed = _parse_iso_to_utc(plain2.get("last_refreshed") or "")
-            if last_refreshed is not None and last_refreshed >= t_lock_request_started:
+            # Obo cache rows are delete+create'd per mint and never touched by
+            # update_user_token_after_refresh, so ``created`` IS the mint time
+            # (``last_refreshed`` stays NULL on this path — the oauth_user
+            # gate's column would never fire here, and every serialized
+            # force_refresh waiter would run its own redundant IdP redemption).
+            minted_at = _parse_iso_to_utc(plain2.get("created") or "")
+            if minted_at is not None and minted_at >= t_lock_request_started:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
 
         # Re-read the credential under the lock — a concurrent mint for a
@@ -2390,14 +2421,40 @@ async def get_obo_access_token_classified(
         # rotation from the refresh leg survives an exchange-leg failure, and an
         # audience-scoped exchange RT never reaches the credential.
         async def _persist_rotation(new_credential_rt: str) -> None:
-            await asyncio.to_thread(
-                token_store.update_oidc_credential_after_redeem,
-                user_id,
-                issuer,
-                refresh_token=new_credential_rt,
-            )
+            # Swallow storage failures: the mint itself succeeded, so the
+            # caller still gets a working access token. On a strict-rotation
+            # IdP the stored credential may now hold a consumed RT — the NEXT
+            # mint then fails invalid_grant and surfaces the re-login rail.
+            # Raising here would be strictly worse: the rotated RT is lost
+            # either way, and a raw storage exception would additionally
+            # escape the classified-result contract (only
+            # MCPOAuthRefreshFailed is caught around mint()) and break the
+            # in-flight dispatch too.
+            try:
+                await asyncio.to_thread(
+                    token_store.update_oidc_credential_after_redeem,
+                    user_id,
+                    issuer,
+                    refresh_token=new_credential_rt,
+                )
+            except Exception:
+                log.error(
+                    "mcp_server.oauth.obo_rotation_persist_failed",
+                    user_id=user_id,
+                    server_name=server_name,
+                    exc_info=True,
+                )
 
-        http_client = getattr(app_state, "oidc_http_client", None)
+        # The login flow's oidc_http_client lives on the uvicorn loop; this
+        # function runs on the MCP loop thread. httpx pools connections per
+        # client object and a pooled connection is bound to the loop that
+        # created it, so sharing the login client here collides routinely —
+        # the login exchange and the first mint hit the same IdP origin
+        # seconds apart by design. No long-lived mint client is kept:
+        # _obo_token_post uses a transient per-request client when this is
+        # None (mints are ~hourly per (user, server), not hot-path).
+        # ``obo_http_client`` is an injection seam for tests / e2e harnesses.
+        http_client = getattr(app_state, "obo_http_client", None)
         try:
             tokens = await mint(
                 oidc_config=oidc_config,
@@ -3474,7 +3531,26 @@ async def _handle_mcp_oauth_list_connections_inner(request: Request) -> Response
         return JSONResponse({"error": "Authentication required"}, status_code=401)
 
     rows = await asyncio.to_thread(token_store.list_user_token_metadata, user_id)
-    return JSONResponse({"connections": list(rows)})
+    # Hide oauth_obo mint-cache rows: they are cache artifacts of sign-in
+    # passthrough, not per-server consents. Listing them offered a
+    # "Disconnect" that silently undid itself — the row deletes, then
+    # session-start priming re-mints from the surviving captured credential —
+    # so the connections list shows only rows the user can actually revoke.
+    # Fail open on a server-list read error: worst case an obo row renders
+    # and the revoke endpoint below still refuses it honestly.
+    storage = _get_storage(request.app.state)
+    obo_names: set[str] = set()
+    if storage is not None:
+        try:
+            servers = await asyncio.to_thread(storage.list_mcp_servers)
+            obo_names = {
+                str(s.get("name") or "")
+                for s in servers
+                if str(s.get("auth_type") or "") == "oauth_obo"
+            }
+        except Exception:
+            obo_names = set()
+    return JSONResponse({"connections": [r for r in rows if r["server_name"] not in obo_names]})
 
 
 async def handle_mcp_oauth_revoke_connection(request: Request) -> Response:
@@ -3634,6 +3710,27 @@ async def _handle_mcp_oauth_revoke_connection_inner(request: Request) -> Respons
     server_id_for_audit = ""
     if server_row is not None:
         server_id_for_audit = str(server_row.get("server_id") or "")
+
+    if server_row is not None and str(server_row.get("auth_type") or "") == "oauth_obo":
+        # Sign-in passthrough rows are mint-cache, not per-server consent:
+        # deleting the row here would 204, audit token_revoked, and then
+        # session-start priming would silently re-mint from the surviving
+        # captured credential — a "disconnect" that undoes itself. Refuse
+        # honestly instead (the admin bulk path exposes the same truth as
+        # effect=cache_flush_remints; removing the sign-in credential is the
+        # real revocation lever). The listing endpoint hides these rows, so
+        # this is a backstop for direct API calls.
+        return JSONResponse(
+            {
+                "error": (
+                    "This server uses your Turnstone sign-in, not a per-server "
+                    "connection — there is nothing to disconnect here. Access "
+                    "ends when your sign-in credential is removed or an "
+                    "administrator disables the server."
+                )
+            },
+            status_code=409,
+        )
 
     # Local delete — authoritative. Even if the upstream revoke fails or
     # is unsupported, the consent is invalidated for this deployment.

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -930,7 +930,21 @@ async def _hardened_token_post(
         raise MCPOAuthRefreshFailed(f"{request_label} request failed: {exc}") from exc
 
     if len(resp.content) > _MAX_TOKEN_BODY_BYTES:
-        raise MCPOAuthRefreshFailed(f"{endpoint_label} response body exceeds size limit")
+        # Classify by STATUS without reading the over-sized body (reading it to
+        # pin PERMANENT would defeat the guard). A client-error status — a likely
+        # dead grant — becomes AMBIGUOUS so it still escalates to re-consent after
+        # a streak, rather than the default TRANSIENT that would loop "please
+        # retry" forever on a permanently-dead grant whose error body happened to
+        # exceed the cap.
+        oversized_class = (
+            _RefreshFailureClass.AMBIGUOUS
+            if resp.status_code in (400, 401, 403)
+            else _RefreshFailureClass.TRANSIENT
+        )
+        raise MCPOAuthRefreshFailed(
+            f"{endpoint_label} response body exceeds size limit",
+            failure_class=oversized_class,
+        )
 
     if resp.status_code != 200:
         raise MCPOAuthRefreshFailed(
@@ -3588,6 +3602,24 @@ async def _handle_mcp_oauth_callback_inner(request: Request) -> Response:
     return RedirectResponse(pending["return_url"] or "/", status_code=302)
 
 
+def obo_server_names(storage: StorageBackend) -> set[str]:
+    """Names of all ``auth_type='oauth_obo'`` MCP servers (raises on storage error).
+
+    One definition of "which servers are sign-in passthrough", shared by the
+    connections-list filter (which hides obo cache rows) and the identity-delete
+    cache purge, so a change to how obo is recognised — or a second passthrough
+    auth type — can't leave one path silently missing servers (which would
+    expose obo rows in the connections list, or leave a deprovisioned user's
+    minted-token cache un-purged). Callers wrap their own try/except so each
+    keeps its context-specific fail-open logging.
+    """
+    return {
+        str(row.get("name") or "")
+        for row in storage.list_mcp_servers()
+        if str(row.get("auth_type") or "") == "oauth_obo"
+    }
+
+
 async def handle_mcp_oauth_list_connections(request: Request) -> Response:
     """``GET /v1/api/mcp/oauth/connections``.
 
@@ -3626,12 +3658,7 @@ async def _handle_mcp_oauth_list_connections_inner(request: Request) -> Response
     obo_names: set[str] = set()
     if storage is not None:
         try:
-            servers = await asyncio.to_thread(storage.list_mcp_servers)
-            obo_names = {
-                str(s.get("name") or "")
-                for s in servers
-                if str(s.get("auth_type") or "") == "oauth_obo"
-            }
+            obo_names = await asyncio.to_thread(obo_server_names, storage)
         except Exception:
             obo_names = set()
     return JSONResponse({"connections": [r for r in rows if r["server_name"] not in obo_names]})

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1419,6 +1419,13 @@ class _RefreshBackoffState:
 
     last_failure_monotonic: float = 0.0
     ambiguous_streak: int = 0
+    # True when the failure that armed the current cooldown was a PERMANENT
+    # dead-grant (only the oauth_obo path arms a cooldown on permanent, because
+    # its shared credential survives the per-server revoke). The in-cooldown
+    # short-circuit reads this so it surfaces the honest permanent classification
+    # (re-login / admin remedy) instead of a misleading "retry" transient for the
+    # whole window. Reset to False whenever a transient/ambiguous failure arms.
+    last_failure_permanent: bool = False
 
 
 def _refresh_backoff_state(app_state: Any, user_id: str, server_name: str) -> _RefreshBackoffState:
@@ -1435,7 +1442,9 @@ def _refresh_backoff_state(app_state: Any, user_id: str, server_name: str) -> _R
     return state
 
 
-def _arm_cooldown(app_state: Any, user_id: str, server_name: str) -> _RefreshBackoffState:
+def _arm_cooldown(
+    app_state: Any, user_id: str, server_name: str, *, permanent: bool = False
+) -> _RefreshBackoffState:
     """Stamp the per-(user, server) transient-failure cooldown clock to now.
 
     Single definition of the "back off this pair" operation (previously written
@@ -1444,9 +1453,16 @@ def _arm_cooldown(app_state: Any, user_id: str, server_name: str) -> _RefreshBac
     missed site can't silently keep hammering the AS/IdP on that path. Returns
     the backoff state so a caller that also mutates the ambiguous streak reuses
     the same object instead of re-fetching it.
+
+    ``permanent`` records whether the failure that armed the cooldown was a
+    dead-grant (obo only): the in-cooldown short-circuit reads it to surface the
+    honest permanent vs. transient classification. A transient/ambiguous arm
+    resets it to False so a later transient window can't inherit a stale
+    permanent flag.
     """
     state = _refresh_backoff_state(app_state, user_id, server_name)
     state.last_failure_monotonic = time.monotonic()
+    state.last_failure_permanent = permanent
     return state
 
 
@@ -1701,8 +1717,10 @@ async def _handle_refresh_failure(
         )
         if arm_cooldown_on_permanent:
             # _revoke_after_refresh_failure cleared the backoff; re-arm the
-            # cooldown as the terminal backstop for the surviving credential.
-            _arm_cooldown(app_state, user_id, server_name)
+            # cooldown as the terminal backstop for the surviving credential, and
+            # mark it permanent so the in-cooldown short-circuit surfaces the
+            # honest dead-grant classification (not a misleading "retry").
+            _arm_cooldown(app_state, user_id, server_name, permanent=True)
         return result
     # Transient or ambiguous: keep the token (a blip must never revoke a
     # user's consent) and arm the cooldown so a down AS isn't hit on
@@ -1724,7 +1742,7 @@ async def _handle_refresh_failure(
                     streak=backoff.ambiguous_streak,
                     error=str(exc),
                 )
-                return await _revoke_after_refresh_failure(
+                escalation_result = await _revoke_after_refresh_failure(
                     app_state,
                     token_store,
                     user_id,
@@ -1732,6 +1750,16 @@ async def _handle_refresh_failure(
                     server_id_for_audit,
                     reason=escalation_reason,
                 )
+                if arm_cooldown_on_permanent:
+                    # Same shared-credential backstop as the PERMANENT branch: an
+                    # escalation is a treated-as-dead grant, but the revoke
+                    # cleared the cooldown, and for obo the credential survives —
+                    # so without re-arming, the very next dispatch immediately
+                    # re-mints against the still-failing IdP and re-escalates
+                    # each cycle. Re-arm (marked permanent for the honest
+                    # in-cooldown classification).
+                    _arm_cooldown(app_state, user_id, server_name, permanent=True)
+                return escalation_result
             # Background priming: an UNCLASSIFIABLE sustained rejection is
             # exactly where a bulk prime of servers the user may not be
             # using must not revoke consent. Defer the escalation-revoke to
@@ -2319,8 +2347,6 @@ async def get_obo_access_token_classified(
         log.debug("mcp_server.oauth.token_store_unconfigured")
         return TokenLookupResult(kind="missing")
 
-    t_lock_request_started = datetime.now(UTC).replace(microsecond=0)
-
     # Resolve the server row + audience FIRST (callers on the dispatch/priming
     # path pass server_row, so this is normally no SQL) — the fast-path cache
     # serve must validate the row's audience against the CURRENT one, so it can't
@@ -2363,6 +2389,14 @@ async def get_obo_access_token_classified(
     # still-fresh cache must fall through to the locked re-read so it can pick up
     # a token a cluster-mate just minted, rather than fail transient in-cooldown.
     if not fresh and _refresh_in_cooldown(app_state, user_id, server_name):
+        # Surface the classification that armed the cooldown: obo arms it on a
+        # PERMANENT dead-grant too (its credential survives the per-server
+        # revoke), and reporting that as a retryable "transient" for the whole
+        # window would tell the user to retry a permanently-broken server and
+        # flap against the honest re-login/admin affordance the mint returned.
+        backoff = _refresh_backoff_state(app_state, user_id, server_name)
+        if backoff.last_failure_permanent:
+            return TokenLookupResult(kind="refresh_failed")
         return TokenLookupResult(kind="refresh_failed_transient")
     if oidc_config is not None and not getattr(oidc_config, "enabled", False):
         # A node that booted during a transient IdP outage carries
@@ -2435,13 +2469,18 @@ async def get_obo_access_token_classified(
         if _is_fresh_obo_cache_row(plain2, audience, scopes) and plain2 is not None:
             if not force_refresh:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
-            # Obo cache rows are delete+create'd per mint and never touched by
-            # update_user_token_after_refresh, so ``created`` IS the mint time
-            # (``last_refreshed`` stays NULL on this path — the oauth_user
-            # gate's column would never fire here, and every serialized
-            # force_refresh waiter would run its own redundant IdP redemption).
-            minted_at = _parse_iso_to_utc(plain2.get("created") or "")
-            if minted_at is not None and minted_at >= t_lock_request_started:
+            # force_refresh means the caller's bearer was rejected; serialized
+            # waiters must single-flight the re-mint (avoid N redundant IdP
+            # redemptions) WITHOUT re-serving the very token that was just
+            # rejected. Distinguish by token IDENTITY, not mint time: the pre-lock
+            # ``plain`` is the token this caller came in with (the rejected one);
+            # if the under-lock row now holds a DIFFERENT token, a concurrent
+            # waiter re-minted while we waited — reuse it. If it is the SAME
+            # token, nothing has changed, so fall through and re-mint. (Mint time
+            # can't distinguish these at the cache row's 1-second ``created``
+            # granularity — a same-second own-mint would read as "fresh".)
+            pre_lock_token = plain["access_token"] if plain is not None else None
+            if plain2["access_token"] != pre_lock_token:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
 
         # Re-read the credential under the lock — a concurrent mint for a
@@ -3577,6 +3616,10 @@ async def _handle_mcp_oauth_list_connections_inner(request: Request) -> Response
     # "Disconnect" that silently undid itself — the row deletes, then
     # session-start priming re-mints from the surviving captured credential —
     # so the connections list shows only rows the user can actually revoke.
+    # Classify by the authoritative server ``auth_type`` (one read on this cold
+    # settings-page path) rather than inferring obo from a NULL refresh token:
+    # the auth_type is the source of truth, and a token-shape heuristic would
+    # silently hide any oauth_user row that ever lacked a refresh token.
     # Fail open on a server-list read error: worst case an obo row renders
     # and the revoke endpoint below still refuses it honestly.
     storage = _get_storage(request.app.state)

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -39,7 +39,6 @@ import httpx
 from turnstone.core.audit import record_audit
 from turnstone.core.log import get_logger
 from turnstone.core.mcp_crypto import (
-    USER_SCOPED_AUTH_TYPES,
     MCPTokenDecryptError,
     OIDCCredentialPlain,
     is_user_scoped_auth,
@@ -1500,19 +1499,62 @@ async def _revoke_after_refresh_failure(
     Drops the per-key refresh lock and backoff state — both safe to call when no
     entry exists — and returns ``refresh_failed`` so the dispatcher surfaces
     re-consent.
+
+    The ``token_revoked`` audit is emitted ONLY when a row was actually deleted.
+    This matters for oauth_obo: its shared credential survives a per-server
+    revoke, so after the first permanent rejection deletes the cache row, every
+    later dispatch/prime past the cooldown re-runs the doomed redemption and
+    lands here again with nothing to delete — auditing unconditionally would
+    append a fresh "token_revoked" row for a token that no longer exists on
+    every cycle, forever (misleading forensics + alert fatigue for operators
+    who alert on token_revoked). oauth_user cannot hit the empty-delete case (a
+    revoke there also removes the only refresh source, so no recurrence), so
+    this gate is a no-op for it.
     """
-    await asyncio.to_thread(token_store.delete_user_token, user_id, server_name)
-    await _audit_event(
-        app_state,
-        server_id=server_id_for_audit,
-        user_id=user_id,
-        action="mcp_server.oauth.token_revoked",
-        server_name=server_name,
-        detail={"reason": reason},
-    )
+    deleted = await asyncio.to_thread(token_store.delete_user_token, user_id, server_name)
+    if deleted:
+        await _audit_event(
+            app_state,
+            server_id=server_id_for_audit,
+            user_id=user_id,
+            action="mcp_server.oauth.token_revoked",
+            server_name=server_name,
+            detail={"reason": reason},
+        )
     _drop_refresh_lock(app_state, user_id, server_name)
     _clear_refresh_backoff(app_state, user_id, server_name)
     return TokenLookupResult(kind="refresh_failed")
+
+
+def _decrypt_failure_result(
+    app_state: Any,
+    user_id: str,
+    server_name: str,
+    exc: MCPTokenDecryptError,
+    *,
+    event: str | None,
+) -> TokenLookupResult:
+    """Map an ``MCPTokenDecryptError`` to a classified ``decrypt_failure`` result.
+
+    One construction of the (optional warning log + ``_no_token_result`` +
+    fingerprint-carrying ``TokenLookupResult``) shape, shared by the five
+    token/credential read sites in the oauth_user and oauth_obo state machines
+    (the raw ``get_user_token`` / ``get_oidc_credential`` calls each raise this
+    on a key rotated away, and each must keep the classified-result contract).
+    Pass the site's structured *event* name to log, or ``None`` for a re-read
+    whose first read already logged.
+    """
+    if event is not None:
+        log.warning(event, user_id=user_id, server_name=server_name, exc_info=True)
+    return _no_token_result(
+        app_state,
+        user_id,
+        server_name,
+        TokenLookupResult(
+            kind="decrypt_failure",
+            decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
+        ),
+    )
 
 
 async def get_user_access_token(*, app_state: Any, user_id: str, server_name: str) -> str | None:
@@ -1786,20 +1828,12 @@ async def get_user_access_token_classified(
     try:
         plain = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
     except MCPTokenDecryptError as exc:
-        log.warning(
-            "mcp_server.oauth.token_decrypt_failed_classified",
-            user_id=user_id,
-            server_name=server_name,
-            exc_info=True,
-        )
-        return _no_token_result(
+        return _decrypt_failure_result(
             app_state,
             user_id,
             server_name,
-            TokenLookupResult(
-                kind="decrypt_failure",
-                decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
-            ),
+            exc,
+            event="mcp_server.oauth.token_decrypt_failed_classified",
         )
     if plain is None:
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
@@ -1856,20 +1890,12 @@ async def get_user_access_token_classified(
         try:
             plain2 = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
         except MCPTokenDecryptError as exc:
-            log.warning(
-                "mcp_server.oauth.token_decrypt_failed_classified",
-                user_id=user_id,
-                server_name=server_name,
-                exc_info=True,
-            )
-            return _no_token_result(
+            return _decrypt_failure_result(
                 app_state,
                 user_id,
                 server_name,
-                TokenLookupResult(
-                    kind="decrypt_failure",
-                    decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
-                ),
+                exc,
+                event="mcp_server.oauth.token_decrypt_failed_classified",
             )
         if plain2 is None:
             return _no_token_result(
@@ -2185,20 +2211,12 @@ async def _read_obo_credential(
     try:
         credential = await asyncio.to_thread(token_store.get_oidc_credential, user_id, issuer)
     except MCPTokenDecryptError as exc:
-        log.warning(
-            "mcp_server.oauth.obo_credential_decrypt_failed",
-            user_id=user_id,
-            server_name=server_name,
-            exc_info=True,
-        )
-        return _no_token_result(
+        return _decrypt_failure_result(
             app_state,
             user_id,
             server_name,
-            TokenLookupResult(
-                kind="decrypt_failure",
-                decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
-            ),
+            exc,
+            event="mcp_server.oauth.obo_credential_decrypt_failed",
         )
     if credential is None:
         # No captured credential → the consent affordance is a re-login.
@@ -2206,10 +2224,12 @@ async def _read_obo_credential(
     return credential
 
 
-def _is_fresh_obo_cache_row(plain: MCPUserTokenPlain | None, current_audience: str) -> bool:
+def _is_fresh_obo_cache_row(
+    plain: MCPUserTokenPlain | None, current_audience: str, current_scopes: str
+) -> bool:
     """True when a cache row may be served as a minted obo access token.
 
-    Three conditions, all required (single source of truth for the pre-lock read
+    Four conditions, all required (single source of truth for the pre-lock read
     AND the post-lock re-read so they can't drift):
 
     - refresh_token is NULL — minted rows carry no refresh token; a
@@ -2219,12 +2239,20 @@ def _is_fresh_obo_cache_row(plain: MCPUserTokenPlain | None, current_audience: s
       for a since-narrowed audience must NOT be served, so an operator's
       privilege reduction takes effect immediately rather than at token TTL
       (the audience-change purge is best-effort; this is the authoritative gate);
+    - the row's scopes equal the server's CURRENT scopes — the same authoritative
+      gate for the rfc8693 exchange scope (which shapes the minted bearer's
+      privileges just like the audience): a scope NARROWING must take effect on
+      the next dispatch even if the admin's best-effort cache purge failed,
+      rather than serving the wider-privilege bearer until its TTL. Under the
+      entra leg scopes are inert, so the stored and current values track the
+      same server column and this term is a no-op there;
     - not at/near expiry.
     """
     return (
         plain is not None
         and plain["refresh_token"] is None
         and (plain.get("audience") or "") == current_audience
+        and (plain.get("scopes") or "") == current_scopes
         and not _token_needs_refresh(plain["expires_at"])
     )
 
@@ -2295,25 +2323,18 @@ async def get_obo_access_token_classified(
     try:
         plain = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
     except MCPTokenDecryptError as exc:
-        log.warning(
-            "mcp_server.oauth.obo_cache_decrypt_failed",
-            user_id=user_id,
-            server_name=server_name,
-            exc_info=True,
-        )
-        return _no_token_result(
+        return _decrypt_failure_result(
             app_state,
             user_id,
             server_name,
-            TokenLookupResult(
-                kind="decrypt_failure",
-                decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
-            ),
+            exc,
+            event="mcp_server.oauth.obo_cache_decrypt_failed",
         )
-    # Serve the cache only when it is a fresh, right-audience, refresh-less row
-    # (see _is_fresh_obo_cache_row). A stale-audience or refresh-bearing row
-    # falls through to a fresh mint (which overwrites it via _persist_obo_cache_row).
-    fresh = _is_fresh_obo_cache_row(plain, audience)
+    # Serve the cache only when it is a fresh, right-audience, right-scopes,
+    # refresh-less row (see _is_fresh_obo_cache_row). A stale-audience/-scopes or
+    # refresh-bearing row falls through to a fresh mint (which overwrites it via
+    # _persist_obo_cache_row).
+    fresh = _is_fresh_obo_cache_row(plain, audience, scopes)
     if fresh and not force_refresh and plain is not None:
         return _token_result(app_state, user_id, server_name, plain["access_token"])
 
@@ -2384,19 +2405,12 @@ async def get_obo_access_token_classified(
         try:
             plain2 = await asyncio.to_thread(token_store.get_user_token, user_id, server_name)
         except MCPTokenDecryptError as exc:
-            return _no_token_result(
-                app_state,
-                user_id,
-                server_name,
-                TokenLookupResult(
-                    kind="decrypt_failure",
-                    decrypt_fingerprints=tuple(exc.key_fingerprints_attempted),
-                ),
-            )
+            # First read already logged obo_cache_decrypt_failed; this re-read
+            # under the lock stays silent (event=None) to avoid a double line.
+            return _decrypt_failure_result(app_state, user_id, server_name, exc, event=None)
         # Same servability gate as the pre-lock read (refresh-less, right-audience,
-        # not-expired) — a stale-audience or refresh-bearing row falls through and
-        # re-mints.
-        if _is_fresh_obo_cache_row(plain2, audience) and plain2 is not None:
+        # right-scopes, not-expired) — a stale row falls through and re-mints.
+        if _is_fresh_obo_cache_row(plain2, audience, scopes) and plain2 is not None:
             if not force_refresh:
                 return _token_result(app_state, user_id, server_name, plain2["access_token"])
             # Obo cache rows are delete+create'd per mint and never touched by
@@ -4008,7 +4022,6 @@ __all__ = [
     "MCP_OAUTH_STATE_TTL_SECONDS",
     "OBO_GRANT_PROFILES",
     "TokenLookupResult",
-    "USER_SCOPED_AUTH_TYPES",
     "build_authorize_url",
     "close_mcp_oauth_state",
     "create_pending_state",

--- a/turnstone/core/oauth_ssrf.py
+++ b/turnstone/core/oauth_ssrf.py
@@ -42,6 +42,20 @@ KNOWN_TRUSTED_OAUTH_ENDPOINT_HOSTS: dict[str, frozenset[str]] = {
             "openidconnect.googleapis.com",
         }
     ),
+    # Microsoft Entra ID (commercial cloud). The tenant issuer is
+    # login.microsoftonline.com/<tenant>/v2.0, but its discovery document
+    # advertises userinfo_endpoint on graph.microsoft.com — a distinct host.
+    # Without this entry, discovery rejects the cross-host userinfo and
+    # disables OIDC, so every Azure AD deployment would need a manual
+    # trusted_endpoint_hosts override to log in. (Sovereign clouds —
+    # login.microsoftonline.us / *.chinacloudapi.cn — use their own graph
+    # hosts and can be added the same way.)
+    "login.microsoftonline.com": frozenset(
+        {
+            "login.microsoftonline.com",
+            "graph.microsoft.com",
+        }
+    ),
 }
 
 

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -106,7 +106,8 @@ class OIDCConfig:
     Startup-config fields (set by :func:`load_oidc_config`):
         ``enabled``, ``issuer``, ``client_id``, ``client_secret``, ``scopes``,
         ``provider_name``, ``role_claim``, ``role_map``, ``password_enabled``,
-        ``redirect_base``, ``trusted_endpoint_hosts``, ``allow_private_network``.
+        ``redirect_base``, ``trusted_endpoint_hosts``, ``allow_private_network``,
+        ``capture_user_credential``.
 
     Discovery-derived fields (set by :func:`discover_oidc`; empty before
     discovery completes):
@@ -129,6 +130,11 @@ class OIDCConfig:
     # (and its same-origin discovered endpoints) to resolve to private
     # addresses. Link-local/multicast/reserved stay refused regardless.
     allow_private_network: bool = False
+    # Opt-in single-credential capture (issue #551): persist the user's IdP
+    # refresh token (encrypted) at login so `auth_type='oauth_obo'` MCP
+    # servers can mint per-server access tokens on demand.  Requires the
+    # [security] MCP token encryption key — enforced at startup.
+    capture_user_credential: bool = False
     # Discovered from .well-known/openid-configuration
     authorization_endpoint: str = ""
     token_endpoint: str = ""
@@ -197,6 +203,14 @@ def load_oidc_config() -> OIDCConfig:
     allow_private_network = _env_or_cfg_bool(
         "TURNSTONE_OIDC_ALLOW_PRIVATE_NETWORK", cfg, "allow_private_network", False
     )
+    capture_user_credential = _env_or_cfg_bool(
+        "TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL", cfg, "capture_user_credential", False
+    )
+    if capture_user_credential and "offline_access" not in scopes.split():
+        # The captured credential IS the offline_access refresh token; ask
+        # for it at login so operators don't have to edit two keys in step.
+        scopes = f"{scopes} offline_access".strip()
+        log.info("oidc.capture: appended offline_access to login scopes")
 
     # Role map: env var is "admin:builtin-admin,eng:builtin-operator"
     role_map_raw = os.environ.get("TURNSTONE_OIDC_ROLE_MAP", "").strip()
@@ -289,6 +303,7 @@ def load_oidc_config() -> OIDCConfig:
         redirect_base=redirect_base,
         trusted_endpoint_hosts=trusted_endpoint_hosts,
         allow_private_network=allow_private_network,
+        capture_user_credential=capture_user_credential,
     )
 
 

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -135,6 +135,11 @@ class OIDCConfig:
     # servers can mint per-server access tokens on demand.  Requires the
     # [security] MCP token encryption key — enforced at startup.
     capture_user_credential: bool = False
+    # Grant leg used to redeem the captured credential for per-server access
+    # tokens: "entra" (refresh-token redemption with scope=<audience>/.default)
+    # or "rfc8693" (refresh grant + standard token exchange).  The IdP
+    # determines the leg, so this is deployment-level, not per-server.
+    obo_grant_profile: str = "entra"
     # Discovered from .well-known/openid-configuration
     authorization_endpoint: str = ""
     token_endpoint: str = ""
@@ -206,6 +211,15 @@ def load_oidc_config() -> OIDCConfig:
     capture_user_credential = _env_or_cfg_bool(
         "TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL", cfg, "capture_user_credential", False
     )
+    obo_grant_profile = _env_or_cfg_str(
+        "TURNSTONE_OIDC_OBO_GRANT_PROFILE", cfg, "obo_grant_profile", "entra"
+    ).strip()
+    if obo_grant_profile not in ("entra", "rfc8693"):
+        log.warning(
+            "oidc: unknown obo_grant_profile %r (expected 'entra' or 'rfc8693') — "
+            "oauth_obo MCP servers will not mint until this is fixed",
+            obo_grant_profile,
+        )
     if capture_user_credential and "offline_access" not in scopes.split():
         # The captured credential IS the offline_access refresh token; ask
         # for it at login so operators don't have to edit two keys in step.
@@ -304,6 +318,7 @@ def load_oidc_config() -> OIDCConfig:
         trusted_endpoint_hosts=trusted_endpoint_hosts,
         allow_private_network=allow_private_network,
         capture_user_credential=capture_user_credential,
+        obo_grant_profile=obo_grant_profile,
     )
 
 

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -449,8 +449,14 @@ async def discover_oidc(
     setup across calls; when ``None`` a transient client is used (the
     legacy shape, kept so tests don't need lifecycle management).
     """
+    # Config-error branches force ``discovery_retryable=False`` (terminal): they
+    # reflect a bad CONFIG (no issuer, an SSRF-rejected URL), not a transient IdP
+    # outage, so a runtime re-probe would only fail identically forever. This is
+    # explicit rather than preserved-from-input because ``maybe_rediscover_oidc``
+    # probes with the retryable boot config (``discovery_retryable=True``); left
+    # preserved, a config-invalid IdP would re-probe every cooldown window.
     if not config.issuer:
-        return dataclasses.replace(config, enabled=False)
+        return dataclasses.replace(config, enabled=False, discovery_retryable=False)
 
     try:
         issuer_parsed = _validate_url_no_ssrf(
@@ -458,7 +464,7 @@ async def discover_oidc(
         )
     except OIDCError as exc:
         log.warning("OIDC issuer URL rejected: %s", exc)
-        return dataclasses.replace(config, enabled=False)
+        return dataclasses.replace(config, enabled=False, discovery_retryable=False)
 
     url = config.issuer.rstrip("/") + "/.well-known/openid-configuration"
     try:
@@ -517,8 +523,10 @@ async def discover_oidc(
                 allow_private=config.allow_private_network,
             )
         except OIDCError as exc:
+            # Config error (discovered endpoint fails SSRF/validation), not a
+            # transient outage — latch terminal so rediscovery stops re-probing.
             log.warning("OIDC discovered %s rejected (url=%s): %s", name, endpoint_url, exc)
-            return dataclasses.replace(config, enabled=False)
+            return dataclasses.replace(config, enabled=False, discovery_retryable=False)
 
     if userinfo_endpoint:
         try:
@@ -535,7 +543,8 @@ async def discover_oidc(
                 userinfo_endpoint,
                 exc,
             )
-            return dataclasses.replace(config, enabled=False)
+            # Config error — latch terminal (see the issuer-rejection branch).
+            return dataclasses.replace(config, enabled=False, discovery_retryable=False)
 
     log.info("OIDC discovery complete: %s", config.issuer)
     return dataclasses.replace(
@@ -746,7 +755,14 @@ async def maybe_rediscover_oidc(app_state: Any) -> None:
         # failure clears it back to False).
         fresh = await discover_oidc(dataclasses.replace(cfg, enabled=True))
         if not fresh.enabled:
-            return  # still failing — next probe after the cooldown lapses
+            if not fresh.discovery_retryable:
+                # Discovery now fails for a CONFIG reason (bad issuer, an
+                # SSRF-rejected endpoint), not a transient outage — latch that
+                # terminal config onto app_state so this node stops re-probing
+                # every cooldown window. Without installing it, app_state would
+                # keep the retryable flag and re-probe an IdP that can never heal.
+                app_state.oidc_config = fresh
+            return  # still disabled (transient → retry next window; terminal → latched)
         app_state.oidc_config = dataclasses.replace(fresh, discovery_retryable=False)
         log.info("OIDC discovery recovered at runtime: %s", fresh.issuer)
     finally:

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -730,11 +730,21 @@ async def maybe_rediscover_oidc(app_state: Any) -> None:
         return
     try:
         now = time.monotonic()
-        last = float(getattr(app_state, "oidc_rediscover_last", 0.0))
-        if now - last < _REDISCOVER_COOLDOWN_SECONDS:
+        # ``None`` (not 0.0) means "never probed" — otherwise the first probe
+        # within ~60s of the monotonic reference (host boot) would be suppressed
+        # by the cooldown against a phantom probe at time 0.
+        last = getattr(app_state, "oidc_rediscover_last", None)
+        if last is not None and now - float(last) < _REDISCOVER_COOLDOWN_SECONDS:
             return
         app_state.oidc_rediscover_last = now
-        fresh = await discover_oidc(cfg)
+        # Probe with enabled=True FORCED ON: discover_oidc PRESERVES the input's
+        # ``enabled`` on success (only ``load_oidc_config`` ever sets it True) and
+        # sets it False on any failure. Passing the disabled boot config verbatim
+        # would make a SUCCESSFUL rediscovery still return enabled=False, so the
+        # swap below would be unreachable and the feature inert. Forcing it True
+        # up front makes ``fresh.enabled`` a reliable success signal (a real
+        # failure clears it back to False).
+        fresh = await discover_oidc(dataclasses.replace(cfg, enabled=True))
         if not fresh.enabled:
             return  # still failing — next probe after the cooldown lapses
         app_state.oidc_config = dataclasses.replace(fresh, discovery_retryable=False)

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -224,8 +224,11 @@ def load_oidc_config() -> OIDCConfig:
         "TURNSTONE_OIDC_OBO_GRANT_PROFILE", cfg, "obo_grant_profile", "entra"
     ).strip()
     # Validate against the operative mint-leg registry (single source of truth,
-    # so a new leg needs no second edit here). Lazy import: mcp_oauth pulls in
-    # the MCP stack, and it does not import this module, so there is no cycle.
+    # so a new leg needs no second edit here). Function-level import: oidc and
+    # mcp_oauth reference each other's runtime helpers (mcp_oauth's mint path
+    # imports this module's ``maybe_rediscover_oidc`` likewise lazily), so BOTH
+    # directions stay off the module-import graph to keep the cycle unrealised —
+    # neither module may import the other at module scope.
     from turnstone.core.mcp_oauth import OBO_GRANT_PROFILES
 
     if obo_grant_profile not in OBO_GRANT_PROFILES:

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -14,6 +14,8 @@ import hashlib
 import os
 import re
 import secrets
+import threading
+import time
 import urllib.parse
 import uuid
 from dataclasses import dataclass, field
@@ -145,6 +147,13 @@ class OIDCConfig:
     token_endpoint: str = ""
     userinfo_endpoint: str = ""
     jwks_uri: str = ""
+    # True when ``enabled`` was forced False by a discovery failure that a
+    # later retry could clear (IdP unreachable / bad gateway page at boot),
+    # as opposed to operator config problems (bad issuer URL, SSRF-rejected
+    # endpoints) where retrying is pointless. Consumed by
+    # :func:`maybe_rediscover_oidc` — without it a node that boots during a
+    # transient IdP outage can never mint oauth_obo tokens until restarted.
+    discovery_retryable: bool = False
 
 
 def _parse_role_map(raw: str) -> dict[str, str]:
@@ -460,17 +469,19 @@ async def discover_oidc(
                 resp.raise_for_status()
                 doc = resp.json()
     except (httpx.HTTPError, ValueError, KeyError) as exc:
-        # ValueError covers json.JSONDecodeError (subclass).
+        # ValueError covers json.JSONDecodeError (subclass). Retryable: the
+        # IdP being unreachable at boot says nothing about the config.
         log.warning("OIDC discovery failed for %s: %s", config.issuer, exc, exc_info=True)
-        return dataclasses.replace(config, enabled=False)
+        return dataclasses.replace(config, enabled=False, discovery_retryable=True)
 
     if not isinstance(doc, dict):
+        # Retryable: a proxy/CDN error page in front of a healthy IdP.
         log.warning(
             "OIDC discovery document for %s is not a JSON object (got %s)",
             config.issuer,
             type(doc).__name__,
         )
-        return dataclasses.replace(config, enabled=False)
+        return dataclasses.replace(config, enabled=False, discovery_retryable=True)
 
     authorization_endpoint = str(doc.get("authorization_endpoint", ""))
     token_endpoint = str(doc.get("token_endpoint", ""))
@@ -478,11 +489,13 @@ async def discover_oidc(
     jwks_uri = str(doc.get("jwks_uri", ""))
 
     if not authorization_endpoint or not token_endpoint or not jwks_uri:
+        # Retryable: could equally be a degraded IdP serving a partial
+        # document; a genuinely misconfigured IdP just re-warns once per cooldown.
         log.warning(
             "OIDC discovery document missing required endpoints for %s",
             config.issuer,
         )
-        return dataclasses.replace(config, enabled=False)
+        return dataclasses.replace(config, enabled=False, discovery_retryable=True)
 
     allow_http = is_localhost(issuer_parsed.hostname or "")
     trusted_hosts = frozenset(h.lower() for h in config.trusted_endpoint_hosts)
@@ -614,7 +627,11 @@ async def initialize_oidc_state(app_state: Any) -> None:
             cfg = await discover_oidc(cfg, client=transient_client)
         except Exception:
             log.warning("OIDC discovery failed -- OIDC login disabled", exc_info=True)
-            app_state.oidc_config = dataclasses.replace(cfg, enabled=False)
+            # Unexpected failure — allow the runtime retry path to probe it
+            # (cooldown-gated), matching the in-band transient branches.
+            app_state.oidc_config = dataclasses.replace(
+                cfg, enabled=False, discovery_retryable=True
+            )
             app_state.jwks_data = None
             app_state.oidc_http_client = None
             return
@@ -654,6 +671,73 @@ async def initialize_oidc_state(app_state: Any) -> None:
     app_state.oidc_config = cfg
     app_state.jwks_data = jwks_data
     log.info("OIDC enabled: %s (%s)", cfg.provider_name, cfg.issuer)
+
+
+#: Minimum spacing between runtime discovery retries — one probe GET to the
+#: IdP per node per window while it stays down, however many callers ask.
+_REDISCOVER_COOLDOWN_SECONDS = 60.0
+
+#: Guards lazy creation of the per-app-state gate below.
+_rediscover_create_lock = threading.Lock()
+
+
+def _rediscover_gate(app_state: Any) -> threading.Lock:
+    """Single-flight gate for runtime re-discovery, lazily created per app state.
+
+    A ``threading.Lock`` (not ``asyncio.Lock``) on purpose: callers live on
+    different event loops — OIDC login on the uvicorn loop, oauth_obo minting
+    on the MCP loop thread — and asyncio primitives are bound to the loop
+    that created them.
+    """
+    with _rediscover_create_lock:
+        gate = getattr(app_state, "oidc_rediscover_gate", None)
+        if gate is None:
+            gate = threading.Lock()
+            app_state.oidc_rediscover_gate = gate
+        return gate
+
+
+async def maybe_rediscover_oidc(app_state: Any) -> None:
+    """Retry OIDC discovery at runtime after a retryable boot-time failure.
+
+    A node that boots while the IdP is briefly unreachable comes up with
+    ``oidc_config.enabled=False`` and would otherwise stay that way until an
+    operator restarts it — OIDC login stays dark on the node and every
+    ``oauth_obo`` mint fails "transient" forever. This helper re-runs
+    :func:`discover_oidc` (cooldown-gated, single-flight across threads) and
+    swaps the recovered config onto *app_state* on success.
+
+    No-op when OIDC is operator-disabled, already enabled, or discovery
+    failed for a non-retryable configuration reason (``discovery_retryable``
+    False). Uses a transient HTTP client so it is safe to call from any
+    event loop; the recovered config leaves ``jwks_data`` unset — the login
+    path's existing lazy JWKS refetch fills it on first use.
+    """
+    cfg = getattr(app_state, "oidc_config", None)
+    if (
+        cfg is None
+        or getattr(cfg, "enabled", False)
+        or not getattr(cfg, "discovery_retryable", False)
+    ):
+        return
+    gate = _rediscover_gate(app_state)
+    if not gate.acquire(blocking=False):
+        # Another caller (possibly on another loop) is already probing; this
+        # caller proceeds on the still-disabled config and heals next tick.
+        return
+    try:
+        now = time.monotonic()
+        last = float(getattr(app_state, "oidc_rediscover_last", 0.0))
+        if now - last < _REDISCOVER_COOLDOWN_SECONDS:
+            return
+        app_state.oidc_rediscover_last = now
+        fresh = await discover_oidc(cfg)
+        if not fresh.enabled:
+            return  # still failing — next probe after the cooldown lapses
+        app_state.oidc_config = dataclasses.replace(fresh, discovery_retryable=False)
+        log.info("OIDC discovery recovered at runtime: %s", fresh.issuer)
+    finally:
+        gate.release()
 
 
 async def close_oidc_state(app_state: Any) -> None:

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -107,7 +107,7 @@ class OIDCConfig:
         ``enabled``, ``issuer``, ``client_id``, ``client_secret``, ``scopes``,
         ``provider_name``, ``role_claim``, ``role_map``, ``password_enabled``,
         ``redirect_base``, ``trusted_endpoint_hosts``, ``allow_private_network``,
-        ``capture_user_credential``.
+        ``capture_user_credential``, ``obo_grant_profile``.
 
     Discovery-derived fields (set by :func:`discover_oidc`; empty before
     discovery completes):
@@ -214,11 +214,17 @@ def load_oidc_config() -> OIDCConfig:
     obo_grant_profile = _env_or_cfg_str(
         "TURNSTONE_OIDC_OBO_GRANT_PROFILE", cfg, "obo_grant_profile", "entra"
     ).strip()
-    if obo_grant_profile not in ("entra", "rfc8693"):
+    # Validate against the operative mint-leg registry (single source of truth,
+    # so a new leg needs no second edit here). Lazy import: mcp_oauth pulls in
+    # the MCP stack, and it does not import this module, so there is no cycle.
+    from turnstone.core.mcp_oauth import OBO_GRANT_PROFILES
+
+    if obo_grant_profile not in OBO_GRANT_PROFILES:
         log.warning(
-            "oidc: unknown obo_grant_profile %r (expected 'entra' or 'rfc8693') — "
+            "oidc: unknown obo_grant_profile %r (expected one of %s) — "
             "oauth_obo MCP servers will not mint until this is fixed",
             obo_grant_profile,
+            ", ".join(sorted(OBO_GRANT_PROFILES)),
         )
     if capture_user_credential and "offline_access" not in scopes.split():
         # The captured credential IS the offline_access refresh token; ask

--- a/turnstone/core/oidc.py
+++ b/turnstone/core/oidc.py
@@ -753,7 +753,19 @@ async def maybe_rediscover_oidc(app_state: Any) -> None:
         # swap below would be unreachable and the feature inert. Forcing it True
         # up front makes ``fresh.enabled`` a reliable success signal (a real
         # failure clears it back to False).
-        fresh = await discover_oidc(dataclasses.replace(cfg, enabled=True))
+        #
+        # Wrapped in ``except Exception`` exactly like the boot path
+        # (initialize_oidc_state): discover_oidc catches httpx/ValueError/OIDC
+        # errors, but the runtime SSRF/DNS validation can raise something outside
+        # that set, and this runs inside get_obo_access_token_classified — which
+        # promises a TokenLookupResult, never a raise. An unexpected failure just
+        # leaves OIDC disabled for this probe (retry next window); it must not
+        # escape into the caller's classified-result contract.
+        try:
+            fresh = await discover_oidc(dataclasses.replace(cfg, enabled=True))
+        except Exception:
+            log.warning("OIDC runtime rediscovery raised unexpectedly", exc_info=True)
+            return
         if not fresh.enabled:
             if not fresh.discovery_retryable:
                 # Discovery now fails for a CONFIG reason (bad issuer, an

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -26,6 +26,7 @@ from turnstone.core.storage._protocol import (
     MCPUserTokenMetadataRow,
     OIDCIdentity,
     OIDCPendingState,
+    OIDCUserCredential,
 )
 from turnstone.core.storage._schema import (
     api_tokens,
@@ -43,6 +44,7 @@ from turnstone.core.storage._schema import (
     model_definitions,
     oidc_identities,
     oidc_pending_states,
+    oidc_user_credentials,
     orgs,
     output_assessments,
     output_guard_patterns,
@@ -1502,6 +1504,9 @@ class PostgreSQLBackend:
             conn.execute(sa.delete(channel_users).where(channel_users.c.user_id == user_id))
             conn.execute(sa.delete(api_tokens).where(api_tokens.c.user_id == user_id))
             conn.execute(sa.delete(oidc_identities).where(oidc_identities.c.user_id == user_id))
+            conn.execute(
+                sa.delete(oidc_user_credentials).where(oidc_user_credentials.c.user_id == user_id)
+            )
             conn.execute(sa.delete(mcp_user_tokens).where(mcp_user_tokens.c.user_id == user_id))
             conn.execute(sa.delete(mcp_oauth_pending).where(mcp_oauth_pending.c.user_id == user_id))
             result = conn.execute(sa.delete(users).where(users.c.user_id == user_id))
@@ -5557,6 +5562,80 @@ class PostgreSQLBackend:
             result = conn.execute(
                 sa.delete(oidc_identities).where(
                     (oidc_identities.c.issuer == issuer) & (oidc_identities.c.subject == subject)
+                )
+            )
+            conn.commit()
+            return result.rowcount > 0
+
+    # -- OIDC user credential (single-credential MCP minting, #551) -------------
+
+    def upsert_oidc_user_credential(
+        self, user_id: str, issuer: str, *, refresh_token_ct: bytes
+    ) -> None:
+        """Create or replace the user's captured IdP refresh token."""
+        from sqlalchemy.dialects import postgresql
+
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with self._conn() as conn:
+            stmt = postgresql.insert(oidc_user_credentials).values(
+                user_id=user_id,
+                issuer=issuer,
+                refresh_token_ct=refresh_token_ct,
+                created=now,
+                last_refreshed=now,
+            )
+            conn.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["user_id", "issuer"],
+                    set_={"refresh_token_ct": refresh_token_ct, "last_refreshed": now},
+                )
+            )
+            conn.commit()
+
+    def get_oidc_user_credential(self, user_id: str, issuer: str) -> OIDCUserCredential | None:
+        """Return the captured credential row or None."""
+        with self._conn() as conn:
+            row = conn.execute(
+                sa.select(oidc_user_credentials).where(
+                    (oidc_user_credentials.c.user_id == user_id)
+                    & (oidc_user_credentials.c.issuer == issuer)
+                )
+            ).fetchone()
+            if row is None:
+                return None
+            m = row._mapping
+            return OIDCUserCredential(
+                user_id=m["user_id"],
+                issuer=m["issuer"],
+                refresh_token_ct=bytes(m["refresh_token_ct"]),
+                created=m["created"],
+                last_refreshed=m["last_refreshed"],
+            )
+
+    def update_oidc_user_credential_refresh(
+        self, user_id: str, issuer: str, *, refresh_token_ct: bytes
+    ) -> bool:
+        """Persist the newest refresh token after a rotating redemption."""
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.update(oidc_user_credentials)
+                .where(
+                    (oidc_user_credentials.c.user_id == user_id)
+                    & (oidc_user_credentials.c.issuer == issuer)
+                )
+                .values(refresh_token_ct=refresh_token_ct, last_refreshed=now)
+            )
+            conn.commit()
+            return result.rowcount > 0
+
+    def delete_oidc_user_credential(self, user_id: str, issuer: str) -> bool:
+        """Remove the captured credential. Returns True if existed."""
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.delete(oidc_user_credentials).where(
+                    (oidc_user_credentials.c.user_id == user_id)
+                    & (oidc_user_credentials.c.issuer == issuer)
                 )
             )
             conn.commit()

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -5044,6 +5044,16 @@ class PostgreSQLBackend:
             ).scalar()
         return result is not None
 
+    def any_user_scoped_mcp_servers(self) -> bool:
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.select(sa.literal(1))
+                .select_from(mcp_servers)
+                .where(mcp_servers.c.auth_type.in_(("oauth_user", "oauth_obo")))
+                .limit(1)
+            ).scalar()
+        return result is not None
+
     # -- Model definitions -----------------------------------------------------
 
     def create_model_definition(

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -20,6 +20,7 @@ import sqlalchemy as sa
 
 from turnstone.core.log import get_logger
 from turnstone.core.storage._protocol import (
+    USER_SCOPED_AUTH_TYPES,
     MCPOAuthPendingState,
     MCPPendingConsentRow,
     MCPUserToken,
@@ -5039,7 +5040,7 @@ class PostgreSQLBackend:
             result = conn.execute(
                 sa.select(sa.literal(1))
                 .select_from(mcp_servers)
-                .where(mcp_servers.c.auth_type.in_(("oauth_user", "oauth_obo")))
+                .where(mcp_servers.c.auth_type.in_(sorted(USER_SCOPED_AUTH_TYPES)))
                 .limit(1)
             ).scalar()
         return result is not None

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -5034,16 +5034,6 @@ class PostgreSQLBackend:
             ).fetchall()
         return {row[0]: int(row[1] or 0) for row in rows}
 
-    def any_oauth_user_mcp_servers(self) -> bool:
-        with self._conn() as conn:
-            result = conn.execute(
-                sa.select(sa.literal(1))
-                .select_from(mcp_servers)
-                .where(mcp_servers.c.auth_type == "oauth_user")
-                .limit(1)
-            ).scalar()
-        return result is not None
-
     def any_user_scoped_mcp_servers(self) -> bool:
         with self._conn() as conn:
             result = conn.execute(

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -38,6 +38,23 @@ class OIDCIdentity(TypedDict):
     tid: str
 
 
+class OIDCUserCredential(TypedDict):
+    """Row shape for the per-(user, issuer) captured IdP refresh token.
+
+    ``refresh_token_ct`` is a Fernet ciphertext blob (same envelope as
+    ``mcp_user_tokens``); the storage layer returns it verbatim and
+    ``MCPTokenStore`` handles encrypt/decrypt.  One row per user per
+    issuer — the single credential that ``auth_type='oauth_obo'`` MCP
+    servers redeem on demand (issue #551).
+    """
+
+    user_id: str
+    issuer: str
+    refresh_token_ct: bytes
+    created: str
+    last_refreshed: str
+
+
 class OIDCPendingState(TypedDict):
     """Row shape returned when popping a pending OIDC authorization-flow state."""
 
@@ -995,6 +1012,39 @@ class StorageBackend(Protocol):
 
     def delete_oidc_identity(self, issuer: str, subject: str) -> bool:
         """Remove an OIDC identity link. Returns True if existed."""
+        ...
+
+    # -- OIDC user credential (single-credential MCP minting, #551) -------------
+
+    def upsert_oidc_user_credential(
+        self, user_id: str, issuer: str, *, refresh_token_ct: bytes
+    ) -> None:
+        """Create or replace the user's captured IdP refresh token.
+
+        Replace-on-conflict: a fresh login must overwrite a stale or
+        revoked credential.  ``created`` is preserved on replace;
+        ``last_refreshed`` is reset to now either way.
+        """
+        ...
+
+    def get_oidc_user_credential(self, user_id: str, issuer: str) -> OIDCUserCredential | None:
+        """Return the captured credential row or None."""
+        ...
+
+    def update_oidc_user_credential_refresh(
+        self, user_id: str, issuer: str, *, refresh_token_ct: bytes
+    ) -> bool:
+        """Rotation write-back after a redemption returned a new refresh token.
+
+        Both verified grant legs rotate (Entra returns a new RT per
+        redemption; Keycloak rotates on the refresh grant), so the mint
+        path MUST persist the newest token every time.  Returns True when
+        a row was updated.
+        """
+        ...
+
+    def delete_oidc_user_credential(self, user_id: str, issuer: str) -> bool:
+        """Remove the captured credential (logout-all / admin revoke). Returns True if existed."""
         ...
 
     # -- OIDC pending state ----------------------------------------------------

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -2362,6 +2362,17 @@ class StorageBackend(Protocol):
         """
         ...
 
+    def any_user_scoped_mcp_servers(self) -> bool:
+        """Install-level gate for the pending-consent badge (issue #551).
+
+        Returns True iff at least one ``mcp_servers`` row is pool-backed
+        (``auth_type`` in ``oauth_user`` / ``oauth_obo``) — both write
+        ``mcp_pending_consent`` rows on a non-interactive dispatch failure, so
+        an oauth_obo-only install must NOT short-circuit the badge to
+        ``{pending: 0}`` (that would hide the re-login affordance).
+        """
+        ...
+
     def any_oauth_user_mcp_servers(self) -> bool:
         """Install-level gate for OAuth-MCP features.
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -2369,17 +2369,9 @@ class StorageBackend(Protocol):
         (``auth_type`` in ``oauth_user`` / ``oauth_obo``) — both write
         ``mcp_pending_consent`` rows on a non-interactive dispatch failure, so
         an oauth_obo-only install must NOT short-circuit the badge to
-        ``{pending: 0}`` (that would hide the re-login affordance).
-        """
-        ...
-
-    def any_oauth_user_mcp_servers(self) -> bool:
-        """Install-level gate for OAuth-MCP features.
-
-        Returns True iff at least one ``mcp_servers`` row has
-        ``auth_type='oauth_user'``.  Used to short-circuit the pending-
-        consent badge endpoint to ``{pending: 0}`` on local-auth installs
-        with no OAuth MCP servers, so those code paths exercise zero new
+        ``{pending: 0}`` (that would hide the re-login affordance). Used to
+        short-circuit the pending-consent badge endpoint on local-auth installs
+        with no pool-backed MCP servers, so those code paths exercise zero new
         storage queries.
         """
         ...

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -13,6 +13,16 @@ if TYPE_CHECKING:
     from turnstone.core.workstream import WorkstreamKind
 
 
+#: MCP auth types whose connections and per-user token rows are keyed
+#: per-(user, server): ``oauth_user`` (per-server browser consent + refresh
+#: token) and ``oauth_obo`` (minted on demand from the user's single captured
+#: credential, issue #551). Defined here — the bottom of the import graph — so
+#: the backend SQL predicates (``any_user_scoped_mcp_servers``) and the
+#: application layer (via :mod:`turnstone.core.mcp_crypto`, which re-exports
+#: it) agree on ONE set that cannot drift.
+USER_SCOPED_AUTH_TYPES: frozenset[str] = frozenset({"oauth_user", "oauth_obo"})
+
+
 class StorageConflictError(Exception):
     """Raised by storage methods when a unique-constraint violation occurs.
 

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -953,6 +953,23 @@ oidc_pending_states = sa.Table(
     sa.Column("created_at", sa.Text, nullable=False),
 )
 
+# One captured IdP refresh token per (user, issuer) — the single credential
+# that `auth_type='oauth_obo'` MCP servers redeem on demand (issue #551).
+# Deliberately separate from `oidc_identities`: this row is a Fernet-encrypted
+# secret with hot rotation writes on the mint path, while identity rows are
+# freely-read metadata.  Keyed (user_id, issuer) — the mint path enters with
+# user_id; issuer future-proofs multi-IdP (OIDCConfig is single-issuer today).
+oidc_user_credentials = sa.Table(
+    "oidc_user_credentials",
+    metadata,
+    sa.Column("user_id", sa.Text, nullable=False),
+    sa.Column("issuer", sa.Text, nullable=False),
+    sa.Column("refresh_token_ct", sa.LargeBinary, nullable=False),
+    sa.Column("created", sa.Text, nullable=False),
+    sa.Column("last_refreshed", sa.Text, nullable=False),
+    sa.PrimaryKeyConstraint("user_id", "issuer"),
+)
+
 # ---------------------------------------------------------------------------
 # MCP per-(user, server) OAuth tokens and pending authorization-flow state.
 # No FKs at the schema level (matches `oidc_*` tables; tests avoid orphan

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -26,6 +26,7 @@ from turnstone.core.storage._protocol import (
     MCPUserTokenMetadataRow,
     OIDCIdentity,
     OIDCPendingState,
+    OIDCUserCredential,
 )
 from turnstone.core.storage._schema import (
     api_tokens,
@@ -43,6 +44,7 @@ from turnstone.core.storage._schema import (
     model_definitions,
     oidc_identities,
     oidc_pending_states,
+    oidc_user_credentials,
     orgs,
     output_assessments,
     output_guard_patterns,
@@ -1651,6 +1653,9 @@ class SQLiteBackend:
             conn.execute(sa.delete(channel_users).where(channel_users.c.user_id == user_id))
             conn.execute(sa.delete(api_tokens).where(api_tokens.c.user_id == user_id))
             conn.execute(sa.delete(oidc_identities).where(oidc_identities.c.user_id == user_id))
+            conn.execute(
+                sa.delete(oidc_user_credentials).where(oidc_user_credentials.c.user_id == user_id)
+            )
             conn.execute(sa.delete(mcp_user_tokens).where(mcp_user_tokens.c.user_id == user_id))
             conn.execute(sa.delete(mcp_oauth_pending).where(mcp_oauth_pending.c.user_id == user_id))
             result = conn.execute(sa.delete(users).where(users.c.user_id == user_id))
@@ -5701,6 +5706,80 @@ class SQLiteBackend:
             result = conn.execute(
                 sa.delete(oidc_identities).where(
                     (oidc_identities.c.issuer == issuer) & (oidc_identities.c.subject == subject)
+                )
+            )
+            conn.commit()
+            return result.rowcount > 0
+
+    # -- OIDC user credential (single-credential MCP minting, #551) -------------
+
+    def upsert_oidc_user_credential(
+        self, user_id: str, issuer: str, *, refresh_token_ct: bytes
+    ) -> None:
+        """Create or replace the user's captured IdP refresh token."""
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with self._conn() as conn:
+            stmt = sqlite_insert(oidc_user_credentials).values(
+                user_id=user_id,
+                issuer=issuer,
+                refresh_token_ct=refresh_token_ct,
+                created=now,
+                last_refreshed=now,
+            )
+            conn.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["user_id", "issuer"],
+                    set_={"refresh_token_ct": refresh_token_ct, "last_refreshed": now},
+                )
+            )
+            conn.commit()
+
+    def get_oidc_user_credential(self, user_id: str, issuer: str) -> OIDCUserCredential | None:
+        """Return the captured credential row or None."""
+        with self._conn() as conn:
+            row = conn.execute(
+                sa.select(oidc_user_credentials).where(
+                    (oidc_user_credentials.c.user_id == user_id)
+                    & (oidc_user_credentials.c.issuer == issuer)
+                )
+            ).fetchone()
+            if row is None:
+                return None
+            m = row._mapping
+            return OIDCUserCredential(
+                user_id=m["user_id"],
+                issuer=m["issuer"],
+                refresh_token_ct=bytes(m["refresh_token_ct"]),
+                created=m["created"],
+                last_refreshed=m["last_refreshed"],
+            )
+
+    def update_oidc_user_credential_refresh(
+        self, user_id: str, issuer: str, *, refresh_token_ct: bytes
+    ) -> bool:
+        """Persist the newest refresh token after a rotating redemption."""
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.update(oidc_user_credentials)
+                .where(
+                    (oidc_user_credentials.c.user_id == user_id)
+                    & (oidc_user_credentials.c.issuer == issuer)
+                )
+                .values(refresh_token_ct=refresh_token_ct, last_refreshed=now)
+            )
+            conn.commit()
+            return result.rowcount > 0
+
+    def delete_oidc_user_credential(self, user_id: str, issuer: str) -> bool:
+        """Remove the captured credential. Returns True if existed."""
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.delete(oidc_user_credentials).where(
+                    (oidc_user_credentials.c.user_id == user_id)
+                    & (oidc_user_credentials.c.issuer == issuer)
                 )
             )
             conn.commit()

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -5198,6 +5198,16 @@ class SQLiteBackend:
             ).scalar()
         return result is not None
 
+    def any_user_scoped_mcp_servers(self) -> bool:
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.select(sa.literal(1))
+                .select_from(mcp_servers)
+                .where(mcp_servers.c.auth_type.in_(("oauth_user", "oauth_obo")))
+                .limit(1)
+            ).scalar()
+        return result is not None
+
     # -- Model definitions -----------------------------------------------------
 
     def create_model_definition(

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -5188,16 +5188,6 @@ class SQLiteBackend:
             ).fetchall()
         return {row[0]: int(row[1] or 0) for row in rows}
 
-    def any_oauth_user_mcp_servers(self) -> bool:
-        with self._conn() as conn:
-            result = conn.execute(
-                sa.select(sa.literal(1))
-                .select_from(mcp_servers)
-                .where(mcp_servers.c.auth_type == "oauth_user")
-                .limit(1)
-            ).scalar()
-        return result is not None
-
     def any_user_scoped_mcp_servers(self) -> bool:
         with self._conn() as conn:
             result = conn.execute(

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 from turnstone.core.log import get_logger
 from turnstone.core.storage._protocol import (
+    USER_SCOPED_AUTH_TYPES,
     MCPOAuthPendingState,
     MCPPendingConsentRow,
     MCPUserToken,
@@ -5193,7 +5194,7 @@ class SQLiteBackend:
             result = conn.execute(
                 sa.select(sa.literal(1))
                 .select_from(mcp_servers)
-                .where(mcp_servers.c.auth_type.in_(("oauth_user", "oauth_obo")))
+                .where(mcp_servers.c.auth_type.in_(sorted(USER_SCOPED_AUTH_TYPES)))
                 .limit(1)
             ).scalar()
         return result is not None

--- a/turnstone/core/storage/migrations/versions/067_oidc_user_credentials.py
+++ b/turnstone/core/storage/migrations/versions/067_oidc_user_credentials.py
@@ -1,0 +1,40 @@
+"""Add oidc_user_credentials for single-credential MCP token minting.
+
+One encrypted IdP refresh token per (user, issuer), captured at OIDC login
+when ``[oidc] capture_user_credential`` is enabled.  Servers with
+``auth_type='oauth_obo'`` redeem this single credential on demand for
+short-lived per-server access tokens instead of holding a per-(user, server)
+refresh token — see issue #551.
+
+Keyed ``(user_id, issuer)`` rather than ``user_id`` alone so a future
+multi-IdP login surface needs no re-keying; today's OIDCConfig is
+single-issuer, so the table holds at most one row per user in practice.
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "067"
+down_revision = "066"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oidc_user_credentials",
+        sa.Column("user_id", sa.Text, nullable=False),
+        sa.Column("issuer", sa.Text, nullable=False),
+        sa.Column("refresh_token_ct", sa.LargeBinary, nullable=False),
+        sa.Column("created", sa.Text, nullable=False),
+        sa.Column("last_refreshed", sa.Text, nullable=False),
+        sa.PrimaryKeyConstraint("user_id", "issuer"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("oidc_user_credentials")

--- a/turnstone/core/web_search.py
+++ b/turnstone/core/web_search.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import httpx
 
 from turnstone.core.log import get_logger
-from turnstone.core.mcp_oauth import is_user_scoped_auth
+from turnstone.core.mcp_crypto import is_user_scoped_auth
 
 if TYPE_CHECKING:
     from turnstone.core.mcp_client import MCPClientManager

--- a/turnstone/core/web_search.py
+++ b/turnstone/core/web_search.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import httpx
 
 from turnstone.core.log import get_logger
+from turnstone.core.mcp_oauth import is_user_scoped_auth
 
 if TYPE_CHECKING:
     from turnstone.core.mcp_client import MCPClientManager
@@ -237,14 +238,15 @@ def resolve_web_search_client(
             # the bearer can't be (RFC §3, invariant 8 corollary).
             if mcp_client.is_mcp_tool(prefixed):
                 # Defence-in-depth: even if a future change widens
-                # ``_tool_map`` to include oauth_user names by accident,
+                # ``_tool_map`` to include pool-backed names by accident,
                 # refuse the backend explicitly. ``server_auth_type``
                 # is an in-memory accessor — this resolver is invoked
                 # per LLM turn, so a SQL hop here would amplify token
-                # cost on every chat round.
-                if mcp_client.server_auth_type(server) == "oauth_user":
+                # cost on every chat round. oauth_obo is equally
+                # unusable here: minting needs a signed-in user.
+                if is_user_scoped_auth(mcp_client.server_auth_type(server)):
                     log.warning(
-                        "web_search_backend %r points at oauth_user MCP server; "
+                        "web_search_backend %r points at a per-user-auth MCP server; "
                         "per-node web search cannot use per-user tokens — disabling",
                         backend,
                     )

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -4462,6 +4462,13 @@ function buildMcpErrorEmbed(err, rawJson, onConsent) {
   // pointing at a panel with nothing to connect). In that case the honest
   // remedy is the detail text (sign in again / ask your administrator), so we
   // show the card without a broken affordance.
+  //
+  // This never wrongly hides a needed button for oauth_user: the backend
+  // invariant is that _build_consent_url returns a /v1/api/mcp/oauth/start URL
+  // for EVERY oauth_user row and None only for non-oauth_user auth types, so an
+  // oauth_user actionable error always carries a valid consent_url and always
+  // renders its button. The removed click-time "open Settings" fallback guarded
+  // a producer path that that invariant makes unreachable.
   const consentUrl = err.consent_url;
   const hasConsentAffordance =
     typeof consentUrl === "string" &&

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -4453,7 +4453,20 @@ function buildMcpErrorEmbed(err, rawJson, onConsent) {
     body.appendChild(scopesLine);
   }
 
-  if (category === "actionable") {
+  // Render the Connect / Re-consent button only when the dispatcher actually
+  // supplied a per-server consent URL. An "actionable"-category code with no
+  // consent_url means there is no per-server consent flow for this server —
+  // sign-in passthrough (oauth_obo) mints from the user's Turnstone sign-in and
+  // is deliberately absent from the Settings connections list and rejected by
+  // /start — so a button here would dead-end ("no consent URL; open Settings"
+  // pointing at a panel with nothing to connect). In that case the honest
+  // remedy is the detail text (sign in again / ask your administrator), so we
+  // show the card without a broken affordance.
+  const consentUrl = err.consent_url;
+  const hasConsentAffordance =
+    typeof consentUrl === "string" &&
+    consentUrl.startsWith("/v1/api/mcp/oauth/start");
+  if (category === "actionable" && hasConsentAffordance) {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "mcp-error-action-btn";
@@ -4469,20 +4482,10 @@ function buildMcpErrorEmbed(err, rawJson, onConsent) {
         : "Connect to " + serverLabel,
     );
     btn.addEventListener("click", function () {
-      const consentUrl = err.consent_url;
-      if (!consentUrl || typeof consentUrl !== "string") {
-        // Defensive: should always be present per the dispatcher.  If a
-        // path forgets to include it the user can still connect via the
-        // Settings panel (gear icon).
-        showToast("No consent URL available; open Settings to connect.");
-        return;
-      }
-      // Defence-in-depth: reject anything that isn't path-relative to
-      // the dispatcher's known prefix. ``_build_consent_url`` always
-      // emits ``/v1/api/mcp/oauth/start?...`` — a non-prefix value
-      // would indicate a future producer drift or a compromised
-      // dispatcher, and ``window.open("javascript:...")`` would be
-      // catastrophic. Never rely on the producer-side guarantee alone.
+      // Defence-in-depth: the render gate already proved the prefix, but
+      // re-check at click time — a non-prefix value would indicate producer
+      // drift or a compromised dispatcher, and window.open("javascript:...")
+      // would be catastrophic. Never rely on the producer-side guarantee alone.
       if (!consentUrl.startsWith("/v1/api/mcp/oauth/start")) {
         showToast("Invalid consent URL");
         return;


### PR DESCRIPTION
Adds `auth_type=oauth_obo` — single-credential sign-in passthrough for MCP servers. Closes #551.

Where `oauth_user` makes each user complete a separate per-server browser consent, `oauth_obo` reuses the user's Turnstone OIDC login: one refresh credential is captured at sign-in (opt-in) and, on each tool call, redeemed for a short-lived access token scoped to that server's audience. One credential covers every `oauth_obo` server and there is no per-server connect step — the right shape for enterprise deployments where the identity provider governs downstream access (Entra, Keycloak).

## Grant legs (deployment-level `[oidc] obo_grant_profile`)
- `entra` — refresh-token redemption with `scope=<audience>/.default`.
- `rfc8693` — refresh grant → RFC 8693 token exchange for the server audience.

## What's included
- **Storage**: `oidc_user_credentials` (migration 067), encrypted with the existing MCP token envelope; opt-in capture at OIDC login via `[oidc] capture_user_credential`.
- **Mint engine**: `get_obo_access_token_classified` mints on demand and caches a per-(user, server) short-lived token (no stored refresh token); rotation write-back, cooldown/backoff shared with the `oauth_user` state machine, and audience-bound cache serving so an audience change takes effect immediately.
- **Pool routing + session-start priming** so a user's tools surface automatically (no consent step to trigger them).
- **Console**: a "Sign-in passthrough" option in the admin MCP form; audience/encryption-key validation at write time; token purges on auth-type / URL / audience transitions; a per-server "flush cache" action (honest re-mint, not a revoke).
- **Revocation**: identity-unlink revokes the captured credential and purges the user's minted tokens; per-server access is IdP-governed.
- **Docs**: `docs/mcp-oauth.md` operator guide — per-IdP setup (incl. the Entra admin-consent propagation gotcha) and the revocation model.
- **Manual e2e harnesses** under `scripts/obo-e2e/` (Entra + ephemeral Keycloak), not wired into CI.

Additive and default-off: installs with no `oauth_obo` rows and capture disabled exercise no new code paths, and `oauth_user` behavior is unchanged.
