### PR TITLE
fix(mcp): retain per-user pool catalogs across evictions and converge dead grants

### DIFF
--- a/tests/test_mcp_consent_url_sibling_audit.py
+++ b/tests/test_mcp_consent_url_sibling_audit.py
@@ -97,23 +97,23 @@ def test_every_user_actionable_structured_error_passes_consent_url() -> None:
 def test_audit_finds_all_known_user_actionable_sites() -> None:
     """Lock the count so accidental deletions are caught.
 
-    There are 7 user-actionable ``_structured_error`` call sites today:
-    3 in ``_pool_lookup_error`` (the single lookup-kind → error mapping
-    shared by the tool / resource / prompt dispatchers — it replaced the
-    9 hand-synced per-dispatcher copies), 3 in the post-retry-failed
-    branches, and 1 in ``_handle_auth_403``'s insufficient-scope branch.
-    If a new exec path is added the count can rise; if a branch is
-    removed the count can fall — both are fine, but require an
-    intentional bump of this number to confirm the change went through
-    review.
+    There are 5 user-actionable ``_structured_error`` call sites today:
+    1 in ``_pool_lookup_error`` (the ``_pool_lookup_verdict`` split
+    collapsed the former 3 consent-required renderings into one site —
+    the per-kind branches now select only the DETAIL copy), 3 in the
+    post-retry-failed branches, and 1 in ``_handle_auth_403``'s
+    insufficient-scope branch. If a new exec path is added the count
+    can rise; if a branch is removed the count can fall — both are
+    fine, but require an intentional bump of this number to confirm
+    the change went through review.
     """
     source = _read_source()
     blocks = _find_structured_error_blocks(source)
     user_actionable_count = sum(
         1 for _, blk in blocks if any(f'code="{code}"' in blk for code in _USER_ACTIONABLE_CODES)
     )
-    assert user_actionable_count == 7, (
-        f"Expected 7 user-actionable _structured_error sites, got "
+    assert user_actionable_count == 5, (
+        f"Expected 5 user-actionable _structured_error sites, got "
         f"{user_actionable_count}. If this is intentional, bump the "
         f"expected count and document why in the commit message."
     )

--- a/tests/test_mcp_oauth_connections.py
+++ b/tests/test_mcp_oauth_connections.py
@@ -804,6 +804,7 @@ class TestEvictUserSession:
             mgr._loop = loop  # type: ignore[attr-defined]
             mgr._user_pool_entries = {}  # type: ignore[attr-defined]
             mgr._last_pool_notification_refresh = {}  # type: ignore[attr-defined]
+            mgr._background_tasks = set()  # type: ignore[attr-defined]
             evicted: list[tuple[str, str]] = []
 
             async def _fake_evict(key: tuple[str, str]) -> None:

--- a/tests/test_mcp_oauth_connections.py
+++ b/tests/test_mcp_oauth_connections.py
@@ -809,7 +809,10 @@ class TestEvictUserSession:
             def _fake_evict(key: tuple[str, str]) -> None:
                 evicted.append(key)
 
-            mgr._evict_session = _fake_evict  # type: ignore[method-assign]
+            # The revoke entry point must take the DROP-CATALOG flavor —
+            # the user asked for the disconnect, so their live sessions
+            # see the tools leave (unlike dispatch-failure eviction, #836).
+            mgr._evict_session_drop_catalog = _fake_evict  # type: ignore[method-assign]
 
             # Run the dispatch on a separate thread so the loop can drain.
             import threading

--- a/tests/test_mcp_oauth_connections.py
+++ b/tests/test_mcp_oauth_connections.py
@@ -807,7 +807,7 @@ class TestEvictUserSession:
             mgr._background_tasks = set()  # type: ignore[attr-defined]
             evicted: list[tuple[str, str]] = []
 
-            async def _fake_evict(key: tuple[str, str]) -> None:
+            async def _fake_evict(key: tuple[str, str], **_kwargs: object) -> None:
                 evicted.append(key)
 
             # The revoke entry point must take the LOCKED drop-catalog

--- a/tests/test_mcp_oauth_connections.py
+++ b/tests/test_mcp_oauth_connections.py
@@ -806,13 +806,15 @@ class TestEvictUserSession:
             mgr._last_pool_notification_refresh = {}  # type: ignore[attr-defined]
             evicted: list[tuple[str, str]] = []
 
-            def _fake_evict(key: tuple[str, str]) -> None:
+            async def _fake_evict(key: tuple[str, str]) -> None:
                 evicted.append(key)
 
-            # The revoke entry point must take the DROP-CATALOG flavor —
-            # the user asked for the disconnect, so their live sessions
-            # see the tools leave (unlike dispatch-failure eviction, #836).
-            mgr._evict_session_drop_catalog = _fake_evict  # type: ignore[method-assign]
+            # The revoke entry point must take the LOCKED drop-catalog
+            # path — the user asked for the disconnect, so their live
+            # sessions see the tools leave (unlike dispatch-failure
+            # eviction, #836), serialized against an in-flight connect
+            # so a completing discovery can't resurrect the catalog.
+            mgr._drop_catalog_locked = _fake_evict  # type: ignore[method-assign]
 
             # Run the dispatch on a separate thread so the loop can drain.
             import threading

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -571,6 +571,7 @@ class TestDispatcherAuthFlows:
             *,
             auth_capture: Any = None,
             auth_fired_event: Any = None,
+            expected_gen: Any = None,
         ) -> Any:
             entry = await self_inner._ensure_pool_entry(key)
             sess = MagicMock()
@@ -980,6 +981,7 @@ class TestBreakerInvariant:
             *,
             auth_capture: Any = None,
             auth_fired_event: Any = None,
+            expected_gen: Any = None,
         ) -> Any:
             entry = await self_inner._ensure_pool_entry(key)
             sess = MagicMock()
@@ -1600,7 +1602,11 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[tuple[str, str], str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             primed.append((key, token))
             return 3
@@ -1631,7 +1637,11 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[tuple[str, str], str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             primed.append((key, token))
             return 3
@@ -1671,7 +1681,11 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[str, str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             primed.append(key)
             return 0
@@ -1806,7 +1820,11 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[str, str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             primed.append(key)
             return 0
@@ -1858,7 +1876,11 @@ class TestPoolPrimingAndTokenRotation:
         done = threading.Event()
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             captured["key"] = key
             captured["token"] = token
@@ -1918,6 +1940,7 @@ class TestPoolPrimingAndTokenRotation:
             *,
             auth_capture: Any = None,
             auth_fired_event: Any = None,
+            expected_gen: Any = None,
         ) -> Any:
             reconnect_tokens.append(access_token)
             entry = await self_inner._ensure_pool_entry(key)
@@ -1954,7 +1977,11 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[str, str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             primed.append(key)
             return 0
@@ -1978,7 +2005,11 @@ class TestPoolPrimingAndTokenRotation:
         self._wire(mgr, storage, cipher)
 
         async def _fake_prime(
-            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
+            self_inner: MCPClientManager,
+            key: tuple[str, str],
+            cfg: dict[str, Any],
+            token: str,
+            expected_gen: Any = None,
         ) -> int:
             return 1
 

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -571,7 +571,6 @@ class TestDispatcherAuthFlows:
             *,
             auth_capture: Any = None,
             auth_fired_event: Any = None,
-            expected_gen: Any = None,
         ) -> Any:
             entry = await self_inner._ensure_pool_entry(key)
             sess = MagicMock()
@@ -981,7 +980,6 @@ class TestBreakerInvariant:
             *,
             auth_capture: Any = None,
             auth_fired_event: Any = None,
-            expected_gen: Any = None,
         ) -> Any:
             entry = await self_inner._ensure_pool_entry(key)
             sess = MagicMock()
@@ -1602,11 +1600,7 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[tuple[str, str], str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             primed.append((key, token))
             return 3
@@ -1637,11 +1631,7 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[tuple[str, str], str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             primed.append((key, token))
             return 3
@@ -1681,11 +1671,7 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[str, str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             primed.append(key)
             return 0
@@ -1820,11 +1806,7 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[str, str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             primed.append(key)
             return 0
@@ -1876,11 +1858,7 @@ class TestPoolPrimingAndTokenRotation:
         done = threading.Event()
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             captured["key"] = key
             captured["token"] = token
@@ -1940,7 +1918,6 @@ class TestPoolPrimingAndTokenRotation:
             *,
             auth_capture: Any = None,
             auth_fired_event: Any = None,
-            expected_gen: Any = None,
         ) -> Any:
             reconnect_tokens.append(access_token)
             entry = await self_inner._ensure_pool_entry(key)
@@ -1977,11 +1954,7 @@ class TestPoolPrimingAndTokenRotation:
         primed: list[tuple[str, str]] = []
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             primed.append(key)
             return 0
@@ -2005,11 +1978,7 @@ class TestPoolPrimingAndTokenRotation:
         self._wire(mgr, storage, cipher)
 
         async def _fake_prime(
-            self_inner: MCPClientManager,
-            key: tuple[str, str],
-            cfg: dict[str, Any],
-            token: str,
-            expected_gen: Any = None,
+            self_inner: MCPClientManager, key: tuple[str, str], cfg: dict[str, Any], token: str
         ) -> int:
             return 1
 

--- a/tests/test_mcp_pool_owner.py
+++ b/tests/test_mcp_pool_owner.py
@@ -370,6 +370,10 @@ class TestPoolTransportOwnerLifecycle:
         assert owner.done()
         assert entry.session is None  # evicted by the done-callback
         assert entry.owner_task is None
+        # Third session-drop site of the bearer-clearing sweep: the entry
+        # may now cool indefinitely, so the dead plaintext bearer copy
+        # must not cool with it.
+        assert entry.bound_token is None
         assert key in mgr._user_pool_entries  # entry kept
         assert entry.tools == [
             {"name": "mcp__pool-srv__ping", "server": "pool-srv"}

--- a/tests/test_mcp_user_catalog.py
+++ b/tests/test_mcp_user_catalog.py
@@ -474,9 +474,10 @@ def test_evict_session_keeps_catalog_and_fires_no_listener(
 
     mgr._evict_session(("user-1", "pool-srv"))
 
-    # Session dropped; catalog RETAINED.
+    # Session dropped; catalog RETAINED; dead bearer copy cleared.
     entry = mgr._user_pool_entries[("user-1", "pool-srv")]
     assert entry.session is None
+    assert entry.bound_token is None
     assert entry.tools is not None
     # User map intact — the live session's merged tool list is untouched.
     assert "user-1" in mgr._user_tool_map
@@ -571,6 +572,8 @@ def test_close_pool_entry_if_idle_cools_entry_for_live_session_user(
 
     _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
     key = ("user-1", "pool-srv")
+    # Retention also requires the server to still exist as a pool server.
+    mgr._oauth_user_server_names = {"pool-srv"}
     assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
     assert mgr._user_pool_entries[key].in_flight == 0
     # Seed the debounce dict so the prune-on-close is observable.
@@ -591,11 +594,13 @@ def test_close_pool_entry_if_idle_cools_entry_for_live_session_user(
 
     _run_on_loop(loop, mgr._close_pool_entry_if_idle(key))
 
-    # Entry cooled, not dropped: transport gone, catalog intact.
+    # Entry cooled, not dropped: transport gone, catalog intact, dead
+    # bearer copy cleared with the transport.
     entry = mgr._user_pool_entries.get(key)
     assert entry is not None, "cooled entry must survive TTL eviction"
     assert entry.session is None
     assert entry.owner_task is None
+    assert entry.bound_token is None
     assert entry.tools is not None
     # The lock object must survive with the entry — an in-flight
     # dispatcher's next acquire needs the same lock.
@@ -644,6 +649,9 @@ def test_close_pool_entry_if_idle_drops_entry_without_live_listener(
 
     _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
     key = ("user-1", "pool-srv")
+    # Registry seeded so the DROP below is attributable to the missing
+    # listener alone, not to registry-liveness.
+    mgr._oauth_user_server_names = {"pool-srv"}
     assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
     assert mgr._user_pool_entries[key].in_flight == 0
     # Seed the debounce dict so the perf-1 prune is observable.
@@ -1875,6 +1883,7 @@ def test_close_pool_entry_if_idle_cooling_keeps_resources_and_prompts(
 
     _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
     key = ("user-1", "pool-srv")
+    mgr._oauth_user_server_names = {"pool-srv"}
 
     res_calls = [0]
     prompt_calls = [0]

--- a/tests/test_mcp_user_catalog.py
+++ b/tests/test_mcp_user_catalog.py
@@ -430,17 +430,75 @@ def test_pool_tool_visibility_user_isolation(
     assert mgr.is_mcp_tool("mcp__pool-srv__shared_tool", user_id="user-3") is False
 
 
-def test_eviction_drops_catalog_and_fires_listener(
+def test_evict_session_keeps_catalog_and_fires_no_listener(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``_evict_session`` clears ``entry.tools``, rebuilds the user's
-    map (drops the now-empty entry), and fires user + admin listeners.
+    """``_evict_session`` (dispatch-failure eviction: 401 / 403 /
+    transport blip) drops ONLY the session — the catalog and per-user
+    maps stay, no listener fires, and ``is_mcp_tool`` keeps resolving
+    the name (#836).
 
-    Verified by reverting the catalog-cleanup block in ``_evict_session``
-    (drop the ``evict.tools = None`` / ``_rebuild_user_tool_map`` /
-    ``_notify_user_tool_listeners`` calls): the test fails because the
+    Clearing the catalog here silently removed the server's tools from
+    the user's live sessions on the first failed dispatch: the maps
+    rebuilt empty, the session-side ``is_mcp_tool`` gate closed, and
+    with no re-prime path the tools never came back — which also made
+    the breaker's half-open recovery and the consent / step-up cards
+    unreachable.
+
+    Verified by restoring the old catalog-cleanup block in
+    ``_evict_session`` (``evict.tools = None`` + rebuild + notify):
+    this test fails because the listener fires AND ``is_mcp_tool``
+    flips to False.
+    """
+    mgr, loop, _ = running_loop_mgr
+    handler = _make_jsonrpc_handler(
+        list_tools_response=_list_tools_payload([_tool_spec("do_thing")]),
+    )
+    _build_mock_transport_factory(mgr, monkeypatch, handler)
+    _patch_tcp_probe(mgr, monkeypatch)
+
+    _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
+    assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
+
+    user_calls = [0]
+    admin_calls = [0]
+
+    def _user_cb() -> None:
+        user_calls[0] += 1
+
+    def _admin_cb() -> None:
+        admin_calls[0] += 1
+
+    mgr.add_listener(_user_cb, user_id="user-1")
+    mgr.add_listener(_admin_cb)  # admin / None
+
+    mgr._evict_session(("user-1", "pool-srv"))
+
+    # Session dropped; catalog RETAINED.
+    entry = mgr._user_pool_entries[("user-1", "pool-srv")]
+    assert entry.session is None
+    assert entry.tools is not None
+    # User map intact — the live session's merged tool list is untouched.
+    assert "user-1" in mgr._user_tool_map
+    assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
+    # Nothing changed catalog-wise → NO fan-out.
+    assert user_calls[0] == 0, f"user-keyed listener fired {user_calls[0]} times; expected 0"
+    assert admin_calls[0] == 0, f"admin listener fired {admin_calls[0]} times; expected 0"
+
+
+def test_evict_user_session_drops_catalog_and_fires_listener(
+    running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_evict_session_drop_catalog`` (the explicit-revocation flavor
+    behind ``evict_user_session``) clears ``entry.tools``, rebuilds the
+    user's map (drops the now-empty entry), and fires user + admin
+    listeners — the user asked for the disconnect, so their live
+    sessions SHOULD see the tools leave.
+
+    Verified by reverting the catalog-cleanup block in
+    ``_evict_session_drop_catalog``: the test fails because the
     listener never fires AND ``is_mcp_tool`` keeps returning True for
-    the now-evicted tool.
+    the now-revoked tool.
     """
     mgr, loop, _ = running_loop_mgr
     handler = _make_jsonrpc_handler(
@@ -453,7 +511,7 @@ def test_eviction_drops_catalog_and_fires_listener(
     assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
 
     # Register one user-keyed and one admin (None) listener; both
-    # MUST fire on this user's eviction.
+    # MUST fire on this user's revocation.
     user_calls = [0]
     admin_calls = [0]
     other_calls = [0]
@@ -471,7 +529,7 @@ def test_eviction_drops_catalog_and_fires_listener(
     mgr.add_listener(_admin_cb)  # admin / None
     mgr.add_listener(_other_cb, user_id="user-2")
 
-    mgr._evict_session(("user-1", "pool-srv"))
+    mgr._evict_session_drop_catalog(("user-1", "pool-srv"))
 
     # Catalog cleared.
     entry = mgr._user_pool_entries[("user-1", "pool-srv")]
@@ -479,7 +537,7 @@ def test_eviction_drops_catalog_and_fires_listener(
     assert entry.tools is None
     # User map dropped (no remaining pool entries for this user).
     assert "user-1" not in mgr._user_tool_map
-    # is_mcp_tool no longer surfaces the evicted name.
+    # is_mcp_tool no longer surfaces the revoked name.
     assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is False
     # Listener fan-out: matching user + admin fire, OTHER user does not.
     assert user_calls[0] == 1, f"user-keyed listener fired {user_calls[0]} times; expected 1"
@@ -490,22 +548,19 @@ def test_eviction_drops_catalog_and_fires_listener(
     )
 
 
-def test_close_pool_entry_if_idle_clears_catalog_and_fires_listener(
+def test_close_pool_entry_if_idle_cools_entry_for_live_session_user(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """LRU/TTL eviction (``_close_pool_entry_if_idle``) mirrors
-    ``_evict_session``'s catalog-cleanup contract: drops the entry,
-    prunes the notification-debounce dict, rebuilds the user's tool
-    map, and fires user + admin listeners.
+    """TTL/LRU eviction COOLS the entry when the user has a live
+    session (a registered user-scoped tool listener): the transport is
+    torn down but the entry, its catalog, the per-user maps, and the
+    entry's ``open_lock`` all survive, and NO listener fires — the live
+    session's model-visible tool list must not shrink because the user
+    went 10 minutes without an MCP dispatch (#836).
 
-    Phase 7 round-2 review hardening (round2-1): the bug-2 fix added
-    the catalog-cleanup block to this method but no integration test
-    drove it — exactly the failure mode flagged in
-    ``feedback_tests_through_boundaries.md``. Negative test: drop the
-    ``_rebuild_user_tool_map`` / ``_notify_user_tool_listeners`` calls
-    from ``_close_pool_entry_if_idle``'s post-pop block; this test
-    fails because ``is_mcp_tool`` keeps returning ``True`` for the
-    evicted name AND no listener fires.
+    Negative test: restore the unconditional pop + rebuild + notify in
+    ``_close_pool_entry_if_idle``: this test fails because the entry
+    vanishes, ``is_mcp_tool`` flips to False, and the listener fires.
     """
     mgr, loop, _ = running_loop_mgr
     handler = _make_jsonrpc_handler(
@@ -517,14 +572,12 @@ def test_close_pool_entry_if_idle_clears_catalog_and_fires_listener(
     _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
     key = ("user-1", "pool-srv")
     assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
-    # Sanity: in_flight must be 0 for the eviction path to proceed.
     assert mgr._user_pool_entries[key].in_flight == 0
-    # Seed the debounce dict so the perf-1 prune is observable.
+    # Seed the debounce dict so the prune-on-close is observable.
     mgr._last_pool_notification_refresh[key] = 0.0
 
     user_calls = [0]
     admin_calls = [0]
-    other_calls = [0]
 
     def _user_cb() -> None:
         user_calls[0] += 1
@@ -532,21 +585,87 @@ def test_close_pool_entry_if_idle_clears_catalog_and_fires_listener(
     def _admin_cb() -> None:
         admin_calls[0] += 1
 
+    # The user-scoped tool listener is the liveness signal (#836).
+    mgr.add_listener(_user_cb, user_id="user-1")
+    mgr.add_listener(_admin_cb)  # admin / None
+
+    _run_on_loop(loop, mgr._close_pool_entry_if_idle(key))
+
+    # Entry cooled, not dropped: transport gone, catalog intact.
+    entry = mgr._user_pool_entries.get(key)
+    assert entry is not None, "cooled entry must survive TTL eviction"
+    assert entry.session is None
+    assert entry.owner_task is None
+    assert entry.tools is not None
+    # The lock object must survive with the entry — an in-flight
+    # dispatcher's next acquire needs the same lock.
+    assert key in mgr._user_pool_locks
+    # Debounce stamp pruned with the transport.
+    assert key not in mgr._last_pool_notification_refresh
+    # Per-user catalog view untouched.
+    assert "user-1" in mgr._user_tool_map
+    assert "user-1" in mgr._user_tools
+    assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
+    # Nothing changed catalog-wise → NO fan-out (a fan-out here would
+    # make every live session rebuild its tool list every idle TTL).
+    assert user_calls[0] == 0, f"user-keyed listener fired {user_calls[0]} times; expected 0"
+    assert admin_calls[0] == 0, f"admin listener fired {admin_calls[0]} times; expected 0"
+
+    # A second close on the already-cooled entry is a no-op — no drop,
+    # no fan-out (the eviction loop additionally skips cooled entries
+    # before even getting here).
+    _run_on_loop(loop, mgr._close_pool_entry_if_idle(key))
+    assert key in mgr._user_pool_entries
+    assert user_calls[0] == 0 and admin_calls[0] == 0
+
+
+def test_close_pool_entry_if_idle_drops_entry_without_live_listener(
+    running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TTL/LRU eviction FULLY drops the entry when the user has no live
+    session: entry popped, notification-debounce dict pruned, per-user
+    maps rebuilt, and the (admin-only) fan-out fires — departed users'
+    entries must not outlive their sessions.
+
+    Phase 7 round-2 review hardening (round2-1) heritage: the
+    catalog-cleanup block needs an integration test driving it — the
+    failure mode flagged in ``feedback_tests_through_boundaries.md``.
+    Negative test: drop the ``_rebuild_user_tool_map`` /
+    ``_notify_user_tool_listeners`` calls from the post-pop block; this
+    test fails because ``is_mcp_tool`` keeps returning ``True`` for the
+    evicted name AND the admin listener never fires.
+    """
+    mgr, loop, _ = running_loop_mgr
+    handler = _make_jsonrpc_handler(
+        list_tools_response=_list_tools_payload([_tool_spec("do_thing")]),
+    )
+    _build_mock_transport_factory(mgr, monkeypatch, handler)
+    _patch_tcp_probe(mgr, monkeypatch)
+
+    _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
+    key = ("user-1", "pool-srv")
+    assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
+    assert mgr._user_pool_entries[key].in_flight == 0
+    # Seed the debounce dict so the perf-1 prune is observable.
+    mgr._last_pool_notification_refresh[key] = 0.0
+
+    admin_calls = [0]
+    other_calls = [0]
+
+    def _admin_cb() -> None:
+        admin_calls[0] += 1
+
     def _other_cb() -> None:
         other_calls[0] += 1
 
-    mgr.add_listener(_user_cb, user_id="user-1")
+    # NO user-1 tool listener — user-1 has no live session. The admin
+    # (None) and unrelated-user listeners don't count as liveness.
     mgr.add_listener(_admin_cb)  # admin / None
     mgr.add_listener(_other_cb, user_id="user-2")
 
-    # Drive the LRU/TTL eviction path directly. ``open_lock`` is
-    # uncontested (no concurrent dispatch) and ``in_flight`` is 0,
-    # so the close proceeds without retry.
     _run_on_loop(loop, mgr._close_pool_entry_if_idle(key))
 
-    # Entry fully removed (LRU eviction pops the dict — unlike
-    # ``_evict_session`` which keeps the entry as a ``session=None``
-    # phantom for the next dispatch to re-connect).
+    # Entry fully removed.
     assert key not in mgr._user_pool_entries
     assert key not in mgr._user_pool_last_used
     assert key not in mgr._user_pool_locks
@@ -556,8 +675,8 @@ def test_close_pool_entry_if_idle_clears_catalog_and_fires_listener(
     assert "user-1" not in mgr._user_tool_map
     assert "user-1" not in mgr._user_tools
     assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is False
-    # Listener fan-out: matching user + admin fire, OTHER user does not.
-    assert user_calls[0] == 1, f"user-keyed listener fired {user_calls[0]} times; expected 1"
+    # Admin fan-out fires (operator tooling observes the drop); the
+    # unrelated user's listener does not.
     assert admin_calls[0] == 1, f"admin listener fired {admin_calls[0]} times; expected 1"
     assert other_calls[0] == 0, (
         f"unrelated user-2 listener fired {other_calls[0]} times; expected 0 — "
@@ -565,18 +684,25 @@ def test_close_pool_entry_if_idle_clears_catalog_and_fires_listener(
     )
 
 
-def test_reconnect_after_eviction_repopulates_catalog(
+def test_reconnect_after_eviction_corrects_catalog_drift(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """After eviction, the next ``_connect_one_pool`` re-populates the
-    catalog from the SDK by construction — no extra glue required.
+    """The retained catalog self-corrects at reconnect: the next
+    ``_connect_one_pool`` re-runs discovery and REPLACES the stale
+    snapshot — no extra glue required (#836).
+
+    Between eviction and reconnect the OLD names stay visible (that is
+    the point of retention — the model can still emit them, and the
+    dispatch that follows performs this reconnect); a name the server
+    dropped in the meantime dies at the server as a per-call error
+    while the refreshed catalog fans out.
 
     Verified by reverting the discovery block in ``_connect_one_pool``:
-    the reconnected entry's ``tools`` stays ``None`` and the user map
-    never re-emerges.
+    the reconnected entry keeps serving the stale ``tool_a`` and
+    ``tool_b`` never appears.
     """
     mgr, loop, _ = running_loop_mgr
-    # Sequence: first connect sees [tool_a]; eviction clears; second
+    # Sequence: first connect sees [tool_a]; the session dies; second
     # connect (after backend rotates) sees [tool_b].
     handler = _make_jsonrpc_handler(
         list_tools_seq=[
@@ -591,7 +717,9 @@ def test_reconnect_after_eviction_repopulates_catalog(
     assert mgr.is_mcp_tool("mcp__pool-srv__tool_a", user_id="user-1") is True
 
     mgr._evict_session(("user-1", "pool-srv"))
-    assert mgr.is_mcp_tool("mcp__pool-srv__tool_a", user_id="user-1") is False
+    # Retention: the stale snapshot keeps serving the live session
+    # until the reconnect refreshes it.
+    assert mgr.is_mcp_tool("mcp__pool-srv__tool_a", user_id="user-1") is True
 
     _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
     # Reconnect picked up the rotated catalog.
@@ -1555,17 +1683,14 @@ def test_refresh_pool_server_prompts_skips_when_capability_unset(
 # ---------------------------------------------------------------------------
 
 
-def test_eviction_clears_resource_and_prompt_catalogs_and_fires_listeners(
+def test_evict_session_keeps_resource_and_prompt_catalogs(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``_evict_session`` clears ``entry.resources`` and ``entry.prompts``,
-    rebuilds both per-user maps (drops the now-empty entries), and
-    fires the matching user-keyed + admin listeners for ALL three
-    catalogs (tools, resources, prompts).
-
-    Negative-test: drop the resource/prompt cleanup additions in
-    ``_evict_session``: this test fails because the user-resource map
-    keeps the evicted URIs and no resource listener fires.
+    """``_evict_session`` retains ``entry.resources`` / ``entry.prompts``
+    and their per-user maps, firing NO listeners — symmetric with the
+    tool-catalog retention (#836). The revocation flavor
+    (``_evict_session_drop_catalog``) is what clears and notifies; see
+    the sibling test below.
     """
     mgr, loop, _ = running_loop_mgr
     handler = _make_jsonrpc_handler(
@@ -1606,13 +1731,79 @@ def test_eviction_clears_resource_and_prompt_catalogs_and_fires_listeners(
 
     entry = mgr._user_pool_entries[("user-1", "pool-srv")]
     assert entry.session is None
+    # All three catalogs retained.
+    assert entry.tools is not None
+    assert entry.resources is not None
+    assert entry.prompts is not None
+    # Per-user maps keep the entries.
+    assert "res://r/1" in (mgr._user_resource_map.get("user-1") or {})
+    assert "mcp__pool-srv__p1" in (mgr._user_prompt_map.get("user-1") or {})
+    # Nothing changed catalog-wise → NO fan-out for anyone.
+    assert res_calls[0] == 0
+    assert prompt_calls[0] == 0
+    assert other_res_calls[0] == 0, "unrelated user-2 resource listener fired — RFC §3.3 violation"
+    assert other_prompt_calls[0] == 0, "unrelated user-2 prompt listener fired — RFC §3.3 violation"
+
+
+def test_evict_user_session_clears_resource_and_prompt_catalogs(
+    running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_evict_session_drop_catalog`` (explicit revocation) clears
+    ``entry.resources`` / ``entry.prompts``, rebuilds both per-user
+    maps (drops the now-empty entries), and fires the matching
+    user-keyed listeners for resources and prompts.
+
+    Negative-test: drop the resource/prompt cleanup in
+    ``_evict_session_drop_catalog``: this test fails because the
+    user-resource map keeps the revoked URIs and no resource listener
+    fires.
+    """
+    mgr, loop, _ = running_loop_mgr
+    handler = _make_jsonrpc_handler(
+        init_response=_init_response_with_caps(resources=True, prompts=True),
+        list_resources_response=_list_resources_payload([_resource_spec("res://r/1")]),
+        list_prompts_response=_list_prompts_payload([_prompt_spec("p1")]),
+    )
+    _build_mock_transport_factory(mgr, monkeypatch, handler)
+    _patch_tcp_probe(mgr, monkeypatch)
+
+    _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
+    assert "res://r/1" in (mgr._user_resource_map.get("user-1") or {})
+    assert "mcp__pool-srv__p1" in (mgr._user_prompt_map.get("user-1") or {})
+
+    res_calls = [0]
+    prompt_calls = [0]
+    other_res_calls = [0]
+    other_prompt_calls = [0]
+
+    def _user_res_cb() -> None:
+        res_calls[0] += 1
+
+    def _user_prompt_cb() -> None:
+        prompt_calls[0] += 1
+
+    def _other_res_cb() -> None:
+        other_res_calls[0] += 1
+
+    def _other_prompt_cb() -> None:
+        other_prompt_calls[0] += 1
+
+    mgr.add_resource_listener(_user_res_cb, user_id="user-1")
+    mgr.add_resource_listener(_other_res_cb, user_id="user-2")
+    mgr.add_prompt_listener(_user_prompt_cb, user_id="user-1")
+    mgr.add_prompt_listener(_other_prompt_cb, user_id="user-2")
+
+    mgr._evict_session_drop_catalog(("user-1", "pool-srv"))
+
+    entry = mgr._user_pool_entries[("user-1", "pool-srv")]
+    assert entry.session is None
     assert entry.tools is None
     assert entry.resources is None
     assert entry.prompts is None
-    # Per-user maps drop the evicted entries.
+    # Per-user maps drop the revoked entries.
     assert "user-1" not in mgr._user_resource_map
     assert "user-1" not in mgr._user_prompt_map
-    # Listeners fire for the evicted user but not for the unrelated user.
+    # Listeners fire for the revoked user but not for the unrelated user.
     assert res_calls[0] == 1
     assert prompt_calls[0] == 1
     assert other_res_calls[0] == 0, "unrelated user-2 resource listener fired — RFC §3.3 violation"
@@ -1623,8 +1814,13 @@ def test_close_pool_entry_if_idle_clears_resource_and_prompt_catalogs(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """LRU/TTL eviction (``_close_pool_entry_if_idle``) symmetric
-    cleanup for resources & prompts. Bug-pair to the tools-only
-    cleanup added in Phase 7 round-2."""
+    cleanup for resources & prompts on the FULL-DROP path. Bug-pair to
+    the tools-only cleanup added in Phase 7 round-2.
+
+    Deliberately registers NO user-1 TOOL listener: the user-scoped
+    tool listener is the liveness signal (#836) — resource/prompt
+    listeners alone do not mark a user live (every real ChatSession
+    registers the tool listener), so this drives the full drop."""
     mgr, loop, _ = running_loop_mgr
     handler = _make_jsonrpc_handler(
         init_response=_init_response_with_caps(resources=True, prompts=True),
@@ -1661,12 +1857,62 @@ def test_close_pool_entry_if_idle_clears_resource_and_prompt_catalogs(
     assert prompt_calls[0] == 1
 
 
+def test_close_pool_entry_if_idle_cooling_keeps_resources_and_prompts(
+    running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cooled path retains resources & prompts symmetrically with
+    tools: a user-1 TOOL listener (the liveness signal, #836) makes
+    TTL/LRU eviction keep the entry, both per-user maps, and fire no
+    resource/prompt listener."""
+    mgr, loop, _ = running_loop_mgr
+    handler = _make_jsonrpc_handler(
+        init_response=_init_response_with_caps(resources=True, prompts=True),
+        list_resources_response=_list_resources_payload([_resource_spec("res://r/1")]),
+        list_prompts_response=_list_prompts_payload([_prompt_spec("p1")]),
+    )
+    _build_mock_transport_factory(mgr, monkeypatch, handler)
+    _patch_tcp_probe(mgr, monkeypatch)
+
+    _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
+    key = ("user-1", "pool-srv")
+
+    res_calls = [0]
+    prompt_calls = [0]
+
+    def _res_cb() -> None:
+        res_calls[0] += 1
+
+    def _prompt_cb() -> None:
+        prompt_calls[0] += 1
+
+    # The TOOL listener marks user-1 live; the resource/prompt
+    # listeners observe (non-)fan-out.
+    mgr.add_listener(lambda: None, user_id="user-1")
+    mgr.add_resource_listener(_res_cb, user_id="user-1")
+    mgr.add_prompt_listener(_prompt_cb, user_id="user-1")
+
+    _run_on_loop(loop, mgr._close_pool_entry_if_idle(key))
+
+    # Entry cooled: transport gone, catalogs and maps intact.
+    entry = mgr._user_pool_entries.get(key)
+    assert entry is not None
+    assert entry.session is None
+    assert entry.resources is not None
+    assert entry.prompts is not None
+    assert "res://r/1" in (mgr._user_resource_map.get("user-1") or {})
+    assert "mcp__pool-srv__p1" in (mgr._user_prompt_map.get("user-1") or {})
+    # No fan-out — nothing changed catalog-wise.
+    assert res_calls[0] == 0
+    assert prompt_calls[0] == 0
+
+
 def test_reconnect_after_eviction_repopulates_resource_and_prompt_catalogs(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """After eviction, the next ``_connect_one_pool`` re-populates the
-    resource and prompt catalogs from the SDK. Bug-class: an extra
-    glue layer would only repopulate tools."""
+    """After a session eviction the next ``_connect_one_pool`` REPLACES
+    the retained resource and prompt catalogs from the SDK — drift
+    self-corrects for all three catalogs, not just tools (#836).
+    Bug-class: an extra glue layer would only repopulate tools."""
     mgr, loop, _ = running_loop_mgr
     handler = _make_jsonrpc_handler(
         init_response=_init_response_with_caps(resources=True, prompts=True),
@@ -1687,8 +1933,9 @@ def test_reconnect_after_eviction_repopulates_resource_and_prompt_catalogs(
     assert "mcp__pool-srv__p_a" in (mgr._user_prompt_map.get("user-1") or {})
 
     mgr._evict_session(("user-1", "pool-srv"))
-    assert "user-1" not in mgr._user_resource_map
-    assert "user-1" not in mgr._user_prompt_map
+    # Retention: the stale snapshots keep serving until reconnect.
+    assert "res://a" in (mgr._user_resource_map.get("user-1") or {})
+    assert "mcp__pool-srv__p_a" in (mgr._user_prompt_map.get("user-1") or {})
 
     _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
     # New catalogs reflect the rotated payload.

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -521,6 +521,38 @@ class TestEviction:
         assert blocked, "drop must wait for the in-flight connect's open_lock"
         assert cleared, "drop must win once the connect completes — no resurrection"
 
+    def test_lookup_grant_dead_requires_wired_infrastructure(self, running_loop_mgr) -> None:
+        """kind='missing' is authoritative only when the stores that
+        could know are wired: the obo lookup returns 'missing' for an
+        unconfigured token store / storage too, and a boot-window blip
+        must not clear a user's catalog (it can't re-prime until a new
+        session). With the stores present, missing / refresh_failed /
+        the empty-token fallback classify as dead; transient and
+        decrypt failures never do."""
+        mgr, _loop, _ = running_loop_mgr
+
+        missing = SimpleNamespace(kind="missing", token=None)
+        # No app_state at all → not authoritative.
+        assert mgr._lookup_grant_dead(missing) is False
+        # Token store present but storage unwired → not authoritative.
+        mgr._app_state = SimpleNamespace(mcp_token_store=object())
+        mgr._storage = None
+        assert mgr._lookup_grant_dead(missing) is False
+        # Fully wired → authoritative.
+        mgr._storage = object()
+        assert mgr._lookup_grant_dead(missing) is True
+        assert mgr._lookup_grant_dead(SimpleNamespace(kind="refresh_failed", token=None)) is True
+        assert mgr._lookup_grant_dead(SimpleNamespace(kind="token", token="")) is True
+        assert mgr._lookup_grant_dead(SimpleNamespace(kind="token", token="tok")) is False
+        assert (
+            mgr._lookup_grant_dead(SimpleNamespace(kind="refresh_failed_transient", token=None))
+            is False
+        )
+        assert mgr._lookup_grant_dead(SimpleNamespace(kind="decrypt_failure", token=None)) is False
+        # Token store unconfigured on a wired app_state → not authoritative.
+        mgr._app_state = SimpleNamespace(mcp_token_store=None)
+        assert mgr._lookup_grant_dead(missing) is False
+
     def test_status_reports_cooled_catalog_as_idle(self, running_loop_mgr) -> None:
         """A cooled entry's catalog is still model-visible, so status
         must not report '0 tools' for it: counts fall back to the
@@ -719,6 +751,9 @@ class TestDispatchStateMachine:
         # kind="missing" is a DEAD grant: the retained catalog drops and
         # the live session is notified — tools leave instead of dangling
         # behind a consent card for access the user no longer holds.
+        # The drop is SCHEDULED (never awaited on the dispatch path, which
+        # may be parked behind a long same-key call) — flush the loop.
+        _run_on_loop(loop, asyncio.sleep(0.05))
         assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
         assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is False
         assert fired[0] == 1
@@ -788,7 +823,9 @@ class TestDispatchStateMachine:
             )
         payload = json.loads(str(exc_info.value))
         assert payload["error"]["code"] == "mcp_consent_required"
-        # kind="refresh_failed" is likewise a DEAD grant → catalog drops.
+        # kind="refresh_failed" is likewise a DEAD grant → catalog drops
+        # (scheduled — flush the loop before asserting).
+        _run_on_loop(loop, asyncio.sleep(0.05))
         assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
         assert fired[0] == 1
 

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -521,6 +521,62 @@ class TestEviction:
         assert blocked, "drop must wait for the in-flight connect's open_lock"
         assert cleared, "drop must win once the connect completes — no resurrection"
 
+    def test_connect_refuses_when_generation_moved(self, running_loop_mgr) -> None:
+        """``_connect_one_pool`` must refuse to connect (and so to
+        publish) when the entry's revocation generation moved past the
+        caller's pre-token-read snapshot — the bearer in hand predates
+        a disconnect, and publishing would resurrect the dropped
+        catalog with nothing left to clear it."""
+        from turnstone.core.mcp_client import _PoolGrantRevokedError
+
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+
+        async def _scenario() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            gen0 = entry.catalog_gen
+            entry.catalog_gen += 1  # a revocation drop landed in the window
+            with pytest.raises(_PoolGrantRevokedError):
+                await mgr._connect_one_pool(
+                    key,
+                    {"type": "streamable-http", "url": "https://mcp.example.com/sse"},
+                    "stale-bearer",
+                    expected_gen=gen0,
+                )
+
+        _run_on_loop(loop, _scenario())
+
+    def test_refresh_discards_result_when_generation_moved(self, running_loop_mgr) -> None:
+        """A ``list_changed`` refresh whose await straddles a revocation
+        drop must DISCARD its result — publishing would resurrect the
+        revoked catalog, which retention then keeps alive forever."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._oauth_user_server_names = {"pool-srv"}
+        key = ("u0", "pool-srv")
+
+        async def _scenario() -> tuple[list, list, Any, bool]:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.tools = self._fake_tools("pool-srv", 0)
+            mgr._rebuild_user_tool_map("u0")
+
+            class _RacingSession:
+                async def list_tools(self) -> Any:
+                    # The disconnect lands while list_tools is in flight.
+                    mgr._evict_session_drop_catalog(key)
+                    res = MagicMock()
+                    res.tools = []
+                    return res
+
+            entry.session = _RacingSession()
+            added, removed = await mgr._refresh_pool_server_tools(key)
+            return added, removed, entry.tools, "u0" in mgr._user_tool_map
+
+        added, removed, tools, in_map = _run_on_loop(loop, _scenario())
+        assert (added, removed) == ([], [])
+        # The drop's clear stands; the refresh did not republish.
+        assert tools is None
+        assert in_map is False
+
     def test_lookup_grant_dead_requires_wired_infrastructure(self, running_loop_mgr) -> None:
         """kind='missing' is authoritative only when the stores that
         could know are wired: the obo lookup returns 'missing' for an
@@ -1369,7 +1425,9 @@ class TestOboPriming:
 
         warmed: list[tuple[Any, Any, str]] = []
 
-        async def _fake_prime_server(key: Any, cfg: Any, token: str) -> None:
+        async def _fake_prime_server(
+            key: Any, cfg: Any, token: str, expected_gen: Any = None
+        ) -> None:
             warmed.append((key, cfg, token))
 
         obo_lookup = AsyncMock(return_value=SimpleNamespace(kind="token", token="minted-at"))
@@ -1387,6 +1445,60 @@ class TestOboPriming:
         user_lookup.assert_not_awaited()
         assert len(warmed) == 1
         assert warmed[0][2] == "minted-at"
+
+    def test_prime_drops_retained_catalog_on_dead_grant(self, running_loop_mgr, storage) -> None:
+        """Priming is a convergence point (#836): a NEW session's prime
+        that finds the grant durably GONE must drop the retained catalog
+        that other live sessions still serve (e.g. a disconnect made on
+        another node) — not just skip the server."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        mgr.set_storage(storage)
+        app_state = _make_app_state(storage, cipher=cipher)
+        mgr.set_app_state(app_state)
+        storage.create_mcp_server(
+            server_id="srv-o",
+            name="pool-srv",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_user",
+        )
+        mgr._oauth_user_server_names = {"pool-srv"}
+        key = ("user-1", "pool-srv")
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__pool-srv__t",
+                        "description": "",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            mgr._rebuild_user_tool_map("user-1")
+
+        _run_on_loop(loop, _seed())
+        fired = [0]
+
+        def _cb() -> None:
+            fired[0] += 1
+
+        mgr.add_listener(_cb, user_id="user-1")
+        assert mgr.is_mcp_tool("mcp__pool-srv__t", user_id="user-1") is True
+
+        dead = AsyncMock(return_value=SimpleNamespace(kind="missing", token=None))
+        with patch("turnstone.core.mcp_client.get_user_access_token_classified", new=dead):
+            _run_on_loop(loop, mgr._prime_user_pools("user-1"))
+            # The drop is scheduled — flush the loop before asserting.
+            _run_on_loop(loop, asyncio.sleep(0.05))
+
+        entry = mgr._user_pool_entries[key]
+        assert entry.tools is None
+        assert mgr.is_mcp_tool("mcp__pool-srv__t", user_id="user-1") is False
+        assert fired[0] == 1
 
     def test_prime_skips_obo_server_when_no_credential(self, running_loop_mgr, storage) -> None:
         """A user without a captured credential is skipped BEFORE any

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -400,6 +400,145 @@ class TestEviction:
         # All entries removed from the dict regardless.
         assert mgr._user_pool_entries == {}
 
+    @staticmethod
+    def _fake_tools(server_name: str, i: int) -> list[dict]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": f"mcp__{server_name}__t{i}",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+    def test_idle_eviction_cools_entries_for_live_listener_users(self, running_loop_mgr) -> None:
+        """TTL eviction cools (retains) a live-listener user's
+        catalog-bearing entry and full-drops a listener-less user's —
+        the #836 split. A second tick must not disturb the cooled entry
+        (the already-cooled skip)."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 0.0  # everything is stale
+
+        async def _seed() -> None:
+            for i in range(2):
+                entry = await mgr._ensure_pool_entry((f"u{i}", "pool-srv"))
+                entry.session = MagicMock()
+                entry.tools = self._fake_tools("pool-srv", i)
+
+        _run_on_loop(loop, _seed())
+        # u0 has a live session (tool listener); u1 does not.
+        mgr.add_listener(lambda: None, user_id="u0")
+
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+
+        # u0: cooled — retained without a session, catalog intact.
+        cooled = mgr._user_pool_entries.get(("u0", "pool-srv"))
+        assert cooled is not None
+        assert cooled.session is None
+        assert cooled.tools is not None
+        # u1: full drop.
+        assert ("u1", "pool-srv") not in mgr._user_pool_entries
+
+        # Second tick: the cooled entry is skipped, not re-processed.
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+        assert ("u0", "pool-srv") in mgr._user_pool_entries
+
+    def test_idle_eviction_drops_catalogless_stub_despite_live_listener(
+        self, running_loop_mgr
+    ) -> None:
+        """A cold, never-discovered stub (``_ensure_pool_entry``
+        allocated, connect failed before discovery) carries no catalog
+        worth retaining — TTL eviction drops it even for a live-listener
+        user, so revoke-cleared and connect-failed entries can't
+        accumulate as zombies behind an open session."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 0.0
+
+        async def _seed() -> None:
+            await mgr._ensure_pool_entry(("u-stub", "pool-srv"))
+
+        _run_on_loop(loop, _seed())
+        mgr.add_listener(lambda: None, user_id="u-stub")
+
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+        assert ("u-stub", "pool-srv") not in mgr._user_pool_entries
+
+    def test_lru_cap_ignores_cooled_entries(self, running_loop_mgr) -> None:
+        """The LRU cap bounds WARM entries (connection resources), not
+        cooled catalog-only ones — cooled entries neither count toward
+        the cap nor get evicted by it."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 999_999.0  # TTL effectively disabled
+        mgr._user_pool_lru_max = 2
+
+        async def _seed() -> None:
+            base = time.monotonic()
+            # Three cooled entries (no session/owner, catalog present).
+            for i in range(3):
+                key = (f"cool{i}", "pool-srv")
+                entry = await mgr._ensure_pool_entry(key)
+                entry.tools = self._fake_tools("pool-srv", i)
+                entry.last_used = base + i
+                mgr._user_pool_last_used[key] = base + i
+            # Two warm entries, newer than the cooled ones.
+            for i in range(2):
+                key = (f"warm{i}", "pool-srv")
+                entry = await mgr._ensure_pool_entry(key)
+                entry.session = MagicMock()
+                entry.tools = self._fake_tools("pool-srv", 10 + i)
+                entry.last_used = base + 10 + i
+                mgr._user_pool_last_used[key] = base + 10 + i
+
+        _run_on_loop(loop, _seed())
+        for i in range(3):
+            mgr.add_listener(lambda: None, user_id=f"cool{i}")
+
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+
+        # Warm count (2) is at the cap — nothing evicted, cooled
+        # entries (which would be "oldest" by last_used) untouched.
+        assert len(mgr._user_pool_entries) == 5
+        assert all((f"cool{i}", "pool-srv") in mgr._user_pool_entries for i in range(3))
+
+    def test_lru_cap_cools_live_listener_entries(self, running_loop_mgr) -> None:
+        """Over the cap, warm entries of live-listener users are COOLED
+        (transport closed, entry + catalog retained) oldest-first until
+        the warm count meets the cap — cap pressure must not reintroduce
+        the #836 tool loss for live sessions."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 999_999.0
+        mgr._user_pool_lru_max = 1
+
+        async def _seed() -> None:
+            base = time.monotonic()
+            for i in range(3):
+                key = (f"u{i}", "pool-srv")
+                entry = await mgr._ensure_pool_entry(key)
+                entry.session = MagicMock()
+                entry.tools = self._fake_tools("pool-srv", i)
+                entry.last_used = base + i
+                mgr._user_pool_last_used[key] = base + i
+
+        _run_on_loop(loop, _seed())
+        for i in range(3):
+            mgr.add_listener(lambda: None, user_id=f"u{i}")
+
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+
+        # All three entries survive with catalogs; only the newest is
+        # still warm.
+        assert len(mgr._user_pool_entries) == 3
+        warm = [
+            key
+            for key, e in mgr._user_pool_entries.items()
+            if e.session is not None or e.owner_task is not None
+        ]
+        assert warm == [("u2", "pool-srv")]
+        for i in range(3):
+            assert mgr._user_pool_entries[(f"u{i}", "pool-srv")].tools is not None
+
 
 # ---------------------------------------------------------------------------
 # Dispatch state machine

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import mcp.types as mcp_types
 import pytest
 
 from tests.conftest import make_mcp_token_cipher, stop_loop_thread
@@ -149,6 +150,40 @@ def _run_on_loop(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:
     """Submit *coro* to *loop*, wait for the result with a 5s timeout."""
     fut = asyncio.run_coroutine_threadsafe(coro, loop)
     return fut.result(timeout=5)
+
+
+def _fake_pool_tools(server_name: str, tool_name: str) -> list[dict[str, Any]]:
+    """One OpenAI-format tool entry, shaped as the pool catalog seeds expect.
+
+    Single copy — ``_rebuild_user_tool_map`` / ``is_mcp_tool`` consume
+    this shape, and divergent per-test copies silently stop exercising
+    the real catalog format when the schema evolves.
+    """
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": f"mcp__{server_name}__{tool_name}",
+                "description": "",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _drain_background(mgr: MCPClientManager, loop: asyncio.AbstractEventLoop) -> None:
+    """Deterministically await the manager's tracked background tasks.
+
+    Replaces fixed sleeps for synchronizing with scheduled dead-grant
+    drops / spawned refreshes: exact, and immune to slow-runner flake.
+    """
+
+    async def _drain() -> None:
+        tasks = [t for t in list(mgr._background_tasks) if not t.done()]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    _run_on_loop(loop, _drain())
 
 
 # ---------------------------------------------------------------------------
@@ -402,16 +437,7 @@ class TestEviction:
 
     @staticmethod
     def _fake_tools(server_name: str, i: int) -> list[dict]:
-        return [
-            {
-                "type": "function",
-                "function": {
-                    "name": f"mcp__{server_name}__t{i}",
-                    "description": "",
-                    "parameters": {"type": "object", "properties": {}},
-                },
-            }
-        ]
+        return _fake_pool_tools(server_name, f"t{i}")
 
     def test_idle_eviction_cools_entries_for_live_listener_users(self, running_loop_mgr) -> None:
         """TTL eviction cools (retains) a live-listener user's
@@ -553,6 +579,93 @@ class TestEviction:
         assert (added, removed) == ([], [])
         # The stale result was not published onto the replacement entry.
         assert fresh_tools is None
+
+    def test_dead_grant_drop_skips_freshly_reconnected_entry(self, running_loop_mgr) -> None:
+        """A dead-grant drop parked behind ``open_lock`` must NOT clear a
+        catalog that a re-consent prime published while it waited: a
+        live session at drop time proves a connect succeeded after the
+        failed lookup, i.e. the grant is alive again. The explicit
+        revocation path (skip_if_connected=False) still clears warm
+        entries — that is its purpose."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._oauth_user_server_names = {"pool-srv"}
+        key = ("u0", "pool-srv")
+
+        async def _scenario() -> tuple[Any, Any, Any]:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.tools = _fake_pool_tools("pool-srv", "t")
+            entry.session = MagicMock()  # re-consent prime reconnected
+            await mgr._drop_catalog_locked(key, skip_if_connected=True)
+            kept = entry.tools
+            # Cold entry (no session): the dead-grant drop proceeds.
+            entry.session = None
+            await mgr._drop_catalog_locked(key, skip_if_connected=True)
+            dropped = entry.tools
+            # Revocation flavor clears even a warm entry.
+            entry.tools = _fake_pool_tools("pool-srv", "t")
+            entry.session = MagicMock()
+            await mgr._drop_catalog_locked(key)
+            revoked = entry.tools
+            return kept, dropped, revoked
+
+        kept, dropped, revoked = _run_on_loop(loop, _scenario())
+        assert kept is not None, "drop must skip an entry a fresh grant reconnected"
+        assert dropped is None
+        assert revoked is None
+
+    def test_notification_refresh_failure_returns_debounce_stamp(self, running_loop_mgr) -> None:
+        """A failed spawned ``list_changed`` refresh must return the
+        debounce stamp so the server's next notification retries — a
+        consumed stamp with no retry silently drops the catalog change
+        for the whole debounce window."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        mgr._last_pool_notification_refresh[key] = 123.0
+
+        async def _boom(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
+            raise TimeoutError("slow server")
+
+        _run_on_loop(loop, mgr._run_notification_refresh(key, "tools", _boom))
+        assert key not in mgr._last_pool_notification_refresh
+
+        async def _ok(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
+            return [], []
+
+        mgr._last_pool_notification_refresh[key] = 456.0
+        _run_on_loop(loop, mgr._run_notification_refresh(key, "tools", _ok))
+        assert mgr._last_pool_notification_refresh[key] == 456.0
+
+    def test_list_changed_handler_spawns_refresh_off_receive_loop(self, running_loop_mgr) -> None:
+        """The notification handler must SPAWN the refresh, not await it:
+        the SDK awaits handlers inline in its receive loop, so an
+        in-handler request on the same session can never receive its
+        response — push-driven refreshes structurally never completed."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        refreshed: list[tuple[str, str]] = []
+
+        async def _fake_refresh(k: tuple[str, str]) -> tuple[list[str], list[str]]:
+            refreshed.append(k)
+            return [], []
+
+        mgr._refresh_pool_server_tools = _fake_refresh  # type: ignore[method-assign]
+        handler = mgr._make_pool_notification_handler(key)
+
+        async def _fire() -> bool:
+            note = mcp_types.ServerNotification(
+                mcp_types.ToolListChangedNotification(method="notifications/tools/list_changed")
+            )
+            await handler(note)
+            # The handler returned WITHOUT running the refresh inline —
+            # it must complete even though the refresh hasn't run yet.
+            return len(refreshed) == 0
+
+        returned_before_refresh = _run_on_loop(loop, _fire())
+        assert returned_before_refresh, "handler must not await the refresh inline"
+        _drain_background(mgr, loop)
+        assert refreshed == [key]
+        # Debounce stamp consumed at schedule time (storm dedupe).
+        assert key in mgr._last_pool_notification_refresh
 
     def test_lookup_grant_dead_requires_wired_infrastructure(self, running_loop_mgr) -> None:
         """kind='missing' is authoritative only when the stores that
@@ -739,16 +852,7 @@ class TestDispatchStateMachine:
 
         async def _seed() -> None:
             entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
-            entry.tools = [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "mcp__pool-srv__do_thing",
-                        "description": "",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                }
-            ]
+            entry.tools = _fake_pool_tools("pool-srv", "do_thing")
             mgr._rebuild_user_tool_map("user-1")
 
         _run_on_loop(loop, _seed())
@@ -785,8 +889,8 @@ class TestDispatchStateMachine:
         # the live session is notified — tools leave instead of dangling
         # behind a consent card for access the user no longer holds.
         # The drop is SCHEDULED (never awaited on the dispatch path, which
-        # may be parked behind a long same-key call) — flush the loop.
-        _run_on_loop(loop, asyncio.sleep(0.05))
+        # may be parked behind a long same-key call) — drain the tracked tasks.
+        _drain_background(mgr, loop)
         assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
         assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is False
         assert fired[0] == 1
@@ -857,8 +961,8 @@ class TestDispatchStateMachine:
         payload = json.loads(str(exc_info.value))
         assert payload["error"]["code"] == "mcp_consent_required"
         # kind="refresh_failed" is likewise a DEAD grant → catalog drops
-        # (scheduled — flush the loop before asserting).
-        _run_on_loop(loop, asyncio.sleep(0.05))
+        # (scheduled — drain the tracked tasks before asserting).
+        _drain_background(mgr, loop)
         assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
         assert fired[0] == 1
 
@@ -1443,16 +1547,7 @@ class TestOboPriming:
 
         async def _seed() -> None:
             entry = await mgr._ensure_pool_entry(key)
-            entry.tools = [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "mcp__pool-srv__t",
-                        "description": "",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                }
-            ]
+            entry.tools = _fake_pool_tools("pool-srv", "t")
             mgr._rebuild_user_tool_map("user-1")
 
         _run_on_loop(loop, _seed())
@@ -1467,8 +1562,8 @@ class TestOboPriming:
         dead = AsyncMock(return_value=SimpleNamespace(kind="missing", token=None))
         with patch("turnstone.core.mcp_client.get_user_access_token_classified", new=dead):
             _run_on_loop(loop, mgr._prime_user_pools("user-1"))
-            # The drop is scheduled — flush the loop before asserting.
-            _run_on_loop(loop, asyncio.sleep(0.05))
+        # The drop is scheduled — drain the tracked tasks before asserting.
+        _drain_background(mgr, loop)
 
         entry = mgr._user_pool_entries[key]
         assert entry.tools is None
@@ -1512,6 +1607,54 @@ class TestOboPriming:
 
         obo_lookup.assert_not_awaited()
         assert warmed == []
+
+    def test_prime_drops_retained_obo_catalog_when_credential_gone(
+        self, running_loop_mgr, storage
+    ) -> None:
+        """The credential-presence gate must not starve dead-grant
+        convergence: a user whose captured credential is GONE (unlink /
+        deprovision) still has retained obo catalogs, and every
+        new-session prime must drop them — the gate skips exactly the
+        per-server lookup that would have."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        mgr.set_storage(storage)
+        app_state = _make_app_state(storage, cipher=cipher)
+        app_state.oidc_config = SimpleNamespace(issuer="https://idp.example.com")
+        mgr.set_app_state(app_state)
+        storage.create_mcp_server(
+            server_id="srv-obo",
+            name="obo-srv",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        mgr._obo_server_names = {"obo-srv"}
+        key = ("user-1", "obo-srv")
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.tools = _fake_pool_tools("obo-srv", "t")
+            mgr._rebuild_user_tool_map("user-1")
+
+        _run_on_loop(loop, _seed())
+        fired = [0]
+
+        def _cb() -> None:
+            fired[0] += 1
+
+        mgr.add_listener(_cb, user_id="user-1")
+        assert mgr.is_mcp_tool("mcp__obo-srv__t", user_id="user-1") is True
+
+        # No credential row seeded — the gate fires.
+        _run_on_loop(loop, mgr._prime_user_pools("user-1"))
+        _drain_background(mgr, loop)
+
+        entry = mgr._user_pool_entries[key]
+        assert entry.tools is None
+        assert mgr.is_mcp_tool("mcp__obo-srv__t", user_id="user-1") is False
+        assert fired[0] == 1
 
 
 class TestPendingConsentClearGate:

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -855,8 +855,63 @@ class TestEviction:
         _drain_background(mgr, loop)
         assert spawned == 1, "second notification must coalesce into the parked runner"
         assert refreshed == [key]
-        # The runner released its marker (at lock acquire + finally).
+        # The runner released its own marker at lock acquire.
         assert not mgr._pool_refresh_pending
+
+    def test_finally_does_not_clobber_successor_marker(self, running_loop_mgr) -> None:
+        """After the at-acquire discard, a marker present at the
+        runner's exit belongs to the SUCCESSOR spawned during its
+        in-flight list call — the finally must not discard it, or the
+        handler mints runners past the one-parked-runner bound (one
+        extra 30s list call serialized ahead of the user's dispatch per
+        debounce window)."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        marker = (key, "tools")
+
+        async def _refresh_readding(_k: tuple[str, str]) -> tuple[list[str], list[str]]:
+            # Our own marker was discarded at lock-acquire; a successor
+            # spawned mid-refresh re-adds the same (key, kind) marker.
+            assert marker not in mgr._pool_refresh_pending
+            mgr._pool_refresh_pending.add(marker)
+            return [], []
+
+        async def _scenario() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
+            mgr._pool_refresh_pending.add(marker)  # our spawn's marker
+            await mgr._run_notification_refresh(key, "tools", _refresh_readding)
+
+        _run_on_loop(loop, _scenario())
+        assert marker in mgr._pool_refresh_pending, "successor's marker must survive our exit"
+        mgr._pool_refresh_pending.discard(marker)
+
+    def test_cancel_while_parked_releases_marker(self, running_loop_mgr) -> None:
+        """A runner cancelled while PARKED on open_lock never reached
+        the at-acquire discard — the finally must release its marker,
+        or the key+kind never refreshes again."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        marker = (key, "tools")
+
+        async def _rec(_k: tuple[str, str]) -> tuple[list[str], list[str]]:
+            return [], []
+
+        async def _scenario() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
+            await entry.open_lock.acquire()
+            mgr._pool_refresh_pending.add(marker)
+            task = asyncio.ensure_future(mgr._run_notification_refresh(key, "tools", _rec))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            entry.open_lock.release()
+
+        _run_on_loop(loop, _scenario())
+        assert marker not in mgr._pool_refresh_pending
 
     def test_teardown_pool_entry_pops_debounce_stamp(self, running_loop_mgr) -> None:
         """Every teardown path must pop the debounce stamp — the

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -428,22 +428,126 @@ class TestEviction:
                 entry.tools = self._fake_tools("pool-srv", i)
 
         _run_on_loop(loop, _seed())
+        # The server must exist in the pool registries for retention.
+        mgr._oauth_user_server_names = {"pool-srv"}
         # u0 has a live session (tool listener); u1 does not.
         mgr.add_listener(lambda: None, user_id="u0")
 
         _run_on_loop(loop, mgr._evict_idle_pool_entries())
 
-        # u0: cooled — retained without a session, catalog intact.
+        # u0: cooled — retained without a session, catalog intact, and
+        # the dead bearer copy cleared with the transport.
         cooled = mgr._user_pool_entries.get(("u0", "pool-srv"))
         assert cooled is not None
         assert cooled.session is None
         assert cooled.tools is not None
+        assert cooled.bound_token is None
         # u1: full drop.
         assert ("u1", "pool-srv") not in mgr._user_pool_entries
 
         # Second tick: the cooled entry is skipped, not re-processed.
         _run_on_loop(loop, mgr._evict_idle_pool_entries())
         assert ("u0", "pool-srv") in mgr._user_pool_entries
+
+    def test_eviction_drops_cooled_entry_when_server_leaves_registry(
+        self, running_loop_mgr
+    ) -> None:
+        """Registry-liveness: a cooled entry is retained ONLY while its
+        server still exists as a pool server. Admin delete / disable /
+        rename / flip-to-static all remove the name from the pool
+        registries at reconcile — the ghost catalog must leave live
+        sessions within one tick, not survive for the session's life
+        (pre-#836-fix the TTL bounded this to ~10 minutes)."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._user_pool_idle_ttl_s = 0.0
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(("u0", "pool-srv"))
+            entry.session = MagicMock()
+            entry.tools = self._fake_tools("pool-srv", 0)
+
+        _run_on_loop(loop, _seed())
+        mgr._oauth_user_server_names = {"pool-srv"}
+        mgr.add_listener(lambda: None, user_id="u0")
+
+        # While registered: cooled + retained.
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+        assert ("u0", "pool-srv") in mgr._user_pool_entries
+
+        # Auth-flip between POOL types keeps retention (still pool-backed;
+        # the reconcile flip self-heal re-primes the real catalog).
+        mgr._oauth_user_server_names = set()
+        mgr._obo_server_names = {"pool-srv"}
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+        assert ("u0", "pool-srv") in mgr._user_pool_entries
+
+        # Server leaves the pool registries entirely (deleted / disabled /
+        # renamed / flipped to static): full drop despite the live listener.
+        mgr._obo_server_names = set()
+        _run_on_loop(loop, mgr._evict_idle_pool_entries())
+        assert ("u0", "pool-srv") not in mgr._user_pool_entries
+        assert "u0" not in mgr._user_tool_map
+
+    def test_drop_catalog_locked_serializes_with_inflight_connect(self, running_loop_mgr) -> None:
+        """A revocation drop must wait for an in-flight connect holding
+        ``open_lock`` — an unserialized drop is republished (resurrected)
+        by the connect's discovery, with nothing left to ever clear it."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._oauth_user_server_names = {"pool-srv"}
+        key = ("u0", "pool-srv")
+
+        async def _scenario() -> tuple[bool, bool]:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
+            entry.tools = self._fake_tools("pool-srv", 0)
+            mgr._rebuild_user_tool_map("u0")
+            # Simulate an in-flight connect: open_lock held while the
+            # "discovery" publishes the catalog.
+            await entry.open_lock.acquire()
+            drop_task = asyncio.create_task(mgr._drop_catalog_locked(key))
+            await asyncio.sleep(0)
+            # Drop is parked on the lock — catalog still published.
+            blocked = entry.tools is not None and not drop_task.done()
+            # Connect finishes its publish, then releases the lock.
+            mgr._rebuild_user_tool_map("u0")
+            entry.open_lock.release()
+            await drop_task
+            cleared = (
+                entry.tools is None and entry.session is None and "u0" not in mgr._user_tool_map
+            )
+            return blocked, cleared
+
+        blocked, cleared = _run_on_loop(loop, _scenario())
+        assert blocked, "drop must wait for the in-flight connect's open_lock"
+        assert cleared, "drop must win once the connect completes — no resurrection"
+
+    def test_status_reports_cooled_catalog_as_idle(self, running_loop_mgr) -> None:
+        """A cooled entry's catalog is still model-visible, so status
+        must not report '0 tools' for it: counts fall back to the
+        cooled catalog, ``connected`` stays transport-truthful, and the
+        idle pool is surfaced separately."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._oauth_user_server_names = {"pool-srv"}
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(("u0", "pool-srv"))
+            entry.tools = self._fake_tools("pool-srv", 0)
+
+        _run_on_loop(loop, _seed())
+
+        status = mgr._oauth_user_server_status("pool-srv", "u0")
+        assert status["connected"] is False
+        assert status["tools"] == 1
+        assert status["user_pools"] == 0
+        assert status["user_pools_idle"] == 1
+        # Another user sees nothing (per-user scoping unchanged).
+        other = mgr._oauth_user_server_status("pool-srv", "u-other")
+        assert other["tools"] == 0
+        assert other["user_pools_idle"] == 0
+        # Aggregate operator view counts the idle catalog too.
+        agg = mgr._oauth_user_server_status("pool-srv", None, aggregate=True)
+        assert agg["tools"] == 1
+        assert agg["user_pools_idle"] == 1
 
     def test_idle_eviction_drops_catalogless_stub_despite_live_listener(
         self, running_loop_mgr
@@ -460,6 +564,7 @@ class TestEviction:
             await mgr._ensure_pool_entry(("u-stub", "pool-srv"))
 
         _run_on_loop(loop, _seed())
+        mgr._oauth_user_server_names = {"pool-srv"}
         mgr.add_listener(lambda: None, user_id="u-stub")
 
         _run_on_loop(loop, mgr._evict_idle_pool_entries())
@@ -492,6 +597,7 @@ class TestEviction:
                 mgr._user_pool_last_used[key] = base + 10 + i
 
         _run_on_loop(loop, _seed())
+        mgr._oauth_user_server_names = {"pool-srv"}
         for i in range(3):
             mgr.add_listener(lambda: None, user_id=f"cool{i}")
 
@@ -522,6 +628,7 @@ class TestEviction:
                 mgr._user_pool_last_used[key] = base + i
 
         _run_on_loop(loop, _seed())
+        mgr._oauth_user_server_names = {"pool-srv"}
         for i in range(3):
             mgr.add_listener(lambda: None, user_id=f"u{i}")
 
@@ -556,13 +663,48 @@ class TestDispatchStateMachine:
         mgr.set_app_state(state)
         return state
 
+    def _seed_cooled_catalog(self, mgr: MCPClientManager, loop) -> list[int]:
+        """Seed a cooled catalog-bearing entry + live listener for user-1.
+
+        Returns the listener's fire counter. Used by the dead-grant rows:
+        a dispatch that learns the grant is GONE must drop this catalog so
+        live sessions converge with the revocation (#836 cross-node
+        disconnect) instead of re-offering the revoked tools.
+        """
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(("user-1", "pool-srv"))
+            entry.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__pool-srv__do_thing",
+                        "description": "",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            mgr._rebuild_user_tool_map("user-1")
+
+        _run_on_loop(loop, _seed())
+        mgr._oauth_user_server_names = {"pool-srv"}
+        fired = [0]
+
+        def _cb() -> None:
+            fired[0] += 1
+
+        mgr.add_listener(_cb, user_id="user-1")
+        assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
+        return fired
+
     def test_no_token_emits_consent_required(
         self, running_loop_mgr, storage: SQLiteBackend
     ) -> None:
-        mgr, _loop, _ = running_loop_mgr
+        mgr, loop, _ = running_loop_mgr
         cipher = make_mcp_token_cipher()
         _seed_oauth_server(storage, name="pool-srv")
         self._wire_pool(mgr, storage, cipher)
+        fired = self._seed_cooled_catalog(mgr, loop)
 
         with pytest.raises(RuntimeError) as exc_info:
             mgr.call_tool_sync(
@@ -574,6 +716,12 @@ class TestDispatchStateMachine:
         payload = json.loads(str(exc_info.value))
         assert payload["error"]["code"] == "mcp_consent_required"
         assert payload["error"]["server"] == "pool-srv"
+        # kind="missing" is a DEAD grant: the retained catalog drops and
+        # the live session is notified — tools leave instead of dangling
+        # behind a consent card for access the user no longer holds.
+        assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
+        assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is False
+        assert fired[0] == 1
 
     def test_decrypt_failure_does_not_emit_consent(
         self, running_loop_mgr, storage: SQLiteBackend
@@ -609,7 +757,7 @@ class TestDispatchStateMachine:
         assert "key_fingerprints_attempted" not in payload["error"]
 
     def test_refresh_failure_emits_consent(self, running_loop_mgr, storage: SQLiteBackend) -> None:
-        mgr, _loop, _ = running_loop_mgr
+        mgr, loop, _ = running_loop_mgr
         cipher = make_mcp_token_cipher()
         _seed_oauth_server(storage, name="pool-srv")
         # Seed an expired token with no refresh — the classified getter
@@ -629,6 +777,7 @@ class TestDispatchStateMachine:
             as_issuer="https://as.example.com",
             audience="https://mcp.example.com",
         )
+        fired = self._seed_cooled_catalog(mgr, loop)
 
         with pytest.raises(RuntimeError) as exc_info:
             mgr.call_tool_sync(
@@ -639,6 +788,9 @@ class TestDispatchStateMachine:
             )
         payload = json.loads(str(exc_info.value))
         assert payload["error"]["code"] == "mcp_consent_required"
+        # kind="refresh_failed" is likewise a DEAD grant → catalog drops.
+        assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
+        assert fired[0] == 1
 
     def test_token_present_dispatches_to_session(
         self, running_loop_mgr, storage: SQLiteBackend

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -521,61 +521,38 @@ class TestEviction:
         assert blocked, "drop must wait for the in-flight connect's open_lock"
         assert cleared, "drop must win once the connect completes — no resurrection"
 
-    def test_connect_refuses_when_generation_moved(self, running_loop_mgr) -> None:
-        """``_connect_one_pool`` must refuse to connect (and so to
-        publish) when the entry's revocation generation moved past the
-        caller's pre-token-read snapshot — the bearer in hand predates
-        a disconnect, and publishing would resurrect the dropped
-        catalog with nothing left to clear it."""
-        from turnstone.core.mcp_client import _PoolGrantRevokedError
-
-        mgr, loop, _ = running_loop_mgr
-        key = ("u0", "pool-srv")
-
-        async def _scenario() -> None:
-            entry = await mgr._ensure_pool_entry(key)
-            gen0 = entry.catalog_gen
-            entry.catalog_gen += 1  # a revocation drop landed in the window
-            with pytest.raises(_PoolGrantRevokedError):
-                await mgr._connect_one_pool(
-                    key,
-                    {"type": "streamable-http", "url": "https://mcp.example.com/sse"},
-                    "stale-bearer",
-                    expected_gen=gen0,
-                )
-
-        _run_on_loop(loop, _scenario())
-
-    def test_refresh_discards_result_when_generation_moved(self, running_loop_mgr) -> None:
-        """A ``list_changed`` refresh whose await straddles a revocation
-        drop must DISCARD its result — publishing would resurrect the
-        revoked catalog, which retention then keeps alive forever."""
+    def test_refresh_discards_result_when_entry_replaced(self, running_loop_mgr) -> None:
+        """A ``list_changed`` refresh whose await straddles a full drop
+        and re-creation must DISCARD its result — it belongs to the old
+        entry object and would clobber the replacement's state."""
         mgr, loop, _ = running_loop_mgr
         mgr._oauth_user_server_names = {"pool-srv"}
         key = ("u0", "pool-srv")
 
-        async def _scenario() -> tuple[list, list, Any, bool]:
+        async def _scenario() -> tuple[list, list, Any]:
             entry = await mgr._ensure_pool_entry(key)
             entry.tools = self._fake_tools("pool-srv", 0)
             mgr._rebuild_user_tool_map("u0")
 
             class _RacingSession:
                 async def list_tools(self) -> Any:
-                    # The disconnect lands while list_tools is in flight.
-                    mgr._evict_session_drop_catalog(key)
+                    # The entry is fully dropped and re-created while
+                    # list_tools is in flight.
+                    mgr._user_pool_entries.pop(key, None)
+                    await mgr._ensure_pool_entry(key)
                     res = MagicMock()
                     res.tools = []
                     return res
 
             entry.session = _RacingSession()
             added, removed = await mgr._refresh_pool_server_tools(key)
-            return added, removed, entry.tools, "u0" in mgr._user_tool_map
+            fresh = mgr._user_pool_entries[key]
+            return added, removed, fresh.tools
 
-        added, removed, tools, in_map = _run_on_loop(loop, _scenario())
+        added, removed, fresh_tools = _run_on_loop(loop, _scenario())
         assert (added, removed) == ([], [])
-        # The drop's clear stands; the refresh did not republish.
-        assert tools is None
-        assert in_map is False
+        # The stale result was not published onto the replacement entry.
+        assert fresh_tools is None
 
     def test_lookup_grant_dead_requires_wired_infrastructure(self, running_loop_mgr) -> None:
         """kind='missing' is authoritative only when the stores that
@@ -1425,9 +1402,7 @@ class TestOboPriming:
 
         warmed: list[tuple[Any, Any, str]] = []
 
-        async def _fake_prime_server(
-            key: Any, cfg: Any, token: str, expected_gen: Any = None
-        ) -> None:
+        async def _fake_prime_server(key: Any, cfg: Any, token: str) -> None:
             warmed.append((key, cfg, token))
 
         obo_lookup = AsyncMock(return_value=SimpleNamespace(kind="token", token="minted-at"))

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -642,7 +642,7 @@ class TestEviction:
             entry.tools = _fake_pool_tools("pool-srv", "t")
             mgr._rebuild_user_tool_map("u0")
             entry.session = MagicMock()  # warm BEFORE the failed lookup
-            mgr._schedule_dead_grant_drop(dead, key)
+            mgr._schedule_dead_grant_drop(dead, key, observed_session=entry.session)
 
         _run_on_loop(loop, _warm_then_schedule())
         _drain_background(mgr, loop)
@@ -660,13 +660,41 @@ class TestEviction:
             fresh.tools = _fake_pool_tools("pool-srv", "t")
             mgr._rebuild_user_tool_map("u0")
             fresh.session = MagicMock()  # observed at schedule time
-            mgr._schedule_dead_grant_drop(dead, key)
+            mgr._schedule_dead_grant_drop(dead, key, observed_session=fresh.session)
             fresh.session = MagicMock()  # re-consent connect lands first
 
         _run_on_loop(loop, _reseed_and_swap())
         _drain_background(mgr, loop)
         entry = mgr._user_pool_entries[key]
         assert entry.tools is not None, "drop must spare a session newer than its observation"
+
+    def test_dead_grant_drop_skips_when_nothing_to_converge(self, running_loop_mgr) -> None:
+        """At scale every unconsented server classifies as a dead grant
+        on every prime; spawning a tracked no-op drop task per (user,
+        unconsented server) is pure mcp-loop overhead. The schedule-side
+        guard skips when there is no entry, or a session-less entry with
+        no catalog — a catalog appearing later implies a lookup that
+        succeeded after this one failed."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._app_state = SimpleNamespace(mcp_token_store=object())
+        mgr._storage = object()
+        dead = SimpleNamespace(kind="missing", token=None)
+        key = ("u0", "pool-srv")
+
+        async def _schedule_no_entry() -> int:
+            before = len(mgr._background_tasks)
+            mgr._schedule_dead_grant_drop(dead, key, observed_session=None)
+            return len(mgr._background_tasks) - before
+
+        assert _run_on_loop(loop, _schedule_no_entry()) == 0
+
+        async def _schedule_bare_stub() -> int:
+            await mgr._ensure_pool_entry(key)
+            before = len(mgr._background_tasks)
+            mgr._schedule_dead_grant_drop(dead, key, observed_session=None)
+            return len(mgr._background_tasks) - before
+
+        assert _run_on_loop(loop, _schedule_bare_stub()) == 0
 
     def test_notification_refresh_failure_keeps_debounce_stamp(self, running_loop_mgr) -> None:
         """A failed spawned refresh must KEEP the debounce stamp:
@@ -679,7 +707,12 @@ class TestEviction:
         notification refreshes immediately)."""
         mgr, loop, _ = running_loop_mgr
         key = ("u0", "pool-srv")
-        _run_on_loop(loop, mgr._ensure_pool_entry(key))
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()  # runner refreshes only live sessions
+
+        _run_on_loop(loop, _seed())
         mgr._last_pool_notification_refresh[key] = 123.0
 
         async def _boom(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
@@ -707,7 +740,12 @@ class TestEviction:
         catch) — the anyio stray-cancel shape."""
         mgr, loop, _ = running_loop_mgr
         key = ("u0", "pool-srv")
-        _run_on_loop(loop, mgr._ensure_pool_entry(key))
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()  # runner refreshes only live sessions
+
+        _run_on_loop(loop, _seed())
         mgr._last_pool_notification_refresh[key] = 123.0
 
         async def _wedge(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
@@ -732,6 +770,7 @@ class TestEviction:
 
         async def _scenario() -> bool:
             entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()  # runner refreshes only live sessions
             await entry.open_lock.acquire()
             task = asyncio.ensure_future(mgr._run_notification_refresh(key, "tools", _rec))
             for _ in range(3):
@@ -775,6 +814,89 @@ class TestEviction:
         _run_on_loop(loop, _scenario())
         assert refreshed == []
 
+    def test_notification_coalesces_when_refresh_already_queued(self, running_loop_mgr) -> None:
+        """While a runner is queued for a key+kind (coalesce marker
+        set), further notifications spawn NOTHING — the parked runner's
+        fresh list observes their change when it acquires the lock.
+        This bounds the ``open_lock`` waiter queue at one parked runner
+        per key+kind: without it a notifying-but-slow server accretes
+        waiters (admitted 1/5s, drained 1/30s) that starve same-key
+        dispatches past their wall-clock budget and starve idle
+        eviction, while ``_background_tasks`` grows without bound."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        refreshed: list[tuple[str, str]] = []
+
+        async def _fake_refresh(k: tuple[str, str]) -> tuple[list[str], list[str]]:
+            refreshed.append(k)
+            return [], []
+
+        mgr._refresh_pool_server_tools = _fake_refresh  # type: ignore[method-assign]
+        handler = mgr._make_pool_notification_handler(key)
+
+        async def _fire_twice() -> int:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
+            await entry.open_lock.acquire()  # park the first runner
+            note = mcp_types.ServerNotification(
+                mcp_types.ToolListChangedNotification(method="notifications/tools/list_changed")
+            )
+            before = len(mgr._background_tasks)
+            await handler(note)
+            # Age the stamp past the debounce window: the MARKER (not
+            # the stamp) must do the suppression for the second fire.
+            mgr._last_pool_notification_refresh[key] = time.monotonic() - 10.0
+            await handler(note)
+            spawned = len(mgr._background_tasks) - before
+            entry.open_lock.release()
+            return spawned
+
+        spawned = _run_on_loop(loop, _fire_twice())
+        _drain_background(mgr, loop)
+        assert spawned == 1, "second notification must coalesce into the parked runner"
+        assert refreshed == [key]
+        # The runner released its marker (at lock acquire + finally).
+        assert not mgr._pool_refresh_pending
+
+    def test_teardown_pool_entry_pops_debounce_stamp(self, running_loop_mgr) -> None:
+        """Every teardown path must pop the debounce stamp — the
+        keep-stamp-on-failure design leans on it: a reconnect's first
+        ``list_changed`` refreshes immediately, so a change announced
+        in a failed window converges at the next reconnect."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+
+        async def _seed() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
+
+        _run_on_loop(loop, _seed())
+        mgr._last_pool_notification_refresh[key] = 123.0
+        _run_on_loop(loop, mgr._teardown_pool_entry(key))
+        assert key not in mgr._last_pool_notification_refresh
+
+    def test_owner_death_pops_debounce_stamp(self, running_loop_mgr) -> None:
+        """The unrequested-collapse path (owner done-callback) is a
+        teardown too: the stamp must not outlive the transport."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+
+        async def _scenario() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
+
+            async def _noop() -> None:
+                pass
+
+            task = asyncio.ensure_future(_noop())
+            await task
+            entry.owner_task = task
+            mgr._last_pool_notification_refresh[key] = 123.0
+            mgr._on_pool_owner_death(key, task)
+
+        _run_on_loop(loop, _scenario())
+        assert key not in mgr._last_pool_notification_refresh
+
     def test_list_changed_handler_spawns_refresh_off_receive_loop(self, running_loop_mgr) -> None:
         """The notification handler must SPAWN the refresh, not await it:
         the SDK awaits handlers inline in its receive loop, so an
@@ -793,8 +915,10 @@ class TestEviction:
 
         async def _fire() -> bool:
             # The runner refreshes through the entry's ``open_lock``;
-            # without an entry it (correctly) discards the notification.
-            await mgr._ensure_pool_entry(key)
+            # without an entry (or a live session) it correctly
+            # discards the notification.
+            entry = await mgr._ensure_pool_entry(key)
+            entry.session = MagicMock()
             note = mcp_types.ServerNotification(
                 mcp_types.ToolListChangedNotification(method="notifications/tools/list_changed")
             )
@@ -1037,6 +1161,55 @@ class TestDispatchStateMachine:
         assert mgr._user_pool_entries[("user-1", "pool-srv")].tools is None
         assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is False
         assert fired[0] == 1
+
+    def test_mid_lookup_reconsent_survives_dead_grant_drop(
+        self, running_loop_mgr, storage: SQLiteBackend
+    ) -> None:
+        """The dead-grant observation is snapshotted BEFORE the
+        classified lookup's awaits: a consent-completion prime that
+        connects and publishes DURING the lookup (its awaits can park on
+        executor hops) must read as re-consent evidence, not as the
+        pre-observation session — or the scheduled drop evicts the
+        just-restored catalog with no remaining re-prime path."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        _seed_oauth_server(storage, name="pool-srv")
+        self._wire_pool(mgr, storage, cipher)
+        self._seed_cooled_catalog(mgr, loop)
+        key = ("user-1", "pool-srv")
+        fresh_session = MagicMock()
+
+        async def _lookup_with_race(
+            server_row: dict[str, Any],
+            user_id: str,
+            server_name: str,
+            force_refresh: bool = False,
+        ) -> Any:
+            # The consent callback completes mid-lookup: prime connects
+            # and publishes the fresh catalog before the lookup returns
+            # its (now stale) dead-grant verdict.
+            entry = mgr._user_pool_entries[key]
+            entry.session = fresh_session
+            entry.tools = _fake_pool_tools("pool-srv", "do_thing")
+            mgr._rebuild_user_tool_map("user-1")
+            return SimpleNamespace(kind="missing", token=None)
+
+        mgr._pool_token_lookup = _lookup_with_race  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mgr.call_tool_sync(
+                "mcp__pool-srv__do_thing",
+                {},
+                user_id="user-1",
+                timeout=5,
+            )
+        payload = json.loads(str(exc_info.value))
+        assert payload["error"]["code"] == "mcp_consent_required"
+        _drain_background(mgr, loop)
+        entry = mgr._user_pool_entries[key]
+        assert entry.tools is not None, "drop must spare the mid-lookup re-consent"
+        assert entry.session is fresh_session
+        assert mgr.is_mcp_tool("mcp__pool-srv__do_thing", user_id="user-1") is True
 
     def test_decrypt_failure_does_not_emit_consent(
         self, running_loop_mgr, storage: SQLiteBackend

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -583,10 +583,13 @@ class TestEviction:
     def test_dead_grant_drop_skips_freshly_reconnected_entry(self, running_loop_mgr) -> None:
         """A dead-grant drop parked behind ``open_lock`` must NOT clear a
         catalog that a re-consent prime published while it waited: a
-        live session at drop time proves a connect succeeded after the
-        failed lookup, i.e. the grant is alive again. The explicit
-        revocation path (skip_if_connected=False) still clears warm
-        entries — that is its purpose."""
+        live session DIFFERENT from the one observed when the grant
+        died proves a connect succeeded after the failed lookup, i.e.
+        the grant is alive again. Direct calls without an observation
+        (``observed_session=None`` — the cold case) treat any live
+        session as newer. The explicit revocation path
+        (skip_if_connected=False) still clears warm entries — that is
+        its purpose."""
         mgr, loop, _ = running_loop_mgr
         mgr._oauth_user_server_names = {"pool-srv"}
         key = ("u0", "pool-srv")
@@ -613,20 +616,77 @@ class TestEviction:
         assert dropped is None
         assert revoked is None
 
-    def test_notification_refresh_failure_returns_debounce_stamp(self, running_loop_mgr) -> None:
-        """A failed spawned ``list_changed`` refresh must return the
-        debounce stamp so the server's next notification retries — a
-        consumed stamp with no retry silently drops the catalog change
-        for the whole debounce window."""
+    def test_dead_grant_drop_evicts_warm_pre_observation_session(self, running_loop_mgr) -> None:
+        """#836 warm case: the grant dies while the transport is warm
+        (cross-node disconnect, IdP revocation). Failed lookups
+        short-circuit dispatch before touching the session, so no 401
+        ever evicts it — the drop itself must. A session that was
+        ALREADY live when the dead grant was observed proves nothing;
+        only a session that CHANGED since the observation (a later
+        successful connect) proves the grant lives again."""
+        mgr, loop, _ = running_loop_mgr
+        mgr._app_state = SimpleNamespace(mcp_token_store=object())
+        mgr._storage = object()
+        mgr._oauth_user_server_names = {"pool-srv"}
+        key = ("u0", "pool-srv")
+        fired = [0]
+
+        def _cb() -> None:
+            fired[0] += 1
+
+        mgr.add_listener(_cb, user_id="u0")
+        dead = SimpleNamespace(kind="missing", token=None)
+
+        async def _warm_then_schedule() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.tools = _fake_pool_tools("pool-srv", "t")
+            mgr._rebuild_user_tool_map("u0")
+            entry.session = MagicMock()  # warm BEFORE the failed lookup
+            mgr._schedule_dead_grant_drop(dead, key)
+
+        _run_on_loop(loop, _warm_then_schedule())
+        _drain_background(mgr, loop)
+        entry = mgr._user_pool_entries[key]
+        assert entry.tools is None, "pre-observation warm session must not block the drop"
+        assert entry.session is None
+        assert mgr.is_mcp_tool("mcp__pool-srv__t", user_id="u0") is False
+        assert fired[0] == 1
+
+        # A session that CHANGED after the observation (re-consent
+        # prime reconnected before the parked drop ran) is genuine
+        # evidence — the drop must spare it.
+        async def _reseed_and_swap() -> None:
+            fresh = mgr._user_pool_entries[key]
+            fresh.tools = _fake_pool_tools("pool-srv", "t")
+            mgr._rebuild_user_tool_map("u0")
+            fresh.session = MagicMock()  # observed at schedule time
+            mgr._schedule_dead_grant_drop(dead, key)
+            fresh.session = MagicMock()  # re-consent connect lands first
+
+        _run_on_loop(loop, _reseed_and_swap())
+        _drain_background(mgr, loop)
+        entry = mgr._user_pool_entries[key]
+        assert entry.tools is not None, "drop must spare a session newer than its observation"
+
+    def test_notification_refresh_failure_keeps_debounce_stamp(self, running_loop_mgr) -> None:
+        """A failed spawned refresh must KEEP the debounce stamp:
+        popping it re-arms the handler on every notification, so a
+        fast-failing server spawns unthrottled refresh tasks at its
+        notification rate. The bounded cost — a change announced in
+        the remainder of the failed window waits for the server's next
+        ``list_changed`` or the entry's next reconnect — is the lesser
+        failure (teardown pops the stamp, so a reconnect's first
+        notification refreshes immediately)."""
         mgr, loop, _ = running_loop_mgr
         key = ("u0", "pool-srv")
+        _run_on_loop(loop, mgr._ensure_pool_entry(key))
         mgr._last_pool_notification_refresh[key] = 123.0
 
         async def _boom(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
             raise TimeoutError("slow server")
 
         _run_on_loop(loop, mgr._run_notification_refresh(key, "tools", _boom))
-        assert key not in mgr._last_pool_notification_refresh
+        assert mgr._last_pool_notification_refresh[key] == 123.0
 
         async def _ok(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
             return [], []
@@ -634,6 +694,86 @@ class TestEviction:
         mgr._last_pool_notification_refresh[key] = 456.0
         _run_on_loop(loop, mgr._run_notification_refresh(key, "tools", _ok))
         assert mgr._last_pool_notification_refresh[key] == 456.0
+
+    def test_notification_refresh_catches_exception_group(self, running_loop_mgr) -> None:
+        """A wedged anyio transport surfaces session-op failures as
+        ``BaseExceptionGroup`` — which ``except Exception`` misses. An
+        escaping group reaches ``_spawn_background``'s failure log,
+        whose ``exc_info`` serializes the chained httpx request
+        carrying ``Authorization: Bearer <token>``. The runner must
+        swallow the group (and keep the stamp) like any other refresh
+        failure. The member below is a BaseException so the group does
+        NOT collapse to ``ExceptionGroup`` (which ``Exception`` would
+        catch) — the anyio stray-cancel shape."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        _run_on_loop(loop, mgr._ensure_pool_entry(key))
+        mgr._last_pool_notification_refresh[key] = 123.0
+
+        async def _wedge(_key: tuple[str, str]) -> tuple[list[str], list[str]]:
+            raise BaseExceptionGroup("wedged transport", [asyncio.CancelledError()])
+
+        _run_on_loop(loop, mgr._run_notification_refresh(key, "tools", _wedge))
+        assert mgr._last_pool_notification_refresh[key] == 123.0
+
+    def test_notification_refresh_serializes_on_open_lock(self, running_loop_mgr) -> None:
+        """The runner must take ``open_lock`` before refreshing: an
+        unserialized refresh races an in-flight connect's discovery
+        wiring (which would overwrite the refresh's newer catalog with
+        its older snapshot) and sibling same-key refreshes (the slower
+        list call publishing the older catalog last)."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        refreshed: list[tuple[str, str]] = []
+
+        async def _rec(k: tuple[str, str]) -> tuple[list[str], list[str]]:
+            refreshed.append(k)
+            return [], []
+
+        async def _scenario() -> bool:
+            entry = await mgr._ensure_pool_entry(key)
+            await entry.open_lock.acquire()
+            task = asyncio.ensure_future(mgr._run_notification_refresh(key, "tools", _rec))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            held_back = len(refreshed) == 0
+            entry.open_lock.release()
+            await task
+            return held_back
+
+        held_back = _run_on_loop(loop, _scenario())
+        assert held_back, "refresh must wait for open_lock"
+        assert refreshed == [key]
+
+    def test_notification_refresh_discards_when_entry_replaced_while_waiting(
+        self, running_loop_mgr
+    ) -> None:
+        """An entry replaced (full drop + re-create) while the runner
+        waited on the OLD entry's lock must not be refreshed by it:
+        the notification belonged to the old transport, the
+        replacement publishes its own discovery, and the runner holds
+        a lock the new entry does not share."""
+        mgr, loop, _ = running_loop_mgr
+        key = ("u0", "pool-srv")
+        refreshed: list[tuple[str, str]] = []
+
+        async def _rec(k: tuple[str, str]) -> tuple[list[str], list[str]]:
+            refreshed.append(k)
+            return [], []
+
+        async def _scenario() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            await entry.open_lock.acquire()
+            task = asyncio.ensure_future(mgr._run_notification_refresh(key, "tools", _rec))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            mgr._user_pool_entries.pop(key, None)
+            await mgr._ensure_pool_entry(key)
+            entry.open_lock.release()
+            await task
+
+        _run_on_loop(loop, _scenario())
+        assert refreshed == []
 
     def test_list_changed_handler_spawns_refresh_off_receive_loop(self, running_loop_mgr) -> None:
         """The notification handler must SPAWN the refresh, not await it:
@@ -652,6 +792,9 @@ class TestEviction:
         handler = mgr._make_pool_notification_handler(key)
 
         async def _fire() -> bool:
+            # The runner refreshes through the entry's ``open_lock``;
+            # without an entry it (correctly) discards the notification.
+            await mgr._ensure_pool_entry(key)
             note = mcp_types.ServerNotification(
                 mcp_types.ToolListChangedNotification(method="notifications/tools/list_changed")
             )
@@ -1653,6 +1796,54 @@ class TestOboPriming:
 
         entry = mgr._user_pool_entries[key]
         assert entry.tools is None
+        assert mgr.is_mcp_tool("mcp__obo-srv__t", user_id="user-1") is False
+        assert fired[0] == 1
+
+    def test_prime_drops_warm_obo_entry_when_credential_gone(
+        self, running_loop_mgr, storage
+    ) -> None:
+        """The gate's dead-grant drop must converge WARM obo entries
+        too: with the credential unlinked, dispatches fail the
+        classified lookup before ever touching the session, so no 401
+        evicts it — and a session that predates the gate's observation
+        must not read as re-consent evidence."""
+        mgr, loop, _ = running_loop_mgr
+        cipher = make_mcp_token_cipher()
+        mgr.set_storage(storage)
+        app_state = _make_app_state(storage, cipher=cipher)
+        app_state.oidc_config = SimpleNamespace(issuer="https://idp.example.com")
+        mgr.set_app_state(app_state)
+        storage.create_mcp_server(
+            server_id="srv-obo",
+            name="obo-srv",
+            transport="streamable-http",
+            url="https://mcp.example.com/sse",
+            auth_type="oauth_obo",
+            oauth_audience="api://mcp-a",
+        )
+        mgr._obo_server_names = {"obo-srv"}
+        key = ("user-1", "obo-srv")
+
+        async def _seed_warm() -> None:
+            entry = await mgr._ensure_pool_entry(key)
+            entry.tools = _fake_pool_tools("obo-srv", "t")
+            mgr._rebuild_user_tool_map("user-1")
+            entry.session = MagicMock()  # warm at observation time
+
+        _run_on_loop(loop, _seed_warm())
+        fired = [0]
+
+        def _cb() -> None:
+            fired[0] += 1
+
+        mgr.add_listener(_cb, user_id="user-1")
+
+        _run_on_loop(loop, mgr._prime_user_pools("user-1"))
+        _drain_background(mgr, loop)
+
+        entry = mgr._user_pool_entries[key]
+        assert entry.tools is None
+        assert entry.session is None
         assert mgr.is_mcp_tool("mcp__obo-srv__t", user_id="user-1") is False
         assert fired[0] == 1
 

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -8,6 +8,7 @@ on the HTTP handler logic, request/response wiring, and storage side-effects.
 from __future__ import annotations
 
 import urllib.parse
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
@@ -831,6 +832,67 @@ class TestOIDCCallbackCapture:
         plain = store.get_oidc_credential("test-admin", cfg.issuer)
         assert plain is not None
         assert plain["refresh_token"] == "rt-1"
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_capture_success_primes_user_pools(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        """Re-login is the OBO restore moment (#836): a successful
+        credential capture schedules a pool prime so a previously
+        dropped obo catalog returns to the user's LIVE sessions — obo
+        has no consent flow, so nothing else re-primes an open
+        workstream after re-login."""
+        client, store, cfg = self._capture_client(storage, oidc_config)
+        primed: list[str] = []
+        client.app.state.mcp_client = SimpleNamespace(  # type: ignore[attr-defined]
+            prime_user_pools=primed.append
+        )
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "fake.jwt.token", "access_token": "at", "refresh_token": "rt-1"},
+        )
+        assert resp.status_code == 302
+        assert primed == ["test-admin"]
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_no_capture_no_prime(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        """No refresh token in the response → no capture → no prime
+        (the prime is gated on a persisted credential, not on login)."""
+        client, store, cfg = self._capture_client(storage, oidc_config)
+        primed: list[str] = []
+        client.app.state.mcp_client = SimpleNamespace(  # type: ignore[attr-defined]
+            prime_user_pools=primed.append
+        )
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "fake.jwt.token", "access_token": "at"},
+        )
+        assert resp.status_code == 302
+        assert primed == []
 
     @patch("turnstone.core.auth.provision_oidc_user")
     @patch("turnstone.core.auth.validate_id_token")

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -845,14 +845,15 @@ class TestOIDCCallbackCapture:
         oidc_config: OIDCConfig,
     ) -> None:
         """Re-login is the OBO restore moment (#836): a successful
-        credential capture schedules a pool prime so a previously
-        dropped obo catalog returns to the user's LIVE sessions — obo
-        has no consent flow, so nothing else re-primes an open
-        workstream after re-login."""
+        credential capture for a user with a LIVE session schedules a
+        pool prime so a previously dropped obo catalog returns to their
+        open workstreams — obo has no consent flow, so nothing else
+        re-primes them after re-login."""
         client, store, cfg = self._capture_client(storage, oidc_config)
         primed: list[str] = []
         client.app.state.mcp_client = SimpleNamespace(  # type: ignore[attr-defined]
-            prime_user_pools=primed.append
+            prime_user_pools=primed.append,
+            has_live_session_listener=lambda _uid: True,
         )
         resp = self._login(
             client,
@@ -881,7 +882,8 @@ class TestOIDCCallbackCapture:
         client, store, cfg = self._capture_client(storage, oidc_config)
         primed: list[str] = []
         client.app.state.mcp_client = SimpleNamespace(  # type: ignore[attr-defined]
-            prime_user_pools=primed.append
+            prime_user_pools=primed.append,
+            has_live_session_listener=lambda _uid: True,
         )
         resp = self._login(
             client,
@@ -892,6 +894,39 @@ class TestOIDCCallbackCapture:
             tokens={"id_token": "fake.jwt.token", "access_token": "at"},
         )
         assert resp.status_code == 302
+        assert primed == []
+
+    @patch("turnstone.core.auth.provision_oidc_user")
+    @patch("turnstone.core.auth.validate_id_token")
+    @patch("turnstone.core.auth.exchange_code", new_callable=AsyncMock)
+    def test_capture_without_live_session_does_not_prime(
+        self,
+        mock_exchange: AsyncMock,
+        mock_validate: Any,
+        mock_provision: Any,
+        storage: SQLiteBackend,
+        oidc_config: OIDCConfig,
+    ) -> None:
+        """Routine SSO re-login with nothing open must not fan out pool
+        warms — the prime exists to heal LIVE sessions only."""
+        client, store, cfg = self._capture_client(storage, oidc_config)
+        primed: list[str] = []
+        client.app.state.mcp_client = SimpleNamespace(  # type: ignore[attr-defined]
+            prime_user_pools=primed.append,
+            has_live_session_listener=lambda _uid: False,
+        )
+        resp = self._login(
+            client,
+            storage,
+            mock_exchange,
+            mock_validate,
+            mock_provision,
+            tokens={"id_token": "fake.jwt.token", "access_token": "at", "refresh_token": "rt-1"},
+        )
+        assert resp.status_code == 302
+        # Credential captured, but no live session → no prime.
+        assert store is not None
+        assert store.get_oidc_credential("test-admin", cfg.issuer) is not None
         assert primed == []
 
     @patch("turnstone.core.auth.provision_oidc_user")

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -2152,6 +2152,23 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
                 )
             except Exception:
                 log.exception("oidc.capture: failed to persist credential")
+            else:
+                # Re-login is the OBO restore moment (#836): a dropped
+                # obo catalog (credential unlinked / mint rejected) has
+                # no consent flow to heal through, so warm this user's
+                # pools now — live sessions pick the tools back up via
+                # their listeners. Fire-and-forget; a failure changes
+                # nothing about login.
+                mcp_client = getattr(request.app.state, "mcp_client", None)
+                if mcp_client is not None and hasattr(mcp_client, "prime_user_pools"):
+                    try:
+                        mcp_client.prime_user_pools(user["user_id"])
+                    except Exception:
+                        log.debug(
+                            "oidc.capture: post-capture pool prime scheduling failed user=%s",
+                            user["user_id"],
+                            exc_info=True,
+                        )
 
     # Load permissions and issue Turnstone JWT
     perms = await asyncio.to_thread(_load_user_permissions, storage, user["user_id"])

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -2166,10 +2166,13 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
                     mcp_client is not None
                     and hasattr(mcp_client, "prime_user_pools")
                     and hasattr(mcp_client, "has_live_session_listener")
-                    and mcp_client.has_live_session_listener(user["user_id"])
                 ):
+                    # The gate call sits INSIDE the try: nothing on this
+                    # best-effort path may fail the login (the credential
+                    # is already persisted; the JWT is not yet issued).
                     try:
-                        mcp_client.prime_user_pools(user["user_id"])
+                        if mcp_client.has_live_session_listener(user["user_id"]):
+                            mcp_client.prime_user_pools(user["user_id"])
                     except Exception:
                         log.debug(
                             "oidc.capture: post-capture pool prime scheduling failed user=%s",

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from turnstone.core.oidc import OIDCConfig
 
 from turnstone.core.log import get_logger
+from turnstone.core.mcp_client import try_prime_user_pools
 from turnstone.core.oidc import (
     OIDC_STATE_TTL_SECONDS,
     OIDCError,
@@ -2160,25 +2161,15 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
                 # their listeners. Gated on a LIVE session: routine SSO
                 # re-logins by users with nothing open must not fan out
                 # mints and transport connects at deployment scale.
-                # Fire-and-forget; a failure changes nothing about login.
-                mcp_client = getattr(request.app.state, "mcp_client", None)
-                if (
-                    mcp_client is not None
-                    and hasattr(mcp_client, "prime_user_pools")
-                    and hasattr(mcp_client, "has_live_session_listener")
-                ):
-                    # The gate call sits INSIDE the try: nothing on this
-                    # best-effort path may fail the login (the credential
-                    # is already persisted; the JWT is not yet issued).
-                    try:
-                        if mcp_client.has_live_session_listener(user["user_id"]):
-                            mcp_client.prime_user_pools(user["user_id"])
-                    except Exception:
-                        log.debug(
-                            "oidc.capture: post-capture pool prime scheduling failed user=%s",
-                            user["user_id"],
-                            exc_info=True,
-                        )
+                # Fire-and-forget; a failure changes nothing about login
+                # (the credential is already persisted; the JWT is not
+                # yet issued) — the helper owns the swallow.
+                try_prime_user_pools(
+                    getattr(request.app.state, "mcp_client", None),
+                    user["user_id"],
+                    require_live_listener=True,
+                    context="oidc-capture",
+                )
 
     # Load permissions and issue Turnstone JWT
     perms = await asyncio.to_thread(_load_user_permissions, storage, user["user_id"])

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -2157,10 +2157,17 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
                 # obo catalog (credential unlinked / mint rejected) has
                 # no consent flow to heal through, so warm this user's
                 # pools now — live sessions pick the tools back up via
-                # their listeners. Fire-and-forget; a failure changes
-                # nothing about login.
+                # their listeners. Gated on a LIVE session: routine SSO
+                # re-logins by users with nothing open must not fan out
+                # mints and transport connects at deployment scale.
+                # Fire-and-forget; a failure changes nothing about login.
                 mcp_client = getattr(request.app.state, "mcp_client", None)
-                if mcp_client is not None and hasattr(mcp_client, "prime_user_pools"):
+                if (
+                    mcp_client is not None
+                    and hasattr(mcp_client, "prime_user_pools")
+                    and hasattr(mcp_client, "has_live_session_listener")
+                    and mcp_client.has_live_session_listener(user["user_id"])
+                ):
                     try:
                         mcp_client.prime_user_pools(user["user_id"])
                     except Exception:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2082,6 +2082,10 @@ class MCPClientManager:
         entry.close_requested = None
         if entry.session is not None:
             entry.session = None
+            # Third session-drop site of the bearer-clearing sweep (with
+            # _teardown_pool_entry and _evict_session): the copy is dead
+            # without a session, and the entry may now cool indefinitely.
+            entry.bound_token = None
             user_id, server_name = key
             log.info(
                 "MCP pool transport terminated user=%s server=%s; session evicted for reconnect",
@@ -3016,6 +3020,10 @@ class MCPClientManager:
         """
         return entry.session is not None or entry.owner_task is not None
 
+    def _warm_pool_count(self) -> int:
+        """Live count of entries holding connection resources (:meth:`_entry_is_warm`)."""
+        return sum(1 for e in self._user_pool_entries.values() if self._entry_is_warm(e))
+
     def _retain_cooled(
         self,
         key: tuple[str, str],
@@ -3041,6 +3049,14 @@ class MCPClientManager:
         Single copy of the policy — the TTL pass's already-cooled skip
         and :meth:`_close_pool_entry_if_idle`'s cool-vs-drop decision
         must never diverge.
+
+        Accepted residual: the two pool-name registries are replaced by
+        ``reconcile_sync`` on a server thread as two adjacent stores, so
+        a same-tick read here can theoretically observe a flip
+        mid-swap (in neither set) and full-drop a cooled entry. The
+        window is one bytecode boundary, and the same reconcile's
+        flip re-prime restores the catalog seconds later — an atomic
+        single-source registry is not worth the churn for that.
         """
         user_id, server_name = key
         if not self._entry_has_catalog(entry):
@@ -3130,17 +3146,16 @@ class MCPClientManager:
             warm,
             key=lambda kv: self._user_pool_last_used.get(kv[0], kv[1].last_used),
         )
-        # Count actual closes instead of rescanning the whole map per
-        # iteration; a skip (contested lock / in-flight) leaves the
-        # entry warm, so re-read the entry itself to learn the outcome.
-        over = len(warm) - self._user_pool_lru_max
+        # Re-check the LIVE warm count each iteration — concurrent
+        # tasks change the warm set during this pass's awaits
+        # (revocation evictions, owner deaths, new connects), and a
+        # snapshot delta would keep closing healthy transports below
+        # the cap or stop above it. O(entries) per close is fine at
+        # cap scale; cooled entries are excluded from the count.
         for key, _entry in ordered:
-            if over <= 0:
+            if self._warm_pool_count() <= self._user_pool_lru_max:
                 break
             await self._close_pool_entry_if_idle(key)
-            current = self._user_pool_entries.get(key)
-            if current is None or not self._entry_is_warm(current):
-                over -= 1
 
     async def _close_pool_entry_if_idle(self, key: tuple[str, str]) -> None:
         """Close ``key``'s transport iff its open_lock is uncontested AND in_flight==0.
@@ -3207,14 +3222,18 @@ class MCPClientManager:
                 # in-flight dispatcher's next acquire needs the same
                 # lock object), so skip the ``evicted`` cleanup too.
                 return
+            had_catalog = self._entry_has_catalog(entry)
             self._user_pool_entries.pop(key, None)
             self._user_pool_last_used.pop(key, None)
-            # Dropping the entry without rebuilding the per-user
-            # catalogs would leave ``is_mcp_tool`` / per-user resource &
-            # prompt maps returning stale entries whose backing pool is
-            # gone for good (departed user, or a server no longer in
-            # the pool registries).
-            self._rebuild_and_notify_user_catalogs(user_id)
+            if had_catalog:
+                # Dropping the entry without rebuilding the per-user
+                # catalogs would leave ``is_mcp_tool`` / per-user
+                # resource & prompt maps returning stale entries whose
+                # backing pool is gone for good (departed user, or a
+                # server no longer in the pool registries). A
+                # catalog-less stub contributed nothing — skip the
+                # zero-delta fan-out.
+                self._rebuild_and_notify_user_catalogs(user_id)
             evicted = True
         finally:
             lock.release()
@@ -4880,12 +4899,14 @@ class MCPClientManager:
         # just read — feeds :meth:`server_auth_type` so callers (e.g.
         # ``web_search.resolve_web_search_client``) avoid a per-turn SQL
         # roundtrip.
-        self._oauth_user_server_names = {
-            row["name"] for row in rows if row.get("auth_type") == "oauth_user"
-        }
-        self._obo_server_names = {
-            row["name"] for row in rows if row.get("auth_type") == "oauth_obo"
-        }
+        # Build both sets BEFORE storing so the two attribute stores are
+        # adjacent: cross-thread readers (the eviction tick's
+        # _retain_cooled) see at most a single-bytecode tear window on a
+        # flip instead of a full row iteration between the swaps.
+        new_oauth_user_names = {row["name"] for row in rows if row.get("auth_type") == "oauth_user"}
+        new_obo_names = {row["name"] for row in rows if row.get("auth_type") == "oauth_obo"}
+        self._oauth_user_server_names = new_oauth_user_names
+        self._obo_server_names = new_obo_names
         new_pool_auth = {n: "oauth_user" for n in self._oauth_user_server_names}
         new_pool_auth.update(dict.fromkeys(self._obo_server_names, "oauth_obo"))
         # Pool servers newly registered OR migrated between pool auth types
@@ -6383,14 +6404,21 @@ class MCPClientManager:
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            if lookup.kind in _DEAD_GRANT_LOOKUP_KINDS:
+            if self._lookup_grant_dead(lookup):
                 # The grant is GONE (revoked / permanently rejected) —
                 # converge this node's live sessions now instead of
                 # leaving tools dangling behind a consent card for
                 # access the user no longer holds (#836 cross-node
                 # disconnect). Re-consent restores them via the
-                # consent-completion prime.
-                await self._drop_catalog_locked((user_id, server_name))
+                # consent-completion prime. SCHEDULED, not awaited: the
+                # drop waits on open_lock, which a same-key dispatch
+                # may hold across its entire SDK call — awaiting here
+                # let a token-side error stall past the sync timeout
+                # and charge the breaker it is documented to bypass.
+                self._spawn_background(
+                    self._drop_catalog_locked((user_id, server_name)),
+                    f"dead-grant catalog drop for '{server_name}'",
+                )
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6470,10 +6498,13 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
-                # Refreshed bearer also rejected — the grant is dead at
-                # the AS; drop the catalog so this node's live sessions
-                # converge (#836) instead of re-offering revoked tools.
-                await self._drop_catalog_locked(key)
+                # No catalog drop here: the forced refresh SUCCEEDED,
+                # so the grant is alive at the AS — this second 401 is
+                # the resource server rejecting a fresh bearer (JWKS
+                # lag, audience misconfig, clock skew). Retention lets
+                # the next dispatch self-heal once the RS recovers
+                # (#836); a genuinely revoked grant converges via the
+                # token-lookup drop instead (the row is gone by then).
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6538,14 +6569,21 @@ class MCPClientManager:
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            if lookup.kind in _DEAD_GRANT_LOOKUP_KINDS:
+            if self._lookup_grant_dead(lookup):
                 # The grant is GONE (revoked / permanently rejected) —
                 # converge this node's live sessions now instead of
                 # leaving tools dangling behind a consent card for
                 # access the user no longer holds (#836 cross-node
                 # disconnect). Re-consent restores them via the
-                # consent-completion prime.
-                await self._drop_catalog_locked((user_id, server_name))
+                # consent-completion prime. SCHEDULED, not awaited: the
+                # drop waits on open_lock, which a same-key dispatch
+                # may hold across its entire SDK call — awaiting here
+                # let a token-side error stall past the sync timeout
+                # and charge the breaker it is documented to bypass.
+                self._spawn_background(
+                    self._drop_catalog_locked((user_id, server_name)),
+                    f"dead-grant catalog drop for '{server_name}'",
+                )
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6596,10 +6634,13 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
-                # Refreshed bearer also rejected — the grant is dead at
-                # the AS; drop the catalog so this node's live sessions
-                # converge (#836) instead of re-offering revoked tools.
-                await self._drop_catalog_locked(key)
+                # No catalog drop here: the forced refresh SUCCEEDED,
+                # so the grant is alive at the AS — this second 401 is
+                # the resource server rejecting a fresh bearer (JWKS
+                # lag, audience misconfig, clock skew). Retention lets
+                # the next dispatch self-heal once the RS recovers
+                # (#836); a genuinely revoked grant converges via the
+                # token-lookup drop instead (the row is gone by then).
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6671,14 +6712,21 @@ class MCPClientManager:
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            if lookup.kind in _DEAD_GRANT_LOOKUP_KINDS:
+            if self._lookup_grant_dead(lookup):
                 # The grant is GONE (revoked / permanently rejected) —
                 # converge this node's live sessions now instead of
                 # leaving tools dangling behind a consent card for
                 # access the user no longer holds (#836 cross-node
                 # disconnect). Re-consent restores them via the
-                # consent-completion prime.
-                await self._drop_catalog_locked((user_id, server_name))
+                # consent-completion prime. SCHEDULED, not awaited: the
+                # drop waits on open_lock, which a same-key dispatch
+                # may hold across its entire SDK call — awaiting here
+                # let a token-side error stall past the sync timeout
+                # and charge the breaker it is documented to bypass.
+                self._spawn_background(
+                    self._drop_catalog_locked((user_id, server_name)),
+                    f"dead-grant catalog drop for '{server_name}'",
+                )
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6729,10 +6777,13 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
-                # Refreshed bearer also rejected — the grant is dead at
-                # the AS; drop the catalog so this node's live sessions
-                # converge (#836) instead of re-offering revoked tools.
-                await self._drop_catalog_locked(key)
+                # No catalog drop here: the forced refresh SUCCEEDED,
+                # so the grant is alive at the AS — this second 401 is
+                # the resource server rejecting a fresh bearer (JWKS
+                # lag, audience misconfig, clock skew). Retention lets
+                # the next dispatch self-heal once the RS recovers
+                # (#836); a genuinely revoked grant converges via the
+                # token-lookup drop instead (the row is gone by then).
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6829,12 +6880,41 @@ class MCPClientManager:
         evict = self._user_pool_entries.get(key)
         if evict is None:
             return
+        if not self._entry_has_catalog(evict):
+            # Already catalog-less (repeat drop from a racing dispatch,
+            # or a never-discovered stub) — nothing to clear, and a
+            # zero-delta fan-out would wake every session of the user
+            # to rebuild an unchanged list.
+            return
         evict.tools = None
         evict.resources = None
         evict.prompts = None
         # Wake the user's sessions so their merged tool / resource /
         # prompt lists shrink now, not at the next turn boundary.
         self._rebuild_and_notify_user_catalogs(key[0])
+
+    def _lookup_grant_dead(self, lookup: TokenLookupResult) -> bool:
+        """Single source of truth: does this failed lookup prove the grant is GONE?
+
+        True only when the infrastructure that could know is actually
+        wired — the obo lookup returns kind="missing" for an
+        unconfigured token store / storage too, and dropping a catalog
+        on a boot-ordering window would strand live sessions until a
+        fresh prime. With the stores present, "missing" (row /
+        credential absent — revoked, disconnected, or unlinked) and
+        "refresh_failed" (the AS / mint durably rejected the grant) are
+        authoritative; the barely-reachable empty-token fallback maps
+        to the same consent_required verdict and classifies the same
+        way. Transient refresh failures and decrypt failures keep the
+        catalog: access still exists.
+        """
+        if getattr(self._app_state, "mcp_token_store", None) is None:
+            return False
+        if self._storage is None:
+            return False
+        if lookup.kind in ("missing", "refresh_failed"):
+            return True
+        return lookup.kind == "token" and not (lookup.token or "")
 
     async def _drop_catalog_locked(self, key: tuple[str, str]) -> None:
         """Serialize a catalog drop against an in-flight connect.
@@ -7323,14 +7403,11 @@ class MCPClientManager:
             return
         key = (user_id, server_name)
 
-        async def _do_evict() -> None:
+        try:
             # Locked: an in-flight connect completing its discovery
             # after an unserialized drop would republish (resurrect)
             # the revoked catalog with nothing left to clear it.
-            await self._drop_catalog_locked(key)
-
-        try:
-            asyncio.run_coroutine_threadsafe(_do_evict(), self._loop)
+            asyncio.run_coroutine_threadsafe(self._drop_catalog_locked(key), self._loop)
         except RuntimeError as exc:
             log.info(
                 "mcp_pool.evict_user_session_failed server=%s user=%s error=%s",
@@ -7628,14 +7705,6 @@ def _token_rejected_detail(server_row: dict[str, Any]) -> str:
     Named wrapper because the three sync dispatchers each surface it.
     """
     return _pool_error_detail(server_row, "token_rejected")
-
-
-# Lookup kinds meaning the user's grant is durably gone (revoked /
-# permanently rejected) — the dispatchers drop the (user, server)
-# catalog on these so live sessions converge with the revocation
-# (#836). Transient refresh failures and operator-actionable decrypt
-# failures deliberately keep the catalog: access still exists.
-_DEAD_GRANT_LOOKUP_KINDS: frozenset[str] = frozenset({"missing", "refresh_failed"})
 
 
 def _pool_lookup_error(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -278,6 +278,17 @@ class _CarrierAuthSignal(Exception):  # noqa: N818
     """
 
 
+class _PoolGrantRevokedError(Exception):
+    """The grant was revoked between a caller's token read and its locked connect.
+
+    Raised by ``_connect_one_pool`` when the entry's ``catalog_gen``
+    moved past the caller's pre-token-read snapshot: a disconnect ran
+    in that window, and connecting with the pre-revocation bearer would
+    publish (resurrect) a catalog for a dead grant. Classified as a
+    non-breaker failure — the server is healthy; the grant is not.
+    """
+
+
 def _make_capturing_http_factory(
     capture: _AuthCapture, fired_event: asyncio.Event | None = None
 ) -> McpHttpClientFactory:
@@ -538,6 +549,14 @@ class PoolEntryState:
     tools: list[dict[str, Any]] | None = None
     resources: list[dict[str, Any]] | None = None
     prompts: list[dict[str, Any]] | None = None
+    # Revocation generation. Bumped by ``_evict_session_drop_catalog``;
+    # every catalog PUBLISHER (connect wiring, the three list_changed
+    # refreshes) compares against the generation it snapshotted before
+    # its unlocked window and discards its publish on mismatch —
+    # otherwise a publisher that read state before the revocation
+    # republishes (resurrects) a revoked catalog after the drop, and
+    # the retention rules then keep the ghost alive indefinitely.
+    catalog_gen: int = 0
     last_used: float = 0.0
     in_flight: int = 0
     # Access token this session's httpx client was connected with. The bearer is
@@ -564,6 +583,20 @@ class PoolEntryState:
     supports_prompts: bool = False
     supports_resource_list_changed: bool = False
     supports_prompt_list_changed: bool = False
+
+    def drop_session(self) -> None:
+        """Drop the cached session AND its paired plaintext bearer copy.
+
+        The ONE way to null ``session``: ``bound_token`` is read only
+        under a live session (stale-rebind detection) and overwritten
+        at reconnect, so it is dead the moment the session goes — and
+        an entry may cool indefinitely after any drop, which must not
+        retain a plaintext credential for the life of the user's
+        sessions. A site that nulled ``session`` directly would
+        silently re-open that hole.
+        """
+        self.session = None
+        self.bound_token = None
 
 
 # ---------------------------------------------------------------------------
@@ -2025,12 +2058,7 @@ class MCPClientManager:
         entry = self._user_pool_entries.get(key)
         if entry is None:
             return
-        entry.session = None
-        # The bearer copy is dead once the session is gone (read only
-        # under a live session for stale-rebind detection; overwritten
-        # at reconnect) — don't retain a plaintext credential on a
-        # cooled entry for the life of the user's sessions.
-        entry.bound_token = None
+        entry.drop_session()
         owner = entry.owner_task
         close_requested = entry.close_requested
         entry.owner_task = None
@@ -2081,11 +2109,7 @@ class MCPClientManager:
         entry.owner_task = None
         entry.close_requested = None
         if entry.session is not None:
-            entry.session = None
-            # Third session-drop site of the bearer-clearing sweep (with
-            # _teardown_pool_entry and _evict_session): the copy is dead
-            # without a session, and the entry may now cool indefinitely.
-            entry.bound_token = None
+            entry.drop_session()
             user_id, server_name = key
             log.info(
                 "MCP pool transport terminated user=%s server=%s; session evicted for reconnect",
@@ -2145,6 +2169,7 @@ class MCPClientManager:
         *,
         auth_capture: _AuthCapture | None = None,
         auth_fired_event: asyncio.Event | None = None,
+        expected_gen: int | None = None,
     ) -> PoolEntryState:
         """Connect a single per-(user, server) pool entry.
 
@@ -2180,6 +2205,15 @@ class MCPClientManager:
             )
 
         entry = await self._ensure_pool_entry(key)
+        if expected_gen is not None and entry.catalog_gen != expected_gen:
+            # The grant was revoked between the caller's token read and
+            # this locked connect (the drop bumped the generation while
+            # we queued on open_lock). The bearer in hand predates the
+            # revocation — connecting would publish a catalog the drop
+            # can no longer clear (#836).
+            raise _PoolGrantRevokedError(
+                f"grant for user={user_id!r} server={server_name!r} revoked during connect window"
+            )
 
         # Guard: close any stale owner/session so we don't leak, the same way
         # ``_connect_one_locked`` does for the static path (cf. PR #296
@@ -2309,7 +2343,12 @@ class MCPClientManager:
             raise
 
         capped_tools = _cap_server_tools(server_name, tools_result.tools)
-        entry.tools = [_mcp_to_openai(server_name, tool) for tool in capped_tools]
+        # STAGED — published to the entry only in the final wiring block
+        # below, together with resources/prompts: a mid-discovery
+        # failure tears the transport down and must leave the entry's
+        # (retained) catalog exactly as it was, never half-updated with
+        # the per-user maps still holding the old view.
+        server_tools = [_mcp_to_openai(server_name, tool) for tool in capped_tools]
 
         # Phase 7b — discover resources (capability-gated). Same anyio /
         # ``asyncio.timeout`` invariant as the tool discovery above (R1).
@@ -2406,6 +2445,7 @@ class MCPClientManager:
                     }
                 )
 
+        entry.tools = server_tools
         entry.resources = server_resources if resources_cap is not None else None
         entry.prompts = server_prompts if prompts_cap is not None else None
 
@@ -2432,7 +2472,11 @@ class MCPClientManager:
     # -- pool priming ---------------------------------------------------------
 
     async def _prime_user_server(
-        self, key: tuple[str, str], cfg: dict[str, Any], access_token: str
+        self,
+        key: tuple[str, str],
+        cfg: dict[str, Any],
+        access_token: str,
+        expected_gen: int | None = None,
     ) -> int:
         """Proactively connect a pool entry so its catalog populates into
         ``get_tools(user_id)`` WITHOUT waiting for a tool dispatch.
@@ -2462,6 +2506,7 @@ class MCPClientManager:
                 access_token,
                 auth_capture=entry.auth_capture,
                 auth_fired_event=entry.auth_fired_event,
+                expected_gen=expected_gen,
             )
             return len(fresh.tools or [])
 
@@ -2512,8 +2557,19 @@ class MCPClientManager:
         failure must not change the user-observable consent outcome.
         """
         try:
-            count = await self._prime_user_server(key, cfg, access_token)
+            # Snapshot the revocation generation on-loop, before the
+            # locked connect: a disconnect racing this consent-time
+            # prime must not have its drop republished by us.
+            pre = self._user_pool_entries.get(key)
+            expected_gen = pre.catalog_gen if pre is not None else None
+            count = await self._prime_user_server(key, cfg, access_token, expected_gen)
             log.info("mcp pool primed user=%s server=%s tools=%d", user_id, server_name, count)
+        except _PoolGrantRevokedError:
+            log.info(
+                "mcp pool prime skipped: grant revoked mid-prime user=%s server=%s",
+                user_id,
+                server_name,
+            )
         except Exception:
             log.warning(
                 "mcp pool prime failed user=%s server=%s",
@@ -2578,6 +2634,10 @@ class MCPClientManager:
             entry = self._user_pool_entries.get(key)
             if entry is not None and entry.session is not None:
                 return  # already connected — nothing to do
+            # Snapshot the revocation generation before the token read
+            # (see _dispatch_pool); None = no entry existed yet, so
+            # there is no retained catalog a racer could resurrect.
+            expected_gen = entry.catalog_gen if entry is not None else None
             if key in self._priming_keys:
                 return  # a concurrent prime for this (user, server) is in flight
             # Claim synchronously before any await — the mcp-loop is single-
@@ -2632,6 +2692,12 @@ class MCPClientManager:
                                 revoke_ambiguous_escalation=False,
                             )
                         if lookup.kind != "token" or not lookup.token:
+                            # Priming is also a convergence point (#836):
+                            # a NEW session's prime discovering the grant
+                            # is durably gone must drop the retained
+                            # catalog other live sessions still serve —
+                            # e.g. a disconnect made on another node.
+                            self._schedule_dead_grant_drop(lookup, key)
                             return  # not consented / no credential / refresh failed — lazy paths handle it
                         if server_row is None:
                             server_row = await asyncio.to_thread(
@@ -2640,9 +2706,15 @@ class MCPClientManager:
                             if not server_row:
                                 return
                         cfg = _pool_cfg_from_row(server_row)
-                        await self._prime_user_server(key, cfg, lookup.token)
+                        await self._prime_user_server(key, cfg, lookup.token, expected_gen)
                         log.info(
                             "mcp pool auto-primed at session start user=%s server=%s",
+                            user_id,
+                            server_name,
+                        )
+                    except _PoolGrantRevokedError:
+                        log.info(
+                            "mcp pool prime skipped: grant revoked mid-prime user=%s server=%s",
                             user_id,
                             server_name,
                         )
@@ -3532,7 +3604,13 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_names = {t["function"]["name"] for t in (entry.tools or [])}
+        gen = entry.catalog_gen
         result = await session.list_tools()
+        if self._user_pool_entries.get(key) is not entry or entry.catalog_gen != gen:
+            # A revocation drop landed while list_tools was in flight —
+            # publishing now would resurrect the revoked catalog with
+            # nothing left to ever clear it (retention keeps it). Discard.
+            return [], []
         capped = _cap_server_tools(server_name, result.tools)
         server_tools = [_mcp_to_openai(server_name, tool) for tool in capped]
         new_names = {t["function"]["name"] for t in server_tools}
@@ -3573,6 +3651,7 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_uris = {r["uri"] for r in (entry.resources or []) if not r.get("template")}
+        gen = entry.catalog_gen
 
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
             # 1-RTT (gather) instead of 2 sequential RTTs — both calls
@@ -3582,6 +3661,9 @@ class MCPClientManager:
                 session.list_resources(),
                 session.list_resource_templates(),
             )
+        if self._user_pool_entries.get(key) is not entry or entry.catalog_gen != gen:
+            # Revocation drop landed mid-flight — discard, don't resurrect.
+            return [], []
 
         server_resources: list[dict[str, Any]] = []
         for r in _cap_server_resources(server_name, res_result.resources):
@@ -3645,9 +3727,13 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_names = {p["name"] for p in (entry.prompts or [])}
+        gen = entry.catalog_gen
 
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
             prompt_result = await session.list_prompts()
+        if self._user_pool_entries.get(key) is not entry or entry.catalog_gen != gen:
+            # Revocation drop landed mid-flight — discard, don't resurrect.
+            return [], []
 
         server_prompts: list[dict[str, Any]] = []
         for p in _cap_server_prompts(server_name, prompt_result.prompts):
@@ -4342,7 +4428,7 @@ class MCPClientManager:
                     entry = self._user_pool_entries.get(key)
                     if entry is None:
                         continue
-                    entry.session = None
+                    entry.drop_session()
                     owner = entry.owner_task
                     close_requested = entry.close_requested
                     entry.owner_task = None
@@ -6399,26 +6485,19 @@ class MCPClientManager:
         # this retry; the local cached token is the one the AS just
         # rejected, so reading it back without ``force_refresh=True``
         # would re-attempt with the same (rejected) bearer.
+        # Ensure the entry and snapshot its revocation generation BEFORE
+        # the token read: a disconnect landing between the row read and
+        # the locked connect bumps the generation, and _connect_one_pool
+        # then refuses to publish for the revoked grant (#836).
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
+        expected_gen = entry.catalog_gen
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            if self._lookup_grant_dead(lookup):
-                # The grant is GONE (revoked / permanently rejected) —
-                # converge this node's live sessions now instead of
-                # leaving tools dangling behind a consent card for
-                # access the user no longer holds (#836 cross-node
-                # disconnect). Re-consent restores them via the
-                # consent-completion prime. SCHEDULED, not awaited: the
-                # drop waits on open_lock, which a same-key dispatch
-                # may hold across its entire SDK call — awaiting here
-                # let a token-side error stall past the sync timeout
-                # and charge the breaker it is documented to bypass.
-                self._spawn_background(
-                    self._drop_catalog_locked((user_id, server_name)),
-                    f"dead-grant catalog drop for '{server_name}'",
-                )
+            self._schedule_dead_grant_drop(lookup, key)
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6442,8 +6521,6 @@ class MCPClientManager:
         self._cb_gate(server_name)
 
         cfg = _pool_cfg_from_row(server_row)
-        key = (user_id, server_name)
-        entry = await self._ensure_pool_entry(key)
 
         # See PoolEntryState.auth_capture for why the carrier is
         # entry-owned; _dispatch_pool_with_entry resets it under
@@ -6457,6 +6534,7 @@ class MCPClientManager:
                 access_token=access_token,
                 original_name=original_name,
                 arguments=arguments,
+                expected_gen=expected_gen,
             )
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
@@ -6564,26 +6642,17 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
+        # Snapshot the revocation generation before the token read —
+        # see _dispatch_pool.
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
+        expected_gen = entry.catalog_gen
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            if self._lookup_grant_dead(lookup):
-                # The grant is GONE (revoked / permanently rejected) —
-                # converge this node's live sessions now instead of
-                # leaving tools dangling behind a consent card for
-                # access the user no longer holds (#836 cross-node
-                # disconnect). Re-consent restores them via the
-                # consent-completion prime. SCHEDULED, not awaited: the
-                # drop waits on open_lock, which a same-key dispatch
-                # may hold across its entire SDK call — awaiting here
-                # let a token-side error stall past the sync timeout
-                # and charge the breaker it is documented to bypass.
-                self._spawn_background(
-                    self._drop_catalog_locked((user_id, server_name)),
-                    f"dead-grant catalog drop for '{server_name}'",
-                )
+            self._schedule_dead_grant_drop(lookup, key)
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6605,8 +6674,6 @@ class MCPClientManager:
         self._cb_gate(server_name)
 
         cfg = _pool_cfg_from_row(server_row)
-        key = (user_id, server_name)
-        entry = await self._ensure_pool_entry(key)
         capture = entry.auth_capture
         try:
             sdk_result = await self._dispatch_pool_with_entry_call(
@@ -6615,6 +6682,7 @@ class MCPClientManager:
                 cfg=cfg,
                 access_token=access_token,
                 sdk_call=lambda s: s.read_resource(uri),
+                expected_gen=expected_gen,
             )
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
@@ -6707,26 +6775,17 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
+        # Snapshot the revocation generation before the token read —
+        # see _dispatch_pool.
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
+        expected_gen = entry.catalog_gen
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            if self._lookup_grant_dead(lookup):
-                # The grant is GONE (revoked / permanently rejected) —
-                # converge this node's live sessions now instead of
-                # leaving tools dangling behind a consent card for
-                # access the user no longer holds (#836 cross-node
-                # disconnect). Re-consent restores them via the
-                # consent-completion prime. SCHEDULED, not awaited: the
-                # drop waits on open_lock, which a same-key dispatch
-                # may hold across its entire SDK call — awaiting here
-                # let a token-side error stall past the sync timeout
-                # and charge the breaker it is documented to bypass.
-                self._spawn_background(
-                    self._drop_catalog_locked((user_id, server_name)),
-                    f"dead-grant catalog drop for '{server_name}'",
-                )
+            self._schedule_dead_grant_drop(lookup, key)
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6748,8 +6807,6 @@ class MCPClientManager:
         self._cb_gate(server_name)
 
         cfg = _pool_cfg_from_row(server_row)
-        key = (user_id, server_name)
-        entry = await self._ensure_pool_entry(key)
         capture = entry.auth_capture
         try:
             sdk_result = await self._dispatch_pool_with_entry_call(
@@ -6758,6 +6815,7 @@ class MCPClientManager:
                 cfg=cfg,
                 access_token=access_token,
                 sdk_call=lambda s: s.get_prompt(original_name, arguments=arguments),
+                expected_gen=expected_gen,
             )
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
@@ -6850,9 +6908,7 @@ class MCPClientManager:
         """
         evict = self._user_pool_entries.get(key)
         if evict is not None:
-            evict.session = None
-            # Dead once the session is gone (see _teardown_pool_entry).
-            evict.bound_token = None
+            evict.drop_session()
             # Prune the push-notification debounce stamp so a
             # reconnect's first ``list_changed`` refreshes immediately.
             self._last_pool_notification_refresh.pop(key, None)
@@ -6880,6 +6936,11 @@ class MCPClientManager:
         evict = self._user_pool_entries.get(key)
         if evict is None:
             return
+        # Invalidate in-flight publishers FIRST — even when the entry is
+        # catalog-less, a racer that read pre-revocation state (a token
+        # row, a live session) must find the generation moved and
+        # discard its publish, or it resurrects the revoked catalog.
+        evict.catalog_gen += 1
         if not self._entry_has_catalog(evict):
             # Already catalog-less (repeat drop from a racing dispatch,
             # or a never-discovered stub) — nothing to clear, and a
@@ -6894,27 +6955,48 @@ class MCPClientManager:
         self._rebuild_and_notify_user_catalogs(key[0])
 
     def _lookup_grant_dead(self, lookup: TokenLookupResult) -> bool:
-        """Single source of truth: does this failed lookup prove the grant is GONE?
+        """Does this failed lookup prove the grant is GONE?
 
-        True only when the infrastructure that could know is actually
-        wired — the obo lookup returns kind="missing" for an
-        unconfigured token store / storage too, and dropping a catalog
-        on a boot-ordering window would strand live sessions until a
-        fresh prime. With the stores present, "missing" (row /
-        credential absent — revoked, disconnected, or unlinked) and
-        "refresh_failed" (the AS / mint durably rejected the grant) are
-        authoritative; the barely-reachable empty-token fallback maps
-        to the same consent_required verdict and classifies the same
-        way. Transient refresh failures and decrypt failures keep the
+        Derived from :func:`_pool_lookup_verdict` — the classification
+        has ONE source, so the consent card the user sees and the
+        catalog-drop convergence can never disagree by kind. True only
+        when the infrastructure that could know is actually wired: the
+        obo lookup returns kind="missing" for an unconfigured token
+        store / storage too, and dropping a catalog on a boot-ordering
+        window would strand live sessions until a fresh prime.
+        Transient refresh failures and decrypt failures keep the
         catalog: access still exists.
         """
         if getattr(self._app_state, "mcp_token_store", None) is None:
             return False
         if self._storage is None:
             return False
-        if lookup.kind in ("missing", "refresh_failed"):
-            return True
-        return lookup.kind == "token" and not (lookup.token or "")
+        return _pool_lookup_verdict(lookup) == "mcp_consent_required"
+
+    def _schedule_dead_grant_drop(self, lookup: TokenLookupResult, key: tuple[str, str]) -> None:
+        """Converge live sessions with a durably-gone grant (#836).
+
+        Called on the mcp-loop wherever a classified lookup fails — the
+        three dispatchers and session-start priming. When
+        :meth:`_lookup_grant_dead` confirms the grant is gone (revoked,
+        disconnected, or unlinked — not an infrastructure blip), the
+        (user, server) catalog is dropped so the tools leave the user's
+        live sessions instead of dangling behind a consent card for
+        access that no longer exists. Re-consent restores them via the
+        consent-completion prime; obo re-login via the capture prime.
+
+        SCHEDULED, never awaited: the locked drop can park behind a
+        same-key dispatch holding ``open_lock`` across its entire SDK
+        call — awaiting here stalled token-side errors past the sync
+        timeout and charged the breaker they are documented to bypass.
+        ``_spawn_background`` tracks the task so shutdown cancels it.
+        """
+        if not self._lookup_grant_dead(lookup):
+            return
+        self._spawn_background(
+            self._drop_catalog_locked(key),
+            f"dead-grant catalog drop for '{key[1]}'",
+        )
 
     async def _drop_catalog_locked(self, key: tuple[str, str]) -> None:
         """Serialize a catalog drop against an in-flight connect.
@@ -7015,6 +7097,7 @@ class MCPClientManager:
         access_token: str,
         original_name: str,
         arguments: dict[str, Any],
+        expected_gen: int | None = None,
     ) -> str:
         """Hold ``entry.open_lock`` across connect-or-reuse AND ``call_tool``.
 
@@ -7041,6 +7124,7 @@ class MCPClientManager:
             cfg=cfg,
             access_token=access_token,
             sdk_call=lambda s: s.call_tool(original_name, arguments),
+            expected_gen=expected_gen,
         )
         return _decode_tool_result(result)
 
@@ -7052,6 +7136,7 @@ class MCPClientManager:
         cfg: dict[str, Any],
         access_token: str,
         sdk_call: Callable[[Any], Awaitable[Any]],
+        expected_gen: int | None = None,
     ) -> Any:
         """Hold ``entry.open_lock`` across connect-or-reuse AND ``sdk_call``.
 
@@ -7117,6 +7202,7 @@ class MCPClientManager:
                     access_token,
                     auth_capture=entry.auth_capture,
                     auth_fired_event=entry.auth_fired_event,
+                    expected_gen=expected_gen,
                 )
                 session = fresh.session
                 if session is None:
@@ -7403,11 +7489,23 @@ class MCPClientManager:
             return
         key = (user_id, server_name)
 
+        async def _spawn_tracked() -> None:
+            # ``_spawn_background`` is loop-thread-only — hop first.
+            # Tracking matters: the locked drop can park behind a
+            # same-key dispatch's long SDK call, and an untracked task
+            # still pending at shutdown is abandoned with "Task was
+            # destroyed but it is pending!" noise; tracked tasks are
+            # cancelled by shutdown().
+            self._spawn_background(
+                self._drop_catalog_locked(key),
+                f"revocation catalog drop for '{server_name}'",
+            )
+
         try:
             # Locked: an in-flight connect completing its discovery
             # after an unserialized drop would republish (resurrect)
             # the revoked catalog with nothing left to clear it.
-            asyncio.run_coroutine_threadsafe(self._drop_catalog_locked(key), self._loop)
+            asyncio.run_coroutine_threadsafe(_spawn_tracked(), self._loop)
         except RuntimeError as exc:
             log.info(
                 "mcp_pool.evict_user_session_failed server=%s user=%s error=%s",
@@ -7712,19 +7810,20 @@ def _pool_lookup_error(
 ) -> str | None:
     """Map a failed pool token lookup to its structured error; ``None`` on success.
 
-    Single copy of the lookup-kind → structured-error mapping shared by the
-    tool / resource / prompt dispatchers — previously three hand-synced
+    Single copy of the lookup-kind → structured-error RENDERING shared by
+    the tool / resource / prompt dispatchers — previously three hand-synced
     copies that every auth-model change had to edit in lockstep. Returns
-    ``None`` exactly when *lookup* carries a non-empty bearer.
+    ``None`` exactly when *lookup* carries a non-empty bearer. The
+    CLASSIFICATION lives in :func:`_pool_lookup_verdict`; this function
+    only chooses per-kind detail copy for the code it returns.
     """
-    if lookup.kind == "missing":
-        return _structured_error(
-            code="mcp_consent_required",
-            server=server_name,
-            detail=_consent_missing_detail(server_row),
-            consent_url=_build_consent_url(server_row),
-        )
-    if lookup.kind == "decrypt_failure":
+    # Literal ``code=`` strings in each branch (not ``code=verdict``) so the
+    # consent-url sibling audit (tests/test_mcp_consent_url_sibling_audit.py)
+    # keeps seeing these sites — a variable code is invisible to its scan.
+    verdict = _pool_lookup_verdict(lookup)
+    if verdict is None:
+        return None
+    if verdict == "mcp_token_undecryptable_key_unknown":
         return _structured_error(
             code="mcp_token_undecryptable_key_unknown",
             server=server_name,
@@ -7733,7 +7832,7 @@ def _pool_lookup_error(
                 "Operator action required."
             ),
         )
-    if lookup.kind == "refresh_failed_transient":
+    if verdict == "mcp_refresh_unavailable":
         # Transient refresh failure (AS/network blip) — the token was kept;
         # a retry may succeed once the AS recovers. Retryable, NOT re-consent.
         return _structured_error(
@@ -7741,27 +7840,45 @@ def _pool_lookup_error(
             server=server_name,
             detail="Token refresh temporarily failed; please retry.",
         )
+    # verdict == "mcp_consent_required": pick the detail by kind.
     if lookup.kind == "refresh_failed":
         # The ``mcp_server.oauth.token_revoked`` audit was already emitted by
         # the classified lookup when it deleted the row; no second audit here.
-        return _structured_error(
-            code="mcp_consent_required",
-            server=server_name,
-            detail=_pool_error_detail(server_row, "refresh_failed"),
-            consent_url=_build_consent_url(server_row),
-        )
+        detail = _pool_error_detail(server_row, "refresh_failed")
+    else:
+        # kind == "missing", or the barely-reachable empty-token fallback —
+        # auth-model-aware so an obo row never shows per-server-consent copy
+        # + a null consent_url.
+        detail = _consent_missing_detail(server_row)
+    return _structured_error(
+        code="mcp_consent_required",
+        server=server_name,
+        detail=detail,
+        consent_url=_build_consent_url(server_row),
+    )
+
+
+def _pool_lookup_verdict(lookup: TokenLookupResult) -> str | None:
+    """Classify a pool token lookup outcome as a structured-error code.
+
+    THE single classification of failed lookups: ``_pool_lookup_error``
+    renders it, and ``MCPClientManager._lookup_grant_dead`` derives the
+    catalog-drop decision from it (``mcp_consent_required`` == the grant
+    is gone) — so the card the user sees and the convergence behavior
+    can never disagree by kind. Returns ``None`` exactly when *lookup*
+    carries a non-empty bearer.
+    """
+    if lookup.kind == "missing":
+        return "mcp_consent_required"
+    if lookup.kind == "decrypt_failure":
+        return "mcp_token_undecryptable_key_unknown"
+    if lookup.kind == "refresh_failed_transient":
+        return "mcp_refresh_unavailable"
+    if lookup.kind == "refresh_failed":
+        return "mcp_consent_required"
     # kind == "token"
     if not (lookup.token or ""):
-        # A classified lookup returns kind=="token" only with a real token, so
-        # this empty-token fallback is barely reachable — but keep it
-        # auth-model-aware like the sibling ``missing`` branch above, so an obo
-        # row never shows per-server-consent copy + a null consent_url.
-        return _structured_error(
-            code="mcp_consent_required",
-            server=server_name,
-            detail=_consent_missing_detail(server_row),
-            consent_url=_build_consent_url(server_row),
-        )
+        return "mcp_consent_required"
     return None
 
 

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -278,17 +278,6 @@ class _CarrierAuthSignal(Exception):  # noqa: N818
     """
 
 
-class _PoolGrantRevokedError(Exception):
-    """The grant was revoked between a caller's token read and its locked connect.
-
-    Raised by ``_connect_one_pool`` when the entry's ``catalog_gen``
-    moved past the caller's pre-token-read snapshot: a disconnect ran
-    in that window, and connecting with the pre-revocation bearer would
-    publish (resurrect) a catalog for a dead grant. Classified as a
-    non-breaker failure — the server is healthy; the grant is not.
-    """
-
-
 def _make_capturing_http_factory(
     capture: _AuthCapture, fired_event: asyncio.Event | None = None
 ) -> McpHttpClientFactory:
@@ -549,14 +538,6 @@ class PoolEntryState:
     tools: list[dict[str, Any]] | None = None
     resources: list[dict[str, Any]] | None = None
     prompts: list[dict[str, Any]] | None = None
-    # Revocation generation. Bumped by ``_evict_session_drop_catalog``;
-    # every catalog PUBLISHER (connect wiring, the three list_changed
-    # refreshes) compares against the generation it snapshotted before
-    # its unlocked window and discards its publish on mismatch —
-    # otherwise a publisher that read state before the revocation
-    # republishes (resurrects) a revoked catalog after the drop, and
-    # the retention rules then keep the ghost alive indefinitely.
-    catalog_gen: int = 0
     last_used: float = 0.0
     in_flight: int = 0
     # Access token this session's httpx client was connected with. The bearer is
@@ -2169,7 +2150,6 @@ class MCPClientManager:
         *,
         auth_capture: _AuthCapture | None = None,
         auth_fired_event: asyncio.Event | None = None,
-        expected_gen: int | None = None,
     ) -> PoolEntryState:
         """Connect a single per-(user, server) pool entry.
 
@@ -2205,15 +2185,6 @@ class MCPClientManager:
             )
 
         entry = await self._ensure_pool_entry(key)
-        if expected_gen is not None and entry.catalog_gen != expected_gen:
-            # The grant was revoked between the caller's token read and
-            # this locked connect (the drop bumped the generation while
-            # we queued on open_lock). The bearer in hand predates the
-            # revocation — connecting would publish a catalog the drop
-            # can no longer clear (#836).
-            raise _PoolGrantRevokedError(
-                f"grant for user={user_id!r} server={server_name!r} revoked during connect window"
-            )
 
         # Guard: close any stale owner/session so we don't leak, the same way
         # ``_connect_one_locked`` does for the static path (cf. PR #296
@@ -2472,11 +2443,7 @@ class MCPClientManager:
     # -- pool priming ---------------------------------------------------------
 
     async def _prime_user_server(
-        self,
-        key: tuple[str, str],
-        cfg: dict[str, Any],
-        access_token: str,
-        expected_gen: int | None = None,
+        self, key: tuple[str, str], cfg: dict[str, Any], access_token: str
     ) -> int:
         """Proactively connect a pool entry so its catalog populates into
         ``get_tools(user_id)`` WITHOUT waiting for a tool dispatch.
@@ -2506,7 +2473,6 @@ class MCPClientManager:
                 access_token,
                 auth_capture=entry.auth_capture,
                 auth_fired_event=entry.auth_fired_event,
-                expected_gen=expected_gen,
             )
             return len(fresh.tools or [])
 
@@ -2557,19 +2523,8 @@ class MCPClientManager:
         failure must not change the user-observable consent outcome.
         """
         try:
-            # Snapshot the revocation generation on-loop, before the
-            # locked connect: a disconnect racing this consent-time
-            # prime must not have its drop republished by us.
-            pre = self._user_pool_entries.get(key)
-            expected_gen = pre.catalog_gen if pre is not None else None
-            count = await self._prime_user_server(key, cfg, access_token, expected_gen)
+            count = await self._prime_user_server(key, cfg, access_token)
             log.info("mcp pool primed user=%s server=%s tools=%d", user_id, server_name, count)
-        except _PoolGrantRevokedError:
-            log.info(
-                "mcp pool prime skipped: grant revoked mid-prime user=%s server=%s",
-                user_id,
-                server_name,
-            )
         except Exception:
             log.warning(
                 "mcp pool prime failed user=%s server=%s",
@@ -2634,10 +2589,6 @@ class MCPClientManager:
             entry = self._user_pool_entries.get(key)
             if entry is not None and entry.session is not None:
                 return  # already connected — nothing to do
-            # Snapshot the revocation generation before the token read
-            # (see _dispatch_pool); None = no entry existed yet, so
-            # there is no retained catalog a racer could resurrect.
-            expected_gen = entry.catalog_gen if entry is not None else None
             if key in self._priming_keys:
                 return  # a concurrent prime for this (user, server) is in flight
             # Claim synchronously before any await — the mcp-loop is single-
@@ -2706,15 +2657,9 @@ class MCPClientManager:
                             if not server_row:
                                 return
                         cfg = _pool_cfg_from_row(server_row)
-                        await self._prime_user_server(key, cfg, lookup.token, expected_gen)
+                        await self._prime_user_server(key, cfg, lookup.token)
                         log.info(
                             "mcp pool auto-primed at session start user=%s server=%s",
-                            user_id,
-                            server_name,
-                        )
-                    except _PoolGrantRevokedError:
-                        log.info(
-                            "mcp pool prime skipped: grant revoked mid-prime user=%s server=%s",
                             user_id,
                             server_name,
                         )
@@ -3054,6 +2999,16 @@ class MCPClientManager:
         """
         with self._listeners_lock:
             return any(uid == user_id for uid, _cb in self._listeners)
+
+    def has_live_session_listener(self, user_id: str) -> bool:
+        """Public: does *user_id* have a live session's tool listener?
+
+        Lets outside callers (the OIDC capture-site prime) fan out work
+        only for users who actually have an open session to heal —
+        priming on every routine SSO re-login would warm transports and
+        mint tokens for users with nothing open, at deployment scale.
+        """
+        return self._user_has_live_listener(user_id)
 
     def _live_listener_uids(self) -> set[str]:
         """Snapshot the user ids with a live tool listener (one lock take).
@@ -3604,12 +3559,14 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_names = {t["function"]["name"] for t in (entry.tools or [])}
-        gen = entry.catalog_gen
-        result = await session.list_tools()
-        if self._user_pool_entries.get(key) is not entry or entry.catalog_gen != gen:
-            # A revocation drop landed while list_tools was in flight —
-            # publishing now would resurrect the revoked catalog with
-            # nothing left to ever clear it (retention keeps it). Discard.
+        # ``asyncio.timeout`` mandatory (R6) — a wedged server must not
+        # hang the notification-handler task; siblings already comply.
+        async with asyncio.timeout(self._CONNECT_TIMEOUT):
+            result = await session.list_tools()
+        if self._user_pool_entries.get(key) is not entry:
+            # The entry was replaced (full drop + re-create) while
+            # list_tools was in flight — this result belongs to the
+            # old entry; publishing it would clobber the new one.
             return [], []
         capped = _cap_server_tools(server_name, result.tools)
         server_tools = [_mcp_to_openai(server_name, tool) for tool in capped]
@@ -3651,7 +3608,6 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_uris = {r["uri"] for r in (entry.resources or []) if not r.get("template")}
-        gen = entry.catalog_gen
 
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
             # 1-RTT (gather) instead of 2 sequential RTTs — both calls
@@ -3661,8 +3617,8 @@ class MCPClientManager:
                 session.list_resources(),
                 session.list_resource_templates(),
             )
-        if self._user_pool_entries.get(key) is not entry or entry.catalog_gen != gen:
-            # Revocation drop landed mid-flight — discard, don't resurrect.
+        if self._user_pool_entries.get(key) is not entry:
+            # Entry replaced mid-flight — stale result, discard.
             return [], []
 
         server_resources: list[dict[str, Any]] = []
@@ -3727,12 +3683,11 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_names = {p["name"] for p in (entry.prompts or [])}
-        gen = entry.catalog_gen
 
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
             prompt_result = await session.list_prompts()
-        if self._user_pool_entries.get(key) is not entry or entry.catalog_gen != gen:
-            # Revocation drop landed mid-flight — discard, don't resurrect.
+        if self._user_pool_entries.get(key) is not entry:
+            # Entry replaced mid-flight — stale result, discard.
             return [], []
 
         server_prompts: list[dict[str, Any]] = []
@@ -6485,19 +6440,12 @@ class MCPClientManager:
         # this retry; the local cached token is the one the AS just
         # rejected, so reading it back without ``force_refresh=True``
         # would re-attempt with the same (rejected) bearer.
-        # Ensure the entry and snapshot its revocation generation BEFORE
-        # the token read: a disconnect landing between the row read and
-        # the locked connect bumps the generation, and _connect_one_pool
-        # then refuses to publish for the revoked grant (#836).
-        key = (user_id, server_name)
-        entry = await self._ensure_pool_entry(key)
-        expected_gen = entry.catalog_gen
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, key)
+            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6521,6 +6469,8 @@ class MCPClientManager:
         self._cb_gate(server_name)
 
         cfg = _pool_cfg_from_row(server_row)
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
 
         # See PoolEntryState.auth_capture for why the carrier is
         # entry-owned; _dispatch_pool_with_entry resets it under
@@ -6534,7 +6484,6 @@ class MCPClientManager:
                 access_token=access_token,
                 original_name=original_name,
                 arguments=arguments,
-                expected_gen=expected_gen,
             )
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
@@ -6576,13 +6525,9 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
-                # No catalog drop here: the forced refresh SUCCEEDED,
-                # so the grant is alive at the AS — this second 401 is
-                # the resource server rejecting a fresh bearer (JWKS
-                # lag, audience misconfig, clock skew). Retention lets
-                # the next dispatch self-heal once the RS recovers
-                # (#836); a genuinely revoked grant converges via the
-                # token-lookup drop instead (the row is gone by then).
+                # No catalog drop: refresh SUCCEEDED, so this 401 is
+                # RS-side (JWKS lag / audience / skew), not a dead
+                # grant — see _evict_session's docstring.
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6642,17 +6587,12 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
-        # Snapshot the revocation generation before the token read —
-        # see _dispatch_pool.
-        key = (user_id, server_name)
-        entry = await self._ensure_pool_entry(key)
-        expected_gen = entry.catalog_gen
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, key)
+            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6674,6 +6614,8 @@ class MCPClientManager:
         self._cb_gate(server_name)
 
         cfg = _pool_cfg_from_row(server_row)
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
         capture = entry.auth_capture
         try:
             sdk_result = await self._dispatch_pool_with_entry_call(
@@ -6682,7 +6624,6 @@ class MCPClientManager:
                 cfg=cfg,
                 access_token=access_token,
                 sdk_call=lambda s: s.read_resource(uri),
-                expected_gen=expected_gen,
             )
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
@@ -6702,13 +6643,9 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
-                # No catalog drop here: the forced refresh SUCCEEDED,
-                # so the grant is alive at the AS — this second 401 is
-                # the resource server rejecting a fresh bearer (JWKS
-                # lag, audience misconfig, clock skew). Retention lets
-                # the next dispatch self-heal once the RS recovers
-                # (#836); a genuinely revoked grant converges via the
-                # token-lookup drop instead (the row is gone by then).
+                # No catalog drop: refresh SUCCEEDED, so this 401 is
+                # RS-side (JWKS lag / audience / skew), not a dead
+                # grant — see _evict_session's docstring.
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6775,17 +6712,12 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
-        # Snapshot the revocation generation before the token read —
-        # see _dispatch_pool.
-        key = (user_id, server_name)
-        entry = await self._ensure_pool_entry(key)
-        expected_gen = entry.catalog_gen
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, key)
+            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6807,6 +6739,8 @@ class MCPClientManager:
         self._cb_gate(server_name)
 
         cfg = _pool_cfg_from_row(server_row)
+        key = (user_id, server_name)
+        entry = await self._ensure_pool_entry(key)
         capture = entry.auth_capture
         try:
             sdk_result = await self._dispatch_pool_with_entry_call(
@@ -6815,7 +6749,6 @@ class MCPClientManager:
                 cfg=cfg,
                 access_token=access_token,
                 sdk_call=lambda s: s.get_prompt(original_name, arguments=arguments),
-                expected_gen=expected_gen,
             )
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
@@ -6835,13 +6768,9 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
-                # No catalog drop here: the forced refresh SUCCEEDED,
-                # so the grant is alive at the AS — this second 401 is
-                # the resource server rejecting a fresh bearer (JWKS
-                # lag, audience misconfig, clock skew). Retention lets
-                # the next dispatch self-heal once the RS recovers
-                # (#836); a genuinely revoked grant converges via the
-                # token-lookup drop instead (the row is gone by then).
+                # No catalog drop: refresh SUCCEEDED, so this 401 is
+                # RS-side (JWKS lag / audience / skew), not a dead
+                # grant — see _evict_session's docstring.
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6931,16 +6860,23 @@ class MCPClientManager:
         one-cancel close protocol). Callers that can race an in-flight
         connect must serialize via :meth:`_drop_catalog_locked` so a
         completing discovery can't republish the cleared catalog.
+
+        ACCEPTED RESIDUAL (deliberate, after a rev-generation protocol
+        proved buggier than the race it closed): a publisher already
+        suspended across this drop — a ``list_changed`` refresh in
+        flight, or a connect whose token was read pre-revocation and
+        queued on ``open_lock`` ahead of us — can republish the catalog
+        after the drop. The ghost is bounded and self-healing: any use
+        of it fails the token lookup and re-schedules this drop
+        (:meth:`_schedule_dead_grant_drop`, from dispatch AND priming),
+        and a reconnected stale bearer dies at access-token expiry —
+        the same bound every warm session already rides at revocation
+        time.
         """
         self._evict_session(key)
         evict = self._user_pool_entries.get(key)
         if evict is None:
             return
-        # Invalidate in-flight publishers FIRST — even when the entry is
-        # catalog-less, a racer that read pre-revocation state (a token
-        # row, a live session) must find the generation moved and
-        # discard its publish, or it resurrects the revoked catalog.
-        evict.catalog_gen += 1
         if not self._entry_has_catalog(evict):
             # Already catalog-less (repeat drop from a racing dispatch,
             # or a never-discovered stub) — nothing to clear, and a
@@ -7097,7 +7033,6 @@ class MCPClientManager:
         access_token: str,
         original_name: str,
         arguments: dict[str, Any],
-        expected_gen: int | None = None,
     ) -> str:
         """Hold ``entry.open_lock`` across connect-or-reuse AND ``call_tool``.
 
@@ -7124,7 +7059,6 @@ class MCPClientManager:
             cfg=cfg,
             access_token=access_token,
             sdk_call=lambda s: s.call_tool(original_name, arguments),
-            expected_gen=expected_gen,
         )
         return _decode_tool_result(result)
 
@@ -7136,7 +7070,6 @@ class MCPClientManager:
         cfg: dict[str, Any],
         access_token: str,
         sdk_call: Callable[[Any], Awaitable[Any]],
-        expected_gen: int | None = None,
     ) -> Any:
         """Hold ``entry.open_lock`` across connect-or-reuse AND ``sdk_call``.
 
@@ -7202,7 +7135,6 @@ class MCPClientManager:
                     access_token,
                     auth_capture=entry.auth_capture,
                     auth_fired_event=entry.auth_fired_event,
-                    expected_gen=expected_gen,
                 )
                 session = fresh.session
                 if session is None:
@@ -7858,7 +7790,14 @@ def _pool_lookup_error(
     )
 
 
-def _pool_lookup_verdict(lookup: TokenLookupResult) -> str | None:
+_PoolLookupVerdict = Literal[
+    "mcp_consent_required",
+    "mcp_token_undecryptable_key_unknown",
+    "mcp_refresh_unavailable",
+]
+
+
+def _pool_lookup_verdict(lookup: TokenLookupResult) -> _PoolLookupVerdict | None:
     """Classify a pool token lookup outcome as a structured-error code.
 
     THE single classification of failed lookups: ``_pool_lookup_error``

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -696,8 +696,8 @@ class MCPClientManager:
         # this via a single dict-get (atomic under GIL) so sync-thread
         # callers (ChatSession) never iterate ``_user_pool_entries``
         # concurrently with the mcp-loop's mutations of the same dict
-        # (insert in ``_ensure_pool_entry`` / pop in
-        # ``_close_pool_entry_if_idle`` / ``_evict_session_drop_catalog``).
+        # (insert in ``_ensure_pool_entry`` / the SOLE pop in
+        # ``_close_pool_entry_if_idle``'s full-drop path).
         self._user_tools: dict[str, list[dict[str, Any]]] = {}
 
         # Per-user resource catalog. Mirrors ``_user_tool_map`` /
@@ -2026,6 +2026,11 @@ class MCPClientManager:
         if entry is None:
             return
         entry.session = None
+        # The bearer copy is dead once the session is gone (read only
+        # under a live session for stale-rebind detection; overwritten
+        # at reconnect) — don't retain a plaintext credential on a
+        # cooled entry for the life of the user's sessions.
+        entry.bound_token = None
         owner = entry.owner_task
         close_requested = entry.close_requested
         entry.owner_task = None
@@ -2415,16 +2420,9 @@ class MCPClientManager:
 
         # Loop-only mutation; sync-thread readers observe the new
         # catalog atomically via per-user dict-gets on ``_user_tools`` /
-        # ``_user_resources`` / ``_user_prompts``.
-        self._rebuild_user_tool_map(user_id)
-        self._rebuild_user_resource_map(user_id)
-        self._rebuild_user_prompt_map(user_id)
-        # Wake user-keyed AND admin (None) listeners; per-user fan-out
-        # ensures another user's session never observes this user's
-        # catalog change.
-        self._notify_user_tool_listeners(user_id)
-        self._notify_user_resource_listeners(user_id)
-        self._notify_user_prompt_listeners(user_id)
+        # ``_user_resources`` / ``_user_prompts``. Per-user fan-out
+        # ensures another user's session never observes this change.
+        self._rebuild_and_notify_user_catalogs(user_id)
         return entry
 
     # -- pool priming ---------------------------------------------------------
@@ -2951,8 +2949,12 @@ class MCPClientManager:
         Note: the loop wakes on a fixed tick rather than a condition
         variable. Event-driven evictions would be more efficient on
         large idle pools but add complexity (tracking per-entry
-        deadlines + a wakeup ``asyncio.Event``); at the design cap of
-        200 entries the unconditional 30 s wake is negligible.
+        deadlines + a wakeup ``asyncio.Event``). Warm entries are
+        bounded by the LRU cap (default 200); cooled catalog-only
+        entries are bounded by live-session users × registered pool
+        servers, and each tick's work over them is a per-entry set
+        lookup against a once-per-tick listener snapshot — negligible
+        either way.
         """
         while True:
             try:
@@ -2977,6 +2979,19 @@ class MCPClientManager:
         with self._listeners_lock:
             return any(uid == user_id for uid, _cb in self._listeners)
 
+    def _live_listener_uids(self) -> set[str]:
+        """Snapshot the user ids with a live tool listener (one lock take).
+
+        The TTL pass checks retention for every idle entry every tick;
+        a per-entry ``_user_has_live_listener`` scan would be
+        O(entries × listeners) under ``_listeners_lock`` on the
+        mcp-loop. Snapshot staleness is bounded by one tick and benign:
+        a listener added after the snapshot re-primes at session start
+        anyway, and one removed after it is caught next tick.
+        """
+        with self._listeners_lock:
+            return {uid for uid, _cb in self._listeners if uid}
+
     @staticmethod
     def _entry_has_catalog(entry: PoolEntryState) -> bool:
         """True when the entry carries a discovered catalog worth retaining.
@@ -2989,18 +3004,70 @@ class MCPClientManager:
         """
         return entry.tools is not None or entry.resources is not None or entry.prompts is not None
 
-    def _warm_pool_count(self) -> int:
-        """Count pool entries still holding connection resources.
+    @staticmethod
+    def _entry_is_warm(entry: PoolEntryState) -> bool:
+        """True when the entry holds connection resources.
 
         Warm = an open session OR a live owner task (an owner parked
         after ``_evict_session`` still holds the transport until the
         close protocol runs). Cooled catalog-only entries hold neither.
+        This is THE definition the LRU cap bounds; every warm check in
+        the eviction passes must go through it.
         """
-        return sum(
-            1
-            for e in self._user_pool_entries.values()
-            if e.session is not None or e.owner_task is not None
-        )
+        return entry.session is not None or entry.owner_task is not None
+
+    def _retain_cooled(
+        self,
+        key: tuple[str, str],
+        entry: PoolEntryState,
+        live_uids: set[str] | None = None,
+    ) -> bool:
+        """Retention policy: keep this entry cooled for a live session?
+
+        True iff ALL of:
+        - the entry carries a discovered catalog (stubs and
+          revoke-cleared entries retain nothing);
+        - the server still exists as a pool server in the in-memory
+          registries (:meth:`_is_pool_server`, rebuilt wholesale by
+          every reconcile). Without this, an admin delete / disable /
+          rename / auth-flip left an IMMORTAL cooled entry serving
+          ghost tools to live sessions — pre-#836-fix those aged out
+          with the idle TTL; with the registry check they full-drop
+          within one eviction tick, faster than before;
+        - the user has a live session (a registered user-scoped tool
+          listener). ``live_uids`` is the per-tick snapshot; ``None``
+          consults the registry directly (authoritative, single key).
+
+        Single copy of the policy — the TTL pass's already-cooled skip
+        and :meth:`_close_pool_entry_if_idle`'s cool-vs-drop decision
+        must never diverge.
+        """
+        user_id, server_name = key
+        if not self._entry_has_catalog(entry):
+            return False
+        if not self._is_pool_server(server_name):
+            return False
+        if live_uids is not None:
+            return user_id in live_uids
+        return self._user_has_live_listener(user_id)
+
+    def _rebuild_and_notify_user_catalogs(self, user_id: str) -> None:
+        """Rebuild all three per-user catalog maps, then fan out to all
+        three listener classes (user-keyed + admin ``None``).
+
+        MUST run on the mcp-loop. Rebuild-before-notify is the
+        invariant (listeners re-read the maps), and tools / resources /
+        prompts move together — the Phase 7 round-2 "bug-pair" was
+        exactly a tools-only cleanup missing its resource/prompt half.
+        Shared by connect wiring, the full-drop eviction path, and the
+        revocation drop.
+        """
+        self._rebuild_user_tool_map(user_id)
+        self._rebuild_user_resource_map(user_id)
+        self._rebuild_user_prompt_map(user_id)
+        self._notify_user_tool_listeners(user_id)
+        self._notify_user_resource_listeners(user_id)
+        self._notify_user_prompt_listeners(user_id)
 
     async def _evict_idle_pool_entries(self) -> None:
         """Evict pool entries past the idle TTL or above the LRU cap.
@@ -3025,6 +3092,7 @@ class MCPClientManager:
             return
         now = time.monotonic()
         ttl = self._user_pool_idle_ttl_s
+        live_uids = self._live_listener_uids()
 
         # First pass: TTL-based eviction. Run closes in parallel so a tick
         # that needs to evict many entries doesn't block on serial teardowns.
@@ -3033,16 +3101,12 @@ class MCPClientManager:
             last = self._user_pool_last_used.get(key, entry.last_used)
             if (now - last) < ttl:
                 continue
-            if (
-                entry.session is None
-                and entry.owner_task is None
-                and self._entry_has_catalog(entry)
-                and self._user_has_live_listener(key[0])
-            ):
+            if not self._entry_is_warm(entry) and self._retain_cooled(key, entry, live_uids):
                 # Already cooled — nothing to close. Retained for the
-                # live session's tool list; the tick after that user's
-                # last listener is removed, this stops matching and the
-                # entry takes the full-drop path below.
+                # live session's tool list; once the user's last
+                # listener goes away OR the server leaves the pool
+                # registries, this stops matching and the entry takes
+                # the full-drop path below.
                 continue
             ttl_targets.append(key)
         if ttl_targets:
@@ -3058,7 +3122,7 @@ class MCPClientManager:
         warm = [
             (key, entry)
             for key, entry in self._user_pool_entries.items()
-            if entry.session is not None or entry.owner_task is not None
+            if self._entry_is_warm(entry)
         ]
         if len(warm) <= self._user_pool_lru_max:
             return
@@ -3066,12 +3130,17 @@ class MCPClientManager:
             warm,
             key=lambda kv: self._user_pool_last_used.get(kv[0], kv[1].last_used),
         )
-        # Compute the eviction batch up front; we re-check the cap after
-        # each close (in-flight skips can leave us still over).
+        # Count actual closes instead of rescanning the whole map per
+        # iteration; a skip (contested lock / in-flight) leaves the
+        # entry warm, so re-read the entry itself to learn the outcome.
+        over = len(warm) - self._user_pool_lru_max
         for key, _entry in ordered:
-            if self._warm_pool_count() <= self._user_pool_lru_max:
+            if over <= 0:
                 break
             await self._close_pool_entry_if_idle(key)
+            current = self._user_pool_entries.get(key)
+            if current is None or not self._entry_is_warm(current):
+                over -= 1
 
     async def _close_pool_entry_if_idle(self, key: tuple[str, str]) -> None:
         """Close ``key``'s transport iff its open_lock is uncontested AND in_flight==0.
@@ -3080,21 +3149,21 @@ class MCPClientManager:
         function to return without mutation; the next eviction tick
         retries.
 
-        What happens to the ENTRY depends on whether the user still has
-        a live session (:meth:`_user_has_live_listener`) and the entry
-        carries a discovered catalog (:meth:`_entry_has_catalog`):
+        What happens to the ENTRY is :meth:`_retain_cooled` — ONE
+        policy shared with the TTL pass's already-cooled skip:
 
-        - live listener + catalog → the entry is COOLED: transport torn down,
-          catalog kept, no rebuild, no listener fan-out. The user's
-          merged tool list is untouched and the next dispatch or prime
-          reconnects — the evict-session-keep-entry shape of
+        - retained → the entry is COOLED: transport torn down, catalog
+          kept, no rebuild, no listener fan-out. The user's merged tool
+          list is untouched and the next dispatch or prime reconnects —
+          the evict-session-keep-entry shape of
           ``_on_pool_owner_death``. Dropping the catalog here instead
           silently removed the server's tools from live sessions with
           no re-prime path (#836).
         - otherwise → full drop: entry popped, per-user catalogs
-          rebuilt, listeners notified (reaching only admin/``None``
-          listeners — operator tooling tracking catalog state). This
-          keeps departed users' entries from outliving their sessions.
+          rebuilt, listeners notified. Covers departed users (no live
+          listener), catalog-less stubs, and servers that left the pool
+          registries (deleted / disabled / renamed / auth-flipped) —
+          whose ghost tools must leave live sessions within a tick.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None:
@@ -3130,7 +3199,7 @@ class MCPClientManager:
             # ``list_changed`` must refresh immediately.
             self._last_pool_notification_refresh.pop(key, None)
             user_id, _server_name = key
-            if self._entry_has_catalog(entry) and self._user_has_live_listener(user_id):
+            if self._retain_cooled(key, entry):
                 # Cooled: entry + catalog stay, so the live session's
                 # tool list and ``is_mcp_tool`` are untouched. Nothing
                 # changed catalog-wise → no rebuild, no fan-out. The
@@ -3143,14 +3212,9 @@ class MCPClientManager:
             # Dropping the entry without rebuilding the per-user
             # catalogs would leave ``is_mcp_tool`` / per-user resource &
             # prompt maps returning stale entries whose backing pool is
-            # gone for good (this user has no live session left to
-            # re-warm it lazily).
-            self._rebuild_user_tool_map(user_id)
-            self._rebuild_user_resource_map(user_id)
-            self._rebuild_user_prompt_map(user_id)
-            self._notify_user_tool_listeners(user_id)
-            self._notify_user_resource_listeners(user_id)
-            self._notify_user_prompt_listeners(user_id)
+            # gone for good (departed user, or a server no longer in
+            # the pool registries).
+            self._rebuild_and_notify_user_catalogs(user_id)
             evicted = True
         finally:
             lock.release()
@@ -4727,18 +4791,22 @@ class MCPClientManager:
         # and the eviction loop snapshot the same way.
         entries = list(self._user_pool_entries.items())
         if aggregate:
-            warm = [e for (uid, sname), e in entries if sname == name and e.session is not None]
+            scoped = [e for (uid, sname), e in entries if sname == name]
         elif user_id:
-            warm = [
-                e
-                for (uid, sname), e in entries
-                if sname == name and uid == user_id and e.session is not None
-            ]
+            scoped = [e for (uid, sname), e in entries if sname == name and uid == user_id]
         else:
-            warm = []
+            scoped = []
+        warm = [e for e in scoped if e.session is not None]
+        # Cooled entries (transport idled out, catalog retained for the
+        # user's live sessions, #836) still SERVE their tools — a
+        # warm-only view told the user "0 tools" for a catalog their
+        # own chat was actively offered. ``connected`` stays
+        # transport-truthful; the catalog counts must not.
+        idle = [e for e in scoped if e.session is None and self._entry_has_catalog(e)]
         # rep is the first warm entry (insertion order): the requester's own pool
-        # when scoped, or a representative catalog for the aggregate operator view.
-        rep = warm[0] if warm else None
+        # when scoped, or a representative catalog for the aggregate operator
+        # view — falling back to a cooled catalog when nothing is warm.
+        rep = warm[0] if warm else (idle[0] if idle else None)
         cb_deadline = self._circuit_open_until.get(name)
         cb_open = cb_deadline is not None and time.monotonic() < cb_deadline
         last_refresh = self._last_refresh.get(name)
@@ -4755,6 +4823,7 @@ class MCPClientManager:
             "consecutive_failures": self._consecutive_failures.get(name, 0),
             "auth_type": self.server_auth_type(name) or "oauth_user",
             "user_pools": len(warm),
+            "user_pools_idle": len(idle),
             "last_refresh_at": last_refresh[0] if last_refresh is not None else None,
             "last_refresh_outcome": last_refresh[1] if last_refresh is not None else None,
         }
@@ -6314,6 +6383,14 @@ class MCPClientManager:
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
+            if lookup.kind in _DEAD_GRANT_LOOKUP_KINDS:
+                # The grant is GONE (revoked / permanently rejected) —
+                # converge this node's live sessions now instead of
+                # leaving tools dangling behind a consent card for
+                # access the user no longer holds (#836 cross-node
+                # disconnect). Re-consent restores them via the
+                # consent-completion prime.
+                await self._drop_catalog_locked((user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6393,6 +6470,10 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
+                # Refreshed bearer also rejected — the grant is dead at
+                # the AS; drop the catalog so this node's live sessions
+                # converge (#836) instead of re-offering revoked tools.
+                await self._drop_catalog_locked(key)
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6457,6 +6538,14 @@ class MCPClientManager:
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
+            if lookup.kind in _DEAD_GRANT_LOOKUP_KINDS:
+                # The grant is GONE (revoked / permanently rejected) —
+                # converge this node's live sessions now instead of
+                # leaving tools dangling behind a consent card for
+                # access the user no longer holds (#836 cross-node
+                # disconnect). Re-consent restores them via the
+                # consent-completion prime.
+                await self._drop_catalog_locked((user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6507,6 +6596,10 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
+                # Refreshed bearer also rejected — the grant is dead at
+                # the AS; drop the catalog so this node's live sessions
+                # converge (#836) instead of re-offering revoked tools.
+                await self._drop_catalog_locked(key)
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6578,6 +6671,14 @@ class MCPClientManager:
         )
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
+            if lookup.kind in _DEAD_GRANT_LOOKUP_KINDS:
+                # The grant is GONE (revoked / permanently rejected) —
+                # converge this node's live sessions now instead of
+                # leaving tools dangling behind a consent card for
+                # access the user no longer holds (#836 cross-node
+                # disconnect). Re-consent restores them via the
+                # consent-completion prime.
+                await self._drop_catalog_locked((user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6628,6 +6729,10 @@ class MCPClientManager:
                     user_id,
                     type(exc).__name__,
                 )
+                # Refreshed bearer also rejected — the grant is dead at
+                # the AS; drop the catalog so this node's live sessions
+                # converge (#836) instead of re-offering revoked tools.
+                await self._drop_catalog_locked(key)
                 return _structured_error(
                     code="mcp_consent_required",
                     server=server_name,
@@ -6695,6 +6800,8 @@ class MCPClientManager:
         evict = self._user_pool_entries.get(key)
         if evict is not None:
             evict.session = None
+            # Dead once the session is gone (see _teardown_pool_entry).
+            evict.bound_token = None
             # Prune the push-notification debounce stamp so a
             # reconnect's first ``list_changed`` refreshes immediately.
             self._last_pool_notification_refresh.pop(key, None)
@@ -6702,37 +6809,48 @@ class MCPClientManager:
     def _evict_session_drop_catalog(self, key: tuple[str, str]) -> None:
         """Drop the cached session AND the entry's catalog contribution.
 
-        The explicit-revocation flavor of :meth:`_evict_session`, used
-        by :meth:`evict_user_session` (the OAuth disconnect handler):
-        the user asked for the server to be disconnected, so their live
-        sessions SHOULD see the tools leave — the opposite of the
-        dispatch-failure paths, where the catalog is retained (#836).
+        The dead-grant flavor of :meth:`_evict_session`, used when the
+        user's grant for this server is GONE — explicit disconnect
+        (:meth:`evict_user_session`) or a dispatch that failed with the
+        token-missing / grant-rejected class — so their live sessions
+        SHOULD see the tools leave rather than keep offering a card for
+        access that no longer exists (#836 cross-node convergence).
         Clearing the catalog also makes the eviction passes treat the
         entry as a droppable stub (``_entry_has_catalog`` is False), so
         it doesn't linger cooled behind a live listener.
 
-        Owner/streams left for reconnect teardown exactly as in
-        :meth:`_evict_session` (the one-cancel close protocol).
+        Session-drop prologue is delegated to :meth:`_evict_session` —
+        owner/streams left for reconnect teardown exactly as there (the
+        one-cancel close protocol). Callers that can race an in-flight
+        connect must serialize via :meth:`_drop_catalog_locked` so a
+        completing discovery can't republish the cleared catalog.
         """
+        self._evict_session(key)
         evict = self._user_pool_entries.get(key)
         if evict is None:
             return
-        evict.session = None
         evict.tools = None
         evict.resources = None
         evict.prompts = None
-        self._last_pool_notification_refresh.pop(key, None)
-        user_id, _server_name = key
-        self._rebuild_user_tool_map(user_id)
-        self._rebuild_user_resource_map(user_id)
-        self._rebuild_user_prompt_map(user_id)
         # Wake the user's sessions so their merged tool / resource /
-        # prompt lists shrink now, not at the next turn boundary. Admin
-        # (None) listeners also fire — operator tooling tracking pool
-        # catalog state observes the drop.
-        self._notify_user_tool_listeners(user_id)
-        self._notify_user_resource_listeners(user_id)
-        self._notify_user_prompt_listeners(user_id)
+        # prompt lists shrink now, not at the next turn boundary.
+        self._rebuild_and_notify_user_catalogs(key[0])
+
+    async def _drop_catalog_locked(self, key: tuple[str, str]) -> None:
+        """Serialize a catalog drop against an in-flight connect.
+
+        ``_evict_session_drop_catalog`` alone races
+        ``_connect_one_pool``: a connect already past the token check
+        publishes its discovery AFTER the drop, resurrecting a revoked
+        server's catalog with no remaining path that ever clears it.
+        ``open_lock`` is held for the connect/reuse window only, so the
+        wait is bounded by connect+discovery. Runs on the mcp-loop.
+        """
+        entry = self._user_pool_entries.get(key)
+        if entry is None:
+            return
+        async with entry.open_lock:
+            self._evict_session_drop_catalog(key)
 
     async def _handle_auth_403(
         self,
@@ -7206,7 +7324,10 @@ class MCPClientManager:
         key = (user_id, server_name)
 
         async def _do_evict() -> None:
-            self._evict_session_drop_catalog(key)
+            # Locked: an in-flight connect completing its discovery
+            # after an unserialized drop would republish (resurrect)
+            # the revoked catalog with nothing left to clear it.
+            await self._drop_catalog_locked(key)
 
         try:
             asyncio.run_coroutine_threadsafe(_do_evict(), self._loop)
@@ -7507,6 +7628,14 @@ def _token_rejected_detail(server_row: dict[str, Any]) -> str:
     Named wrapper because the three sync dispatchers each surface it.
     """
     return _pool_error_detail(server_row, "token_rejected")
+
+
+# Lookup kinds meaning the user's grant is durably gone (revoked /
+# permanently rejected) — the dispatchers drop the (user, server)
+# catalog on these so live sessions converge with the revocation
+# (#836). Transient refresh failures and operator-actionable decrypt
+# failures deliberately keep the catalog: access still exists.
+_DEAD_GRANT_LOOKUP_KINDS: frozenset[str] = frozenset({"missing", "refresh_failed"})
 
 
 def _pool_lookup_error(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -1866,6 +1866,13 @@ class MCPClientManager:
                 )
                 return
             try:
+                # SPAWNED, never awaited: the SDK awaits notification
+                # handlers inline in its receive loop, so a handler that
+                # awaits a request on the SAME session deadlocks — the
+                # response can never be routed while the handler is
+                # parked, every in-flight call on the session stalls
+                # with it, and the refresh only ever exits via its
+                # timeout. The refresh runs as its own tracked task.
                 if isinstance(root, mcp_types.ToolListChangedNotification):
                     log.info(
                         "Received tools/list_changed from pool user=%s server=%s",
@@ -1873,7 +1880,12 @@ class MCPClientManager:
                         server_name,
                     )
                     self._last_pool_notification_refresh[key] = now
-                    await self._refresh_pool_server_tools(key)
+                    self._spawn_background(
+                        self._run_notification_refresh(
+                            key, "tools", self._refresh_pool_server_tools
+                        ),
+                        f"pool tools refresh for '{server_name}'",
+                    )
                 elif isinstance(root, mcp_types.ResourceListChangedNotification):
                     log.info(
                         "Received resources/list_changed from pool user=%s server=%s",
@@ -1881,7 +1893,12 @@ class MCPClientManager:
                         server_name,
                     )
                     self._last_pool_notification_refresh[key] = now
-                    await self._refresh_pool_server_resources(key)
+                    self._spawn_background(
+                        self._run_notification_refresh(
+                            key, "resources", self._refresh_pool_server_resources
+                        ),
+                        f"pool resources refresh for '{server_name}'",
+                    )
                 elif isinstance(root, mcp_types.PromptListChangedNotification):
                     log.info(
                         "Received prompts/list_changed from pool user=%s server=%s",
@@ -1889,23 +1906,54 @@ class MCPClientManager:
                         server_name,
                     )
                     self._last_pool_notification_refresh[key] = now
-                    await self._refresh_pool_server_prompts(key)
+                    self._spawn_background(
+                        self._run_notification_refresh(
+                            key, "prompts", self._refresh_pool_server_prompts
+                        ),
+                        f"pool prompts refresh for '{server_name}'",
+                    )
             except Exception as exc:
-                # Structured fields only — ``exc_info=True`` would
-                # serialize the chained ``httpx.Request`` whose headers
-                # carry ``Authorization: Bearer <token>``. Sentry /
-                # faulthandler-style integrations capture that frame
-                # and the bearer would land in error tracking.
-                # Mirrors the dispatch-path log scrubbing applied in
-                # the sec-1 round-1 fix.
+                # Scheduling failed (loop shutting down). Structured
+                # fields only — ``exc_info=True`` would serialize the
+                # chained ``httpx.Request`` whose headers carry
+                # ``Authorization: Bearer <token>``.
                 log.warning(
-                    "Pool refresh after notification failed user=%s server=%s exc=%s",
+                    "Pool refresh scheduling failed user=%s server=%s exc=%s",
                     user_id,
                     server_name,
                     type(exc).__name__,
                 )
 
         return _on_pool_notification
+
+    async def _run_notification_refresh(
+        self,
+        key: tuple[str, str],
+        kind: str,
+        refresh: Callable[[tuple[str, str]], Awaitable[tuple[list[str], list[str]]]],
+    ) -> None:
+        """Body of a spawned ``list_changed`` refresh — never on the receive loop.
+
+        A FAILED refresh returns the debounce stamp so the server's
+        next ``list_changed`` retries instead of being silently dropped
+        inside the debounce window with the catalog change never
+        landing.
+        """
+        user_id, server_name = key
+        try:
+            await refresh(key)
+        except Exception as exc:
+            self._last_pool_notification_refresh.pop(key, None)
+            # Structured fields only — ``exc_info=True`` would
+            # serialize the chained ``httpx.Request`` whose headers
+            # carry ``Authorization: Bearer <token>``.
+            log.warning(
+                "Pool %s refresh after notification failed user=%s server=%s exc=%s",
+                kind,
+                user_id,
+                server_name,
+                type(exc).__name__,
+            )
 
     async def _pool_transport_owner(
         self,
@@ -2696,6 +2744,16 @@ class MCPClientManager:
                 except Exception:
                     has_credential = True
             if not has_credential:
+                # The credential is GONE — fire the same dead-grant
+                # convergence the per-server lookup would have
+                # (kind="missing") for any retained obo catalogs, or
+                # ghosts survive every new-session prime: this gate
+                # skips exactly the lookup that would drop them.
+                for name in self._obo_server_names:
+                    obo_key = (user_id, name)
+                    obo_entry = self._user_pool_entries.get(obo_key)
+                    if obo_entry is not None and self._entry_has_catalog(obo_entry):
+                        self._schedule_dead_grant_drop(TokenLookupResult(kind="missing"), obo_key)
                 prime_names -= self._obo_server_names
         await asyncio.gather(*(_prime_one(s) for s in list(prime_names)))
 
@@ -3560,7 +3618,7 @@ class MCPClientManager:
         user_id, server_name = key
         old_names = {t["function"]["name"] for t in (entry.tools or [])}
         # ``asyncio.timeout`` mandatory (R6) — a wedged server must not
-        # hang the notification-handler task; siblings already comply.
+        # hang the spawned refresh task forever; siblings already comply.
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
             result = await session.list_tools()
         if self._user_pool_entries.get(key) is not entry:
@@ -6443,9 +6501,8 @@ class MCPClientManager:
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        lookup_error = self._pool_lookup_failure(lookup, server_name, server_row, user_id)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6590,9 +6647,8 @@ class MCPClientManager:
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        lookup_error = self._pool_lookup_failure(lookup, server_name, server_row, user_id)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6715,9 +6771,8 @@ class MCPClientManager:
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        lookup_error = self._pool_lookup_failure(lookup, server_name, server_row, user_id)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
             return lookup_error
         access_token = lookup.token or ""
 
@@ -6909,6 +6964,27 @@ class MCPClientManager:
             return False
         return _pool_lookup_verdict(lookup) == "mcp_consent_required"
 
+    def _pool_lookup_failure(
+        self,
+        lookup: TokenLookupResult,
+        server_name: str,
+        server_row: dict[str, Any],
+        user_id: str,
+    ) -> str | None:
+        """Render a failed pool lookup AND pair it with its convergence drop.
+
+        The pairing is the contract (one helper, three dispatchers): a
+        dispatcher that rendered the error without scheduling the drop
+        would keep offering revoked tools behind a consent card — the
+        cross-node non-convergence #836 fixes, silently split by
+        dispatch surface. Returns ``None`` exactly when *lookup*
+        carries a usable bearer.
+        """
+        lookup_error = _pool_lookup_error(lookup, server_name, server_row)
+        if lookup_error is not None:
+            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
+        return lookup_error
+
     def _schedule_dead_grant_drop(self, lookup: TokenLookupResult, key: tuple[str, str]) -> None:
         """Converge live sessions with a durably-gone grant (#836).
 
@@ -6930,24 +7006,42 @@ class MCPClientManager:
         if not self._lookup_grant_dead(lookup):
             return
         self._spawn_background(
-            self._drop_catalog_locked(key),
+            self._drop_catalog_locked(key, skip_if_connected=True),
             f"dead-grant catalog drop for '{key[1]}'",
         )
 
-    async def _drop_catalog_locked(self, key: tuple[str, str]) -> None:
+    async def _drop_catalog_locked(
+        self, key: tuple[str, str], *, skip_if_connected: bool = False
+    ) -> None:
         """Serialize a catalog drop against an in-flight connect.
 
         ``_evict_session_drop_catalog`` alone races
         ``_connect_one_pool``: a connect already past the token check
         publishes its discovery AFTER the drop, resurrecting a revoked
         server's catalog with no remaining path that ever clears it.
-        ``open_lock`` is held for the connect/reuse window only, so the
-        wait is bounded by connect+discovery. Runs on the mcp-loop.
+        ``open_lock`` is held across a same-key dispatch's ENTIRE SDK
+        call (the carrier serialization), so this wait can be a full
+        tool-call long — which is why every caller schedules it as a
+        tracked background task rather than awaiting it inline.
+
+        ``skip_if_connected`` is the dead-grant flavor's re-validation:
+        a dispatch-scheduled drop can be parked long enough for the
+        user to RE-CONSENT and the consent-completion prime to connect
+        and publish a fresh catalog — clearing that would strand the
+        just-restored tools (nothing re-primes until a new session). A
+        live session at drop time proves a connect succeeded after the
+        failed lookup that scheduled us, i.e. the grant is alive again:
+        connects always resolve their bearer through the classified
+        lookup first, so a session cannot exist without a grant that
+        was valid at its connect. The explicit-revocation path passes
+        False: it must clear even (especially) warm sessions.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None:
             return
         async with entry.open_lock:
+            if skip_if_connected and entry.session is not None:
+                return
             self._evict_session_drop_catalog(key)
 
     async def _handle_auth_403(

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -697,7 +697,7 @@ class MCPClientManager:
         # callers (ChatSession) never iterate ``_user_pool_entries``
         # concurrently with the mcp-loop's mutations of the same dict
         # (insert in ``_ensure_pool_entry`` / pop in
-        # ``_close_pool_entry_if_idle`` / ``_evict_session``).
+        # ``_close_pool_entry_if_idle`` / ``_evict_session_drop_catalog``).
         self._user_tools: dict[str, list[dict[str, Any]]] = {}
 
         # Per-user resource catalog. Mirrors ``_user_tool_map`` /
@@ -2965,12 +2965,61 @@ class MCPClientManager:
                 # — a transport-layer group must not kill the loop.
                 log.warning("MCP pool eviction iteration failed", exc_info=True)
 
+    def _user_has_live_listener(self, user_id: str) -> bool:
+        """True when *user_id* has a registered user-scoped tool listener.
+
+        A live listener means a live ChatSession whose merged tool list
+        is derived from this user's pool catalog — the signal the
+        eviction passes use to decide cool-vs-drop (#836). Admin
+        (``None``) listeners don't count: they track catalog state for
+        operator tooling, not a user's model-visible tool list.
+        """
+        with self._listeners_lock:
+            return any(uid == user_id for uid, _cb in self._listeners)
+
+    @staticmethod
+    def _entry_has_catalog(entry: PoolEntryState) -> bool:
+        """True when the entry carries a discovered catalog worth retaining.
+
+        Never-connected stubs (``_ensure_pool_entry`` allocated, connect
+        failed before discovery) and revoke-cleared entries
+        (:meth:`_evict_session_drop_catalog`) carry none — retaining
+        those serves nobody, so the eviction passes full-drop them even
+        when the user has a live session.
+        """
+        return entry.tools is not None or entry.resources is not None or entry.prompts is not None
+
+    def _warm_pool_count(self) -> int:
+        """Count pool entries still holding connection resources.
+
+        Warm = an open session OR a live owner task (an owner parked
+        after ``_evict_session`` still holds the transport until the
+        close protocol runs). Cooled catalog-only entries hold neither.
+        """
+        return sum(
+            1
+            for e in self._user_pool_entries.values()
+            if e.session is not None or e.owner_task is not None
+        )
+
     async def _evict_idle_pool_entries(self) -> None:
         """Evict pool entries past the idle TTL or above the LRU cap.
 
         Skips any key whose ``open_lock`` is currently held or whose
         ``in_flight`` counter is non-zero — eviction never blocks on a
         contested lock or an active dispatch; the next tick retries.
+
+        Both passes close TRANSPORTS. Whether the ENTRY (and with it the
+        user's catalog contribution) survives is decided per user in
+        :meth:`_close_pool_entry_if_idle`: a user with a live session
+        keeps a cooled catalog-only entry so their model-visible tool
+        list never silently shrinks (#836); a user without one gets the
+        full drop. The LRU cap therefore bounds WARM entries — the
+        connection resources (transport, httpx client, owner task) are
+        what the cap exists to limit. Cooled entries hold none of
+        those; they are bounded by live-session users × pool servers
+        and reaped by the TTL pass within a tick of their user's last
+        listener going away.
         """
         if not self._user_pool_entries:
             return
@@ -2982,37 +3031,70 @@ class MCPClientManager:
         ttl_targets: list[tuple[str, str]] = []
         for key, entry in list(self._user_pool_entries.items()):
             last = self._user_pool_last_used.get(key, entry.last_used)
-            if (now - last) >= ttl:
-                ttl_targets.append(key)
+            if (now - last) < ttl:
+                continue
+            if (
+                entry.session is None
+                and entry.owner_task is None
+                and self._entry_has_catalog(entry)
+                and self._user_has_live_listener(key[0])
+            ):
+                # Already cooled — nothing to close. Retained for the
+                # live session's tool list; the tick after that user's
+                # last listener is removed, this stops matching and the
+                # entry takes the full-drop path below.
+                continue
+            ttl_targets.append(key)
         if ttl_targets:
             await asyncio.gather(
                 *(self._close_pool_entry_if_idle(k) for k in ttl_targets),
                 return_exceptions=True,
             )
 
-        # Second pass: LRU cap. Iterate the canonical entry map (not the
-        # last_used view) so brand-new entries that were created via
-        # ``_ensure_pool_entry`` but haven't dispatched yet are still
-        # eviction-eligible.
-        if len(self._user_pool_entries) <= self._user_pool_lru_max:
+        # Second pass: LRU cap over warm entries. Iterate the canonical
+        # entry map (not the last_used view) so brand-new entries that
+        # were created via ``_ensure_pool_entry`` but haven't dispatched
+        # yet are still eviction-eligible.
+        warm = [
+            (key, entry)
+            for key, entry in self._user_pool_entries.items()
+            if entry.session is not None or entry.owner_task is not None
+        ]
+        if len(warm) <= self._user_pool_lru_max:
             return
         ordered = sorted(
-            self._user_pool_entries.items(),
+            warm,
             key=lambda kv: self._user_pool_last_used.get(kv[0], kv[1].last_used),
         )
         # Compute the eviction batch up front; we re-check the cap after
         # each close (in-flight skips can leave us still over).
         for key, _entry in ordered:
-            if len(self._user_pool_entries) <= self._user_pool_lru_max:
+            if self._warm_pool_count() <= self._user_pool_lru_max:
                 break
             await self._close_pool_entry_if_idle(key)
 
     async def _close_pool_entry_if_idle(self, key: tuple[str, str]) -> None:
-        """Close ``key`` iff its open_lock is uncontested AND in_flight==0.
+        """Close ``key``'s transport iff its open_lock is uncontested AND in_flight==0.
 
         Best-effort: a contested lock or an active dispatch causes the
         function to return without mutation; the next eviction tick
         retries.
+
+        What happens to the ENTRY depends on whether the user still has
+        a live session (:meth:`_user_has_live_listener`) and the entry
+        carries a discovered catalog (:meth:`_entry_has_catalog`):
+
+        - live listener + catalog → the entry is COOLED: transport torn down,
+          catalog kept, no rebuild, no listener fan-out. The user's
+          merged tool list is untouched and the next dispatch or prime
+          reconnects — the evict-session-keep-entry shape of
+          ``_on_pool_owner_death``. Dropping the catalog here instead
+          silently removed the server's tools from live sessions with
+          no re-prime path (#836).
+        - otherwise → full drop: entry popped, per-user catalogs
+          rebuilt, listeners notified (reaching only admin/``None``
+          listeners — operator tooling tracking catalog state). This
+          keeps departed users' entries from outliving their sessions.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None:
@@ -3043,16 +3125,26 @@ class MCPClientManager:
             if entry.in_flight > 0:
                 return
             await self._teardown_pool_entry(key)
-            self._user_pool_entries.pop(key, None)
-            self._user_pool_last_used.pop(key, None)
-            # Mirror ``_evict_session``'s catalog cleanup: dropping the
-            # entry without rebuilding the per-user catalogs would leave
-            # ``is_mcp_tool`` / per-user resource & prompt maps returning
-            # stale entries whose backing pool is gone, and ChatSession's
-            # tool / resource / prompt lists would never rebuild because
-            # no listener fires.
+            # Prune the push-notification debounce stamp with the
+            # transport either way — a future reconnect's first
+            # ``list_changed`` must refresh immediately.
             self._last_pool_notification_refresh.pop(key, None)
             user_id, _server_name = key
+            if self._entry_has_catalog(entry) and self._user_has_live_listener(user_id):
+                # Cooled: entry + catalog stay, so the live session's
+                # tool list and ``is_mcp_tool`` are untouched. Nothing
+                # changed catalog-wise → no rebuild, no fan-out. The
+                # entry's ``open_lock`` must survive with it (an
+                # in-flight dispatcher's next acquire needs the same
+                # lock object), so skip the ``evicted`` cleanup too.
+                return
+            self._user_pool_entries.pop(key, None)
+            self._user_pool_last_used.pop(key, None)
+            # Dropping the entry without rebuilding the per-user
+            # catalogs would leave ``is_mcp_tool`` / per-user resource &
+            # prompt maps returning stale entries whose backing pool is
+            # gone for good (this user has no live session left to
+            # re-warm it lazily).
             self._rebuild_user_tool_map(user_id)
             self._rebuild_user_resource_map(user_id)
             self._rebuild_user_prompt_map(user_id)
@@ -6573,7 +6665,7 @@ class MCPClientManager:
         return _decode_prompt_result(sdk_result)
 
     def _evict_session(self, key: tuple[str, str]) -> None:
-        """Drop the cached session AND catalog on a pool entry.
+        """Drop the cached session on a pool entry; KEEP the catalog.
 
         Owner/streams left for reconnect. Auth/transport branches both call
         this — the next connect's ``_connect_one_pool`` tears down the stale
@@ -6584,39 +6676,63 @@ class MCPClientManager:
         following reconnect is reaped by idle eviction, which drives the same
         protocol.
 
-        Catalog cleanup (Phase 7 / 7b): clearing ``entry.tools`` /
-        ``entry.resources`` / ``entry.prompts`` here ensures an
-        evicted-then-not-yet-reconnected entry contributes no stale
-        entries to ``_user_tool_map`` / ``_user_resource_map`` /
-        ``_user_prompt_map``. Without this, ``is_mcp_tool`` /
-        ``is_mcp_prompt`` / pool resource resolution could return True
-        for names whose backing pool is gone, then the resolver would
-        dispatch into a session-less entry and the next call would
-        surface as a generic transport error instead of a clean
-        reconnect path.
+        The catalog (``entry.tools`` / ``resources`` / ``prompts``) is
+        deliberately RETAINED — the evict-session-keep-entry shape of
+        ``_on_pool_owner_death`` (#836). Clearing it here removed the
+        server's tools from the user's live sessions on the first failed
+        dispatch (a transport blip, a 403, a double-401): the per-user
+        maps rebuilt empty, the session-side ``is_mcp_tool`` gate
+        closed, and with no re-prime path for a live session the tools
+        never came back — which also made the breaker's half-open
+        recovery and the consent / step-up cards unreachable (the model
+        could no longer emit the name they need to fire). A session-less
+        entry stays fully dispatchable: tool-name resolution never reads
+        the catalog (``_resolve_pool_target`` is name + server-row
+        based) and ``_dispatch_pool_with_entry`` connect-or-reuses,
+        re-running discovery — post-reconnect drift self-corrects and
+        the catalog-refresh notification fans out then.
         """
         evict = self._user_pool_entries.get(key)
         if evict is not None:
             evict.session = None
-            evict.tools = None
-            evict.resources = None
-            evict.prompts = None
-            # Prune the debounce stamp in lockstep with the entry — the
-            # dict grows otherwise (slow leak) across (user, server)
-            # churn. Mirrors the cleanup in ``_close_pool_entry_if_idle``.
+            # Prune the push-notification debounce stamp so a
+            # reconnect's first ``list_changed`` refreshes immediately.
             self._last_pool_notification_refresh.pop(key, None)
-            user_id, _server_name = key
-            self._rebuild_user_tool_map(user_id)
-            self._rebuild_user_resource_map(user_id)
-            self._rebuild_user_prompt_map(user_id)
-            # Wake the user's session so its merged tool / resource /
-            # prompt lists shrink back to static-only until the next
-            # connect populates the entry. Admin (None) listeners also
-            # fire — operator tooling tracking pool catalog state
-            # observes the drop.
-            self._notify_user_tool_listeners(user_id)
-            self._notify_user_resource_listeners(user_id)
-            self._notify_user_prompt_listeners(user_id)
+
+    def _evict_session_drop_catalog(self, key: tuple[str, str]) -> None:
+        """Drop the cached session AND the entry's catalog contribution.
+
+        The explicit-revocation flavor of :meth:`_evict_session`, used
+        by :meth:`evict_user_session` (the OAuth disconnect handler):
+        the user asked for the server to be disconnected, so their live
+        sessions SHOULD see the tools leave — the opposite of the
+        dispatch-failure paths, where the catalog is retained (#836).
+        Clearing the catalog also makes the eviction passes treat the
+        entry as a droppable stub (``_entry_has_catalog`` is False), so
+        it doesn't linger cooled behind a live listener.
+
+        Owner/streams left for reconnect teardown exactly as in
+        :meth:`_evict_session` (the one-cancel close protocol).
+        """
+        evict = self._user_pool_entries.get(key)
+        if evict is None:
+            return
+        evict.session = None
+        evict.tools = None
+        evict.resources = None
+        evict.prompts = None
+        self._last_pool_notification_refresh.pop(key, None)
+        user_id, _server_name = key
+        self._rebuild_user_tool_map(user_id)
+        self._rebuild_user_resource_map(user_id)
+        self._rebuild_user_prompt_map(user_id)
+        # Wake the user's sessions so their merged tool / resource /
+        # prompt lists shrink now, not at the next turn boundary. Admin
+        # (None) listeners also fire — operator tooling tracking pool
+        # catalog state observes the drop.
+        self._notify_user_tool_listeners(user_id)
+        self._notify_user_resource_listeners(user_id)
+        self._notify_user_prompt_listeners(user_id)
 
     async def _handle_auth_403(
         self,
@@ -7073,22 +7189,24 @@ class MCPClientManager:
         return _decode_prompt_result(result)
 
     def evict_user_session(self, user_id: str, server_name: str) -> None:
-        """Drop the cached pool session for ``(user_id, server_name)``.
+        """Drop the cached pool session AND catalog for ``(user_id, server_name)``.
 
-        Sync entry point for callers (e.g. the OAuth revoke handler)
-        that mutate token state from outside the mcp-loop and need the
-        next dispatch to reconnect with fresh credentials. Idempotent —
+        Sync entry point for the OAuth revoke handler: the user
+        explicitly disconnected the server, so the session is dropped
+        and — unlike the dispatch-failure eviction (#836) — the user's
+        catalog view of the server is removed and their live sessions
+        notified (:meth:`_evict_session_drop_catalog`). Idempotent —
         a missing key is a silent no-op. Fire-and-forget: schedules
-        :meth:`_evict_session` on the mcp-loop and returns immediately
-        without waiting for the future. Best-effort: a closed loop or
-        scheduling failure logs at info level; never raises.
+        onto the mcp-loop and returns immediately without waiting for
+        the future. Best-effort: a closed loop or scheduling failure
+        logs at info level; never raises.
         """
         if self._loop is None:
             return
         key = (user_id, server_name)
 
         async def _do_evict() -> None:
-            self._evict_session(key)
+            self._evict_session_drop_catalog(key)
 
         try:
             asyncio.run_coroutine_threadsafe(_do_evict(), self._loop)

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2015,7 +2015,11 @@ class MCPClientManager:
         handler's marker check this bounds the waiter queue at one
         parked runner per key+kind: a same-key dispatch waits at most
         two refresh timeouts, not an unbounded runner FIFO. The
-        ``finally`` discard covers cancellation while parked.
+        ``finally`` discard covers cancellation while parked and is
+        GATED on non-acquisition: after the at-acquire discard, a
+        marker present at exit belongs to the successor spawned during
+        our list call, and clobbering it would re-open the unbounded
+        FIFO the marker exists to prevent.
 
         The same-entry recheck under the lock discards a refresh whose
         entry was replaced (full drop + re-create) while it waited —
@@ -2057,9 +2061,11 @@ class MCPClientManager:
         if entry is None:
             self._pool_refresh_pending.discard(marker)
             return
+        acquired = False
         try:
             async with entry.open_lock:
                 self._pool_refresh_pending.discard(marker)
+                acquired = True
                 if self._user_pool_entries.get(key) is not entry:
                     return
                 if entry.session is None:
@@ -2077,7 +2083,15 @@ class MCPClientManager:
                 type(exc).__name__,
             )
         finally:
-            self._pool_refresh_pending.discard(marker)
+            if not acquired:
+                # Cancelled (or failed) while PARKED — the marker still
+                # in the set is OURS; release it or the key+kind never
+                # refreshes again. After the at-acquire discard, a
+                # marker present at exit belongs to the SUCCESSOR
+                # spawned during our in-flight list — discarding it
+                # would let the handler mint runners past the
+                # one-parked-runner bound.
+                self._pool_refresh_pending.discard(marker)
 
     async def _pool_transport_owner(
         self,
@@ -2211,10 +2225,7 @@ class MCPClientManager:
         entry = self._user_pool_entries.get(key)
         if entry is None:
             return
-        entry.drop_session()
-        # The debounce stamp must not outlive the transport: a
-        # reconnect's first ``list_changed`` refreshes immediately.
-        self._last_pool_notification_refresh.pop(key, None)
+        self._drop_session_and_stamp(key, entry)
         owner = entry.owner_task
         close_requested = entry.close_requested
         entry.owner_task = None
@@ -2264,11 +2275,9 @@ class MCPClientManager:
             return
         entry.owner_task = None
         entry.close_requested = None
-        # The debounce stamp must not outlive the transport: the
-        # reconnect's first ``list_changed`` refreshes immediately.
-        self._last_pool_notification_refresh.pop(key, None)
-        if entry.session is not None:
-            entry.drop_session()
+        had_session = entry.session is not None
+        self._drop_session_and_stamp(key, entry)
+        if had_session:
             user_id, server_name = key
             log.info(
                 "MCP pool transport terminated user=%s server=%s; session evicted for reconnect",
@@ -4718,6 +4727,8 @@ class MCPClientManager:
         self._circuit_open_until.clear()
         self._circuit_trip_count.clear()
         self._last_notification_refresh.clear()
+        self._last_pool_notification_refresh.clear()
+        self._pool_refresh_pending.clear()
         # Pool state already cleared above when the loop was alive; this
         # makes shutdown idempotent if the loop exited before pool state
         # could be wound down (e.g., manager constructed but never started).
@@ -6648,15 +6659,8 @@ class MCPClientManager:
         # this retry; the local cached token is the one the AS just
         # rejected, so reading it back without ``force_refresh=True``
         # would re-attempt with the same (rejected) bearer.
-        # Observe the session BEFORE the lookup's awaits: a session the
-        # consent-completion prime connects DURING the lookup must read
-        # as re-consent evidence at drop time, not as pre-observation.
-        observed_session = self._observed_pool_session(user_id, server_name)
-        lookup: TokenLookupResult = await self._pool_token_lookup(
+        lookup, lookup_error = await self._pool_lookup_checked(
             server_row, user_id, server_name, force_refresh=retry_count > 0
-        )
-        lookup_error = self._pool_lookup_failure(
-            lookup, server_name, server_row, user_id, observed_session=observed_session
         )
         if lookup_error is not None:
             return lookup_error
@@ -6800,15 +6804,8 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
-        # Observe the session BEFORE the lookup's awaits: a session the
-        # consent-completion prime connects DURING the lookup must read
-        # as re-consent evidence at drop time, not as pre-observation.
-        observed_session = self._observed_pool_session(user_id, server_name)
-        lookup: TokenLookupResult = await self._pool_token_lookup(
+        lookup, lookup_error = await self._pool_lookup_checked(
             server_row, user_id, server_name, force_refresh=retry_count > 0
-        )
-        lookup_error = self._pool_lookup_failure(
-            lookup, server_name, server_row, user_id, observed_session=observed_session
         )
         if lookup_error is not None:
             return lookup_error
@@ -6930,15 +6927,8 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
-        # Observe the session BEFORE the lookup's awaits: a session the
-        # consent-completion prime connects DURING the lookup must read
-        # as re-consent evidence at drop time, not as pre-observation.
-        observed_session = self._observed_pool_session(user_id, server_name)
-        lookup: TokenLookupResult = await self._pool_token_lookup(
+        lookup, lookup_error = await self._pool_lookup_checked(
             server_row, user_id, server_name, force_refresh=retry_count > 0
-        )
-        lookup_error = self._pool_lookup_failure(
-            lookup, server_name, server_row, user_id, observed_session=observed_session
         )
         if lookup_error is not None:
             return lookup_error
@@ -7030,6 +7020,22 @@ class MCPClientManager:
         self._cb_record_success(server_name)
         return _decode_prompt_result(sdk_result)
 
+    def _drop_session_and_stamp(self, key: tuple[str, str], entry: PoolEntryState) -> None:
+        """Drop the entry's session AND its notification debounce stamp.
+
+        The structural pairing for every teardown path (the same
+        rationale as ``PoolEntryState.drop_session``): the stamp must
+        not outlive the transport, so a reconnect's first
+        ``list_changed`` refreshes immediately — a path that nulled the
+        session without the pop silently re-opens the stale-stamp hole
+        where a post-reconnect change is debounced against a
+        pre-collapse stamp. Safe on an already-session-less entry
+        (owner death after an eviction): ``drop_session`` is idempotent
+        and the pop is a no-op.
+        """
+        entry.drop_session()
+        self._last_pool_notification_refresh.pop(key, None)
+
     def _evict_session(self, key: tuple[str, str]) -> None:
         """Drop the cached session on a pool entry; KEEP the catalog.
 
@@ -7060,10 +7066,7 @@ class MCPClientManager:
         """
         evict = self._user_pool_entries.get(key)
         if evict is not None:
-            evict.drop_session()
-            # Prune the push-notification debounce stamp so a
-            # reconnect's first ``list_changed`` refreshes immediately.
-            self._last_pool_notification_refresh.pop(key, None)
+            self._drop_session_and_stamp(key, evict)
 
     def _evict_session_drop_catalog(self, key: tuple[str, str]) -> None:
         """Drop the cached session AND the entry's catalog contribution.
@@ -7145,6 +7148,35 @@ class MCPClientManager:
         """
         entry = self._user_pool_entries.get((user_id, server_name))
         return entry.session if entry is not None else None
+
+    async def _pool_lookup_checked(
+        self,
+        server_row: dict[str, Any],
+        user_id: str,
+        server_name: str,
+        *,
+        force_refresh: bool,
+    ) -> tuple[TokenLookupResult, str | None]:
+        """Classified pool lookup with its convergence pairing, ordering-safe.
+
+        The ONE copy of the dispatch-side lookup protocol (three
+        dispatchers): the dead-grant observation is taken synchronously
+        BEFORE the lookup's first await — a session the
+        consent-completion prime connects DURING the lookup must read
+        as re-consent evidence at drop time, not as pre-observation —
+        and the failed-lookup render is paired with its convergence
+        drop via :meth:`_pool_lookup_failure`. Structuring the ordering
+        here makes it un-violable per dispatch site. Returns
+        ``(lookup, error)``; ``error`` is ``None`` exactly when the
+        lookup carries a usable bearer.
+        """
+        observed_session = self._observed_pool_session(user_id, server_name)
+        lookup = await self._pool_token_lookup(
+            server_row, user_id, server_name, force_refresh=force_refresh
+        )
+        return lookup, self._pool_lookup_failure(
+            lookup, server_name, server_row, user_id, observed_session=observed_session
+        )
 
     def _pool_lookup_failure(
         self,

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -148,6 +148,18 @@ _MAX_PROMPTS_PER_SERVER = 1000
 # thundering herd of connects on every session start.
 _PRIME_MAX_CONCURRENCY = 4
 
+# One row per pool ``*/list_changed`` kind: notification type → (kind label,
+# refresh-method name). The pool notification handler drives all three catalog
+# kinds through this table so the debounce-stamp/log/spawn protocol exists
+# exactly once — a protocol change cannot silently diverge between kinds.
+# Exact-type lookup is safe: the SDK's discriminated-union parser instantiates
+# these concrete classes, never subclasses.
+_POOL_LIST_CHANGED_REFRESHERS: dict[type, tuple[str, str]] = {
+    mcp_types.ToolListChangedNotification: ("tools", "_refresh_pool_server_tools"),
+    mcp_types.ResourceListChangedNotification: ("resources", "_refresh_pool_server_resources"),
+    mcp_types.PromptListChangedNotification: ("prompts", "_refresh_pool_server_prompts"),
+}
+
 # How long a node trusts its own pending-consent DELETE before re-running it on
 # the next dispatch success. Bounds two things at once: the hot-path SQL rate
 # (at most one DELETE per (user, server) per window) and the staleness of a
@@ -1854,7 +1866,10 @@ class MCPClientManager:
         ) -> None:
             if not isinstance(msg, mcp_types.ServerNotification):
                 return
-            root = msg.root
+            spec = _POOL_LIST_CHANGED_REFRESHERS.get(type(msg.root))
+            if spec is None:
+                return
+            kind, refresh_name = spec
             now = time.monotonic()
             last = self._last_pool_notification_refresh.get(key, 0.0)
             if now - last < self._NOTIFICATION_DEBOUNCE:
@@ -1873,45 +1888,17 @@ class MCPClientManager:
                 # parked, every in-flight call on the session stalls
                 # with it, and the refresh only ever exits via its
                 # timeout. The refresh runs as its own tracked task.
-                if isinstance(root, mcp_types.ToolListChangedNotification):
-                    log.info(
-                        "Received tools/list_changed from pool user=%s server=%s",
-                        user_id,
-                        server_name,
-                    )
-                    self._last_pool_notification_refresh[key] = now
-                    self._spawn_background(
-                        self._run_notification_refresh(
-                            key, "tools", self._refresh_pool_server_tools
-                        ),
-                        f"pool tools refresh for '{server_name}'",
-                    )
-                elif isinstance(root, mcp_types.ResourceListChangedNotification):
-                    log.info(
-                        "Received resources/list_changed from pool user=%s server=%s",
-                        user_id,
-                        server_name,
-                    )
-                    self._last_pool_notification_refresh[key] = now
-                    self._spawn_background(
-                        self._run_notification_refresh(
-                            key, "resources", self._refresh_pool_server_resources
-                        ),
-                        f"pool resources refresh for '{server_name}'",
-                    )
-                elif isinstance(root, mcp_types.PromptListChangedNotification):
-                    log.info(
-                        "Received prompts/list_changed from pool user=%s server=%s",
-                        user_id,
-                        server_name,
-                    )
-                    self._last_pool_notification_refresh[key] = now
-                    self._spawn_background(
-                        self._run_notification_refresh(
-                            key, "prompts", self._refresh_pool_server_prompts
-                        ),
-                        f"pool prompts refresh for '{server_name}'",
-                    )
+                log.info(
+                    "Received %s/list_changed from pool user=%s server=%s",
+                    kind,
+                    user_id,
+                    server_name,
+                )
+                self._last_pool_notification_refresh[key] = now
+                self._spawn_background(
+                    self._run_notification_refresh(key, kind, getattr(self, refresh_name)),
+                    f"pool {kind} refresh for '{server_name}'",
+                )
             except Exception as exc:
                 # Scheduling failed (loop shutting down). Structured
                 # fields only — ``exc_info=True`` would serialize the
@@ -1934,19 +1921,52 @@ class MCPClientManager:
     ) -> None:
         """Body of a spawned ``list_changed`` refresh — never on the receive loop.
 
-        A FAILED refresh returns the debounce stamp so the server's
-        next ``list_changed`` retries instead of being silently dropped
-        inside the debounce window with the catalog change never
-        landing.
+        Serializes on ``open_lock`` before refreshing. An unserialized
+        refresh races two writers: an in-flight ``_connect_one_pool``,
+        whose final wiring block would overwrite the refresh's newer
+        catalog with its older discovery snapshot; and a sibling
+        refresh for the same key, where the slower list call can
+        publish the older catalog last. Under the lock each refresh
+        issues its list call only after the previous publisher
+        finished, so the last publish is always the freshest. The wait
+        is bounded: lock holders are a connect/dispatch (one SDK call)
+        or another refresh (capped by ``_CONNECT_TIMEOUT``).
+
+        The same-entry recheck under the lock discards a refresh whose
+        entry was replaced (full drop + re-create) while it waited —
+        the notification belonged to the old transport and the
+        replacement published its own discovery.
+
+        The debounce stamp (set at schedule time) deliberately SURVIVES
+        a failed refresh: popping it re-armed the handler on every
+        notification, so a fast-failing server spawned refresh tasks at
+        its notification rate. Keeping it caps attempts at one per
+        debounce window; a change announced during the remainder of a
+        failed window converges on the server's next ``list_changed``
+        or the entry's next reconnect (connects run full discovery, and
+        teardown pops the stamp so a reconnect's first notification
+        refreshes immediately).
+
+        ``BaseExceptionGroup`` is caught alongside ``Exception``: a
+        wedged anyio transport surfaces session-op failures as groups,
+        and a group escaping this frame would reach
+        ``_spawn_background``'s failure log, whose ``exc_info``
+        serializes the chained ``httpx.Request`` — headers carrying
+        ``Authorization: Bearer <token>``.
         """
         user_id, server_name = key
+        entry = self._user_pool_entries.get(key)
+        if entry is None:
+            return
         try:
-            await refresh(key)
-        except Exception as exc:
-            self._last_pool_notification_refresh.pop(key, None)
-            # Structured fields only — ``exc_info=True`` would
-            # serialize the chained ``httpx.Request`` whose headers
-            # carry ``Authorization: Bearer <token>``.
+            async with entry.open_lock:
+                if self._user_pool_entries.get(key) is not entry:
+                    return
+                await refresh(key)
+        except (Exception, BaseExceptionGroup) as exc:
+            # Structured fields only — ``exc_info`` would serialize
+            # the chained ``httpx.Request`` whose headers carry
+            # ``Authorization: Bearer <token>``.
             log.warning(
                 "Pool %s refresh after notification failed user=%s server=%s exc=%s",
                 kind,
@@ -2749,6 +2769,12 @@ class MCPClientManager:
                 # (kind="missing") for any retained obo catalogs, or
                 # ghosts survive every new-session prime: this gate
                 # skips exactly the lookup that would drop them.
+                # Contract: the synthesized kind="missing" mirrors
+                # get_obo_access_token_classified's durably-absent-
+                # credential verdict (its missing-credential return
+                # notes this back-reference); if that classification
+                # ever splits — say a transient sub-case — update this
+                # synthesis with it.
                 for name in self._obo_server_names:
                     obo_key = (user_id, name)
                     obo_entry = self._user_pool_entries.get(obo_key)
@@ -3602,10 +3628,11 @@ class MCPClientManager:
         listener fan-out. Static-path catalogs are NEVER touched, so
         invariant 1 (static path byte-identical) is preserved.
 
-        MUST run on the mcp-loop. Caller does not need to hold
-        ``open_lock`` — ``_refresh_pool_server_tools`` is invoked from
-        the pool session's notification handler, which already runs in
-        the SDK's receive task on the loop.
+        MUST run on the mcp-loop, with the entry's ``open_lock`` HELD
+        (:meth:`_run_notification_refresh` acquires it): an unlocked
+        refresh races a connect's discovery wiring and sibling
+        refreshes, either of which can publish an older catalog over
+        this one — see the runner's ordering rationale.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None or entry.session is None:
@@ -3617,8 +3644,9 @@ class MCPClientManager:
         session = entry.session
         user_id, server_name = key
         old_names = {t["function"]["name"] for t in (entry.tools or [])}
-        # ``asyncio.timeout`` mandatory (R6) — a wedged server must not
-        # hang the spawned refresh task forever; siblings already comply.
+        # ``asyncio.timeout`` mandatory — a wedged server must not hang
+        # the spawned refresh task (and the ``open_lock`` it holds)
+        # forever; the resource/prompt siblings already comply.
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
             result = await session.list_tools()
         if self._user_pool_entries.get(key) is not entry:
@@ -5098,8 +5126,7 @@ class MCPClientManager:
         follow-up if IdP rate-limiting is ever observed under a large active-user
         count.
         """
-        with self._listeners_lock:
-            user_ids = {uid for uid, _cb in self._listeners if uid}
+        user_ids = self._live_listener_uids()
         for user_id in user_ids:
             try:
                 self.prime_user_pools(user_id)
@@ -7002,16 +7029,31 @@ class MCPClientManager:
         call — awaiting here stalled token-side errors past the sync
         timeout and charged the breaker they are documented to bypass.
         ``_spawn_background`` tracks the task so shutdown cancels it.
+
+        The entry's CURRENT session is snapshotted here, at the moment
+        the dead grant was observed, and handed to the drop as
+        ``observed_session``: a warm session that already existed when
+        the lookup failed predates the revocation and must be evicted
+        (the #836 warm case — dispatches short-circuit on the failed
+        lookup without ever touching the session, so no 401 path would
+        converge it). Only a session that CHANGED after this snapshot
+        proves a later successful connect, i.e. a live grant.
         """
         if not self._lookup_grant_dead(lookup):
             return
+        entry = self._user_pool_entries.get(key)
+        observed = entry.session if entry is not None else None
         self._spawn_background(
-            self._drop_catalog_locked(key, skip_if_connected=True),
+            self._drop_catalog_locked(key, skip_if_connected=True, observed_session=observed),
             f"dead-grant catalog drop for '{key[1]}'",
         )
 
     async def _drop_catalog_locked(
-        self, key: tuple[str, str], *, skip_if_connected: bool = False
+        self,
+        key: tuple[str, str],
+        *,
+        skip_if_connected: bool = False,
+        observed_session: Any = None,
     ) -> None:
         """Serialize a catalog drop against an in-flight connect.
 
@@ -7028,19 +7070,40 @@ class MCPClientManager:
         a dispatch-scheduled drop can be parked long enough for the
         user to RE-CONSENT and the consent-completion prime to connect
         and publish a fresh catalog — clearing that would strand the
-        just-restored tools (nothing re-primes until a new session). A
-        live session at drop time proves a connect succeeded after the
-        failed lookup that scheduled us, i.e. the grant is alive again:
-        connects always resolve their bearer through the classified
-        lookup first, so a session cannot exist without a grant that
-        was valid at its connect. The explicit-revocation path passes
-        False: it must clear even (especially) warm sessions.
+        just-restored tools (nothing re-primes until a new session).
+        Re-consent evidence is a session DIFFERENT from
+        ``observed_session`` — the one snapshotted when the dead grant
+        was discovered (``_schedule_dead_grant_drop``): connects
+        resolve their bearer through the classified lookup first, so a
+        session created after the failed lookup implies a grant that
+        was valid again at its connect. The session that was ALREADY
+        live at observation time predates the revocation and is
+        evicted along with the catalog — a warm transport is exactly
+        how the #836 warm case dangles, since failed lookups
+        short-circuit dispatch before any 401 could evict it. Callers
+        without an observation leave ``observed_session=None``, which
+        treats any live session as re-consent evidence (the cold
+        case). The explicit-revocation path passes
+        ``skip_if_connected=False``: it must clear even (especially)
+        warm sessions.
+
+        Bounded residual, accepted: if the entry is fully dropped,
+        re-created, connected, and COOLED between the observation and
+        this drop running, the stale drop clears that fresh cooled
+        catalog — it self-heals at next use (the grant is alive, so
+        dispatch/prime reconnects and republishes), and the window
+        requires a full connect-and-cool cycle inside task-scheduling
+        latency.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None:
             return
         async with entry.open_lock:
-            if skip_if_connected and entry.session is not None:
+            if (
+                skip_if_connected
+                and entry.session is not None
+                and entry.session is not observed_session
+            ):
                 return
             self._evict_session_drop_catalog(key)
 

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -148,17 +148,58 @@ _MAX_PROMPTS_PER_SERVER = 1000
 # thundering herd of connects on every session start.
 _PRIME_MAX_CONCURRENCY = 4
 
-# One row per pool ``*/list_changed`` kind: notification type → (kind label,
-# refresh-method name). The pool notification handler drives all three catalog
-# kinds through this table so the debounce-stamp/log/spawn protocol exists
-# exactly once — a protocol change cannot silently diverge between kinds.
-# Exact-type lookup is safe: the SDK's discriminated-union parser instantiates
-# these concrete classes, never subclasses.
-_POOL_LIST_CHANGED_REFRESHERS: dict[type, tuple[str, str]] = {
-    mcp_types.ToolListChangedNotification: ("tools", "_refresh_pool_server_tools"),
-    mcp_types.ResourceListChangedNotification: ("resources", "_refresh_pool_server_resources"),
-    mcp_types.PromptListChangedNotification: ("prompts", "_refresh_pool_server_prompts"),
+# One row per pool ``*/list_changed`` kind: notification type → kind label.
+# The pool notification handler drives all three catalog kinds through this
+# table (plus its kind → bound-method map, which stays mypy-checked attribute
+# access rather than a name-string table) so the debounce/coalesce/log/spawn
+# protocol exists exactly once — a protocol change cannot silently diverge
+# between kinds. Exact-type lookup is safe: the SDK's discriminated-union
+# parser instantiates these concrete classes, never subclasses.
+_POOL_LIST_CHANGED_KINDS: dict[type, str] = {
+    mcp_types.ToolListChangedNotification: "tools",
+    mcp_types.ResourceListChangedNotification: "resources",
+    mcp_types.PromptListChangedNotification: "prompts",
 }
+
+
+def try_prime_user_pools(
+    mcp_client: Any,
+    user_id: str | None,
+    *,
+    require_live_listener: bool = False,
+    context: str = "prime",
+) -> None:
+    """Best-effort per-user pool prime: schedule and swallow, never raise.
+
+    The ONE copy of the fire-and-forget prime idiom shared by the
+    session-construction, acting-user-change, and OIDC capture-success
+    call sites — three hand-synced copies had already drifted.
+    ``mcp_client`` is duck-typed (session and auth tests stub it): a
+    client without the prime surface, or a falsy ``user_id``, is a
+    silent no-op, matching the guards this replaces. Failures never
+    propagate — a prime is an optimisation, and neither login nor
+    session construction may fail on it. ``require_live_listener``
+    gates on an open session to heal (the OIDC capture site: priming on
+    every routine SSO re-login would warm transports and mint tokens
+    for users with nothing open, at deployment scale).
+    """
+    if not user_id or not hasattr(mcp_client, "prime_user_pools"):
+        return
+    try:
+        if require_live_listener and not (
+            hasattr(mcp_client, "has_live_session_listener")
+            and mcp_client.has_live_session_listener(user_id)
+        ):
+            return
+        mcp_client.prime_user_pools(user_id)
+    except Exception:
+        log.debug(
+            "MCP pool prime scheduling failed (%s) user=%s",
+            context,
+            user_id,
+            exc_info=True,
+        )
+
 
 # How long a node trusts its own pending-consent DELETE before re-running it on
 # the next dispatch success. Bounds two things at once: the hot-path SQL rate
@@ -751,6 +792,13 @@ class MCPClientManager:
         # so a noisy server in one user's pool doesn't suppress a refresh
         # in another user's pool of the same server.
         self._last_pool_notification_refresh: dict[tuple[str, str], float] = {}
+        # Coalescing markers for spawned ``list_changed`` refreshes, keyed
+        # ``((user_id, server), kind)``: set at spawn, cleared the moment
+        # the runner acquires ``open_lock`` (before its list call). While
+        # set, further notifications for the key+kind are dropped — the
+        # parked runner's fresh list will observe their change — bounding
+        # the lock's waiter queue at ONE parked runner per key+kind.
+        self._pool_refresh_pending: set[tuple[tuple[str, str], str]] = set()
 
         # Pool tuning (read at construction; falls back to defaults).
         mcp_cfg = load_config("mcp")
@@ -1866,10 +1914,9 @@ class MCPClientManager:
         ) -> None:
             if not isinstance(msg, mcp_types.ServerNotification):
                 return
-            spec = _POOL_LIST_CHANGED_REFRESHERS.get(type(msg.root))
-            if spec is None:
+            kind = _POOL_LIST_CHANGED_KINDS.get(type(msg.root))
+            if kind is None:
                 return
-            kind, refresh_name = spec
             now = time.monotonic()
             last = self._last_pool_notification_refresh.get(key, 0.0)
             if now - last < self._NOTIFICATION_DEBOUNCE:
@@ -1880,6 +1927,21 @@ class MCPClientManager:
                     now - last,
                 )
                 return
+            marker = (key, kind)
+            if marker in self._pool_refresh_pending:
+                # A runner for this key+kind is queued but has not yet
+                # issued its list call — it will observe this change
+                # when it runs. Skipping bounds ``open_lock``'s waiter
+                # queue at one parked runner per key+kind, so a
+                # notifying-but-slow server cannot accrete waiters that
+                # starve same-key dispatches and idle eviction.
+                log.debug(
+                    "Coalescing pool %s notification user=%s server=%s (refresh queued)",
+                    kind,
+                    user_id,
+                    server_name,
+                )
+                return
             try:
                 # SPAWNED, never awaited: the SDK awaits notification
                 # handlers inline in its receive loop, so a handler that
@@ -1888,6 +1950,18 @@ class MCPClientManager:
                 # parked, every in-flight call on the session stalls
                 # with it, and the refresh only ever exits via its
                 # timeout. The refresh runs as its own tracked task.
+                #
+                # Bound at dispatch time (not a module-level name table)
+                # so instance-level overrides keep working and mypy
+                # checks the attribute references.
+                refreshers: dict[
+                    str,
+                    Callable[[tuple[str, str]], Awaitable[tuple[list[str], list[str]]]],
+                ] = {
+                    "tools": self._refresh_pool_server_tools,
+                    "resources": self._refresh_pool_server_resources,
+                    "prompts": self._refresh_pool_server_prompts,
+                }
                 log.info(
                     "Received %s/list_changed from pool user=%s server=%s",
                     kind,
@@ -1895,15 +1969,18 @@ class MCPClientManager:
                     server_name,
                 )
                 self._last_pool_notification_refresh[key] = now
+                self._pool_refresh_pending.add(marker)
                 self._spawn_background(
-                    self._run_notification_refresh(key, kind, getattr(self, refresh_name)),
+                    self._run_notification_refresh(key, kind, refreshers[kind]),
                     f"pool {kind} refresh for '{server_name}'",
                 )
             except Exception as exc:
-                # Scheduling failed (loop shutting down). Structured
-                # fields only — ``exc_info=True`` would serialize the
-                # chained ``httpx.Request`` whose headers carry
-                # ``Authorization: Bearer <token>``.
+                # Scheduling failed (loop shutting down) — release the
+                # coalesce marker or this key+kind never refreshes again.
+                # Structured fields only — ``exc_info=True`` would
+                # serialize the chained ``httpx.Request`` whose headers
+                # carry ``Authorization: Bearer <token>``.
+                self._pool_refresh_pending.discard(marker)
                 log.warning(
                     "Pool refresh scheduling failed user=%s server=%s exc=%s",
                     user_id,
@@ -1928,14 +2005,26 @@ class MCPClientManager:
         refresh for the same key, where the slower list call can
         publish the older catalog last. Under the lock each refresh
         issues its list call only after the previous publisher
-        finished, so the last publish is always the freshest. The wait
-        is bounded: lock holders are a connect/dispatch (one SDK call)
-        or another refresh (capped by ``_CONNECT_TIMEOUT``).
+        finished, so the last publish is always the freshest.
+
+        The coalesce marker (set by the handler at spawn) is cleared
+        the moment the lock is ACQUIRED, before the list call: a
+        notification landing during the in-flight list may announce a
+        change that list already missed, so it must spawn exactly one
+        successor — which parks behind this lock. Together with the
+        handler's marker check this bounds the waiter queue at one
+        parked runner per key+kind: a same-key dispatch waits at most
+        two refresh timeouts, not an unbounded runner FIFO. The
+        ``finally`` discard covers cancellation while parked.
 
         The same-entry recheck under the lock discards a refresh whose
         entry was replaced (full drop + re-create) while it waited —
         the notification belonged to the old transport and the
-        replacement published its own discovery.
+        replacement published its own discovery. A session evicted
+        while we were parked returns quietly for the same reason:
+        the reconnect's discovery republishes, and every teardown path
+        pops the debounce stamp, so the reconnected transport's first
+        notification refreshes immediately.
 
         The debounce stamp (set at schedule time) deliberately SURVIVES
         a failed refresh: popping it re-armed the handler on every
@@ -1943,9 +2032,7 @@ class MCPClientManager:
         its notification rate. Keeping it caps attempts at one per
         debounce window; a change announced during the remainder of a
         failed window converges on the server's next ``list_changed``
-        or the entry's next reconnect (connects run full discovery, and
-        teardown pops the stamp so a reconnect's first notification
-        refreshes immediately).
+        or the entry's next reconnect.
 
         ``BaseExceptionGroup`` is caught alongside ``Exception``: a
         wedged anyio transport surfaces session-op failures as groups,
@@ -1953,14 +2040,29 @@ class MCPClientManager:
         ``_spawn_background``'s failure log, whose ``exc_info``
         serializes the chained ``httpx.Request`` — headers carrying
         ``Authorization: Bearer <token>``.
+
+        Bounded residual, accepted: a server that keeps notifying while
+        every list call hangs to ``_CONNECT_TIMEOUT`` keeps THIS
+        entry's ``open_lock`` near-continuously occupied (one active +
+        one parked runner), deferring idle eviction of the entry (the
+        eviction pass skips a contested lock). The churn ends at the
+        first real dispatch (whose transport failure evicts the
+        session, after which parked runners bail on the session check),
+        at server recovery, or when the notifications stop; other
+        entries are unaffected (per-entry lock).
         """
         user_id, server_name = key
+        marker = (key, kind)
         entry = self._user_pool_entries.get(key)
         if entry is None:
+            self._pool_refresh_pending.discard(marker)
             return
         try:
             async with entry.open_lock:
+                self._pool_refresh_pending.discard(marker)
                 if self._user_pool_entries.get(key) is not entry:
+                    return
+                if entry.session is None:
                     return
                 await refresh(key)
         except (Exception, BaseExceptionGroup) as exc:
@@ -1974,6 +2076,8 @@ class MCPClientManager:
                 server_name,
                 type(exc).__name__,
             )
+        finally:
+            self._pool_refresh_pending.discard(marker)
 
     async def _pool_transport_owner(
         self,
@@ -2108,6 +2212,9 @@ class MCPClientManager:
         if entry is None:
             return
         entry.drop_session()
+        # The debounce stamp must not outlive the transport: a
+        # reconnect's first ``list_changed`` refreshes immediately.
+        self._last_pool_notification_refresh.pop(key, None)
         owner = entry.owner_task
         close_requested = entry.close_requested
         entry.owner_task = None
@@ -2157,6 +2264,9 @@ class MCPClientManager:
             return
         entry.owner_task = None
         entry.close_requested = None
+        # The debounce stamp must not outlive the transport: the
+        # reconnect's first ``list_changed`` refreshes immediately.
+        self._last_pool_notification_refresh.pop(key, None)
         if entry.session is not None:
             entry.drop_session()
             user_id, server_name = key
@@ -2657,6 +2767,10 @@ class MCPClientManager:
             entry = self._user_pool_entries.get(key)
             if entry is not None and entry.session is not None:
                 return  # already connected — nothing to do
+            # Pre-lookup observation for the dead-grant drop below: at
+            # this point the session is None; one connected during the
+            # lookup's awaits must read as re-consent evidence.
+            observed_session = self._observed_pool_session(user_id, server_name)
             if key in self._priming_keys:
                 return  # a concurrent prime for this (user, server) is in flight
             # Claim synchronously before any await — the mcp-loop is single-
@@ -2716,7 +2830,9 @@ class MCPClientManager:
                             # is durably gone must drop the retained
                             # catalog other live sessions still serve —
                             # e.g. a disconnect made on another node.
-                            self._schedule_dead_grant_drop(lookup, key)
+                            self._schedule_dead_grant_drop(
+                                lookup, key, observed_session=observed_session
+                            )
                             return  # not consented / no credential / refresh failed — lazy paths handle it
                         if server_row is None:
                             server_row = await asyncio.to_thread(
@@ -2751,6 +2867,13 @@ class MCPClientManager:
             # kind="missing". The oauth_user branch keeps its own deferred-row
             # optimisation. On any read hiccup, fail open and let the
             # per-server mint path classify it.
+            # Pre-read observation for the dead-grant drops below: a
+            # session connected DURING the credential read (a re-login
+            # capture prime racing this one) must read as re-consent
+            # evidence at drop time, not as the pre-observation session.
+            observed_obo = {
+                name: self._observed_pool_session(user_id, name) for name in self._obo_server_names
+            }
             issuer = str(getattr(getattr(self._app_state, "oidc_config", None), "issuer", "") or "")
             has_credential = False
             if issuer:
@@ -2766,9 +2889,11 @@ class MCPClientManager:
             if not has_credential:
                 # The credential is GONE — fire the same dead-grant
                 # convergence the per-server lookup would have
-                # (kind="missing") for any retained obo catalogs, or
+                # (kind="missing") for any retained obo entries, or
                 # ghosts survive every new-session prime: this gate
-                # skips exactly the lookup that would drop them.
+                # skips exactly the lookup that would drop them (the
+                # schedule-side guard skips entries with nothing to
+                # converge).
                 # Contract: the synthesized kind="missing" mirrors
                 # get_obo_access_token_classified's durably-absent-
                 # credential verdict (its missing-credential return
@@ -2776,10 +2901,11 @@ class MCPClientManager:
                 # ever splits — say a transient sub-case — update this
                 # synthesis with it.
                 for name in self._obo_server_names:
-                    obo_key = (user_id, name)
-                    obo_entry = self._user_pool_entries.get(obo_key)
-                    if obo_entry is not None and self._entry_has_catalog(obo_entry):
-                        self._schedule_dead_grant_drop(TokenLookupResult(kind="missing"), obo_key)
+                    self._schedule_dead_grant_drop(
+                        TokenLookupResult(kind="missing"),
+                        (user_id, name),
+                        observed_session=observed_obo.get(name),
+                    )
                 prime_names -= self._obo_server_names
         await asyncio.gather(*(_prime_one(s) for s in list(prime_names)))
 
@@ -3072,33 +3198,28 @@ class MCPClientManager:
                 # — a transport-layer group must not kill the loop.
                 log.warning("MCP pool eviction iteration failed", exc_info=True)
 
-    def _user_has_live_listener(self, user_id: str) -> bool:
+    def has_live_session_listener(self, user_id: str) -> bool:
         """True when *user_id* has a registered user-scoped tool listener.
 
         A live listener means a live ChatSession whose merged tool list
-        is derived from this user's pool catalog — the signal the
-        eviction passes use to decide cool-vs-drop (#836). Admin
-        (``None``) listeners don't count: they track catalog state for
-        operator tooling, not a user's model-visible tool list.
+        is derived from this user's pool catalog. The ONE liveness
+        predicate: the eviction passes use it to decide cool-vs-drop
+        (#836), and outside callers (the OIDC capture-site prime) use
+        it to fan out work only for users who actually have an open
+        session to heal — priming on every routine SSO re-login would
+        warm transports and mint tokens for users with nothing open, at
+        deployment scale. Admin (``None``) listeners don't count: they
+        track catalog state for operator tooling, not a user's
+        model-visible tool list.
         """
         with self._listeners_lock:
             return any(uid == user_id for uid, _cb in self._listeners)
-
-    def has_live_session_listener(self, user_id: str) -> bool:
-        """Public: does *user_id* have a live session's tool listener?
-
-        Lets outside callers (the OIDC capture-site prime) fan out work
-        only for users who actually have an open session to heal —
-        priming on every routine SSO re-login would warm transports and
-        mint tokens for users with nothing open, at deployment scale.
-        """
-        return self._user_has_live_listener(user_id)
 
     def _live_listener_uids(self) -> set[str]:
         """Snapshot the user ids with a live tool listener (one lock take).
 
         The TTL pass checks retention for every idle entry every tick;
-        a per-entry ``_user_has_live_listener`` scan would be
+        a per-entry ``has_live_session_listener`` scan would be
         O(entries × listeners) under ``_listeners_lock`` on the
         mcp-loop. Snapshot staleness is bounded by one tick and benign:
         a listener added after the snapshot re-primes at session start
@@ -3176,7 +3297,7 @@ class MCPClientManager:
             return False
         if live_uids is not None:
             return user_id in live_uids
-        return self._user_has_live_listener(user_id)
+        return self.has_live_session_listener(user_id)
 
     def _rebuild_and_notify_user_catalogs(self, user_id: str) -> None:
         """Rebuild all three per-user catalog maps, then fan out to all
@@ -3320,10 +3441,6 @@ class MCPClientManager:
             if entry.in_flight > 0:
                 return
             await self._teardown_pool_entry(key)
-            # Prune the push-notification debounce stamp with the
-            # transport either way — a future reconnect's first
-            # ``list_changed`` must refresh immediately.
-            self._last_pool_notification_refresh.pop(key, None)
             user_id, _server_name = key
             if self._retain_cooled(key, entry):
                 # Cooled: entry + catalog stay, so the live session's
@@ -3682,11 +3799,14 @@ class MCPClientManager:
         Mirror of :meth:`_refresh_pool_server_tools` for the resource
         path (RFC §3.2). Skips when ``supports_resources`` is False so
         a server that no longer advertises resources doesn't trigger
-        a list call. ``asyncio.timeout`` is mandatory — see R6.
+        a list call. ``asyncio.timeout`` is mandatory — a wedged server
+        must not hang the refresh (and the lock it holds) forever.
 
-        MUST run on the mcp-loop. Caller does not need to hold
-        ``open_lock``; this is invoked from the pool notification
-        handler running on the SDK's receive task.
+        MUST run on the mcp-loop, with the entry's ``open_lock`` HELD
+        (:meth:`_run_notification_refresh` acquires it): an unlocked
+        refresh races a connect's discovery wiring and sibling
+        refreshes, either of which can publish an older catalog over
+        this one — see the runner's ordering rationale.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None or entry.session is None or not entry.supports_resources:
@@ -3757,11 +3877,14 @@ class MCPClientManager:
         Mirror of :meth:`_refresh_pool_server_tools` for the prompt
         path (RFC §3.3). Skips when ``supports_prompts`` is False so a
         server that no longer advertises prompts doesn't trigger a list
-        call. ``asyncio.timeout`` is mandatory — see R6.
+        call. ``asyncio.timeout`` is mandatory — a wedged server must
+        not hang the refresh (and the lock it holds) forever.
 
-        MUST run on the mcp-loop. Caller does not need to hold
-        ``open_lock``; this is invoked from the pool notification
-        handler running on the SDK's receive task.
+        MUST run on the mcp-loop, with the entry's ``open_lock`` HELD
+        (:meth:`_run_notification_refresh` acquires it): an unlocked
+        refresh races a connect's discovery wiring and sibling
+        refreshes, either of which can publish an older catalog over
+        this one — see the runner's ordering rationale.
         """
         entry = self._user_pool_entries.get(key)
         if entry is None or entry.session is None or not entry.supports_prompts:
@@ -6525,10 +6648,16 @@ class MCPClientManager:
         # this retry; the local cached token is the one the AS just
         # rejected, so reading it back without ``force_refresh=True``
         # would re-attempt with the same (rejected) bearer.
+        # Observe the session BEFORE the lookup's awaits: a session the
+        # consent-completion prime connects DURING the lookup must read
+        # as re-consent evidence at drop time, not as pre-observation.
+        observed_session = self._observed_pool_session(user_id, server_name)
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        lookup_error = self._pool_lookup_failure(lookup, server_name, server_row, user_id)
+        lookup_error = self._pool_lookup_failure(
+            lookup, server_name, server_row, user_id, observed_session=observed_session
+        )
         if lookup_error is not None:
             return lookup_error
         access_token = lookup.token or ""
@@ -6671,10 +6800,16 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
+        # Observe the session BEFORE the lookup's awaits: a session the
+        # consent-completion prime connects DURING the lookup must read
+        # as re-consent evidence at drop time, not as pre-observation.
+        observed_session = self._observed_pool_session(user_id, server_name)
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        lookup_error = self._pool_lookup_failure(lookup, server_name, server_row, user_id)
+        lookup_error = self._pool_lookup_failure(
+            lookup, server_name, server_row, user_id, observed_session=observed_session
+        )
         if lookup_error is not None:
             return lookup_error
         access_token = lookup.token or ""
@@ -6795,10 +6930,16 @@ class MCPClientManager:
         if self._app_state is None:
             raise RuntimeError("Pool dispatch requires set_app_state() to have been called")
 
+        # Observe the session BEFORE the lookup's awaits: a session the
+        # consent-completion prime connects DURING the lookup must read
+        # as re-consent evidence at drop time, not as pre-observation.
+        observed_session = self._observed_pool_session(user_id, server_name)
         lookup: TokenLookupResult = await self._pool_token_lookup(
             server_row, user_id, server_name, force_refresh=retry_count > 0
         )
-        lookup_error = self._pool_lookup_failure(lookup, server_name, server_row, user_id)
+        lookup_error = self._pool_lookup_failure(
+            lookup, server_name, server_row, user_id, observed_session=observed_session
+        )
         if lookup_error is not None:
             return lookup_error
         access_token = lookup.token or ""
@@ -6991,12 +7132,28 @@ class MCPClientManager:
             return False
         return _pool_lookup_verdict(lookup) == "mcp_consent_required"
 
+    def _observed_pool_session(self, user_id: str, server_name: str) -> Any:
+        """Snapshot the entry's session for a dead-grant observation.
+
+        MUST be called BEFORE the classified lookup's first await (the
+        callers' contract with :meth:`_schedule_dead_grant_drop`): a
+        snapshot taken after those awaits can capture a session the
+        consent-completion prime connected mid-lookup, and the drop
+        would then evict the just-restored catalog it was designed to
+        spare — the session has to predate the failure to count as the
+        pre-observation transport.
+        """
+        entry = self._user_pool_entries.get((user_id, server_name))
+        return entry.session if entry is not None else None
+
     def _pool_lookup_failure(
         self,
         lookup: TokenLookupResult,
         server_name: str,
         server_row: dict[str, Any],
         user_id: str,
+        *,
+        observed_session: Any,
     ) -> str | None:
         """Render a failed pool lookup AND pair it with its convergence drop.
 
@@ -7005,24 +7162,34 @@ class MCPClientManager:
         would keep offering revoked tools behind a consent card — the
         cross-node non-convergence #836 fixes, silently split by
         dispatch surface. Returns ``None`` exactly when *lookup*
-        carries a usable bearer.
+        carries a usable bearer. ``observed_session`` is the caller's
+        PRE-lookup snapshot (:meth:`_observed_pool_session`).
         """
         lookup_error = _pool_lookup_error(lookup, server_name, server_row)
         if lookup_error is not None:
-            self._schedule_dead_grant_drop(lookup, (user_id, server_name))
+            self._schedule_dead_grant_drop(
+                lookup, (user_id, server_name), observed_session=observed_session
+            )
         return lookup_error
 
-    def _schedule_dead_grant_drop(self, lookup: TokenLookupResult, key: tuple[str, str]) -> None:
+    def _schedule_dead_grant_drop(
+        self,
+        lookup: TokenLookupResult,
+        key: tuple[str, str],
+        *,
+        observed_session: Any,
+    ) -> None:
         """Converge live sessions with a durably-gone grant (#836).
 
         Called on the mcp-loop wherever a classified lookup fails — the
-        three dispatchers and session-start priming. When
-        :meth:`_lookup_grant_dead` confirms the grant is gone (revoked,
-        disconnected, or unlinked — not an infrastructure blip), the
-        (user, server) catalog is dropped so the tools leave the user's
-        live sessions instead of dangling behind a consent card for
-        access that no longer exists. Re-consent restores them via the
-        consent-completion prime; obo re-login via the capture prime.
+        three dispatchers, session-start priming, and the obo
+        credential gate. When :meth:`_lookup_grant_dead` confirms the
+        grant is gone (revoked, disconnected, or unlinked — not an
+        infrastructure blip), the (user, server) catalog is dropped so
+        the tools leave the user's live sessions instead of dangling
+        behind a consent card for access that no longer exists.
+        Re-consent restores them via the consent-completion prime; obo
+        re-login via the capture prime.
 
         SCHEDULED, never awaited: the locked drop can park behind a
         same-key dispatch holding ``open_lock`` across its entire SDK
@@ -7030,21 +7197,35 @@ class MCPClientManager:
         timeout and charged the breaker they are documented to bypass.
         ``_spawn_background`` tracks the task so shutdown cancels it.
 
-        The entry's CURRENT session is snapshotted here, at the moment
-        the dead grant was observed, and handed to the drop as
-        ``observed_session``: a warm session that already existed when
-        the lookup failed predates the revocation and must be evicted
-        (the #836 warm case — dispatches short-circuit on the failed
-        lookup without ever touching the session, so no 401 path would
-        converge it). Only a session that CHANGED after this snapshot
-        proves a later successful connect, i.e. a live grant.
+        ``observed_session`` is REQUIRED and must be snapshotted by the
+        caller BEFORE the classified lookup's first await
+        (:meth:`_observed_pool_session`): a warm session that already
+        existed at observation time predates the revocation and must be
+        evicted (the #836 warm case — dispatches short-circuit on the
+        failed lookup without ever touching the session, so no 401 path
+        would converge it), while only a session that CHANGED after the
+        observation proves a later successful connect. Snapshotting
+        here, after the lookup returned, would capture a session the
+        consent-completion prime connected mid-lookup and evict the
+        just-restored catalog.
+
+        Skips when there is provably nothing to converge — no entry, or
+        a session-less entry with no catalog. At scale every
+        unconsented server classifies as a dead grant on every prime;
+        spawning a tracked no-op task per (user, unconsented server)
+        for that is pure mcp-loop overhead. A catalog appearing AFTER
+        this check implies a successful connect, i.e. a lookup that
+        succeeded after this one failed.
         """
         if not self._lookup_grant_dead(lookup):
             return
         entry = self._user_pool_entries.get(key)
-        observed = entry.session if entry is not None else None
+        if entry is None or (entry.session is None and not self._entry_has_catalog(entry)):
+            return
         self._spawn_background(
-            self._drop_catalog_locked(key, skip_if_connected=True, observed_session=observed),
+            self._drop_catalog_locked(
+                key, skip_if_connected=True, observed_session=observed_session
+            ),
             f"dead-grant catalog drop for '{key[1]}'",
         )
 

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -2498,6 +2498,11 @@ async def get_obo_access_token_classified(
         )
     if not credential_present:
         # No captured credential → the consent affordance is a re-login.
+        # kind="missing" here means DURABLY absent (no row, not a read
+        # blip) — the obo credential gate in MCPClientManager
+        # ``_prime_user_pools`` synthesizes this exact verdict for its
+        # retained-catalog drops when it skips this lookup wholesale;
+        # keep that site in lock-step if this classification splits.
         return _no_token_result(app_state, user_id, server_name, TokenLookupResult(kind="missing"))
 
     lock = _refresh_lock_for(app_state, user_id, server_name)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1700,9 +1700,11 @@ class ChatSession:
         elif self._mcp_client:
             # ``self._mcp_client`` (not the raw kwarg) so an MCP-off persona
             # falls through to the no-MCP branch below.
-            mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
-            self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
-            self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
+            # Constants first — the attributes must exist for a listener
+            # callback firing mid-construction; the ONE authoritative
+            # merged read runs after the registrations below.
+            self._tools = list(INTERACTIVE_TOOLS)
+            self._task_tools = list(TASK_AGENT_TOOLS)
             # Register for tool-change notifications from MCP servers.
             # ``user_id`` is the listener identity component — pool-only
             # changes for OTHER users must not fire this callback.
@@ -1718,11 +1720,10 @@ class ChatSession:
             # for OTHER users do not wake this session.
             self._mcp_prompt_cb = self._on_mcp_prompts_changed
             self._mcp_client.add_prompt_listener(self._mcp_prompt_cb, user_id=self._mcp_user_id)
-            # Re-read now that the listeners exist: a pool-catalog change
-            # firing between the get_tools above and the registrations just
-            # made fanned out before this session could hear it, and its
-            # only notification is gone. One re-read converges the merged
-            # lists with the post-registration state.
+            # Single authoritative read, AFTER the registrations: a
+            # catalog change firing earlier than this fans out to the
+            # listeners just registered, so nothing can slip between
+            # read and register with its only notification unheard.
             mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
             self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
             self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1725,16 +1725,19 @@ class ChatSession:
             # catalog change firing earlier than this fans out to the
             # listeners just registered, so nothing can slip between
             # read and register with its only notification unheard.
-            seq_before = self._mcp_tools_change_seq
-            mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
-            self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
-            self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
-            if self._mcp_tools_change_seq != seq_before:
-                # The mirror race: a listener callback fired between the
-                # read above and these assignments — its fresher merge
-                # was just clobbered by our staler snapshot. Re-running
-                # the callback converges on the current maps.
-                self._on_mcp_tools_changed()
+            seq_before = self._mcp_tools_change_seq - 1
+            while self._mcp_tools_change_seq != seq_before:
+                # Re-read until stable: a listener callback firing
+                # between a read and its assignments would have its
+                # fresher merge clobbered by our staler snapshot (its
+                # only notification already consumed). NEVER call
+                # _on_mcp_tools_changed here — it dereferences tool-
+                # search state initialized later in construction; the
+                # downstream init consumes these converged lists.
+                seq_before = self._mcp_tools_change_seq
+                mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
+                self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
+                self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
             # Proactively warm this user's per-user OAuth (oauth_user) pools so
             # their tools are present without a manual reconnect (e.g. after a
             # reboot/upgrade, or right after consent). Fire-and-forget — the

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1705,6 +1705,7 @@ class ChatSession:
             # merged read runs after the registrations below.
             self._tools = list(INTERACTIVE_TOOLS)
             self._task_tools = list(TASK_AGENT_TOOLS)
+            self._mcp_tools_change_seq = 0
             # Register for tool-change notifications from MCP servers.
             # ``user_id`` is the listener identity component — pool-only
             # changes for OTHER users must not fire this callback.
@@ -1724,9 +1725,16 @@ class ChatSession:
             # catalog change firing earlier than this fans out to the
             # listeners just registered, so nothing can slip between
             # read and register with its only notification unheard.
+            seq_before = self._mcp_tools_change_seq
             mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
             self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
             self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
+            if self._mcp_tools_change_seq != seq_before:
+                # The mirror race: a listener callback fired between the
+                # read above and these assignments — its fresher merge
+                # was just clobbered by our staler snapshot. Re-running
+                # the callback converges on the current maps.
+                self._on_mcp_tools_changed()
             # Proactively warm this user's per-user OAuth (oauth_user) pools so
             # their tools are present without a manual reconnect (e.g. after a
             # reboot/upgrade, or right after consent). Fire-and-forget — the
@@ -2693,6 +2701,12 @@ class ChatSession:
         # is fixed at COORDINATOR_TOOLS.  Ignore MCP server changes.
         if self._kind == WorkstreamKind.COORDINATOR:
             return
+        # Monotonic change marker: the constructor snapshots this around
+        # its authoritative post-registration read and re-runs this
+        # callback if it advanced — otherwise a notification landing
+        # between that read and its assignments is clobbered by the
+        # staler snapshot (its only notification already consumed).
+        self._mcp_tools_change_seq += 1
         # Pass the effective user_id (acting user on shared workstreams,
         # owner otherwise) so the merged tool list includes that user's
         # pool catalog. The static path is included by ``get_tools``

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -75,6 +75,7 @@ from turnstone.core.lowering import (
     tool_args_preview,
     wire_valid_arguments,
 )
+from turnstone.core.mcp_client import try_prime_user_pools
 from turnstone.core.memory import (
     count_messages,
     count_structured_memories,
@@ -1694,6 +1695,10 @@ class ChatSession:
         #     listeners register so tool/resource/prompt refreshes flow
         #     through to this session.
         #   * interactive (no mcp) — INTERACTIVE_TOOLS.
+        # Construction-scoped (a local, NOT instance state): the seq
+        # value at the authoritative merged read, compared once at the
+        # end of tool setup. Only ``_mcp_tools_change_seq`` lives on.
+        mcp_tools_seq_at_read = 0
         if kind == WorkstreamKind.COORDINATOR:
             self._tools = list(COORDINATOR_TOOLS)
             self._task_tools = []
@@ -1732,7 +1737,7 @@ class ChatSession:
             # attributes and be swallowed by the fan-out, losing its
             # effect, and one that succeeds here would be clobbered by
             # the tool-search construction below reading mixed state.
-            self._mcp_tools_seq_at_read = self._mcp_tools_change_seq
+            mcp_tools_seq_at_read = self._mcp_tools_change_seq
             mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
             self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
             self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
@@ -1742,15 +1747,7 @@ class ChatSession:
             # listeners registered just above deliver the catalog to this
             # session once each prime completes. No-op for users with no
             # consented oauth_user servers.
-            if self._mcp_user_id and hasattr(self._mcp_client, "prime_user_pools"):
-                try:
-                    self._mcp_client.prime_user_pools(self._mcp_user_id)
-                except Exception:
-                    log.debug(
-                        "mcp prime_user_pools scheduling failed user=%s",
-                        self._mcp_user_id,
-                        exc_info=True,
-                    )
+            try_prime_user_pools(self._mcp_client, self._mcp_user_id, context="session-start")
         else:
             self._tools = INTERACTIVE_TOOLS
             self._task_tools = TASK_AGENT_TOOLS
@@ -1808,7 +1805,7 @@ class ChatSession:
         if (
             self._kind != WorkstreamKind.COORDINATOR
             and self._mcp_client
-            and self._mcp_tools_change_seq != self._mcp_tools_seq_at_read
+            and self._mcp_tools_change_seq != mcp_tools_seq_at_read
         ):
             self._on_mcp_tools_changed()
         # Skill: explicit name overrides is_default skills.  ``skill_arguments``
@@ -5877,15 +5874,7 @@ class ChatSession:
                 mcp.remove_prompt_listener(self._mcp_prompt_cb, user_id=old_listener_uid)
                 mcp.add_prompt_listener(self._mcp_prompt_cb, user_id=new_listener_uid)
             self._mcp_listener_user_id = new_listener_uid
-        if new_listener_uid and hasattr(mcp, "prime_user_pools"):
-            try:
-                mcp.prime_user_pools(new_listener_uid)
-            except Exception:
-                log.debug(
-                    "mcp prime_user_pools scheduling failed user=%s",
-                    new_listener_uid,
-                    exc_info=True,
-                )
+        try_prime_user_pools(mcp, new_listener_uid, context="acting-user-change")
         # Rebuild the merged tool list and resource/prompt-dependent
         # state under the new identity NOW — the prime above completes
         # asynchronously and only notifies on catalog changes, while

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1724,20 +1724,18 @@ class ChatSession:
             # Single authoritative read, AFTER the registrations: a
             # catalog change firing earlier than this fans out to the
             # listeners just registered, so nothing can slip between
-            # read and register with its only notification unheard.
-            seq_before = self._mcp_tools_change_seq - 1
-            while self._mcp_tools_change_seq != seq_before:
-                # Re-read until stable: a listener callback firing
-                # between a read and its assignments would have its
-                # fresher merge clobbered by our staler snapshot (its
-                # only notification already consumed). NEVER call
-                # _on_mcp_tools_changed here — it dereferences tool-
-                # search state initialized later in construction; the
-                # downstream init consumes these converged lists.
-                seq_before = self._mcp_tools_change_seq
-                mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
-                self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
-                self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
+            # read and register with its only notification unheard. A
+            # change firing AFTER this read is converged by the seq
+            # re-check at the end of tool setup (once every
+            # _on_mcp_tools_changed dependency exists) — a callback
+            # running mid-construction may crash into not-yet-assigned
+            # attributes and be swallowed by the fan-out, losing its
+            # effect, and one that succeeds here would be clobbered by
+            # the tool-search construction below reading mixed state.
+            self._mcp_tools_seq_at_read = self._mcp_tools_change_seq
+            mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
+            self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
+            self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
             # Proactively warm this user's per-user OAuth (oauth_user) pools so
             # their tools are present without a manual reconnect (e.g. after a
             # reboot/upgrade, or right after consent). Fire-and-forget — the
@@ -1799,6 +1797,20 @@ class ChatSession:
                 max_results=tool_search_max_results,
                 reranker=self._bm25_reranker(),
             )
+        # Converge with any MCP catalog change that fired during
+        # construction: a listener callback landing between the
+        # authoritative read and here either crashed into
+        # not-yet-assigned attributes (swallowed by the fan-out) or was
+        # clobbered by the setup above. Every _on_mcp_tools_changed
+        # dependency now exists, so re-running the full callback is
+        # safe — it rebuilds the merged lists, rendered descriptions,
+        # and search index from the CURRENT maps.
+        if (
+            self._kind != WorkstreamKind.COORDINATOR
+            and self._mcp_client
+            and self._mcp_tools_change_seq != self._mcp_tools_seq_at_read
+        ):
+            self._on_mcp_tools_changed()
         # Skill: explicit name overrides is_default skills.  ``skill_arguments``
         # carries the spec's $ARGUMENTS payload — set at create/load time,
         # substituted into the skill body by ``_load_skills``.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1718,6 +1718,14 @@ class ChatSession:
             # for OTHER users do not wake this session.
             self._mcp_prompt_cb = self._on_mcp_prompts_changed
             self._mcp_client.add_prompt_listener(self._mcp_prompt_cb, user_id=self._mcp_user_id)
+            # Re-read now that the listeners exist: a pool-catalog change
+            # firing between the get_tools above and the registrations just
+            # made fanned out before this session could hear it, and its
+            # only notification is gone. One re-read converges the merged
+            # lists with the post-registration state.
+            mcp_tools = self._mcp_client.get_tools(user_id=self._mcp_user_id)
+            self._tools = merge_mcp_tools(INTERACTIVE_TOOLS, mcp_tools)
+            self._task_tools = merge_mcp_tools(TASK_AGENT_TOOLS, mcp_tools)
             # Proactively warm this user's per-user OAuth (oauth_user) pools so
             # their tools are present without a manual reconnect (e.g. after a
             # reboot/upgrade, or right after consent). Fire-and-forget — the

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1695,6 +1695,12 @@ class ChatSession:
         #     listeners register so tool/resource/prompt refreshes flow
         #     through to this session.
         #   * interactive (no mcp) — INTERACTIVE_TOOLS.
+        # Unconditional — every session kind carries the counter, so its
+        # existence never encodes "MCP was wired at construction" (a
+        # late-bound client or a directly-invoked callback must not
+        # AttributeError inside the listener fan-out, where per-callback
+        # exceptions are swallowed).
+        self._mcp_tools_change_seq = 0
         # Construction-scoped (a local, NOT instance state): the seq
         # value at the authoritative merged read, compared once at the
         # end of tool setup. Only ``_mcp_tools_change_seq`` lives on.
@@ -1710,7 +1716,6 @@ class ChatSession:
             # merged read runs after the registrations below.
             self._tools = list(INTERACTIVE_TOOLS)
             self._task_tools = list(TASK_AGENT_TOOLS)
-            self._mcp_tools_change_seq = 0
             # Register for tool-change notifications from MCP servers.
             # ``user_id`` is the listener identity component — pool-only
             # changes for OTHER users must not fire this callback.


### PR DESCRIPTION
Closes #836.

## Problem

Idle-TTL eviction of per-user MCP pool entries dropped the entry's discovered catalogs out of **live** ChatSessions with no re-prime path: after ~10 idle minutes (default `user_session_idle_ttl_seconds`) a server's tools silently left every open workstream until the user started a new session. The LRU-cap pass had the same defect. The dispatch-failure eviction paths (the double-401 ceiling, any 403, a transport blip mid-call) cleared catalogs the same way — a single blip could permanently strip a server from a live session, which also made the circuit breaker's half-open recovery and the consent/step-up cards unreachable: once the catalog cleared, the session-side `is_mcp_tool` gate closed and the model could no longer emit the tool name needed to reach them. `oauth_user` and `oauth_obo` are equally affected (shared pool).

## What changed

**Retention core.** Transport eviction and catalog teardown are now separate concerns. Idle and dispatch-failure evictions COOL an entry — transport torn down, catalog kept, no listener fan-out — so live sessions keep their tool lists and the next dispatch or prime transparently reconnects (the `_on_pool_owner_death` evict-session-keep-entry shape, now the single policy in `_retain_cooled`). Retention requires: a catalog worth keeping, the server still present in the pool registries (rebuilt wholesale each reconcile, so deleted/disabled/renamed/auth-flipped servers drop within one 30s tick), and a live user-scoped tool listener (departed users' entries still fully drop). The LRU cap counts WARM entries only, with a live recount per closure.

**Dead-grant convergence.** Retained catalogs must still converge when access is genuinely gone — the cross-node disconnect in #836, an IdP revocation, a credential unlink. Every classified-lookup failure site (the three dispatchers, session-start priming, and the obo credential gate) now schedules a serialized catalog drop when the lookup proves the grant durably dead (gated on the token infrastructure actually being wired, so a boot-window blip never clears a catalog). The drop:

- runs under the entry's `open_lock`, so an in-flight connect cannot republish a revoked catalog behind it;
- snapshots the entry's session **before** the lookup's first await and skips only when the session *changed* since. A warm transport that predates the revocation is evicted with the catalog (failed lookups short-circuit dispatch before any 401 could evict it), while a session the consent-completion prime connected mid-lookup — or while the drop was parked — reads as re-consent evidence and is spared;
- skips when there is provably nothing to converge, so unconsented servers don't mint a no-op task per prime.

Re-consent restores tools through the existing consent-completion prime; an obo re-login primes the user's pools from the credential-capture site (gated on a live session listener, so routine SSO re-logins don't fan out connects).

**Push-driven refreshes actually work now.** The pool `*/list_changed` handler awaited its refresh inline in the SDK's receive loop; an in-handler request on the same session can never receive its response, so push refresh structurally never completed and wedged the receive loop. Refreshes are now spawned as tracked tasks, serialized on `open_lock` (an unserialized refresh races the connect's discovery wiring and sibling refreshes — the slower publisher lands last with a stale catalog), coalesced per (key, kind) so a notifying-but-slow server is bounded at one parked runner instead of an unbounded lock-waiter FIFO, time-boxed, and hardened for log hygiene (`BaseExceptionGroup` caught alongside `Exception`; failure paths log the exception type only, since an escaping exception reaches the background-task logger whose `exc_info` serializes the bearer-carrying request). The debounce stamp survives failed refreshes (throttling a fast-failing server to one attempt per window) and is popped on every teardown path, so a reconnected transport's first notification refreshes immediately.

**Consolidations along the way:** one lookup-failure render+drop pairing (`_pool_lookup_checked` / `_pool_lookup_failure`), one session+stamp teardown pairing (`_drop_session_and_stamp`), one fire-and-forget prime helper (`try_prime_user_pools`) replacing three drifted copies, one listener-liveness predicate, and `PoolEntryState.drop_session()` structurally clearing the bound token with the session.

## Accepted residuals (documented at the code sites)

- A publisher already suspended across a drop (a refresh in flight, or a connect whose token was read pre-revocation and queued ahead on `open_lock`) can republish the catalog after it. The ghost self-heals at next use — any dispatch or prime re-schedules the drop — and a reconnected stale bearer dies at access-token expiry (`_evict_session_drop_catalog`).
- A dead-grant drop can clear a catalog established by a full drop → re-create → connect → cool cycle completing between observation and drop; that requires the whole cycle inside task-scheduling latency, and it self-heals at next use (`_drop_catalog_locked`).
- A wedged-but-notifying server keeps its own entry's `open_lock` near-continuously occupied (one active + one parked runner), deferring idle eviction of that one entry until the first real dispatch, server recovery, or silence (`_run_notification_refresh`).

## Follow-ups (pre-existing, out of scope)

- #839 — the STATIC-path notification handler has the same inline-await deadlock; the fix is a port of this branch's refresh protocol onto the static path's primitives.
- The classified lookup's `invalid_grant` row-delete can race a mid-lookup consent persist and delete the freshly persisted token (costs one extra re-consent; catalog convergence is unaffected).
- Shared-workstream sessions listen under the owner's identity, so a non-acting participant's pool changes don't fan out to that workstream — known limit; converges at the next acting-user change.

## Testing

Full sqlite suite green, mypy strict, ruff. ~30 new regression tests pin the retention policy, cooling vs full-drop for all three catalog kinds, LRU warm counting, the dead-grant state machine (cold, warm, re-consent-spared, and the mid-lookup race at dispatch level), refresh serialization/coalescing and the marker lifecycle (successor preservation, parked-cancel release), the stamp lifecycle across every teardown path, obo gate drops (cooled and warm), and the capture-site prime gating.
