### PR TITLE
Quick feature to mandate project assignment of workstreams

### DIFF
--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2145,6 +2145,22 @@ async def create_workstream(request: Request) -> JSONResponse:
     auth = getattr(getattr(request, "state", None), "auth_result", None)
     uid: str = getattr(auth, "user_id", "") or ""
 
+    # Optional deployment gate (server.require_project): refuse to create a chat
+    # that isn't filed under a project.  Exemptions fail OPEN to "allowed":
+    #   * resume_ws         -> resuming an existing workstream (already has a project)
+    #   * service scope     -> cluster machinery / scheduled automation
+    #   * admin.coordinator -> coordinator spawns; children inherit the parent's project
+    _cs = getattr(request.app.state, "config_store", None)
+    if _cs is not None and _cs.get("server.require_project") and not project_id and not resume_ws:
+        _exempt = auth is not None and (
+            auth.has_scope("service") or auth.has_permission("admin.coordinator")
+        )
+        if not _exempt:
+            return JSONResponse(
+                {"error": "This deployment requires every chat to be assigned to a project."},
+                status_code=400,
+            )
+
     # Pool — pick any available node
     if node_id == "pool":
         node_id = _pick_best_node(collector)

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2539,6 +2539,44 @@ def make_create_handler(
             if err_validate is not None:
                 return err_validate
 
+        # --- Require-project deployment gate (server.require_project) -----
+        # Optional policy: when a deployment flips ``server.require_project``
+        # on, every INTERACTIVE chat must be filed under a project. The gate
+        # lives here in the shared factory rather than the console-only
+        # ``create_workstream`` route because interactive workstreams are
+        # created on the WORKER via
+        # ``make_create_handler(interactive_endpoint_config)`` — that is where
+        # the overwhelming majority of workstream creation happens. Scoped to
+        # the interactive kind so coordinator workstreams (operator/automation
+        # orchestration) are never forced to carry a project. It runs AFTER
+        # ``create_validate_request``, so ``body["project_id"]`` already
+        # reflects a child's parent-inherited project — legitimate branches
+        # are not false-blocked. Exemptions fail OPEN to "allowed": a resume
+        # keeps its existing project; ``service`` scope covers cluster
+        # machinery / scheduled automation; ``admin.coordinator`` covers
+        # coordinator spawns. Off by default (registry default False), so this
+        # is inert until an admin sets the flag.
+        if cfg.list_kind == "interactive":
+            _cfg_store = getattr(request.app.state, "config_store", None)
+            if _cfg_store is not None and _cfg_store.get("server.require_project"):
+                _proj_raw = body.get("project_id")
+                _proj = _proj_raw.strip() if isinstance(_proj_raw, str) else ""
+                _resume_raw = body.get("resume_ws")
+                _resuming = isinstance(_resume_raw, str) and _resume_raw.strip() != ""
+                _exempt = auth is not None and (
+                    auth.has_scope("service") or auth.has_permission("admin.coordinator")
+                )
+                if not _proj and not _resuming and not _exempt:
+                    return JSONResponse(
+                        {
+                            "error": (
+                                "This deployment requires every chat to be "
+                                "assigned to a project."
+                            )
+                        },
+                        status_code=400,
+                    )
+
         # --- Skill resolution --------------------------------------------
         # Both kinds resolve a body ``skill`` field through
         # ``get_skill_by_name`` to the skill_data dict + the next

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -358,6 +358,17 @@ def _build_registry() -> dict[str, SettingDef]:
             "When the limit is reached, the oldest idle workstream is evicted to make room. "
             "Each workstream uses memory proportional to its conversation history.",
         ),
+        SettingDef(
+            "server.require_project",
+            "bool",
+            False,
+            "Require every interactive chat to be assigned to a project",
+            "server",
+            help="When on, creating a chat that isn't attached to a project is refused. "
+            "Coordinator-spawned children (which inherit the parent's project) and "
+            "service/automation callers are exempt. Users must be a member of at least one "
+            "project to start a chat; existing un-projected chats are unaffected.",
+        ),
         # -- cluster --------------------------------------------------------
         SettingDef(
             "cluster.node_fan_out_limit",

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2830,7 +2830,17 @@ async def list_projects(request: Request) -> JSONResponse:
     )
     storage = get_storage()
     rows = storage.list_projects_for_user(uid, include_archived=include_archived) if storage else []
-    return JSONResponse({"projects": [_project_view(r) for r in rows], "total": len(rows)})
+    # Surface the deployment's require-project gate so the composer can drop its
+    # "No project" option (the create endpoint enforces it regardless).
+    cs = getattr(request.app.state, "config_store", None)
+    require_project = bool(cs.get("server.require_project")) if cs is not None else False
+    return JSONResponse(
+        {
+            "projects": [_project_view(r) for r in rows],
+            "total": len(rows),
+            "require_project": require_project,
+        }
+    )
 
 
 async def create_project(request: Request) -> JSONResponse:

--- a/turnstone/shared_static/projects.js
+++ b/turnstone/shared_static/projects.js
@@ -21,6 +21,7 @@ let _loaded = false; // has the first refresh attempt completed (ok or failed)?
 let _lastError = null; // last failure: HTTP status, 0 for network/parse, null when ok
 let _inflight = null; // shared pending refresh so concurrent callers coalesce
 let _fingerprint = null; // last fired map signature, for change-detection
+let _requireProject = false; // deployment gate: chats must be filed under a project
 const _subs = []; // () => void, fired after each CHANGED refresh
 
 function _fp(rows) {
@@ -85,6 +86,7 @@ export function refreshProjects() {
     .then(function (data) {
       if (data) {
         _lastError = null;
+        _requireProject = !!data.require_project;
         _setCache(data.projects || []);
       }
       return _cache;
@@ -142,6 +144,14 @@ export function projectChoices() {
   });
 }
 
+/** Whether this deployment requires every chat to be filed under a project
+ *  (mirrors `server.require_project`).  Populated by the last successful
+ *  refresh; false until then and on failure, so the composer fails OPEN (the
+ *  create endpoint is the authoritative gate). */
+export function requireProject() {
+  return _requireProject;
+}
+
 /** Subscribe to post-refresh changes (rail re-render, picker repopulate).
  *  Idempotent — the same callback is registered at most once. */
 export function onProjectsChange(cb) {
@@ -171,6 +181,7 @@ window.TurnstoneProjects = {
   projectsError: projectsError,
   projectName: projectName,
   projectChoices: projectChoices,
+  requireProject: requireProject,
   onProjectsChange: onProjectsChange,
   createProject: createProject,
 };

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -526,9 +526,15 @@ function _populateProjectSelect(sel) {
   if (!sel || !window.TurnstoneProjects) return;
   _ensureStandaloneProjectCreator(sel);
   const previous = sel.value;
+  // When the deployment requires a project (server.require_project), drop the
+  // "No project" placeholder so a chat can't be launched unassigned.  The create
+  // endpoint rejects it with 400 regardless — this just avoids the dead option.
+  const requireProject =
+    typeof window.TurnstoneProjects.requireProject === "function" &&
+    window.TurnstoneProjects.requireProject();
   const placeholder = sel.options.length ? sel.options[0] : null;
   sel.replaceChildren();
-  if (placeholder) sel.appendChild(placeholder);
+  if (placeholder && !requireProject) sel.appendChild(placeholder);
   window.TurnstoneProjects.projectChoices().forEach(function (c) {
     const opt = document.createElement("option");
     opt.value = c.value;
@@ -540,6 +546,15 @@ function _populateProjectSelect(sel) {
   newOpt.textContent = "+ New project…";
   sel.appendChild(newOpt);
   if (previous && previous !== _PROJECT_NEW) sel.value = previous;
+  // With the placeholder gone, ensure a real project is selected (not the
+  // "+ New project…" sentinel) so submit carries a project_id.  If the user is
+  // in no project, the value stays empty and the server gate explains why.
+  if (requireProject && (!sel.value || sel.value === _PROJECT_NEW)) {
+    const firstReal = Array.prototype.find.call(sel.options, function (o) {
+      return o.value && o.value !== _PROJECT_NEW;
+    });
+    sel.value = firstReal ? firstReal.value : "";
+  }
 }
 
 function submitNewWs() {


### PR DESCRIPTION
feat(workstreams): optional server.require_project — file every chat under a project

    Add an opt-in deployment gate, server.require_project (default False), that
    requires every INTERACTIVE chat to be created against a project. Inert until an
    admin enables it via the Settings API; zero behavior change when off.

    Enforcement:
    - Shared make_create_handler (core/session_routes.py), scoped to the interactive kind — the real chokepoint, since interactive workstreams are created on the worker through this factory. Runs after create_validate_request so a child branch's parent-inherited project is honored. service scope and admin.coordinator are exempt; a resume keeps its existing project.
    - Console standalone create_workstream (console/server.py) applies the same gate to the coordinator /api/cluster/workstreams/new route.

    Plumbing:
    - settings_registry.py: new SettingDef server.require_project (bool, Server).
    - server.py list_projects surfaces require_project for the UI.
    - shared_static/projects.js exposes requireProject(); ui/static/app.js hides the composer's "No project" option and preselects the first real project when set.