### PR TITLE
Compaction visibility + defer-and-drain send subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Added
 
+- **Compaction is visible now: lifecycle events, a progress bar, and a
+  persistent transcript card.** Context compaction (manual `/compact` and
+  auto) emits a first-class `compaction` SSE event
+  (`start` / `progress` / `end` — see the API reference) instead of loose
+  info lines. The web UI renders an in-transcript card with a real progress
+  bar (determinate `part k of N` during chunked summarization, indeterminate
+  for single-call compactions) that settles into a result card — token delta
+  plus the summary behind a fold — in both the interactive pane and the
+  coordinator viewer. The result survives reloads: the persisted compaction
+  marker now projects through `/history` as a `role="system"`,
+  `source="compaction"` entry (resume/export/search unchanged), stamped with
+  the end event's id so repaint and SSE replay can't double-render. The
+  marker's `meta` additionally records `before_tokens` / `after_tokens` /
+  `trigger`. Python and TypeScript SDKs gain a typed `CompactionEvent`.
+
 - **One provider transport: every model call now streams (#831).**
   The per-adapter non-streaming entry (`create_completion`) is retired;
   single-shot lanes — judges, titles, compaction, web-fetch extraction,
@@ -159,6 +174,73 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   current model.
 
 ### Fixed
+
+- **Manual `/compact` from the web UI: no phantom user turn, no frozen
+  server, cancellable.** A slash command typed into the web composer no
+  longer renders as a user chat bubble (it echoes as a distinct command
+  chip — commands aren't conversation turns and were never persisted as
+  such). `/compact` itself now dispatches onto the workstream's worker
+  slot instead of running inline on the server's event loop — previously a
+  long compaction froze every SSE stream on the node for its whole
+  duration, which is also why its own progress only ever arrived as one
+  burst after the fact. The manual path carries `send()`'s full generation
+  discipline (`compact_now()`): a force-abandoned compaction goes stale
+  instead of swapping history under a successor turn — and retires at its
+  next checkpoint instead of running out its remaining summary calls,
+  with its late lifecycle events fenced off (`compaction_id` on every
+  event, `superseded` on end events — both in the SDKs) so they can't
+  animate, tear down, re-title, or falsely narrate a successor's card or
+  activity pill; a cancel aimed at it is consumed on exit (previously it
+  bricked every `/compact` retry until the next message); a Stop click on
+  an idle session can't pre-abort the next compaction; a Stop that lands
+  in the completion tail — after the last cancel check, or during a retry
+  backoff (which now aborts immediately instead of sleeping it out) — is
+  honored rather than silently eaten; and Stop now aborts the in-flight
+  summary HTTP call itself (the compaction lane registers its stream in
+  the same abort seam the main loop uses), so cancelling a compaction is
+  immediate instead of waiting out a model call. Messages sent while any
+  slash command holds the worker slot **park** and then run as ordinary
+  full-fidelity sends when the command finishes — they are never routed
+  through the mid-turn interjection queue, whose semantics are
+  turn-shaped: previously a send during a manual `/compact` was silently
+  truncated to 2,000 characters, a second participant in a shared
+  workstream was locked out with a misleading "another participant's
+  turn" 409 for the whole compaction, and a message queued across a
+  `/resume`/`/new` could be answered into the post-swap workstream.
+  A `/compact` raced against an in-flight turn is refused with an
+  explicit busy response. Every other slash command runs through the same
+  worker slot too — mutual exclusion against sends, a running compaction,
+  and each other, with a busy answer replacing the old silent interleave —
+  while the endpoint still awaits quick commands' completion off-loop
+  (without parking an executor thread per request); the post-command pane
+  refreshes (`clear_ui` after `/clear`/`/new`/`/resume`, the
+  workstream-name sync) ride the worker itself, so a command that
+  outlives the endpoint's 60s response backstop still refreshes every
+  pane on completion (the `/command` response contract — `ok` / `running`,
+  with busy refusals answering a loud HTTP 409 rather than a silent 200 —
+  is now documented in the API reference and the OpenAPI spec). Manual compaction
+  success also refreshes the status line/context pill immediately (parity
+  with auto-compaction), compaction failures keep feeding the typed
+  `error` event and the node error counter (while a CLI Ctrl-C reports as
+  cancelled, not a failure), one Stop prints one notice (a cancelled
+  auto-compaction no longer stacks "Compaction cancelled." on top of
+  send's own "[Generation cancelled]"), the workstream activity pill
+  shows "Compacting context…" for the whole summarize phase, restores
+  cleanly afterwards, and can no longer be stranded by a force-stopped
+  compaction (a new turn's generation claim breaks a stale latch). Every
+  retry backoff on the session (stream retries, task agents, notify
+  delivery, compaction) now aborts immediately on Stop via one shared
+  cancel-aware helper instead of sleeping out its exponential delay. The
+  web composer bounds a parked send at 10 minutes while a compaction card
+  is visible (15 s wedged-node default otherwise, shared by both panes),
+  and dismissing a queued bubble aborts the in-flight POST so a dismissed
+  message can't dispatch minutes later. A compaction failure reports
+  exactly once (auto-compaction errors defer to the turn's fatal handler
+  instead of doubling the red row and the error metric), and a manual
+  `/compact` failure no longer crashes the CLI REPL. Post-command pane
+  refreshes and error notices are owner-guarded, so a force-cancelled
+  wedged command that unwedges late can't wipe panes or inject stray
+  notices into a successor turn.
 
 - **Static MCP servers: a pushed catalog change no longer wedges the shared
   session (#839).** The static-path `*/list_changed` handler awaited its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,16 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Fixed
 
+- **A failed worker-thread spawn no longer wedges the workstream.** If
+  `Thread.start()` itself raised (thread exhaustion, out-of-memory), the
+  dispatcher had already claimed the worker slot but the flag's only
+  clearer lived in the never-started thread — the workstream looked idle
+  forever while every subsequent message queued behind a worker that
+  didn't exist, until an operator force-cancel. The claim is now rolled
+  back under the lock and the error propagates, so the workstream is
+  dispatchable again as soon as resources recover. Affected every
+  dispatch path (sends, wakes, retries, deferred-send drain, init).
+
 - **Manual `/compact` from the web UI: no phantom user turn, no frozen
   server, cancellable.** A slash command typed into the web composer no
   longer renders as a user chat bubble (it echoes as a distinct command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,15 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Changed
 
+- **Breaking (1.8): compaction feedback moved from `info` events to the
+  typed `compaction` SSE event.** Pre-1.8 SSE/SDK clients that ignore
+  unknown event types no longer see compaction lines (they are
+  deliberately not dual-emitted — dual emission would double-render on
+  every current client). Consume the `compaction` lifecycle event (see
+  the API reference and the `CompactionEvent` SDK type); embedders
+  driving `ChatSession` through a duck-typed `SessionUI` are unaffected
+  (the classic `on_info` lines are restored for them — see Fixed).
+
 - **Sampling knobs (temperature, reasoning effort) now ride one assignment
   scheme: per-model alias value → operator-stored global setting → the
   model definition's declared default (effort only) → field omitted.**
@@ -216,8 +225,11 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   honored rather than silently eaten; and Stop now aborts the in-flight
   summary HTTP call itself (the compaction lane registers its stream in
   the same abort seam the main loop uses), so cancelling a compaction is
-  immediate instead of waiting out a model call. Messages sent while any
-  slash command holds the worker slot are **deferred**: answered
+  immediate instead of waiting out a model call.
+
+- **Sends during a command window are deferred, ordered, bounded, and
+  honestly rendered — never silently truncated or lost.** Messages sent
+  while any slash command holds the worker slot are **deferred**: answered
   `{"status": "queued", "msg_id"}` immediately and dispatched as ordinary
   full-fidelity sends (attachments and sender identity included) when the
   command finishes — never routed through the mid-turn interjection
@@ -254,7 +266,12 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   chip instead of a sent-looking bubble, releases the composer (a
   deferred send has no running worker to wait on), and cleans up fully
   when the send is refused or the chip retracted instead of stranding
-  the pane in Stop mode.
+  the pane in Stop mode. Dismissing a queued bubble — interjection or
+  deferred — is a server-confirmed `DELETE`, and retracting a deferred
+  send that carried attachments tells the user they were discarded
+  instead of silently expiring them.
+
+- **Slash commands hold the worker slot with a loud contract.**
   A `/compact` raced against an in-flight turn is refused with an
   explicit busy response. Every other slash command runs through the same
   worker slot too — mutual exclusion against sends, a running compaction,
@@ -269,7 +286,10 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   a proxied pane, which now surfaces it instead of silence; the
   `/command` response contract — `ok` / `running`, with busy refusals
   answering a loud HTTP 409 rather than a silent 200 — is now documented
-  in the API reference and the OpenAPI spec). Manual compaction
+  in the API reference and the OpenAPI spec).
+
+- **Compaction status stays truthful across every UI surface.** Manual
+  compaction
   success also refreshes the status line/context pill immediately (parity
   with auto-compaction), compaction failures keep feeding the typed
   `error` event and the node error counter (while a CLI Ctrl-C reports as
@@ -282,10 +302,9 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   retry backoff on the session (stream retries, task agents, notify
   delivery, compaction) now aborts immediately on Stop via one shared
   cancel-aware helper instead of sleeping out its exponential delay.
-  Dismissing a queued bubble — interjection or deferred — is a
-  server-confirmed `DELETE`, and retracting a deferred send that carried
-  attachments tells the user they were discarded instead of silently
-  expiring them. A compaction failure reports
+
+- **Compaction failures report exactly once, to the right owner.** A
+  compaction failure reports
   exactly once (auto-compaction errors defer to the turn's fatal handler
   instead of doubling the red row and the error metric), failed-end
   notice suppression is computed once by the emitter (a `notice` bool on
@@ -299,13 +318,13 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   the other post-command pane refreshes and error notices remain
   owner-guarded, so a force-cancelled wedged command that unwedges late
   can't wipe panes or inject stray notices into a successor turn.
-  Embedders driving `ChatSession` with a pre-1.8 duck-typed `SessionUI`
+
+- **Pre-1.8 embedder UIs keep their compaction lines.** Embedders
+  driving `ChatSession` with a pre-1.8 duck-typed `SessionUI`
   (no `on_compaction` hook) get the classic `on_info` compaction lines
   back — threshold notice, `part k/N`, retry waits, token delta +
-  summary box — instead of silent history swaps. **Breaking (1.8):**
-  compaction feedback moved from `info` events to the typed `compaction`
-  SSE event; pre-1.8 SSE/SDK clients that ignore unknown event types no
-  longer see compaction lines (they are deliberately not dual-emitted).
+  summary box — instead of silent history swaps. (See the breaking
+  event-contract note under **Changed** for SSE/SDK clients.)
 
 - **Static MCP servers: a pushed catalog change no longer wedges the shared
   session (#839).** The static-path `*/list_changed` handler awaited its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,14 +199,22 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   summary HTTP call itself (the compaction lane registers its stream in
   the same abort seam the main loop uses), so cancelling a compaction is
   immediate instead of waiting out a model call. Messages sent while any
-  slash command holds the worker slot **park** and then run as ordinary
-  full-fidelity sends when the command finishes — they are never routed
-  through the mid-turn interjection queue, whose semantics are
-  turn-shaped: previously a send during a manual `/compact` was silently
-  truncated to 2,000 characters, a second participant in a shared
-  workstream was locked out with a misleading "another participant's
-  turn" 409 for the whole compaction, and a message queued across a
-  `/resume`/`/new` could be answered into the post-swap workstream.
+  slash command holds the worker slot are **deferred**: answered
+  `{"status": "queued", "msg_id"}` immediately and dispatched as ordinary
+  full-fidelity sends (attachments and sender identity included) when the
+  command finishes — never routed through the mid-turn interjection
+  queue, whose semantics are turn-shaped: previously a send during a
+  manual `/compact` was silently truncated to 2,000 characters, a second
+  participant in a shared workstream was locked out with a misleading
+  "another participant's turn" 409 for the whole compaction, and a
+  message queued across a `/resume`/`/new` could be answered into the
+  post-swap workstream. Because the response is immediate,
+  timeout-bounded callers — the coordinator's `send_message`, the console
+  proxy, SDKs, anything behind a stock reverse proxy — can no longer lose
+  a message to a multi-minute command window; the deferred send is
+  retractable until dispatch via the same `DELETE .../send` used for
+  queued interjections (node-local, in-memory — the API reference
+  documents the at-most-once durability contract).
   A `/compact` raced against an in-flight turn is refused with an
   explicit busy response. Every other slash command runs through the same
   worker slot too — mutual exclusion against sends, a running compaction,
@@ -230,17 +238,31 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   compaction (a new turn's generation claim breaks a stale latch). Every
   retry backoff on the session (stream retries, task agents, notify
   delivery, compaction) now aborts immediately on Stop via one shared
-  cancel-aware helper instead of sleeping out its exponential delay. The
-  web composer bounds a parked send at 10 minutes while a compaction card
-  is visible (15 s wedged-node default otherwise, shared by both panes),
-  and dismissing a queued bubble aborts the in-flight POST so a dismissed
-  message can't dispatch minutes later. A compaction failure reports
+  cancel-aware helper instead of sleeping out its exponential delay.
+  Dismissing a queued bubble — interjection or deferred — is a
+  server-confirmed `DELETE`, and retracting a deferred send that carried
+  attachments tells the user they were discarded instead of silently
+  expiring them. A compaction failure reports
   exactly once (auto-compaction errors defer to the turn's fatal handler
-  instead of doubling the red row and the error metric), and a manual
-  `/compact` failure no longer crashes the CLI REPL. Post-command pane
-  refreshes and error notices are owner-guarded, so a force-cancelled
-  wedged command that unwedges late can't wipe panes or inject stray
-  notices into a successor turn.
+  instead of doubling the red row and the error metric), failed-end
+  notice suppression is computed once by the emitter (a `notice` bool on
+  the end event — in the SDKs — replaces hand-synced client policy), and
+  a manual `/compact` failure no longer crashes the CLI REPL. `/compact`
+  on a workstream showing the `error` badge restores the badge on exit
+  instead of stamping `idle` over it (the compaction neither retried nor
+  resolved the failed turn). A force-cancelled initial send that
+  completes late still delivers its scheduled-run completion
+  notification (the only completion signal unattended workstreams have);
+  the other post-command pane refreshes and error notices remain
+  owner-guarded, so a force-cancelled wedged command that unwedges late
+  can't wipe panes or inject stray notices into a successor turn.
+  Embedders driving `ChatSession` with a pre-1.8 duck-typed `SessionUI`
+  (no `on_compaction` hook) get the classic `on_info` compaction lines
+  back — threshold notice, `part k/N`, retry waits, token delta +
+  summary box — instead of silent history swaps. **Breaking (1.8):**
+  compaction feedback moved from `info` events to the typed `compaction`
+  SSE event; pre-1.8 SSE/SDK clients that ignore unknown event types no
+  longer see compaction lines (they are deliberately not dual-emitted).
 
 - **Static MCP servers: a pushed catalog change no longer wedges the shared
   session (#839).** The static-path `*/list_changed` handler awaited its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,8 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Fixed
 
-- **A failed worker-thread spawn no longer wedges the workstream.** If
+- **A failed worker-thread spawn no longer wedges the workstream — at
+  either spawn site — and never masquerades as success.** If
   `Thread.start()` itself raised (thread exhaustion, out-of-memory), the
   dispatcher had already claimed the worker slot but the flag's only
   clearer lived in the never-started thread — the workstream looked idle
@@ -183,7 +184,14 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   didn't exist, until an operator force-cancel. The claim is now rolled
   back under the lock and the error propagates, so the workstream is
   dispatchable again as soon as resources recover. Affected every
-  dispatch path (sends, wakes, retries, deferred-send drain, init).
+  dispatch path (sends, wakes, retries, deferred-send drain, init). The
+  same failure at the deferred-send drain's own spawn rolls back the
+  just-accepted entry and answers the retryable `queue_full` (previously
+  a 500 landed *after* the entry was registered — an invisible,
+  unretractable phantom that later dispatched as duplicate turns), and a
+  `/command` whose worker never spawned now answers **503**
+  `{"status": "error"}` instead of the generic 200 ok that told SDK
+  callers their `/clear` or `/resume` had applied.
 
 - **Manual `/compact` from the web UI: no phantom user turn, no frozen
   server, cancellable.** A slash command typed into the web composer no
@@ -225,17 +233,28 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   retractable until dispatch via the same `DELETE .../send` used for
   queued interjections (node-local, in-memory — the API reference
   documents the at-most-once durability contract). Deferred responses
-  carry `"deferred": true`, the pending list is the **order authority**
+  carry `"deferred": true`; the pending list is the **order authority**
   (a fresh send — or a coordinator dispatch, or a queued-nudge wake —
-  lines up behind acknowledged entries instead of overtaking them, and
-  the wake gate re-arms at the drain's exit even when everything pending
-  was retracted), a dispatch crash re-queues the entry instead of eating
-  an acknowledged message, and each dispatch emits a pane-tier
+  lines up behind acknowledged entries instead of overtaking them, with
+  the two-term barrier defined once on the workstream so the wake gate
+  also honors a claimed entry whose dispatch is mid-flight, and the gate
+  re-arms at the drain's exit even when everything pending was
+  retracted); acceptance is **bounded** (10 pending per workstream — the
+  interjection queue's own backpressure contract; the 11th answers the
+  retryable `queue_full` instead of pinning attachment bytes without
+  limit and then running one unattended turn per entry); a dispatch
+  crash re-queues the entry instead of eating an acknowledged message,
+  and a drain thread that fails to *start* rolls the acceptance back and
+  answers `queue_full` rather than parking a phantom the client can
+  neither see nor retract; each dispatch emits a pane-tier
   `message_dispatched` event (`folded: true` for interjection fold-ins)
   so queued-bubble UI keeps its retract affordance exactly until the
   message truly leaves — including when the send was accepted by a pane
   that believed the workstream idle, which now renders a real queued
-  chip instead of a sent-looking bubble.
+  chip instead of a sent-looking bubble, releases the composer (a
+  deferred send has no running worker to wait on), and cleans up fully
+  when the send is refused or the chip retracted instead of stranding
+  the pane in Stop mode.
   A `/compact` raced against an in-flight turn is refused with an
   explicit busy response. Every other slash command runs through the same
   worker slot too — mutual exclusion against sends, a running compaction,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,18 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   a message to a multi-minute command window; the deferred send is
   retractable until dispatch via the same `DELETE .../send` used for
   queued interjections (node-local, in-memory — the API reference
-  documents the at-most-once durability contract).
+  documents the at-most-once durability contract). Deferred responses
+  carry `"deferred": true`, the pending list is the **order authority**
+  (a fresh send — or a coordinator dispatch, or a queued-nudge wake —
+  lines up behind acknowledged entries instead of overtaking them, and
+  the wake gate re-arms at the drain's exit even when everything pending
+  was retracted), a dispatch crash re-queues the entry instead of eating
+  an acknowledged message, and each dispatch emits a pane-tier
+  `message_dispatched` event (`folded: true` for interjection fold-ins)
+  so queued-bubble UI keeps its retract affordance exactly until the
+  message truly leaves — including when the send was accepted by a pane
+  that believed the workstream idle, which now renders a real queued
+  chip instead of a sent-looking bubble.
   A `/compact` raced against an in-flight turn is refused with an
   explicit busy response. Every other slash command runs through the same
   worker slot too — mutual exclusion against sends, a running compaction,
@@ -223,10 +234,13 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
   (without parking an executor thread per request); the post-command pane
   refreshes (`clear_ui` after `/clear`/`/new`/`/resume`, the
   workstream-name sync) ride the worker itself, so a command that
-  outlives the endpoint's 60s response backstop still refreshes every
-  pane on completion (the `/command` response contract — `ok` / `running`,
-  with busy refusals answering a loud HTTP 409 rather than a silent 200 —
-  is now documented in the API reference and the OpenAPI spec). Manual compaction
+  outlives the endpoint's 25s response backstop still refreshes every
+  pane on completion (the backstop sits under the console proxy's 30s
+  client timeout so the degraded `running` answer can actually traverse
+  a proxied pane, which now surfaces it instead of silence; the
+  `/command` response contract — `ok` / `running`, with busy refusals
+  answering a loud HTTP 409 rather than a silent 200 — is now documented
+  in the API reference and the OpenAPI spec). Manual compaction
   success also refreshes the status line/context pill immediately (parity
   with auto-compaction), compaction failures keep feeding the typed
   `error` event and the node error counter (while a CLI Ctrl-C reports as

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -467,6 +467,43 @@ Each item in `items` (shared by `tool_info` and `approve_request`):
 {"type": "info", "message": "Session cleared."}
 ```
 
+**`compaction`** -- context-compaction lifecycle (manual `/compact` and
+auto-compaction). `phase: "start"` opens the operation (`trigger` is
+`"manual"` or `"auto"`; auto adds `where` — e.g. `"mid-turn"` — and, when
+the percentage threshold actually fired, `pct`; the context-overflow retry
+path compacts without a `pct` since no threshold was evaluated).
+`phase: "progress"` reports chunked summarization (`part`/`total`/`depth`,
+where depth 0 summarizes transcript batches and deeper levels merge partial
+summaries), a transient-error retry wait (`retry_in` seconds + `error`), or
+`warning: "summary_truncated"`. `phase: "end"` settles it: `ok: true`
+carries `before_tokens`/`after_tokens` and the produced `summary`;
+`ok: false` carries a `reason`
+(`"not_enough_messages"` / `"irreducible"` / `"empty_summary"` /
+`"cancelled"` / `"error"`) and a human-readable `message` — for
+`reason: "error"` the same message is also emitted as a paired typed
+`error` event (that is the renderable error surface; the end event is
+card-teardown). Every end (ok or failed) carries `trigger`, and every
+event carries `compaction_id` — an opaque integer correlating the
+start/progress/end of one compaction run (a client that force-stopped one
+compaction can use it to ignore stragglers from the abandoned run). End
+events also carry `superseded`: `true` marks a force-abandoned compaction
+retiring after a successor generation took over — skip failure notices for
+those (an OK end's result card still stands: the history swap happened).
+Superseded start/progress events are never emitted.
+Exactly one `start` and one `end` are emitted per attempt,
+so clients can key an in-progress affordance (progress bar) on the pair. A
+successful end is also persisted: the summary replays from `/history` as a
+`role: "system"`, `source: "compaction"` entry whose `meta` carries
+`{watermark, before_tokens, after_tokens, trigger}` and whose `event_id`
+matches the end event's id (dedup across repaint + replay).
+
+```json
+{"type": "compaction", "phase": "start", "compaction_id": 7, "trigger": "auto", "where": "mid-turn", "pct": 80}
+{"type": "compaction", "phase": "progress", "compaction_id": 7, "part": 2, "total": 5, "depth": 0}
+{"type": "compaction", "phase": "end", "ok": true, "compaction_id": 7, "trigger": "auto",
+ "before_tokens": 128400, "after_tokens": 9200, "summary": "## Decisions\n..."}
+```
+
 **`error`** -- an error message.
 
 ```json
@@ -816,7 +853,41 @@ automatically approved without prompting.
 
 ### `POST /v1/api/command`
 
-Executes a slash command in the given workstream.
+Executes a slash command in the given workstream. Commands run on the
+workstream's worker slot (mutual exclusion against sends, a running
+compaction, and each other) — the endpoint is **not** unconditionally
+synchronous:
+
+- **Quick commands** (everything except `/compact`): the endpoint waits for
+  completion, so `{"status": "ok"}` means the command ran. A command still
+  running after 60 s answers `{"status": "running"}` — the worker keeps
+  going, its output reaches the pane via SSE, and the post-command pane
+  refreshes below still fire when it completes.
+- **`/compact`**: dispatched fire-and-forget — `{"status": "ok"}` means the
+  compaction *started*. A large context can legitimately compact for many
+  minutes; progress streams as `compaction` SSE events (see the event
+  reference) and the persisted marker row lands on completion. Do not read
+  `/history` expecting the compacted transcript immediately after the
+  response.
+- **Busy refusal**: if a turn or another command holds the worker slot, the
+  command is refused with HTTP **409** `{"status": "busy", "error": ...}` and
+  did **not** run. Retry after the current turn finishes. (The old inline
+  endpoint executed commands unconditionally mid-turn; the 409 makes the
+  refusal loud for callers that only check the HTTP status.)
+
+While a command holds the slot, `POST .../send` requests **park** server-side
+and dispatch as ordinary full-fidelity sends when the command's window closes
+— they are never routed through the mid-turn interjection queue (no length
+cap, no cross-user rejection). A client that aborts a parked send before the
+window closes abandons it: the message is not dispatched. Clients must
+therefore bound parked sends generously: the bundled web composer uses a
+10-minute abort while a compaction progress card is visible (its usual bound
+is ~15 s, sized for wedged-node detection), and dismissing a queued bubble
+aborts the in-flight POST so a dismissed message can't dispatch later.
+Deployment note: a reverse proxy's read timeout bounds the effective park —
+behind a stock 60 s proxy, sends parked longer than that fail at the proxy
+(the park sees the disconnect and abandons; nothing is dispatched — resend
+after the command completes, or raise the proxy read timeout).
 
 **Request body:**
 
@@ -832,7 +903,9 @@ Executes a slash command in the given workstream.
 If the command is `/clear` or `/new`, the server pushes a `clear_ui` SSE event
 to instruct the client to reset its message display. If the command is
 `/resume`, the server pushes `clear_ui` followed by a `history` event
-containing the resumed session's messages.
+containing the resumed session's messages. These follow-ups are emitted by the
+command worker itself, so they fire even when the endpoint already answered
+`{"status": "running"}`.
 
 **Response:**
 
@@ -840,12 +913,15 @@ containing the resumed session's messages.
 {"status": "ok"}
 ```
 
+or `{"status": "running"}` as above.
+
 **Error responses:**
 
-| Status | Body                               | Condition            |
-|--------|------------------------------------|----------------------|
-| 400    | `{"error": "Empty command"}`       | Command is empty     |
-| 404    | `{"error": "Unknown workstream"}`  | `ws_id` not found    |
+| Status | Body                               | Condition                        |
+|--------|------------------------------------|----------------------------------|
+| 400    | `{"error": "Empty command"}`       | Command is empty                 |
+| 404    | `{"error": "Unknown workstream"}`  | `ws_id` not found                |
+| 409    | `{"status": "busy", "error": ...}` | A turn/command holds the worker  |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -788,32 +788,37 @@ Sends a user message to a workstream. Spawns a daemon worker thread that calls
 **Request body:**
 
 ```json
-{"message": "Explain how the server works"}
+{"message": "Explain how the server works", "attachment_ids": ["a1"]}
 ```
 
-| Field     | Type   | Required | Description             |
-|-----------|--------|----------|-------------------------|
-| `message` | string | yes      | The user's message text |
+| Field            | Type       | Required | Description                                          |
+|------------------|------------|----------|------------------------------------------------------|
+| `message`        | string     | yes      | The user's message text                              |
+| `attachment_ids` | string[]   | no       | Staged uploads to attach (omit = auto-consume; `[]` = none) |
 
-**Response (success):**
+**Response.** Every 200 body carries `attached_ids` and
+`dropped_attachment_ids` (empty lists when no attachments are involved):
 
-```json
-{"status": "ok"}
-```
-
-**Response (busy):** Returned if the workstream's worker thread is still alive
-from a previous request. Also pushes a `busy_error` event to the SSE stream.
-
-```json
-{"status": "busy"}
-```
+- `{"status": "ok", ...}` — a fresh turn was dispatched.
+- `{"status": "queued", "priority", "msg_id", ...}` — folded into the live
+  turn's interjection queue; delivered at the next tool-result seam.
+  `DELETE .../send` with the `msg_id` retracts it before delivery.
+- `{"status": "queued", "deferred": true, ...}` — parked on the deferred-send
+  list (a command window holds the slot, or earlier deferred sends are
+  pending) and dispatched as its own full-fidelity send afterwards; see the
+  defer contract under `POST /v1/api/command`.
+- `{"status": "queue_full", ...}` — the live worker's queue is at capacity;
+  retry shortly.
+- `{"status": "attachments_busy", ...}` — attachments can't ride a queued
+  turn; the staged uploads survive for a retry once the worker idles.
 
 **Error responses:**
 
-| Status | Body                               | Condition              |
-|--------|------------------------------------|------------------------|
-| 400    | `{"error": "Empty message"}`       | Message is empty       |
-| 404    | `{"error": "Unknown workstream"}`  | `ws_id` not found      |
+| Status | Body                                            | Condition                              |
+|--------|-------------------------------------------------|----------------------------------------|
+| 400    | `{"error": "message is required"}`              | Message is empty                       |
+| 404    | `{"error": "Unknown workstream"}`               | `ws_id` not found (or closed mid-send) |
+| 409    | `{"status": "cross_user_interjection", ...}`    | Another participant's turn is in flight |
 
 ---
 
@@ -863,9 +868,11 @@ synchronous:
 
 - **Quick commands** (everything except `/compact`): the endpoint waits for
   completion, so `{"status": "ok"}` means the command ran. A command still
-  running after 60 s answers `{"status": "running"}` — the worker keeps
+  running after 25 s answers `{"status": "running"}` — the worker keeps
   going, its output reaches the pane via SSE, and the post-command pane
-  refreshes below still fire when it completes.
+  refreshes below still fire when it completes. (The bound sits under
+  common 30 s client/proxy timeouts — the console proxy's included — so
+  the degraded answer actually reaches bounded callers.)
 - **`/compact`**: dispatched fire-and-forget — `{"status": "ok"}` means the
   compaction *started*. A large context can legitimately compact for many
   minutes; progress streams as `compaction` SSE events (see the event
@@ -878,18 +885,25 @@ synchronous:
   endpoint executed commands unconditionally mid-turn; the 409 makes the
   refusal loud for callers that only check the HTTP status.)
 
-While a command holds the slot, `POST .../send` requests are **deferred**:
-the server answers `{"status": "queued", "msg_id": ...}` immediately and
-dispatches the message as an ordinary full-fidelity send (attachments and
-sender identity included) when the command's window closes — it is never
-routed through the mid-turn interjection queue (no length cap, no cross-user
+While a command holds the slot — and afterwards, while earlier deferred
+sends are still waiting (the pending list is the order authority: a fresh
+send never overtakes a message already acknowledged) — `POST .../send`
+requests are **deferred**: the server answers `{"status": "queued",
+"deferred": true, "msg_id": ...}` immediately and dispatches the message
+as an ordinary full-fidelity send (attachments and sender identity
+included) in arrival order once the slot frees — it is never routed
+through the mid-turn interjection queue (no length cap, no cross-user
 rejection). The response arrives within normal round-trip time, so
 timeout-bounded clients (SDKs, proxies, the coordinator) need no special
 handling. To retract a deferred send before it dispatches, issue the same
 `DELETE .../send` with its `msg_id` used for queued interjections —
 `{"status": "removed"}` confirms it will not dispatch; `"not_found"` means
 it already dispatched (or is dispatching). Retracting a deferred send
-discards any attachments it carried; re-attach to send them again.
+discards any attachments it carried; re-attach to send them again. When a
+deferred send dispatches, panes receive a `message_dispatched` event
+(`msg_id`, plus `folded: true` when it folded into a live turn's
+interjection queue rather than spawning its own turn) so queued-message
+UI can settle the right way.
 
 Durability: deferred sends are **node-local and in-memory** (the same
 lifetime as the interjection queue). `"queued"` is at-most-once intake, not
@@ -909,10 +923,10 @@ SSE stream / in `/history`).
 | `command` | string | yes      | The slash command (e.g. `/clear`)  |
 | `ws_id`   | string | yes      | Target workstream ID               |
 
-If the command is `/clear` or `/new`, the server pushes a `clear_ui` SSE event
-to instruct the client to reset its message display. If the command is
-`/resume`, the server pushes `clear_ui` followed by a `history` event
-containing the resumed session's messages. These follow-ups are emitted by the
+If the command is `/clear`, `/new`, or `/resume`, the server pushes a
+`clear_ui` SSE event to instruct the client to reset its message display and
+re-fetch the transcript via `GET .../history` (there is no SSE event that
+carries the messages themselves). These follow-ups are emitted by the
 command worker itself, so they fire even when the endpoint already answered
 `{"status": "running"}`.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -807,8 +807,12 @@ Sends a user message to a workstream. Spawns a daemon worker thread that calls
   list (a command window holds the slot, or earlier deferred sends are
   pending) and dispatched as its own full-fidelity send afterwards; see the
   defer contract under `POST /v1/api/command`.
-- `{"status": "queue_full", ...}` — the live worker's queue is at capacity;
-  retry shortly.
+- `{"status": "queue_full", ...}` — the send was refused with retry-shortly
+  semantics: the live worker's interjection queue is at capacity, the
+  deferred-send list hit its saturation bound (10 pending — the same
+  backpressure contract), or the deferred-send drain could not be started
+  under resource exhaustion (the message was **not** accepted; nothing is
+  parked).
 - `{"status": "attachments_busy", ...}` — attachments can't ride a queued
   turn; the staged uploads survive for a retry once the worker idles.
 
@@ -940,11 +944,12 @@ or `{"status": "running"}` as above.
 
 **Error responses:**
 
-| Status | Body                               | Condition                        |
-|--------|------------------------------------|----------------------------------|
-| 400    | `{"error": "Empty command"}`       | Command is empty                 |
-| 404    | `{"error": "Unknown workstream"}`  | `ws_id` not found                |
-| 409    | `{"status": "busy", "error": ...}` | A turn/command holds the worker  |
+| Status | Body                                | Condition                                        |
+|--------|-------------------------------------|--------------------------------------------------|
+| 400    | `{"error": "Empty command"}`        | Command is empty                                 |
+| 404    | `{"error": "Unknown workstream"}`   | `ws_id` not found                                |
+| 409    | `{"status": "busy", "error": ...}`  | A turn/command holds the worker                  |
+| 503    | `{"status": "error", "error": ...}` | The command worker could not be started (resource exhaustion) — the command did **not** run; retry shortly |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -482,13 +482,16 @@ carries `before_tokens`/`after_tokens` and the produced `summary`;
 `"cancelled"` / `"error"`) and a human-readable `message` — for
 `reason: "error"` the same message is also emitted as a paired typed
 `error` event (that is the renderable error surface; the end event is
-card-teardown). Every end (ok or failed) carries `trigger`, and every
-event carries `compaction_id` — an opaque integer correlating the
-start/progress/end of one compaction run (a client that force-stopped one
-compaction can use it to ignore stragglers from the abandoned run). End
-events also carry `superseded`: `true` marks a force-abandoned compaction
-retiring after a successor generation took over — skip failure notices for
-those (an OK end's result card still stands: the history swap happened).
+card-teardown). Failed ends also carry `notice`: the emitter-computed
+display verdict — show `message` only when it is `true` (the server
+suppresses error-reason, superseded, and cancelled-auto notices once,
+centrally, so clients don't re-derive that policy). Every end (ok or
+failed) carries `trigger`, and every event carries `compaction_id` — an
+opaque integer correlating the start/progress/end of one compaction run (a
+client that force-stopped one compaction can use it to ignore stragglers
+from the abandoned run). End events also carry `superseded`: `true` marks
+a force-abandoned compaction retiring after a successor generation took
+over (an OK end's result card still stands: the history swap happened).
 Superseded start/progress events are never emitted.
 Exactly one `start` and one `end` are emitted per attempt,
 so clients can key an in-progress affordance (progress bar) on the pair. A
@@ -875,19 +878,25 @@ synchronous:
   endpoint executed commands unconditionally mid-turn; the 409 makes the
   refusal loud for callers that only check the HTTP status.)
 
-While a command holds the slot, `POST .../send` requests **park** server-side
-and dispatch as ordinary full-fidelity sends when the command's window closes
-— they are never routed through the mid-turn interjection queue (no length
-cap, no cross-user rejection). A client that aborts a parked send before the
-window closes abandons it: the message is not dispatched. Clients must
-therefore bound parked sends generously: the bundled web composer uses a
-10-minute abort while a compaction progress card is visible (its usual bound
-is ~15 s, sized for wedged-node detection), and dismissing a queued bubble
-aborts the in-flight POST so a dismissed message can't dispatch later.
-Deployment note: a reverse proxy's read timeout bounds the effective park —
-behind a stock 60 s proxy, sends parked longer than that fail at the proxy
-(the park sees the disconnect and abandons; nothing is dispatched — resend
-after the command completes, or raise the proxy read timeout).
+While a command holds the slot, `POST .../send` requests are **deferred**:
+the server answers `{"status": "queued", "msg_id": ...}` immediately and
+dispatches the message as an ordinary full-fidelity send (attachments and
+sender identity included) when the command's window closes — it is never
+routed through the mid-turn interjection queue (no length cap, no cross-user
+rejection). The response arrives within normal round-trip time, so
+timeout-bounded clients (SDKs, proxies, the coordinator) need no special
+handling. To retract a deferred send before it dispatches, issue the same
+`DELETE .../send` with its `msg_id` used for queued interjections —
+`{"status": "removed"}` confirms it will not dispatch; `"not_found"` means
+it already dispatched (or is dispatching). Retracting a deferred send
+discards any attachments it carried; re-attach to send them again.
+
+Durability: deferred sends are **node-local and in-memory** (the same
+lifetime as the interjection queue). `"queued"` is at-most-once intake, not
+durable acceptance — if the workstream is closed or the node restarts before
+the window ends, the message is dropped. Anything that must survive a
+restart should be re-sent after confirming dispatch (the turn appears on the
+SSE stream / in `/history`).
 
 **Request body:**
 

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "turnstone Server API",
-    "version": "1.7.0rc1",
+    "version": "1.8.0a2",
     "description": "Single-node workstream management, chat interaction, and real-time streaming."
   },
   "paths": {
@@ -228,6 +228,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Error 409",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       },
@@ -383,6 +393,16 @@
           },
           "404": {
             "description": "Error 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409",
             "content": {
               "application/json": {
                 "schema": {

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -410,6 +410,16 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2280,15 +2280,22 @@
       "SendResponse": {
         "properties": {
           "status": {
-            "description": "'ok', 'busy', 'queued', or 'queue_full'",
+            "description": "'ok' (fresh turn dispatched), 'queued' (folded into the live turn's interjection queue, or \u2014 when `deferred` is true \u2014 parked for dispatch after the current command window), 'queue_full', 'attachments_busy' (attachments can't ride a queued turn; retry when idle), or 'cross_user_interjection' (another participant's turn is in flight; carried on the 409 body).",
             "examples": [
               "ok",
-              "busy",
               "queued",
-              "queue_full"
+              "queue_full",
+              "attachments_busy",
+              "cross_user_interjection"
             ],
             "title": "Status",
             "type": "string"
+          },
+          "deferred": {
+            "default": false,
+            "description": "Set on `queued` responses: the message is parked on the workstream's deferred-send list (a slash-command window holds the worker slot, or earlier deferred sends are still pending) and dispatches as an ordinary full-fidelity send afterwards \u2014 it is NOT in a live turn's interjection queue. `DELETE .../send` retracts it until dispatch. Node-local and in-memory: a node restart before dispatch drops it (at-most-once intake).",
+            "title": "Deferred",
+            "type": "boolean"
           },
           "attached_ids": {
             "description": "Attachment ids actually attached to this turn. Subset of the request's `attachment_ids` (or the auto-consumed pending set). Empty when the send carries no attachments.",

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -157,6 +157,43 @@ export interface CancelledEvent {
   type: "cancelled";
 }
 
+/**
+ * Context-compaction lifecycle. `start` carries `trigger` ("manual"/"auto";
+ * auto adds `where` + `pct`); `progress` carries chunked-summarization
+ * `part`/`total`/`depth` (or `retry_in`/`error` for a retry wait); `end`
+ * carries `ok` plus either `before_tokens`/`after_tokens`/`summary` or the
+ * failure `reason`/`message`. The successful end's summary also replays from
+ * `/history` as a `role: "system"`, `source: "compaction"` entry.
+ */
+export interface CompactionEvent {
+  type: "compaction";
+  phase: "start" | "progress" | "end";
+  /** Correlates every event of one compaction run (0 from legacy emitters). */
+  compaction_id?: number;
+  /**
+   * End events only: true marks a force-abandoned compaction retiring
+   * after a successor generation took over — skip failure notices for
+   * those (an OK end's result still stands; the history swap happened).
+   */
+  superseded?: boolean;
+  /** Present on start and on every end (ok or failed). */
+  trigger?: "manual" | "auto";
+  where?: string;
+  pct?: number;
+  part?: number;
+  total?: number;
+  depth?: number;
+  retry_in?: number;
+  error?: string;
+  warning?: string;
+  ok?: boolean;
+  reason?: string;
+  message?: string;
+  before_tokens?: number;
+  after_tokens?: number;
+  summary?: string;
+}
+
 // Global events
 
 export interface WsStateEvent {
@@ -212,6 +249,7 @@ export type ServerEvent =
   | BusyErrorEvent
   | ClearUiEvent
   | CancelledEvent
+  | CompactionEvent
   | WsStateEvent
   | WsActivityEvent
   | WsRenameEvent

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -176,6 +176,12 @@ export interface CompactionEvent {
    * those (an OK end's result still stands; the history swap happened).
    */
   superseded?: boolean;
+  /**
+   * Failed ends only: the emitter-computed display verdict — show
+   * `message` only when true, instead of re-deriving suppression from
+   * reason/trigger/superseded client-side.
+   */
+  notice?: boolean;
   /** Present on start and on every end (ok or failed). */
   trigger?: "manual" | "auto";
   where?: string;

--- a/tests/test_compaction_checkpoint.py
+++ b/tests/test_compaction_checkpoint.py
@@ -186,6 +186,41 @@ class TestDisplayPath:
         assert "SUMMARY" not in contents
         assert contents == ["q", "a"]  # true transcript, no injected summary
 
+    def test_include_compaction_projects_marker_as_system_row(self, storage_backend):
+        """The /history display path (include_compaction=True) surfaces the
+        marker IN PLACE as a first-class system row — source="compaction",
+        meta = the marker's stored fields — so the UI re-renders its
+        compaction card after a reload.  Export/search (default False)
+        stay on the drop path pinned above."""
+        st = storage_backend
+        ws = _register(st)
+        st.save_message(ws, "user", "q")
+        st.save_message(ws, "assistant", "a")
+        wm = st.get_compaction_watermark(ws, 0)
+        st.save_message(
+            ws,
+            "assistant",
+            "SUMMARY",
+            source="compaction",
+            meta=json.dumps(
+                {"watermark": wm, "before_tokens": 900, "after_tokens": 80, "trigger": "manual"}
+            ),
+        )
+        st.save_message(ws, "user", "later question")
+
+        msgs = st.load_messages(ws, include_compaction=True)
+        assert [m.get("content") for m in msgs] == ["q", "a", "SUMMARY", "later question"]
+        marker = msgs[2]
+        assert marker["role"] == "system"  # display row, not a fake assistant turn
+        assert marker.get("_source") == "compaction"
+        meta = marker.get("_source_meta")
+        assert meta == {
+            "watermark": wm,
+            "before_tokens": 900,
+            "after_tokens": 80,
+            "trigger": "manual",
+        }
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: compaction writes the marker, resume is bounded

--- a/tests/test_conversation_js.py
+++ b/tests/test_conversation_js.py
@@ -168,3 +168,17 @@ def test_unbounded_render_inputs_are_capped() -> None:
     assert "more preview lines not shown" in body
     assert "RAW_CAP" in body
     assert "truncated for display" in body
+
+
+def test_retry_note_validates_backoff_before_rendering() -> None:
+    """retry_in is a server-emitted backoff coerced with Number(); like the
+    part/total pair just below it, it must be finiteness-validated (and
+    non-negative) so a malformed value can't render "retrying in NaNs".  The
+    error text is kept regardless — it is the load-bearing half of the note."""
+    body = _body()
+    assert "Number.isFinite(secs) && secs >= 0" in body, (
+        "retry_in must be validated (finite, non-negative) before its seconds render"
+    )
+    assert "Math.round(Number(evt.retry_in))" not in body, (
+        "retry_in must not be Math.round(Number(...))'d without a finiteness guard"
+    )

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -14,6 +14,7 @@ the harness collapses the transcript:
 
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -154,21 +155,37 @@ class TestMidturnCompactionPolicy:
         advise.assert_not_called()
 
     def test_do_auto_compact_rounds_percentage(self, session):
-        """The notice uses round(), not int() — 0.58 must render '58%', not the
-        float-truncated '57%'."""
+        """The start event's pct uses round(), not int() — 0.58 must render 58,
+        not the float-truncated 57.  The auto notice rides the on_compaction
+        start payload now (where/pct), not an on_info string."""
         session.auto_compact_pct = 0.58
         with (
-            patch.object(session, "_compact_messages") as compact,
+            patch.object(session, "_compact_messages_impl", return_value=True) as impl,
             patch.object(session, "_print_status_line"),
-            patch.object(session.ui, "on_info") as on_info,
+            patch.object(session.ui, "on_compaction") as on_compaction,
         ):
             session._do_auto_compact("mid-turn")
-        compact.assert_called_once_with(
-            auto=True, preserve_tail=0, my_generation=0, carry_spill=False
-        )
-        msg = on_info.call_args.args[0]
-        assert "58%" in msg
-        assert "mid-turn" in msg
+        impl.assert_called_once_with(True, 0, 0, False)
+        start = on_compaction.call_args_list[0].args[0]
+        assert start["phase"] == "start"
+        assert start["trigger"] == "auto"
+        assert start["pct"] == 58
+        assert start["where"] == "mid-turn"
+
+    def test_overflow_auto_compact_start_carries_no_pct(self, session):
+        """The context-overflow retry path compacts with auto=True but never
+        evaluated the percentage threshold — its start event must not claim
+        one (the CLI would print a fabricated 'prompt exceeds N%' notice
+        contradicting the overflow notice above it)."""
+        with (
+            patch.object(session, "_compact_messages_impl", return_value=True),
+            patch.object(session.ui, "on_compaction") as on_compaction,
+        ):
+            session._compact_messages(auto=True, my_generation=3)
+        start = on_compaction.call_args_list[0].args[0]
+        assert start["phase"] == "start"
+        assert start["trigger"] == "auto"
+        assert "pct" not in start
 
 
 # ---------------------------------------------------------------------------
@@ -1216,7 +1233,7 @@ class TestChunkerOverflowSplit:
         blocks = ["A" * 4000, "B" * 4000, "C" * 4000]
         bodies: list[int] = []
 
-        def fake_once(_system_prompt, body):
+        def fake_once(_system_prompt, body, _my_generation=0):
             bodies.append(len(body))
             if len(body) > 6_000:  # a multi-block body overflows the token window
                 raise RuntimeError("maximum context length is 524288 tokens")
@@ -1243,7 +1260,7 @@ class TestChunkerOverflowSplit:
         blocks = [f"b{i:02d} " + "z" * 500 for i in range(8)]
         calls: list[str] = []
 
-        def fake_once(_system_prompt, body):
+        def fake_once(_system_prompt, body, _my_generation=0):
             calls.append(body)
             if body.count("\n\n") >= 4:  # a body of 5+ blocks overflows the window
                 raise RuntimeError("maximum context length is 524288 tokens")
@@ -1269,7 +1286,7 @@ class TestChunkerOverflowSplit:
         floor = session._MIN_SUMMARY_BUDGET_CHARS
         calls: list[int] = []
 
-        def fake_once(_system_prompt, body):
+        def fake_once(_system_prompt, body, _my_generation=0):
             calls.append(len(body))
             if len(body) > floor:
                 raise RuntimeError("maximum context length is 524288 tokens")
@@ -1293,7 +1310,7 @@ class TestChunkerOverflowSplit:
         floor = session._MIN_SUMMARY_BUDGET_CHARS
         calls: list[int] = []
 
-        def fake_once(_system_prompt, body):
+        def fake_once(_system_prompt, body, _my_generation=0):
             calls.append(len(body))
             if len(body) > 9_000:  # only bodies well above the floor overflow
                 raise RuntimeError("maximum context length is 524288 tokens")
@@ -1318,7 +1335,7 @@ class TestChunkerOverflowSplit:
         _CompactionIrreducibleError — NOT an unbounded recurse into RecursionError.
         Regression for the depth-check-only-on-the-multi-batch-path bug."""
 
-        def no_shrink(_system_prompt, body):
+        def no_shrink(_system_prompt, body, _my_generation=0):
             if "\n\n" in body:  # any multi-block body overflows the window
                 raise RuntimeError("maximum context length is 524288 tokens")
             return body  # a single-block 'summary' is the block itself — no shrink
@@ -1338,7 +1355,7 @@ class TestChunkerOverflowSplit:
         blocks = ["A" * 2000, "B" * 2000, "C" * 2000, "D" * 2000]
         bodies: list[str] = []
 
-        def fake_once(_system_prompt, body):
+        def fake_once(_system_prompt, body, _my_generation=0):
             bodies.append(body)
             if "CC" in body and "\n\n" in body:  # the multi-block batch holding C
                 raise RuntimeError("maximum context length is 524288 tokens")
@@ -1579,3 +1596,739 @@ class TestRetryRewindSkipSummary:
             COMPACTION_SUMMARY_LABEL,
             "the dense summary",
         ]
+
+
+# ---------------------------------------------------------------------------
+# Compaction lifecycle events (the on_compaction start/progress/end contract)
+# ---------------------------------------------------------------------------
+
+
+def _compaction_events(on_compaction):
+    """The payload list an on_compaction mock saw."""
+    return [c.args[0] for c in on_compaction.call_args_list]
+
+
+def _seed_two_messages(session):
+    """Minimal compactable history — the shared two-turn seed."""
+    session.messages = turns_from_dicts(
+        [
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "did the thing"},
+        ]
+    )
+    session._msg_tokens = [5, 5]
+    session._system_tokens = 0
+
+
+class TestCompactionLifecycleEvents:
+    """Every _compact_messages exit emits exactly one start and one end —
+    a UI that paints an in-progress card on start must never be left with a
+    stuck progress bar."""
+
+    def test_manual_success_emits_start_then_ok_end(self, session):
+        _seed_two_messages(session)
+        summary = SimpleNamespace(content="## Decisions\ndense", finish_reason="stop")
+        with (
+            patch.object(session, "_utility_completion", return_value=summary),
+            patch.object(session.ui, "on_compaction", return_value=41) as oc,
+        ):
+            assert session._compact_messages() is True
+        events = _compaction_events(oc)
+        assert events[0]["phase"] == "start"
+        assert events[0]["trigger"] == "manual"
+        assert "pct" not in events[0]  # manual start carries no auto notice
+        end = events[-1]
+        assert end["phase"] == "end" and end["ok"] is True
+        assert end["summary"] == "## Decisions\ndense"
+        assert end["before_tokens"] > 0 and end["after_tokens"] > 0
+        # Exactly one start and one end.
+        phases = [e["phase"] for e in events]
+        assert phases.count("start") == 1 and phases.count("end") == 1
+
+    def test_bail_too_few_messages_emits_failed_end(self, session):
+        session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])
+        session._msg_tokens = [1]
+        with patch.object(session.ui, "on_compaction") as oc:
+            assert session._compact_messages() is False
+        events = _compaction_events(oc)
+        assert [e["phase"] for e in events] == ["start", "end"]
+        assert events[1]["ok"] is False
+        assert events[1]["reason"] == "not_enough_messages"
+        assert events[1]["message"] == "Not enough messages to compact."
+
+    def test_summary_error_emits_failed_end_and_returns_false(self, session):
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=RuntimeError("boom")),
+            patch.object(session.ui, "on_compaction") as oc,
+        ):
+            assert session._compact_messages() is False
+        end = _compaction_events(oc)[-1]
+        assert end["phase"] == "end" and end["ok"] is False
+        assert end["reason"] == "error"
+        assert "boom" in end["message"]
+
+    def test_irreducible_emits_failed_end(self, session):
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=_CompactionIrreducibleError()),
+            patch.object(session.ui, "on_compaction") as oc,
+        ):
+            assert session._compact_messages() is False
+        end = _compaction_events(oc)[-1]
+        assert end["reason"] == "irreducible"
+
+    def test_empty_summary_emits_failed_end(self, session):
+        _seed_two_messages(session)
+        blank = SimpleNamespace(content="   ", finish_reason="stop")
+        with (
+            patch.object(session, "_utility_completion", return_value=blank),
+            patch.object(session.ui, "on_compaction") as oc,
+        ):
+            assert session._compact_messages() is False
+        end = _compaction_events(oc)[-1]
+        assert end["reason"] == "empty_summary"
+
+    def test_cancel_mid_summary_emits_cancelled_end_and_reraises(self, session):
+        """GenerationCancelled must still propagate (history untouched) AND
+        retire the in-progress card via a cancelled end event."""
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=GenerationCancelled()),
+            patch.object(session.ui, "on_compaction") as oc,
+            pytest.raises(GenerationCancelled),
+        ):
+            session._compact_messages()
+        events = _compaction_events(oc)
+        assert [e["phase"] for e in events] == ["start", "end"]
+        assert events[1]["ok"] is False
+        assert events[1]["reason"] == "cancelled"
+        assert events[1]["trigger"] == "manual"  # failure ends carry trigger
+
+    def test_keyboard_interrupt_ends_cancelled_not_error(self, session):
+        """Ctrl-C during a CLI compaction is a deliberate abort — the
+        backstop must retire the card as cancelled, never fire the typed
+        error channel with an empty-detail 'Compaction failed: ' line
+        (str(KeyboardInterrupt()) is '')."""
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=KeyboardInterrupt()),
+            patch.object(session.ui, "on_error") as on_error,
+            patch.object(session.ui, "on_compaction") as oc,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            session._compact_messages()
+        on_error.assert_not_called()
+        end = _compaction_events(oc)[-1]
+        assert end["phase"] == "end" and end["ok"] is False
+        assert end["reason"] == "cancelled"
+
+    def test_multi_batch_emits_part_progress(self, session):
+        """Chunked summarization reports part k/N via progress events (the
+        web card's determinate bar), replacing the old on_info lines."""
+        session.context_window = 5_000
+        session.compact_max_tokens = 4_000
+        session._system_tokens = 0
+        session.messages = turns_from_dicts(
+            [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"msg-{i:02d} " + "c" * 200,
+                }
+                for i in range(30)
+            ]
+        )
+        session._msg_tokens = [1] * 30
+
+        def fake_uc(messages, **_kwargs):
+            return SimpleNamespace(content="PARTIAL", finish_reason="stop")
+
+        with (
+            patch.object(session, "_utility_completion", side_effect=fake_uc),
+            patch.object(session.ui, "on_compaction", return_value=7) as oc,
+        ):
+            assert session._compact_messages(auto=True) is True
+        progress = [e for e in _compaction_events(oc) if e["phase"] == "progress"]
+        assert progress, "multi-batch compaction must emit part progress"
+        first = progress[0]
+        assert first["part"] == 1
+        assert first["total"] >= 2
+        assert first["depth"] == 0
+
+    def test_marker_row_carries_token_meta_and_end_event_id(self, session):
+        """The persisted checkpoint marker's meta gains the display fields the
+        /history compaction card renders, and the row is stamped with the end
+        event's id so repaint and replay dedup against each other."""
+        _seed_two_messages(session)
+        session._ws_id = "ws-compact-meta"
+        summary = SimpleNamespace(content="dense", finish_reason="stop")
+        saved: dict = {}
+
+        def fake_save(ws_id, role, content, **kwargs):
+            saved.update({"ws_id": ws_id, "role": role, "content": content, **kwargs})
+            return 1
+
+        with (
+            patch.object(session, "_utility_completion", return_value=summary),
+            patch.object(session.ui, "on_compaction", return_value=99) as oc,
+            patch("turnstone.core.session.get_compaction_watermark", return_value=17),
+            patch("turnstone.core.session.save_message", side_effect=fake_save),
+        ):
+            assert session._compact_messages() is True
+
+        import json as _json
+
+        assert saved["source"] == COMPACTION_SOURCE
+        assert saved["event_id"] == 99  # the ok end event's id
+        meta = _json.loads(saved["meta"])
+        assert meta["watermark"] == 17
+        assert meta["trigger"] == "manual"
+        end = _compaction_events(oc)[-1]
+        assert meta["before_tokens"] == end["before_tokens"]
+        assert meta["after_tokens"] == end["after_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# compact_now — the manual path's generation discipline (review fix round)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactNow:
+    def test_stale_preset_cancel_event_does_not_brick(self, session):
+        """A Stop click on an idle session leaves _cancel_event set; the next
+        /compact must install a fresh event (send()'s entry discipline) and
+        run real work instead of instantly aborting as 'cancelled'."""
+        _seed_two_messages(session)
+        session._cancel_event.set()  # idle-cancel residue
+        summary = SimpleNamespace(content="dense", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session.compact_now() is True
+
+    def test_cancel_during_compaction_is_consumed(self, session):
+        """A cancel aimed at THIS compaction must not leak: the exit clears
+        the event (while still the active generation), so an immediate retry
+        does real work — previously every retry insta-aborted until the next
+        send."""
+        _seed_two_messages(session)
+
+        def cancel_mid_summary(*_a, **_kw):
+            session._cancel_event.set()
+            raise GenerationCancelled()
+
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=cancel_mid_summary),
+            pytest.raises(GenerationCancelled),
+        ):
+            session.compact_now()
+        assert not session._cancel_event.is_set()
+
+        # Retry succeeds without any external reset.
+        summary = SimpleNamespace(content="dense", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session.compact_now() is True
+
+    def test_superseded_compaction_never_swaps_history(self, session):
+        """The force-cancel race: a successor turn claims the next generation
+        while the abandoned compaction is mid-summary — the pre-swap check
+        must abort the swap (send() prevents the identical race the same
+        way).  my_generation=0 used to skip this guard entirely."""
+        _seed_two_messages(session)
+        before = list(session.messages)
+
+        def supersede(*_a, **_kw):
+            # A successor send claims the next generation + fresh event
+            # while this compaction is inside its summarize call.
+            session._generation += 1
+            session._cancel_event = threading.Event()
+            return "stale summary"
+
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=supersede),
+            pytest.raises(GenerationCancelled),
+        ):
+            session.compact_now()
+        assert session.messages == before  # history untouched
+
+    def test_success_refreshes_status_line(self, session):
+        _seed_two_messages(session)
+        summary = SimpleNamespace(content="dense", finish_reason="stop")
+        with (
+            patch.object(session, "_utility_completion", return_value=summary),
+            patch.object(session, "_print_status_line") as status,
+        ):
+            assert session.compact_now() is True
+        status.assert_called_once()
+
+    def test_stop_landing_in_completion_tail_still_raises(self, session):
+        """A Stop that lands AFTER the impl's last cancel check (the swap /
+        marker-persist / status-line tail) completes the compaction but must
+        still be honored: compact_now consumes the event and re-raises, so
+        the web worker's exit seam flushes queued messages instead of
+        auto-running an answering turn the user just tried to stop."""
+        _seed_two_messages(session)
+
+        def complete_then_cancel(*_a, **_kw):
+            # The cancel arrives after every check inside the impl.
+            session._cancel_event.set()
+            return True
+
+        with (
+            patch.object(session, "_compact_messages", side_effect=complete_then_cancel),
+            patch.object(session, "_print_status_line") as status,
+            pytest.raises(GenerationCancelled),
+        ):
+            session.compact_now()
+        assert not session._cancel_event.is_set()  # consumed, not leaked
+        # The compaction genuinely happened — the pill must reflect the
+        # freed window even though the tail Stop is honored: a stale pill
+        # next to a "context compacted" card claims two contradictory
+        # states at once.
+        status.assert_called_once()
+
+
+class TestPreHookUICompat:
+    def test_ui_without_on_compaction_still_compacts(self, session):
+        """A duck-typed SessionUI predating the compaction hook gets no
+        lifecycle events but must not crash — an unguarded emit would
+        AttributeError inside send()'s auto-compaction and permanently
+        wedge every long session on such a UI."""
+        _seed_two_messages(session)
+        session.ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=lambda _m: None,
+        )
+        summary = SimpleNamespace(content="dense", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session._compact_messages() is True
+
+
+class TestPreSwapQueueFlush:
+    def test_new_flushes_stranded_queue_into_old_workstream(self, session):
+        """A message stranded in the queue from BEFORE a /new (a dying send
+        worker's closing race) must be persisted into the workstream it was
+        ADDRESSED to — flushed pre-swap, never carried across the identity
+        change into the fresh workstream's transcript."""
+        session._ws_id = "ws-old"
+        session.queue_message("stranded text")
+        saved: list[tuple[str, str, str]] = []
+
+        def fake_save(ws_id, role, content, **_kw):
+            saved.append((ws_id, role, content))
+            return 1
+
+        with (
+            patch("turnstone.core.session.save_message", side_effect=fake_save),
+            patch("turnstone.core.memory.register_workstream"),
+            patch.object(session, "_save_config"),
+            patch.object(session, "_follow_watch_registration"),
+        ):
+            session.handle_command("/new")
+        assert session._ws_id != "ws-old"
+        assert not session._queued_messages
+        flushed = [row for row in saved if row[2] == "stranded text"]
+        assert flushed and flushed[0][0] == "ws-old"  # old identity, pre-swap
+        assert all(row[2] != "stranded text" for row in saved if row[0] != "ws-old")
+
+
+class TestOrphanedCompactionRetirement:
+    """A force-abandoned compaction must retire at its next checkpoint once
+    a successor claims the generation — the checkpoint's event arm alone
+    can't see it (the successor installed a fresh, clear cancel event)."""
+
+    def test_summarize_batch_raises_when_generation_superseded(self, session):
+        session._generation = 5
+        with (
+            patch.object(session, "_utility_completion") as uc,
+            pytest.raises(GenerationCancelled),
+        ):
+            session._summarize_blocks(["block-a"], my_generation=4)
+        uc.assert_not_called()  # retired BEFORE spending another model call
+
+    def test_cancel_during_retry_backoff_aborts_immediately(self, session):
+        """The backoff waits on the cancel event, not time.sleep — a Stop
+        during the (possibly minutes-long) wait aborts without burning the
+        delay plus one more model call."""
+        session._cancel_event.set()
+        with (
+            patch.object(session, "_utility_completion", side_effect=RuntimeError("transient")),
+            patch.object(session, "_stop_retrying", return_value=False),
+            pytest.raises(GenerationCancelled),
+        ):
+            session._summarize_once("sys", "body")
+
+    def test_summary_call_registers_abortable_stream(self, session):
+        """Each summary attempt passes a fresh _CancelRef so cancel() can
+        close the in-flight summary HTTP stream — Stop during compaction
+        aborts the blocked read instead of waiting out a model call."""
+        from turnstone.core.session import _CancelRef
+
+        seen: list[object] = []
+
+        def fake_uc(_turns, *, cancel_ref=None, **_kw):
+            seen.append(cancel_ref)
+            stream = SimpleNamespace(closed=False, close=lambda: None)
+            cancel_ref.append(stream)
+            assert session._cancel_stream is stream  # eager registration
+            return SimpleNamespace(content="dense", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", side_effect=fake_uc):
+            assert session._summarize_once("sys", "body") == "dense"
+        assert len(seen) == 1
+        assert isinstance(seen[0], _CancelRef)
+        assert seen[0] is not session._cancel_ref  # scoped, never the shared ref
+
+    def test_cancel_ref_aborted_property_tracks_event(self, session):
+        """model_turn consults cancel_ref.aborted to suppress drain retries
+        — a stream our own Stop closed must not be resurrected."""
+        from turnstone.core.session import _CancelRef
+
+        ref = _CancelRef(session)
+        assert ref.aborted is False
+        session._cancel_event.set()
+        assert ref.aborted is True
+        # Close-on-arrival: a stream appended after the Stop is closed
+        # immediately to unblock the waiting read.
+        closed: list[bool] = []
+        ref.append(SimpleNamespace(close=lambda: closed.append(True)))
+        assert closed == [True]
+
+    def test_superseded_ref_does_not_hijack_cancel_stream(self, session):
+        """A zombie summary stream arriving AFTER a successor generation
+        registered its live stream must neither overwrite _cancel_stream
+        (Stop would close the zombie and hang on the live read) nor stay
+        open burning tokens — it is closed on arrival."""
+        from turnstone.core.session import _CancelRef
+
+        session._generation = 5
+        live = SimpleNamespace(close=lambda: None)
+        session._cancel_stream = live
+        ref = _CancelRef(session, my_generation=4)  # abandoned compaction's ref
+        closed: list[bool] = []
+        ref.append(SimpleNamespace(close=lambda: closed.append(True)))
+        assert session._cancel_stream is live  # not hijacked
+        assert closed == [True]  # zombie closed on arrival
+        assert ref.aborted is True  # drain retries suppressed
+
+    def test_current_generation_ref_still_registers(self, session):
+        from turnstone.core.session import _CancelRef
+
+        session._generation = 3
+        ref = _CancelRef(session, my_generation=3)
+        closed: list[bool] = []
+        stream = SimpleNamespace(close=lambda: closed.append(True))
+        ref.append(stream)
+        assert session._cancel_stream is stream
+        assert closed == []
+        assert ref.aborted is False
+
+    def test_summarize_once_scopes_ref_to_its_generation(self, session):
+        """The wiring, not just the mechanism: the ref _summarize_once
+        constructs must carry the compaction's my_generation, or the
+        zombie gate above never engages."""
+        from turnstone.core.session import _CancelRef
+
+        session._generation = 3
+        seen: list[object] = []
+
+        def fake_uc(_turns, *, cancel_ref=None, **_kw):
+            seen.append(cancel_ref)
+            return SimpleNamespace(content="dense", finish_reason="stop")
+
+        with patch.object(session, "_utility_completion", side_effect=fake_uc):
+            session._summarize_once("sys", "body", my_generation=3)
+        assert isinstance(seen[0], _CancelRef)
+        assert seen[0]._my_generation == 3
+
+    def test_stream_closed_by_cancel_maps_to_cancelled_not_error(self, session):
+        """A provider error induced by our own stream close (Stop) must end
+        the compaction as CANCELLED — checked before the retry policy, so
+        even a final-attempt failure never renders 'Compaction failed'."""
+
+        def fake_uc(_turns, **_kw):
+            session._cancel_event.set()  # the Stop lands mid-call
+            raise RuntimeError("connection closed")
+
+        with (
+            patch.object(session, "_utility_completion", side_effect=fake_uc),
+            pytest.raises(GenerationCancelled),
+        ):
+            session._summarize_once("sys", "body")
+
+
+# ---------------------------------------------------------------------------
+# Error channel + activity pill (review fix round)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionErrorChannel:
+    def test_handled_error_bail_fires_on_error(self, session):
+        """reason='error' bails feed the typed error event (red row +
+        Prometheus counter via WebUI.on_error) — the surface compaction
+        failures fed before the lifecycle events replaced on_error here."""
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_summarize_blocks", side_effect=RuntimeError("boom")),
+            patch.object(session.ui, "on_error") as on_error,
+            patch.object(session.ui, "on_compaction") as oc,
+        ):
+            assert session._compact_messages() is False
+        on_error.assert_called_once()
+        assert "boom" in on_error.call_args.args[0]
+        end = [c.args[0] for c in oc.call_args_list][-1]
+        assert end["reason"] == "error"
+
+    def test_non_error_bail_does_not_fire_on_error(self, session):
+        session.messages = turns_from_dicts([{"role": "user", "content": "a"}])
+        session._msg_tokens = [1]
+        with (
+            patch.object(session.ui, "on_error") as on_error,
+            patch.object(session.ui, "on_compaction"),
+        ):
+            assert session._compact_messages() is False
+        on_error.assert_not_called()
+
+    def test_auto_raising_exit_defers_error_to_send_handler(self, session):
+        """An AUTO raising exit propagates into send()'s fatal handler,
+        which owns the single on_error — the wrapper emitting a second one
+        doubled every pane's red rows and the node's error metric."""
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_compact_messages_impl", side_effect=RuntimeError("boom")),
+            patch.object(session.ui, "on_error") as on_error,
+            pytest.raises(RuntimeError),
+        ):
+            session._compact_messages(auto=True, my_generation=1)
+        on_error.assert_not_called()
+
+    def test_manual_raising_exit_emits_exactly_one_error(self, session):
+        """MANUAL raising exits have no downstream emitter (the web compact
+        worker's runner only logs; the CLI suppresses) — the wrapper's red
+        row is the one notification."""
+        _seed_two_messages(session)
+        with (
+            patch.object(session, "_compact_messages_impl", side_effect=RuntimeError("boom")),
+            patch.object(session.ui, "on_error") as on_error,
+            pytest.raises(RuntimeError),
+        ):
+            session._compact_messages()
+        on_error.assert_called_once()
+
+    def test_cli_compact_error_does_not_crash_repl(self, session):
+        """The CLI REPL calls handle_command with no try/except — a raising
+        manual compaction error must be swallowed there (after the
+        wrapper's red row), not crash the whole REPL."""
+        with patch.object(session, "compact_now", side_effect=RuntimeError("boom")):
+            assert not session.handle_command("/compact")
+
+    def test_truncated_summary_warns_via_progress_event(self, session):
+        _seed_two_messages(session)
+        clipped = SimpleNamespace(content="partial", finish_reason="length")
+        with (
+            patch.object(session, "_utility_completion", return_value=clipped),
+            patch.object(session.ui, "on_compaction", return_value=5) as oc,
+        ):
+            assert session._compact_messages() is True
+        warnings = [
+            c.args[0]
+            for c in oc.call_args_list
+            if c.args[0].get("phase") == "progress" and c.args[0].get("warning")
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["warning"] == "summary_truncated"
+
+
+class TestCompactionActivityPill:
+    def test_pill_survives_thinking_start_and_restores_on_end(self, session):
+        """on_compaction(start) owns the pill for the whole window — the
+        impl's own on_thinking_start must not clobber it — and the end
+        restores the pre-compaction pair so a bail can't strand
+        'Compacting context…' on an idle workstream."""
+        ui = session.ui  # NullUI(SessionUIBase) — the real base machinery
+        ui.on_compaction({"phase": "start", "trigger": "manual"})
+        assert ui._ws_current_activity == "Compacting context…"
+        ui.on_thinking_start()
+        assert ui._ws_current_activity == "Compacting context…"  # not clobbered
+        ui.on_compaction({"phase": "end", "ok": False, "reason": "not_enough_messages"})
+        assert ui._ws_current_activity == ""  # idle pair restored
+        assert ui._ws_activity_state == ""
+        # Outside a compaction window, thinking writes normally again.
+        ui.on_thinking_start()
+        assert ui._ws_current_activity == "Thinking…"
+
+    def test_stale_end_leaves_successor_latch_alone(self, session):
+        """A force-abandoned compaction's late end must not unlatch — or
+        restore a stale pill pair over — a successor compaction that has
+        since taken the latch over (owner = compaction_id)."""
+        ui = session.ui
+        ui._ws_current_activity = "Running tool: bash"
+        ui._ws_activity_state = "tool"
+        ui.on_compaction({"phase": "start", "trigger": "manual", "compaction_id": 1})
+        # Successor compaction takes the latch over; the ORIGINAL saved
+        # pair must survive (not the orphan's "Compacting context…").
+        ui.on_compaction({"phase": "start", "trigger": "auto", "compaction_id": 2})
+        # The orphan retires late — superseded, no longer the owner.
+        ui.on_compaction(
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "Compaction cancelled.",
+                "trigger": "manual",
+                "compaction_id": 1,
+                "superseded": True,
+            }
+        )
+        assert ui._compaction_activity_live  # successor still latched
+        assert ui._ws_current_activity == "Compacting context…"
+        # The successor's own end restores the ORIGINAL pre-compaction pair.
+        ui.on_compaction(
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "irreducible",
+                "message": "x",
+                "trigger": "auto",
+                "compaction_id": 2,
+            }
+        )
+        assert not ui._compaction_activity_live
+        assert ui._ws_current_activity == "Running tool: bash"
+        assert ui._ws_activity_state == "tool"
+
+    def test_superseded_end_unlatches_without_restoring(self, session):
+        """When the orphan's end arrives with no successor compaction, the
+        latch must clear (so the live turn's thinking writes resume) but its
+        stale saved pair must NOT overwrite the live turn's pill."""
+        ui = session.ui
+        ui.on_compaction({"phase": "start", "trigger": "manual", "compaction_id": 3})
+        ui.on_compaction(
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "Compaction cancelled.",
+                "trigger": "manual",
+                "compaction_id": 3,
+                "superseded": True,
+            }
+        )
+        assert not ui._compaction_activity_live
+        assert ui._ws_current_activity == "Compacting context…"  # no stale restore
+        ui.on_thinking_start()  # the live turn recovers the pill
+        assert ui._ws_current_activity == "Thinking…"
+
+    def test_superseded_progress_is_swallowed(self, session):
+        """An abandoned compaction's progress chatter is dropped at the base
+        (returns None, nothing enqueued) — panes must not re-create a card
+        for a dead compaction via their defensive-create — while its END
+        still flows so the pane can retire the card it painted live."""
+        ui = session.ui
+        live = ui.on_compaction(
+            {"phase": "progress", "part": 1, "total": 2, "depth": 0, "compaction_id": 4}
+        )
+        assert isinstance(live, int)
+        stale = ui.on_compaction(
+            {
+                "phase": "progress",
+                "part": 2,
+                "total": 2,
+                "depth": 0,
+                "compaction_id": 4,
+                "superseded": True,
+            }
+        )
+        assert stale is None
+        end = ui.on_compaction(
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "x",
+                "trigger": "manual",
+                "compaction_id": 4,
+                "superseded": True,
+            }
+        )
+        assert isinstance(end, int)
+
+    def test_superseded_split_on_the_wire(self, session):
+        """Ends carry ``superseded`` on the wire (typed in both SDKs — a
+        pane must skip failure notices for a force-abandoned compaction's
+        late end); start/progress never carry it: live ones are by
+        definition not superseded and stale ones are swallowed whole."""
+        ui = session.ui
+        with patch.object(ui, "_enqueue", return_value=9) as enq:
+            ui.on_compaction({"phase": "start", "trigger": "manual", "compaction_id": 5})
+        assert "superseded" not in enq.call_args.args[0]
+        assert enq.call_args.args[0]["compaction_id"] == 5
+        with patch.object(ui, "_enqueue", return_value=10) as enq:
+            ui.on_compaction(
+                {
+                    "phase": "end",
+                    "ok": True,
+                    "trigger": "manual",
+                    "compaction_id": 5,
+                    "summary": "s",
+                }
+            )
+        assert enq.call_args.args[0]["superseded"] is False
+        with patch.object(ui, "_enqueue", return_value=11) as enq:
+            ui.on_compaction(
+                {
+                    "phase": "end",
+                    "ok": False,
+                    "reason": "cancelled",
+                    "message": "x",
+                    "trigger": "manual",
+                    "compaction_id": 5,
+                    "superseded": True,
+                }
+            )
+        assert enq.call_args.args[0]["superseded"] is True
+
+    def test_generation_claim_breaks_stale_latch_and_restores(self, session):
+        """A new generation claim is the moment any live latch is provably
+        stale (the worker slot serializes turns) — the claim unlatches AND
+        restores the saved pill pair, so the successor turn's thinking
+        writes resume immediately and a follow-up /compact's start saves a
+        correct pre-pair instead of the orphan's 'Compacting context…'."""
+        ui = session.ui
+        ui._ws_current_activity = "Running tool: bash"
+        ui._ws_activity_state = "tool"
+        ui.on_compaction({"phase": "start", "trigger": "manual", "compaction_id": 7})
+        assert ui._compaction_activity_live
+        # Successor claims (send() or compact_now() entry) — the orphan's
+        # latch breaks and the pre-compaction pair is restored.
+        session._claim_generation()
+        assert not ui._compaction_activity_live
+        assert ui._ws_current_activity == "Running tool: bash"
+        assert ui._ws_activity_state == "tool"
+        # And thinking writes work again for the live turn.
+        ui.on_thinking_start()
+        assert ui._ws_current_activity == "Thinking…"
+        # No live latch: a claim is a no-op (no restore of stale pairs).
+        ui._ws_current_activity = "Custom"
+        session._claim_generation()
+        assert ui._ws_current_activity == "Custom"
+
+    def test_force_stop_then_second_compact_restores_pill(self, session):
+        """End-to-end pill lifecycle across an orphaned compaction: force
+        stop → a second /compact runs and completes → the pill must settle
+        on the PRE-ORPHAN pair, not a stranded 'Compacting context…'."""
+        _seed_two_messages(session)
+        ui = session.ui
+        ui._ws_current_activity = ""
+        ui._ws_activity_state = ""
+        # First /compact latches, then is force-abandoned (no end event
+        # reaches the UI before the successor starts).
+        ui.on_compaction({"phase": "start", "trigger": "manual", "compaction_id": 1})
+        assert ui._ws_current_activity == "Compacting context…"
+        # Second /compact: compact_now claims (breaking the stale latch,
+        # restoring the idle pair), then runs a real compaction.
+        summary = SimpleNamespace(content="dense", finish_reason="stop")
+        with patch.object(session, "_utility_completion", return_value=summary):
+            assert session.compact_now() is True
+        assert not ui._compaction_activity_live
+        assert ui._ws_current_activity == ""  # idle pair, not the orphan's text
+        assert ui._ws_activity_state == ""

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -2013,6 +2013,91 @@ class TestPreHookUICompat:
         )
         assert infos == []
 
+    def test_explicit_protocol_subclass_inherits_classic_lines(self, session):
+        """An explicit ``class MyUI(SessionUI)`` never lands in the getattr
+        fallback — it INHERITS the protocol member as a real method — so
+        the protocol default body itself must be the pre-1.8 rendering.
+        With a bare ``...`` stub, exactly these embedders (the ones the
+        fallback was built for) silently swallowed every lifecycle event."""
+        from turnstone.core.session import SessionUI
+
+        infos: list[str] = []
+
+        class _ExplicitUI(SessionUI):
+            def on_info(self, message: str) -> None:
+                infos.append(message)
+
+        session.ui = _ExplicitUI()
+        result = session._compaction_event(
+            0,
+            {
+                "phase": "end",
+                "ok": True,
+                "trigger": "auto",
+                "before_tokens": 900,
+                "after_tokens": 100,
+                "summary": "dense",
+            },
+        )
+        assert result is None  # inherited default returns None, not a stub echo
+        # Rendered exactly once — via the inherited default, with no second
+        # pass through the duck-type fallback (emit is not None here).
+        assert sum("compacted: ~900 -> ~100 tokens" in m for m in infos) == 1
+        assert any("dense" in m for m in infos)
+
+    def test_explicit_subclass_override_suppresses_default_lines(self, session):
+        """A subclass that implements the hook owns the rendering: no
+        classic info lines from the default body, and its return value
+        reaches the marker stamp."""
+        from turnstone.core.session import SessionUI
+
+        infos: list[str] = []
+        seen: list[dict] = []
+
+        class _HookedUI(SessionUI):
+            def on_info(self, message: str) -> None:
+                infos.append(message)
+
+            def on_compaction(self, payload: dict) -> int | None:
+                seen.append(payload)
+                return 42
+
+        session.ui = _HookedUI()
+        result = session._compaction_event(
+            0, {"phase": "end", "ok": True, "trigger": "auto", "summary": "s"}
+        )
+        assert result == 42
+        assert len(seen) == 1
+        assert infos == []
+
+    def test_duck_hook_bool_return_never_reaches_marker_stamp(self, session):
+        """A duck-typed on_compaction returning ``True`` (bool ⊂ int) must
+        coerce to ``None`` — a boolean stamped into the persisted marker's
+        event_id fails the PG INSERT after the history swap committed and
+        mis-keys the SQLite dedupe (same guard as parse_checkpoint_watermark,
+        via _coerce_event_id)."""
+        session.ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=lambda _m: None,
+            on_compaction=lambda _payload: True,
+        )
+        result = session._compaction_event(
+            0, {"phase": "end", "ok": True, "trigger": "auto", "summary": "s"}
+        )
+        assert result is None
+
+    def test_coerce_event_id_rejects_bools(self):
+        """The shared coercion helper: ints pass, bools and non-ints don't."""
+        from turnstone.core.session import _coerce_event_id
+
+        assert _coerce_event_id(46) == 46
+        assert _coerce_event_id(0) == 0
+        assert _coerce_event_id(True) is None
+        assert _coerce_event_id(False) is None
+        assert _coerce_event_id(None) is None
+        assert _coerce_event_id("46") is None
+
 
 class TestCompactionNoticeStamp:
     """_compaction_event is the single display-policy site: failed ends

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -2098,6 +2098,77 @@ class TestPreHookUICompat:
         assert _coerce_event_id(None) is None
         assert _coerce_event_id("46") is None
 
+    def test_raising_on_error_still_emits_exactly_one_failed_end(self, session):
+        """A raising on_error (bounded listener queue.Full — the duck-typed
+        embedder class) must not void the exactly-one-end contract: the
+        guard in _compaction_bailed lets the end emit run, so no pane is
+        left holding a frozen progress bar."""
+        ends: list[dict] = []
+
+        def _boom(_msg: str) -> None:
+            raise RuntimeError("listener queue full")
+
+        session.ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=_boom,
+            on_compaction=lambda payload: (
+                ends.append(payload) if payload.get("phase") == "end" else None
+            ),
+        )
+        result = session._compaction_bailed(
+            "error", "summarizer exploded", trigger="manual", my_generation=0
+        )
+        assert result is False  # handled bail, no propagation
+        assert len(ends) == 1
+        assert ends[0]["ok"] is False and ends[0]["reason"] == "error"
+
+    def test_raising_lifecycle_hook_never_propagates(self, session):
+        """_compaction_event is the single raise-proofing site for every
+        lifecycle emission: a raising on_compaction degrades to a lost
+        render (marker id None), never to a propagating exception — a
+        raising failed-END re-created the frozen-bar hole one call deeper,
+        and a raising SUCCESS end after the committed swap made the
+        wrapper backstop fabricate a failed end for a compaction that
+        succeeded."""
+
+        def _boom(_payload: dict) -> int:
+            raise RuntimeError("hook broken")
+
+        session.ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=lambda _m: None,
+            on_compaction=_boom,
+        )
+        # Success end: swallowed, marker id lost, nothing fabricated.
+        assert (
+            session._compaction_event(
+                0, {"phase": "end", "ok": True, "trigger": "manual", "summary": "s"}
+            )
+            is None
+        )
+        # Failed end via the bail path: still returns False, no propagation
+        # (pre-guard, the raise re-entered _compaction_bailed through the
+        # wrapper backstop and no end was ever emitted on either pass).
+        assert (
+            session._compaction_bailed("error", "boom", trigger="manual", my_generation=0) is False
+        )
+        # The duck-type fallback route is guarded by the same try: a
+        # raising on_info must not escape either.
+        session.ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=lambda _m: None,
+            on_info=_boom,
+        )
+        assert (
+            session._compaction_event(
+                0, {"phase": "end", "ok": True, "trigger": "manual", "summary": "s"}
+            )
+            is None
+        )
+
 
 class TestCompactionNoticeStamp:
     """_compaction_event is the single display-policy site: failed ends

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -1891,7 +1891,9 @@ class TestPreHookUICompat:
         """A duck-typed SessionUI predating the compaction hook gets no
         lifecycle events but must not crash — an unguarded emit would
         AttributeError inside send()'s auto-compaction and permanently
-        wedge every long session on such a UI."""
+        wedge every long session on such a UI.  (This one has no on_info
+        either — the fallback below is getattr-guarded the same way, so
+        the never-crash floor holds even for a hookless minimal UI.)"""
         _seed_two_messages(session)
         session.ui = SimpleNamespace(
             on_thinking_start=lambda: None,
@@ -1901,6 +1903,193 @@ class TestPreHookUICompat:
         summary = SimpleNamespace(content="dense", finish_reason="stop")
         with patch.object(session, "_utility_completion", return_value=summary):
             assert session._compact_messages() is True
+
+    def _duck_ui_with_info(self):
+        infos: list[str] = []
+        ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=lambda _m: None,
+            on_info=infos.append,
+        )
+        return ui, infos
+
+    def test_pre_hook_ui_gets_classic_info_lines(self, session):
+        """A duck-typed UI WITH on_info but WITHOUT on_compaction gets the
+        pre-1.8 lines back through the shared renderer — an auto-compaction
+        must never swap history with zero announcement for embedders that
+        predate the hook (the old lines reached them unconditionally)."""
+        session.ui, infos = self._duck_ui_with_info()
+        session._compaction_event(
+            0, {"phase": "start", "trigger": "auto", "where": "mid-turn", "pct": 80}
+        )
+        session._compaction_event(0, {"phase": "progress", "part": 1, "total": 2, "depth": 0})
+        session._compaction_event(
+            0,
+            {
+                "phase": "end",
+                "ok": True,
+                "trigger": "auto",
+                "before_tokens": 900,
+                "after_tokens": 100,
+                "summary": "dense",
+            },
+        )
+        assert any("Auto-compacting mid-turn" in m and "80%" in m for m in infos)
+        assert any("compacting part 1/2" in m for m in infos)
+        assert any("compacted: ~900 -> ~100 tokens" in m for m in infos)
+        assert any("dense" in m for m in infos)
+
+    def test_pre_hook_fallback_consumes_notice_not_policy(self, session):
+        """Failed-end display rides the emitter's ``notice`` stamp: a
+        manual cancelled end prints its message; an error-reason end (the
+        red row already came through on_error) and a cancelled AUTO end
+        stay silent — the fallback never re-derives the policy."""
+        session.ui, infos = self._duck_ui_with_info()
+        session._compaction_event(
+            0,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "Compaction cancelled.",
+                "trigger": "manual",
+            },
+        )
+        assert infos == ["Compaction cancelled."]
+        infos.clear()
+        session._compaction_event(
+            0,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "error",
+                "message": "boom",
+                "trigger": "manual",
+            },
+        )
+        session._compaction_event(
+            0,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "Compaction cancelled.",
+                "trigger": "auto",
+            },
+        )
+        assert infos == []
+
+    def test_superseded_ok_end_still_renders_via_fallback(self, session):
+        """A superseded OK end announces a history swap that REALLY
+        committed — suppressing it re-creates the silent-swap failure for
+        duck-typed embedders (the web reducer renders the result card for
+        superseded OK ends for the same reason).  A superseded FAILED end
+        stays silent via the notice stamp."""
+        session.ui, infos = self._duck_ui_with_info()
+        session._generation = 7  # the emitting generation 3 is stale
+        session._compaction_event(
+            3,
+            {
+                "phase": "end",
+                "ok": True,
+                "trigger": "manual",
+                "before_tokens": 500,
+                "after_tokens": 50,
+                "summary": "kept",
+            },
+        )
+        assert any("compacted: ~500 -> ~50 tokens" in m for m in infos)
+        infos.clear()
+        session._compaction_event(
+            3,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "Compaction cancelled.",
+                "trigger": "manual",
+            },
+        )
+        assert infos == []
+
+
+class TestCompactionNoticeStamp:
+    """_compaction_event is the single display-policy site: failed ends
+    carry ``notice`` — renderers show the message iff it is true, instead
+    of each re-deriving suppression from reason/trigger/superseded (the
+    cross-runtime drift trap the old hand-synced cli.py/conversation.js
+    clauses documented)."""
+
+    def _emit(self, session, payload, my_generation=0):
+        seen: dict = {}
+        with patch.object(session.ui, "on_compaction", side_effect=lambda p: seen.update(p)):
+            session._compaction_event(my_generation, payload)
+        return seen
+
+    def test_manual_cancelled_end_notice_true(self, session):
+        seen = self._emit(
+            session,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "x",
+                "trigger": "manual",
+            },
+        )
+        assert seen["notice"] is True
+
+    def test_error_reason_end_notice_false(self, session):
+        """reason=error already fired the one red on_error row — the end
+        event is card-teardown, never a second line."""
+        seen = self._emit(
+            session,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "error",
+                "message": "boom",
+                "trigger": "manual",
+            },
+        )
+        assert seen["notice"] is False
+
+    def test_cancelled_auto_end_notice_false(self, session):
+        """A cancelled AUTO compaction is part of cancelling the turn —
+        the send loop prints its own '[Generation cancelled]'."""
+        seen = self._emit(
+            session,
+            {"phase": "end", "ok": False, "reason": "cancelled", "message": "x", "trigger": "auto"},
+        )
+        assert seen["notice"] is False
+
+    def test_stale_generation_end_notice_false(self, session):
+        """A superseded end is one nobody is waiting on — its notice
+        mid-turn reads as the LIVE work being cancelled."""
+        session._generation = 9
+        seen = self._emit(
+            session,
+            {
+                "phase": "end",
+                "ok": False,
+                "reason": "cancelled",
+                "message": "x",
+                "trigger": "manual",
+            },
+            my_generation=4,
+        )
+        assert seen["superseded"] is True
+        assert seen["notice"] is False
+
+    def test_ok_end_and_start_carry_no_notice(self, session):
+        seen = self._emit(
+            session,
+            {"phase": "end", "ok": True, "trigger": "manual", "summary": "s"},
+        )
+        assert "notice" not in seen
+        seen = self._emit(session, {"phase": "start", "trigger": "manual"})
+        assert "notice" not in seen
 
 
 class TestPreSwapQueueFlush:

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -2170,6 +2170,34 @@ class TestPreHookUICompat:
         )
 
 
+class TestClaimGenerationHookGuard:
+    """_claim_generation's on_generation_claimed emission sits on send()'s
+    PRE-turn path — before the user turn is appended, before
+    _record_fatal_error's coverage — so a raising override must degrade
+    to a lost latch-break, never to a silently dropped user message."""
+
+    def test_raising_claim_hook_does_not_abort_the_claim(self, session):
+        calls: list[int] = []
+
+        def _boom(gen: int) -> None:
+            calls.append(gen)
+            raise RuntimeError("broadcast backend down")
+
+        session.ui = SimpleNamespace(
+            on_thinking_start=lambda: None,
+            on_thinking_stop=lambda: None,
+            on_error=lambda _m: None,
+            on_generation_claimed=_boom,
+        )
+        before = session._generation
+        claimed = session._claim_generation()
+        assert claimed == before + 1  # claim-state writes stayed infallible
+        assert session._generation == claimed
+        assert calls == [claimed]  # the hook WAS attempted, then contained
+        # And again — every claim survives, not just the first.
+        assert session._claim_generation() == claimed + 1
+
+
 class TestCompactionNoticeStamp:
     """_compaction_event is the single display-policy site: failed ends
     carry ``notice`` — renderers show the message iff it is true, instead

--- a/tests/test_coord_rich_ws_state_payload.py
+++ b/tests/test_coord_rich_ws_state_payload.py
@@ -476,7 +476,7 @@ def test_coord_spawn_metrics_increments_messages_and_resets_tool_count() -> None
     ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
     ui._ws_messages = 5
     ui._ws_turn_tool_calls = 3
-    _coord_spawn_metrics(MagicMock(), ui)
+    _coord_spawn_metrics(ui)
     assert ui._ws_messages == 6
     assert ui._ws_turn_tool_calls == 0
 
@@ -489,7 +489,7 @@ def test_coord_spawn_metrics_tolerates_ui_without_counters() -> None:
     class _StubUI:
         pass
 
-    _coord_spawn_metrics(MagicMock(), _StubUI())  # must not raise
+    _coord_spawn_metrics(_StubUI())  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -687,7 +687,14 @@ def test_coordinator_js_gates_send_on_cross_user_busy():
     assert "actingUserId !== me" in coord_js
     assert "composer.setSendBlocked(" in coord_js
     assert "function reconcileSendBlock()" in coord_js
-    # reactive 409 fallback
+    # reactive 409 fallback — the pane converts the 409 body at the fetch
+    # stage; the status ARM itself lives in the shared settle helper
+    # (composer_queue.settleSendResponse) with the rest of the response
+    # matrix, one implementation for both panes.
     assert "r.status === 409" in coord_js
     assert 'status: "cross_user_interjection"' in coord_js
-    assert 'data.status === "cross_user_interjection"' in coord_js
+    assert "settleSendResponse(" in coord_js
+    helper = (
+        Path(__file__).resolve().parents[1] / "turnstone/shared_static/composer_queue.js"
+    ).read_text(encoding="utf-8")
+    assert 'status === "cross_user_interjection"' in helper

--- a/tests/test_idle_nudge_watcher.py
+++ b/tests/test_idle_nudge_watcher.py
@@ -39,6 +39,10 @@ class _FakeWorkstream:
         self._worker_running = False
         self._closed = False
         self.worker_thread: Any = None
+        # Deferred /send entries — the wake gate yields while any are
+        # pending (order barrier); empty is the default every other test
+        # assumes.
+        self._pending_sends: list[Any] = []
 
 
 class _FakeManager:
@@ -193,6 +197,25 @@ class TestWakeWorkstreamIfPending:
         with patch("turnstone.core.session_worker.send") as mock_send:
             assert wake_workstream_if_pending(ws) is False
             assert mock_send.call_count == 0
+
+    def test_yields_to_pending_deferred_sends(self, fake_mgr_and_ws):
+        """Deferred /send entries hold the order barrier: a wake worker
+        claiming the slot would push messages already acknowledged
+        "queued" behind its whole turn, so the gate yields.  Re-armed
+        structurally — every deferred turn's exit re-runs the gate, and
+        the drain's clean exit (trigger="drain-exit") covers a list that
+        emptied by pure retraction and never ran a turn."""
+        _mgr, ws = fake_mgr_and_ws
+        ws.session._nudge_queue.enqueue("watch_triggered", "output", "any")
+        ws._pending_sends.append(object())
+        with patch("turnstone.core.session_worker.send", return_value=True) as mock_send:
+            assert wake_workstream_if_pending(ws, trigger="worker-exit") is False
+            assert mock_send.call_count == 0
+        # Barrier cleared (the drain retired) — the same call dispatches.
+        ws._pending_sends.clear()
+        with patch("turnstone.core.session_worker.send", return_value=True) as mock_send:
+            assert wake_workstream_if_pending(ws, trigger="drain-exit") is True
+            assert mock_send.call_count == 1
 
     def test_skips_closed_ws(self, fake_mgr_and_ws):
         """A workstream mid-``close()`` must not get a wake spawned on

--- a/tests/test_idle_nudge_watcher.py
+++ b/tests/test_idle_nudge_watcher.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -39,10 +40,17 @@ class _FakeWorkstream:
         self._worker_running = False
         self._closed = False
         self.worker_thread: Any = None
-        # Deferred /send entries — the wake gate yields while any are
-        # pending (order barrier); empty is the default every other test
+        # Deferred /send entries — the wake gate yields while the order
+        # barrier holds; empty/None is the default every other test
         # assumes.
         self._pending_sends: list[Any] = []
+        self._pending_drain: Any = None
+
+    def send_barrier_active(self) -> bool:
+        # Mirrors Workstream.send_barrier_active — the gate calls the
+        # METHOD, so the stub must carry the same two-term pair.
+        drain = self._pending_drain
+        return bool(self._pending_sends) or (drain is not None and drain.is_alive())
 
 
 class _FakeManager:
@@ -211,8 +219,18 @@ class TestWakeWorkstreamIfPending:
         with patch("turnstone.core.session_worker.send", return_value=True) as mock_send:
             assert wake_workstream_if_pending(ws, trigger="worker-exit") is False
             assert mock_send.call_count == 0
-        # Barrier cleared (the drain retired) — the same call dispatches.
+        # CLAIMED-entry window: list empty but the drain is alive (an
+        # acked entry was popped, its dispatch in flight).  The one-term
+        # list check let a wake jump the acknowledged send here — the
+        # barrier's drain-alive term must hold the yield.
         ws._pending_sends.clear()
+        ws._pending_drain = SimpleNamespace(is_alive=lambda: True)
+        with patch("turnstone.core.session_worker.send", return_value=True) as mock_send:
+            assert wake_workstream_if_pending(ws, trigger="worker-exit") is False
+            assert mock_send.call_count == 0
+        # Barrier fully cleared (the drain retired) — the same call
+        # dispatches.
+        ws._pending_drain = None
         with patch("turnstone.core.session_worker.send", return_value=True) as mock_send:
             assert wake_workstream_if_pending(ws, trigger="drain-exit") is True
             assert mock_send.call_count == 1

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -636,3 +636,35 @@ def test_connectsse_defers_open_when_tab_hidden() -> None:
     )
     assert head.index("this.wsId = wsId;") < head.index("if (document.hidden) {")
     assert head.index('addEventListener("visibilitychange"') < head.index("if (document.hidden) {")
+
+
+def test_send_abort_bound_is_compaction_aware() -> None:
+    """The send POST's abort bound must be selected via the shared
+    ``sendAbortMs`` helper in BOTH panes: sends during a slash-command
+    window park server-side (a manual /compact legitimately runs for
+    minutes), so a hard-coded ~15s abort silently dropped any send made
+    >15s into a long compaction.  The compaction card is the long-bound
+    signal; the wedged-node default stays otherwise."""
+    interactive = _INTERACTIVE.read_text(encoding="utf-8")
+    assert "sendAbortMs(this._compaction)" in interactive, (
+        "interactive sendMessage must select its abort bound off the compaction holder"
+    )
+    coordinator = (_ROOT / "turnstone/console/static/coordinator/coordinator.js").read_text(
+        encoding="utf-8"
+    )
+    assert "sendAbortMs(compactionHolder)" in coordinator, (
+        "coordinator coordSend must share the same abort-bound policy"
+    )
+    conversation = (_ROOT / "turnstone/shared_static/conversation.js").read_text(encoding="utf-8")
+    assert "export function sendAbortMs" in conversation
+    assert "600000 : 15000" in conversation.replace("\n", " "), (
+        "long bound while a compaction card is live; 15s wedged-node default otherwise"
+    )
+    # The queued bubble's pre-response x must abort the in-flight (possibly
+    # parked) POST — otherwise a dismissed message dispatches anyway when
+    # the command window closes.
+    assert "queuedEl._sendAbort = () => sendCtrl.abort()" in interactive
+    composer_queue = (_ROOT / "turnstone/shared_static/composer_queue.js").read_text(
+        encoding="utf-8"
+    )
+    assert "el._sendAbort()" in composer_queue

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -398,17 +398,21 @@ def test_pane_gates_send_on_cross_user_busy() -> None:
     # ...and drives the composer's hard block, re-run on every busy edge.
     assert "this.composer.setSendBlocked(" in body
     stripped = _strip_comments(body)
-    setbusy = stripped.index("setBusy(b) {")
-    assert "this._reconcileSendBlock();" in stripped[setbusy : setbusy + 600]
+    setbusy = stripped.index("setBusy(b, source) {")
+    assert "this._reconcileSendBlock();" in stripped[setbusy : setbusy + 800]
 
 
 def test_pane_handles_cross_user_409() -> None:
     """The reactive fallback: a 409 (button not yet disabled) surfaces a clean
-    message, not the generic 'Connection error' catch."""
+    message, not the generic 'Connection error' catch.  The pane converts
+    the 409 body at the fetch stage; the status ARM itself lives in the
+    shared settle helper (composer_queue.settleSendResponse) with the rest
+    of the response matrix."""
     body = _INTERACTIVE.read_text(encoding="utf-8")
     assert "r.status === 409" in body
     assert 'status: "cross_user_interjection"' in body
-    assert 'data.status === "cross_user_interjection"' in body
+    helper = (_ROOT / "turnstone/shared_static/composer_queue.js").read_text(encoding="utf-8")
+    assert 'status === "cross_user_interjection"' in helper
 
 
 def test_sync_approval_state_prunes_orphan_cycles() -> None:
@@ -713,16 +717,40 @@ def test_deferred_send_settle_protocol_pins() -> None:
     # so the SSE settle can beat the POST response's bind(): the controller
     # parks chip-absent settles and bind() reconciles them — without this a
     # raced chip stays flagged deferred and the idle sweep skips it forever.
+    # Expiry is TTL-based: a size cap evicted exactly this tab's raced
+    # settle when a window closed with a burst of deferred sends (ours
+    # parks FIRST, the foreign settles behind it overflow the cap).
     assert "_preBindSettles" in composer_queue
     assert "_preBindSettles.has(msgId)" in composer_queue
-    # Both panes pass the response through the options seam and consume the
-    # pane-tier settle event.
+    assert "PRE_BIND_SETTLE_TTL_MS" in composer_queue
+    assert "_preBindSettles.size" not in composer_queue, "size-cap eviction must stay dead"
+    # The full send-response settle matrix lives ONCE, in the shared
+    # helper — retro-convert (a parked, still-retractable message must not
+    # render as a sent bubble), the deferred busy-undo, and the queue_full
+    # idle-pane cleanup (bubble removed + busy restored: the refusal can
+    # now fire with no worker and no drain alive, so no state event would
+    # ever unstick the composer).
+    assert "export function settleSendResponse(queue, data, ctx)" in composer_queue
+    assert "!queuedEl && data.deferred" in composer_queue
+    assert "deferred: !!data.deferred" in composer_queue
+    assert "attachedCount: (data.attached_ids || []).length" in composer_queue
+    assert "ctx.busyIsOptimistic()" in composer_queue
+    assert composer_queue.count("ctx.optimisticEl.remove()") >= 2, (
+        "both the retro-convert and queue_full arms must clear the optimistic bubble"
+    )
+    # Both panes route their parsed /send response through the helper and
+    # consume the pane-tier settle event; the busy stamp is centralized in
+    # each pane's setBusy (source defaults to "server" — only the send
+    # flow's optimistic flip may ever be undone).
     for name, src in (("interactive.js", interactive), ("coordinator.js", coordinator)):
-        assert "deferred: !!data.deferred" in src, f"{name}: bind must carry the deferred flag"
-        assert "attachedCount: (data.attached_ids || []).length" in src, name
+        assert "settleSendResponse(" in src, f"{name}: settle matrix must be the shared helper"
+        assert "busyIsOptimistic" in src, name
+        assert 'setBusy(true, "optimistic")' in src, f"{name}: optimistic flip must stamp"
+        assert "parsePriority(" in src, f"{name}: shared !!! parse"
         assert 'case "message_dispatched"' in src, f"{name}: settle event not consumed"
         assert "settleDeferred(" in src, name
-        # queuedEl-absent + deferred: the idle-thinking pane must render a
-        # real queued chip (retro-convert), not leave a sent-looking bubble
-        # for a parked, still-retractable message.
-        assert "!queuedEl && data.deferred" in src, f"{name}: idle-pane defer must chip"
+    # /command's degraded statuses are all surfaced: busy, running (the
+    # backstop answer), and error (503 — the worker never spawned; silence
+    # here reads as success).
+    assert 'body.status === "running"' in interactive
+    assert 'body.status === "error"' in interactive

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -830,6 +830,16 @@ if (c.includes("promote"))
 c = run(makeEl({ hasAttribute: (a) => a === "aria-busy" }), false, queued);
 if (c.includes("promote"))
   throw new Error("dismiss-in-flight chip must be left to its DELETE verdict: " + c);
+// Null / non-object 2xx body (a misbehaving proxy answering `200 null`): the
+// helper normalizes it to {} so neither call site guards — it must fall through
+// to the unknown/"ok" arm and SETTLE the optimistic chip (promote), never throw
+// and strand a delivered message as a connection error.  (The no-op
+// consumeAttachments stub cannot prevent this: data.attached_ids is evaluated to
+// build the :639 call args, so against unfixed code this line throws and crashes
+// the harness.)
+c = run(makeEl(), false, null);
+if (!c.includes("promote"))
+  throw new Error("null body must settle via unknown-ok, not throw: " + c);
 console.log("settle matrix OK");
 """,
         encoding="utf-8",

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -638,33 +638,39 @@ def test_connectsse_defers_open_when_tab_hidden() -> None:
     assert head.index('addEventListener("visibilitychange"') < head.index("if (document.hidden) {")
 
 
-def test_send_abort_bound_is_compaction_aware() -> None:
-    """The send POST's abort bound must be selected via the shared
-    ``sendAbortMs`` helper in BOTH panes: sends during a slash-command
-    window park server-side (a manual /compact legitimately runs for
-    minutes), so a hard-coded ~15s abort silently dropped any send made
-    >15s into a long compaction.  The compaction card is the long-bound
-    signal; the wedged-node default stays otherwise."""
+def test_send_post_abort_machinery_is_gone() -> None:
+    """The parked-POST era's client abort machinery must stay deleted in
+    BOTH panes: sends during a command window are answered "queued"
+    immediately (server-side defer-and-drain), so there is no long-lived
+    POST for a compaction-aware bound (``sendAbortMs``) to protect, and
+    dismissal is bind() → server-confirmed DELETE — never a POST abort
+    (``_sendAbort``), which fired on the interjection path too and
+    dispatched "dismissed" messages anyway.  Reintroducing either hook
+    means re-parking the POST; that design deterministically dropped
+    messages from every timeout-bounded caller (coordinator client and
+    console proxy at 30s, SDKs, stock proxies)."""
     interactive = _INTERACTIVE.read_text(encoding="utf-8")
-    assert "sendAbortMs(this._compaction)" in interactive, (
-        "interactive sendMessage must select its abort bound off the compaction holder"
-    )
     coordinator = (_ROOT / "turnstone/console/static/coordinator/coordinator.js").read_text(
         encoding="utf-8"
     )
-    assert "sendAbortMs(compactionHolder)" in coordinator, (
-        "coordinator coordSend must share the same abort-bound policy"
-    )
     conversation = (_ROOT / "turnstone/shared_static/conversation.js").read_text(encoding="utf-8")
-    assert "export function sendAbortMs" in conversation
-    assert "600000 : 15000" in conversation.replace("\n", " "), (
-        "long bound while a compaction card is live; 15s wedged-node default otherwise"
-    )
-    # The queued bubble's pre-response x must abort the in-flight (possibly
-    # parked) POST — otherwise a dismissed message dispatches anyway when
-    # the command window closes.
-    assert "queuedEl._sendAbort = () => sendCtrl.abort()" in interactive
     composer_queue = (_ROOT / "turnstone/shared_static/composer_queue.js").read_text(
         encoding="utf-8"
     )
-    assert "el._sendAbort()" in composer_queue
+    for name, src in (
+        ("interactive.js", interactive),
+        ("coordinator.js", coordinator),
+        ("conversation.js", conversation),
+        ("composer_queue.js", composer_queue),
+    ):
+        assert "sendAbortMs" not in src, f"{name}: the compaction-aware abort bound is dead"
+        assert "_sendAbort" not in src, f"{name}: dismiss must be bind() → DELETE, not a POST abort"
+    # The flat wedged-node bound stands in both panes: every /send answers
+    # within RTT now (dispatched / queued / deferred-with-msg_id).
+    assert "sendCtrl.abort(), 15000" in interactive
+    assert "sendCtrl.abort(), 15000" in coordinator
+    # Retracting a deferred send discards its attachments — both panes
+    # stash the count and composer_queue surfaces the consequence.
+    assert "_deferredAttachments" in interactive
+    assert "_deferredAttachments" in coordinator
+    assert "_deferredAttachments" in composer_queue

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 _ROOT = Path(__file__).resolve().parent.parent
 _INTERACTIVE = _ROOT / "turnstone/shared_static/interactive.js"
 _COMPOSER = _ROOT / "turnstone/shared_static/composer.js"
@@ -738,6 +740,12 @@ def test_deferred_send_settle_protocol_pins() -> None:
     assert composer_queue.count("ctx.optimisticEl.remove()") >= 2, (
         "both the retro-convert and queue_full arms must clear the optimistic bubble"
     )
+    # The missed-edge settle: a non-deferred chip binding onto an
+    # already-idle pane missed its only sweep — the post-bind promote
+    # (keyed on POST-bind chip state, honoring the aria-busy
+    # dismiss-in-flight discipline) is what settles it.
+    assert "!ctx.paneIsBusy()" in composer_queue
+    assert 'queuedEl.hasAttribute("aria-busy")' in composer_queue
     # Both panes route their parsed /send response through the helper and
     # consume the pane-tier settle event; the busy stamp is centralized in
     # each pane's setBusy (source defaults to "server" — only the send
@@ -745,12 +753,91 @@ def test_deferred_send_settle_protocol_pins() -> None:
     for name, src in (("interactive.js", interactive), ("coordinator.js", coordinator)):
         assert "settleSendResponse(" in src, f"{name}: settle matrix must be the shared helper"
         assert "busyIsOptimistic" in src, name
+        assert "paneIsBusy" in src, f"{name}: the missed-edge settle needs the live flag"
         assert 'setBusy(true, "optimistic")' in src, f"{name}: optimistic flip must stamp"
         assert "parsePriority(" in src, f"{name}: shared !!! parse"
         assert 'case "message_dispatched"' in src, f"{name}: settle event not consumed"
         assert "settleDeferred(" in src, name
-    # /command's degraded statuses are all surfaced: busy, running (the
-    # backstop answer), and error (503 — the worker never spawned; silence
-    # here reads as success).
+    # /command's degraded outcomes are ALL surfaced: busy, running (the
+    # backstop answer), error (503 — the worker never spawned), the
+    # status-less non-2xx arm (404 / proxy 502), and the transport catch —
+    # silence at any of them reads as success.
     assert 'body.status === "running"' in interactive
     assert 'body.status === "error"' in interactive
+    assert "Command failed (HTTP " in interactive
+    assert '"Command failed: " + err.message' in interactive
+
+
+def test_settle_send_response_missed_edge_behavior(tmp_path) -> None:
+    """Execute the shared settle helper under node and pin the
+    missed-edge matrix behaviorally (not just textually): a non-deferred
+    chip binding onto an idle pane promotes; a busy pane, a deferred
+    chip, and a dismiss-in-flight chip do not."""
+    import shutil
+    import subprocess
+
+    if shutil.which("node") is None:
+        pytest.skip("node binary not available on PATH")
+    helper = _ROOT / "turnstone/shared_static/composer_queue.js"
+    script = tmp_path / "settle_harness.mjs"
+    script.write_text(
+        f'const {{ settleSendResponse }} = await import("file://{helper}");\n'
+        + """
+function makeEl(over) {
+  const el = {
+    isConnected: true,
+    classList: { contains: (c) => c === "msg-queued" },
+    dataset: {},
+    hasAttribute: () => false,
+  };
+  return Object.assign(el, over || {});
+}
+function run(queuedEl, paneBusy, data) {
+  const calls = [];
+  const queue = {
+    bind: (el, id, opts) => {
+      calls.push("bind");
+      // Mirror the real bind: stamp the deferred flag from opts.
+      if (opts && opts.deferred) el.dataset.deferred = "1";
+    },
+    promote: () => calls.push("promote"),
+    remove: () => calls.push("remove"),
+    addQueuedMessage: () => makeEl(),
+  };
+  settleSendResponse(queue, data, {
+    queuedEl,
+    optimisticEl: null,
+    isBusy: true,
+    displayText: "t",
+    priority: "notice",
+    setBusy: () => {},
+    busyIsOptimistic: () => false,
+    paneIsBusy: () => paneBusy,
+    renderError: () => {},
+    consumeAttachments: () => {},
+  });
+  return calls;
+}
+const queued = { status: "queued", msg_id: "m1" };
+let c = run(makeEl(), false, queued);
+if (!(c.includes("bind") && c.includes("promote")))
+  throw new Error("missed-edge chip must promote: " + c);
+c = run(makeEl(), true, queued);
+if (c.includes("promote")) throw new Error("busy pane must not promote: " + c);
+c = run(makeEl(), false, { status: "queued", msg_id: "m1", deferred: true });
+if (c.includes("promote"))
+  throw new Error("deferred chip is message_dispatched's: " + c);
+c = run(makeEl({ hasAttribute: (a) => a === "aria-busy" }), false, queued);
+if (c.includes("promote"))
+  throw new Error("dismiss-in-flight chip must be left to its DELETE verdict: " + c);
+console.log("settle matrix OK");
+""",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["node", str(script)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, f"settle harness failed:\n{proc.stderr}\n{proc.stdout}"

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -669,8 +669,60 @@ def test_send_post_abort_machinery_is_gone() -> None:
     # within RTT now (dispatched / queued / deferred-with-msg_id).
     assert "sendCtrl.abort(), 15000" in interactive
     assert "sendCtrl.abort(), 15000" in coordinator
-    # Retracting a deferred send discards its attachments — both panes
-    # stash the count and composer_queue surfaces the consequence.
-    assert "_deferredAttachments" in interactive
-    assert "_deferredAttachments" in coordinator
-    assert "_deferredAttachments" in composer_queue
+    # The deferred-attachment count rides bind()'s documented options seam
+    # (controller dataset) — the per-pane element expando is dead.
+    for name, src in (
+        ("interactive.js", interactive),
+        ("coordinator.js", coordinator),
+        ("composer_queue.js", composer_queue),
+    ):
+        assert "_deferredAttachments" not in src, (
+            f"{name}: deferred state must ride bind(el, msgId, opts), not an expando"
+        )
+
+
+def test_deferred_send_settle_protocol_pins() -> None:
+    """The deferred-chip settle protocol (round 7, C4): a deferred send's
+    queued chip keeps its retraction affordance exactly until the message
+    truly leaves the parked list.  Pins the controller's contract and both
+    panes' wiring — losing any of these silently re-promotes parked
+    messages to "sent" while the server still honors DELETE (loss
+    disguised as delivery on a node restart)."""
+    interactive = _INTERACTIVE.read_text(encoding="utf-8")
+    coordinator = (_ROOT / "turnstone/console/static/coordinator/coordinator.js").read_text(
+        encoding="utf-8"
+    )
+    composer_queue = (_ROOT / "turnstone/shared_static/composer_queue.js").read_text(
+        encoding="utf-8"
+    )
+    # Controller: bind() stores the options on its own dataset state...
+    assert "function bind(el, msgId, opts)" in composer_queue
+    assert 'el.dataset.deferred = "1"' in composer_queue
+    assert "el.dataset.attachedCount = String(opts.attachedCount)" in composer_queue
+    # ...the idle sweep skips deferred AND unbound chips (the "idle ⇒
+    # drained" invariant is untrue for both)...
+    assert "if (el.dataset.deferred) return;" in composer_queue
+    assert "if (!el.dataset.msgId) return;" in composer_queue
+    # ...and settleDeferred branches on the fold-in arm: clear the flag
+    # only (DELETE still genuinely removes a folded message until the seam
+    # drains), promote only on the fresh-spawn arm.
+    assert "function settleDeferred(msgId, folded)" in composer_queue
+    assert "delete target.dataset.deferred;" in composer_queue
+    assert "settleDeferred: settleDeferred" in composer_queue
+    # A barrier-deferred entry can dispatch within milliseconds of its ack,
+    # so the SSE settle can beat the POST response's bind(): the controller
+    # parks chip-absent settles and bind() reconciles them — without this a
+    # raced chip stays flagged deferred and the idle sweep skips it forever.
+    assert "_preBindSettles" in composer_queue
+    assert "_preBindSettles.has(msgId)" in composer_queue
+    # Both panes pass the response through the options seam and consume the
+    # pane-tier settle event.
+    for name, src in (("interactive.js", interactive), ("coordinator.js", coordinator)):
+        assert "deferred: !!data.deferred" in src, f"{name}: bind must carry the deferred flag"
+        assert "attachedCount: (data.attached_ids || []).length" in src, name
+        assert 'case "message_dispatched"' in src, f"{name}: settle event not consumed"
+        assert "settleDeferred(" in src, name
+        # queuedEl-absent + deferred: the idle-thinking pane must render a
+        # real queued chip (retro-convert), not leave a sent-looking bubble
+        # for a parked, still-retractable message.
+        assert "!queuedEl && data.deferred" in src, f"{name}: idle-pane defer must chip"

--- a/tests/test_notify_tool.py
+++ b/tests/test_notify_tool.py
@@ -222,7 +222,7 @@ class TestExecNotify:
 
         with (
             patch("turnstone.core.session.get_storage", return_value=storage),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
         ):
             call_id, msg = session._exec_notify(item)
 
@@ -293,7 +293,7 @@ class TestExecNotify:
                 side_effect=ConnectionError("refused"),
             ),
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
         ):
             # All fail — counter should stay at 0
             for _i in range(3):
@@ -330,7 +330,7 @@ class TestExecNotify:
                 side_effect=ConnectionError("refused"),
             ),
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
         ):
             call_id, msg = session._exec_notify(item)
 
@@ -401,7 +401,7 @@ class TestExecNotify:
             patch("turnstone.core.session.get_storage", return_value=storage),
             patch("turnstone.core.session.httpx.post") as mock_post,
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
         ):
             call_id, msg = session._exec_notify(item)
 
@@ -456,13 +456,14 @@ class TestExecNotify:
             patch("turnstone.core.session.get_storage", return_value=mock_storage),
             patch("turnstone.core.session.httpx.post", return_value=mock_resp),
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep") as mock_sleep,
+            patch.object(session, "_backoff_or_cancelled") as mock_backoff,
         ):
             call_id, msg = session._exec_notify(item)
 
         assert "sent successfully" in msg.lower()
-        # Should have slept twice (retry delays)
-        assert mock_sleep.call_count == 2
+        # Should have backed off twice (retry delays) — via the shared
+        # cancel-aware helper, not a Stop-blind time.sleep.
+        assert mock_backoff.call_count == 2
 
     def test_retry_on_all_gateways_failed(self, tmp_path):
         """Retries when all gateways fail on first attempt but succeed on retry."""
@@ -502,12 +503,12 @@ class TestExecNotify:
             patch("turnstone.core.session.get_storage", return_value=storage),
             patch("turnstone.core.session.httpx.post", side_effect=_post),
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep") as mock_sleep,
+            patch.object(session, "_backoff_or_cancelled") as mock_backoff,
         ):
             call_id, msg = session._exec_notify(item)
 
         assert "sent successfully" in msg.lower()
-        assert mock_sleep.call_count == 1
+        assert mock_backoff.call_count == 1
 
     def test_no_services_logs_warning(self, tmp_path):
         """Server-side warning is logged when no services are available."""
@@ -530,7 +531,7 @@ class TestExecNotify:
 
         with (
             patch("turnstone.core.session.get_storage", return_value=storage),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
             patch("turnstone.core.session.log") as mock_log,
         ):
             session._exec_notify(item)
@@ -569,7 +570,7 @@ class TestExecNotify:
                 side_effect=ConnectionError("refused"),
             ),
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
             patch("turnstone.core.session.log") as mock_log,
         ):
             session._exec_notify(item)
@@ -610,7 +611,7 @@ class TestExecNotify:
             patch("turnstone.core.session.get_storage", return_value=storage),
             patch("turnstone.core.session.httpx.post", return_value=mock_resp),
             patch.dict("os.environ", {}, clear=False),
-            patch("turnstone.core.session.time.sleep"),
+            patch.object(session, "_backoff_or_cancelled"),
         ):
             call_id, msg = session._exec_notify(item)
 

--- a/tests/test_server_attachments_endpoints.py
+++ b/tests/test_server_attachments_endpoints.py
@@ -504,6 +504,11 @@ class TestSendMessageAttachments:
         ws.worker_thread = None
         ws._worker_running = False
         ws._closed = False  # a bare Mock attr is truthy → send() would refuse
+        # Same truthy-Mock trap as _closed: the /send order barrier reads
+        # both — a bare Mock attr would defer every send behind a phantom
+        # pending list.
+        ws._pending_sends = []
+        ws._pending_drain = None
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return captured, session
@@ -703,6 +708,10 @@ class TestQueuedSendWithAttachments:
         ws.worker_thread = worker
         ws._worker_running = True
         ws._closed = False  # a bare Mock attr is truthy → send() would refuse
+        # Same truthy-Mock trap: the /send order barrier reads both — a
+        # bare Mock attr would defer every send behind a phantom list.
+        ws._pending_sends = []
+        ws._pending_drain = None
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return captured
@@ -767,6 +776,10 @@ class TestBusyWorkerAttachments:
         ws.session = session
         ws.worker_thread = worker
         ws._closed = False  # a bare Mock attr is truthy → send() would refuse
+        # Same truthy-Mock trap: the /send order barrier reads both — a
+        # bare Mock attr would defer every send behind a phantom list.
+        ws._pending_sends = []
+        ws._pending_drain = None
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return ws, session

--- a/tests/test_server_attachments_endpoints.py
+++ b/tests/test_server_attachments_endpoints.py
@@ -509,6 +509,10 @@ class TestSendMessageAttachments:
         # pending list.
         ws._pending_sends = []
         ws._pending_drain = None
+        # The /send route consults the order barrier as a METHOD — a bare
+        # Mock attr would be a truthy callable result and defer every send
+        # behind a phantom barrier (same class as the fields above).
+        ws.send_barrier_active = lambda: False
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return captured, session
@@ -712,6 +716,10 @@ class TestQueuedSendWithAttachments:
         # bare Mock attr would defer every send behind a phantom list.
         ws._pending_sends = []
         ws._pending_drain = None
+        # The /send route consults the order barrier as a METHOD — a bare
+        # Mock attr would be a truthy callable result and defer every send
+        # behind a phantom barrier (same class as the fields above).
+        ws.send_barrier_active = lambda: False
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return captured
@@ -780,6 +788,10 @@ class TestBusyWorkerAttachments:
         # bare Mock attr would defer every send behind a phantom list.
         ws._pending_sends = []
         ws._pending_drain = None
+        # The /send route consults the order barrier as a METHOD — a bare
+        # Mock attr would be a truthy callable result and defer every send
+        # behind a phantom barrier (same class as the fields above).
+        ws.send_barrier_active = lambda: False
         ws._lock = threading.RLock()
         mgr.get.return_value = ws
         return ws, session

--- a/tests/test_server_attachments_endpoints.py
+++ b/tests/test_server_attachments_endpoints.py
@@ -105,6 +105,28 @@ def _auth(user: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {_make_jwt(user)}"}
 
 
+def _harden_ws_mock(ws) -> None:
+    """Neutralize every truthy-Mock trap the /send dispatch path reads.
+
+    A bare ``MagicMock()`` auto-creates truthy attributes and callables,
+    which the route misreads: a truthy ``_closed`` makes ``send()``
+    refuse; truthy ``_pending_sends``/``_pending_drain`` (and a truthy
+    ``send_barrier_active()`` result — the route consults the barrier as
+    a METHOD) defer every send behind a phantom order barrier.  Every
+    NEW Workstream field the dispatch path reads gets added HERE, once —
+    not appended to each fixture (missing one copy made that fixture's
+    sends defer/hang with an error pointing nowhere near the cause).
+    Deliberately does NOT set ``_worker_running``: fixtures choose that
+    per scenario (one even relies on the truthy auto-Mock to force the
+    queue path).
+    """
+    ws._closed = False
+    ws._pending_sends = []
+    ws._pending_drain = None
+    ws.send_barrier_active = lambda: False
+    ws._lock = threading.RLock()
+
+
 # ---------------------------------------------------------------------------
 # Upload
 # ---------------------------------------------------------------------------
@@ -503,17 +525,7 @@ class TestSendMessageAttachments:
         ws.session = session
         ws.worker_thread = None
         ws._worker_running = False
-        ws._closed = False  # a bare Mock attr is truthy → send() would refuse
-        # Same truthy-Mock trap as _closed: the /send order barrier reads
-        # both — a bare Mock attr would defer every send behind a phantom
-        # pending list.
-        ws._pending_sends = []
-        ws._pending_drain = None
-        # The /send route consults the order barrier as a METHOD — a bare
-        # Mock attr would be a truthy callable result and defer every send
-        # behind a phantom barrier (same class as the fields above).
-        ws.send_barrier_active = lambda: False
-        ws._lock = threading.RLock()
+        _harden_ws_mock(ws)
         mgr.get.return_value = ws
         return captured, session
 
@@ -711,16 +723,7 @@ class TestQueuedSendWithAttachments:
         ws.session = session
         ws.worker_thread = worker
         ws._worker_running = True
-        ws._closed = False  # a bare Mock attr is truthy → send() would refuse
-        # Same truthy-Mock trap: the /send order barrier reads both — a
-        # bare Mock attr would defer every send behind a phantom list.
-        ws._pending_sends = []
-        ws._pending_drain = None
-        # The /send route consults the order barrier as a METHOD — a bare
-        # Mock attr would be a truthy callable result and defer every send
-        # behind a phantom barrier (same class as the fields above).
-        ws.send_barrier_active = lambda: False
-        ws._lock = threading.RLock()
+        _harden_ws_mock(ws)
         mgr.get.return_value = ws
         return captured
 
@@ -783,16 +786,9 @@ class TestBusyWorkerAttachments:
         ws.ui = ui
         ws.session = session
         ws.worker_thread = worker
-        ws._closed = False  # a bare Mock attr is truthy → send() would refuse
-        # Same truthy-Mock trap: the /send order barrier reads both — a
-        # bare Mock attr would defer every send behind a phantom list.
-        ws._pending_sends = []
-        ws._pending_drain = None
-        # The /send route consults the order barrier as a METHOD — a bare
-        # Mock attr would be a truthy callable result and defer every send
-        # behind a phantom barrier (same class as the fields above).
-        ws.send_barrier_active = lambda: False
-        ws._lock = threading.RLock()
+        # No explicit _worker_running: the truthy auto-Mock forces the
+        # queue path (deliberate — see _harden_ws_mock's exclusion note).
+        _harden_ws_mock(ws)
         mgr.get.return_value = ws
         return ws, session
 

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import queue
 import threading
+import time
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -102,6 +103,9 @@ class _FakeUI:
         self.auto_approve = False
         self.auto_approve_tools: set[str] = set()
         self._enqueued: list[dict[str, Any]] = []
+        self.states: list[str] = []
+        self.infos: list[str] = []
+        self.errors: list[str] = []
         self._listeners: list[queue.Queue[dict[str, Any]]] = []
         self._listeners_lock = threading.Lock()
         self._pending_approval: dict[str, Any] | None = None
@@ -196,11 +200,14 @@ class _FakeUI:
     def on_stream_end(self) -> None:
         pass
 
-    def on_state_change(self, _state: str) -> None:
-        pass
+    def on_state_change(self, state: str) -> None:
+        self.states.append(state)
 
-    def on_error(self, _msg: str) -> None:
-        pass
+    def on_info(self, msg: str) -> None:
+        self.infos.append(msg)
+
+    def on_error(self, msg: str) -> None:
+        self.errors.append(msg)
 
     def resolve_approval(self, *_a: Any, **_kw: Any) -> None:
         self._approval_event.set()
@@ -217,10 +224,41 @@ class _FakeSession:
         self.messages: list[dict[str, Any]] = []
         self._last_usage: dict[str, int] | None = None
         self._pending_retry: str | None = None
+        # Real sessions always carry one; the /send route's cancel-drain
+        # poll reads it whenever a worker is live at send time.
+        self._cancel_event = threading.Event()
         self.sends: list[tuple[str, Any, Any]] = []
+        self.commands: list[str] = []
+        self.compacts = 0
+        self.compact_raises: BaseException | None = None
+        self.send_raises: BaseException | None = None
+        self.exit_commands: set[str] = set()
+        self.queued_flushes = 0
+        self.queued_text = ""
+        # Gates let a test hold the worker slot open mid-command so a
+        # concurrent /send provably lands in the PARK path.
+        self.compact_gate: threading.Event | None = None
+        self.command_gate: threading.Event | None = None
+        self.command_raises: BaseException | None = None
+        # Every queue_message call — the park invariant is that command
+        # windows NEVER reach the interjection queue.
+        self.queue_calls: list[str] = []
 
     def send(self, text: str, *, attachments: Any = None, send_id: Any = None) -> None:
         self.sends.append((text, attachments, send_id))
+        if self.send_raises is not None:
+            raise self.send_raises
+
+    def queue_message(
+        self,
+        text: str,
+        attachment_ids: Any = None,
+        queue_msg_id: str | None = None,
+        interjector_user_id: str = "",
+    ) -> tuple[str, str, str]:
+        self.queue_calls.append(text)
+        cleaned = text[:2000] + "..." if len(text) > 2000 else text
+        return cleaned, "notice", queue_msg_id or "m1"
 
     def set_watch_runner(self, *_a: Any, **_kw: Any) -> None:
         pass
@@ -234,8 +272,26 @@ class _FakeSession:
     def close(self) -> None:
         pass
 
-    def handle_command(self, _cmd: str) -> bool:
-        return False
+    def handle_command(self, cmd: str) -> bool:
+        self.commands.append(cmd)
+        if self.command_gate is not None:
+            self.command_gate.wait(timeout=10)
+        if self.command_raises is not None:
+            raise self.command_raises
+        return cmd in self.exit_commands
+
+    def compact_now(self) -> bool:
+        self.compacts += 1
+        if self.compact_gate is not None:
+            self.compact_gate.wait(timeout=10)
+        if self.compact_raises is not None:
+            raise self.compact_raises
+        return True
+
+    def flush_queued_messages(self) -> bool:
+        self.queued_flushes += 1
+        had, self.queued_text = bool(self.queued_text), ""
+        return had
 
     def request_title_refresh(self, _title: str) -> None:
         pass
@@ -1177,3 +1233,403 @@ class TestInteractiveEventsLifted:
             headers=_auth("user-1"),
         )
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/api/command — /compact worker dispatch (progress-events fix)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactCommandDispatch:
+    """Manual /compact runs on the workstream's worker slot: the event loop
+    stays free to stream the compaction progress events, and a concurrent
+    send takes the queue path instead of racing the history swap."""
+
+    def _create_ws(self, client) -> str:
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "compact-me"},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        return resp.json()["ws_id"]
+
+    def test_compact_dispatches_to_worker(self, app_client):
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        # The compaction runs on the spawned worker — join it (the runner
+        # clears _worker_running before the thread exits, so the join
+        # subsumes the flag).
+        ws.worker_thread.join(timeout=5)
+        assert not ws.worker_thread.is_alive()
+        assert ws.session.compacts == 1
+        assert ws._worker_running is False
+        # The slot was classified as a command window (what the /send
+        # route's park keys on; stale after exit is harmless — every
+        # reader conjoins _worker_running).
+        assert ws.worker_kind == "command"
+        # Exit seam: stranded-text backstop flush only — no drain, no
+        # answering send (sends during the window park in the /send route
+        # and dispatch as their own workers afterwards).
+        assert ws.session.queued_flushes == 1
+        assert ws.session.sends == []
+        # The worker wrapped the run in busy/idle state transitions.
+        assert ws.ui.states == ["thinking", "idle"]
+
+    def test_send_during_compact_window_parks_then_dispatches_fully(self, app_client):
+        """A /send during a manual /compact PARKS and then runs as an
+        ordinary full-fidelity send — it must never enter the interjection
+        queue, whose 2000-char cap silently truncated pasted logs/code and
+        whose cross-user guard locked second participants out for the
+        whole compaction."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.json() == {"status": "ok"}
+        big = "x" * 5000  # over the interjection cap — must survive intact
+        send_result: dict = {}
+
+        def _send() -> None:
+            r = client.post(
+                f"/v1/api/workstreams/{ws_id}/send",
+                json={"message": big},
+                headers=_auth("user-1"),
+            )
+            send_result["status"] = r.status_code
+            send_result["body"] = r.json()
+
+        sender = threading.Thread(target=_send, daemon=True)
+        sender.start()
+        # The send is parked: give it time to have taken the park path,
+        # then prove nothing was dispatched or queued yet.
+        for _ in range(50):
+            if ws.session.queue_calls or ws.session.sends:
+                break
+            time.sleep(0.02)
+        assert ws.session.sends == []
+        assert ws.session.queue_calls == []  # the queue is unreachable
+        gate.set()  # compaction finishes; the park releases
+        sender.join(timeout=10)
+        assert not sender.is_alive()
+        assert send_result["status"] == 200
+        assert send_result["body"]["status"] == "ok"
+        # Full fidelity: the exact 5000-char text, via a normal send.
+        assert [s[0] for s in ws.session.sends] == [big]
+        assert ws.session.queue_calls == []
+
+    def test_cancelled_compact_flushes_queue_without_answering(self, app_client):
+        """A user-stopped compaction must not auto-run a turn they may no
+        longer want — queued text lands in the transcript via the flush
+        drain instead (the cancel-seam precedent)."""
+        from turnstone.core.session import GenerationCancelled
+
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        ws.session.compact_raises = GenerationCancelled()
+        ws.session.queued_text = "queued mid-compact"
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        ws.worker_thread.join(timeout=5)
+        assert ws.session.compacts == 1
+        assert ws.session.queued_flushes == 1
+        assert ws.session.sends == []
+        assert ws.ui.states == ["thinking", "idle"]
+
+    def test_compact_refused_while_worker_running(self, app_client):
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        with ws._lock:
+            ws._worker_running = True  # a turn is in flight
+        try:
+            resp = client.post(
+                "/v1/api/command",
+                json={"command": "/compact", "ws_id": ws_id},
+                headers=_auth("user-1"),
+            )
+        finally:
+            with ws._lock:
+                ws._worker_running = False
+        assert resp.status_code == 409  # loud refusal for status-code-only callers
+        body = resp.json()
+        assert body["status"] == "busy"
+        assert "busy" in body["error"].lower()
+        # Never ran inline, never queued a phantom compaction.
+        assert ws.session.compacts == 0
+        assert ws.session.commands == []
+
+    def test_non_compact_commands_complete_before_response(self, app_client):
+        """Quick commands dispatch through the same worker slot (mutual
+        exclusion vs sends / a running compaction / each other) but the
+        endpoint awaits completion, preserving the synchronous contract:
+        handle_command has finished by the time the response returns."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/skill", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+        ws = mgr.get(ws_id)
+        # handle_command completed before the response (the done-Event
+        # gates it); join before asserting the slot state (the runner
+        # clears _worker_running before the thread exits, so the join
+        # subsumes the flag; without it this assert races the worker's
+        # last steps).
+        assert ws.session.commands == ["/skill"]
+        ws.worker_thread.join(timeout=5)
+        assert not ws.worker_thread.is_alive()
+        assert ws._worker_running is False
+        # No exit seam work at all for quick commands: no drain, no flush,
+        # no follow-up send, and no state chatter (they never left idle).
+        assert ws.session.queued_flushes == 0
+        assert ws.session.sends == []
+        assert ws.ui.states == []
+
+    def test_parked_send_delivers_attachments_after_release(self, app_client, monkeypatch):
+        """Attachments are peek-resolved BEFORE the park (the bytes ride the
+        request closure), so a send parked through a long compaction still
+        delivers them on dispatch — the pre-park refusal
+        (attachments_busy) must never apply to a command window."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+
+        def fake_resolve(requested_ids, _ws_id, _user_id):
+            assert list(requested_ids) == ["a1"]
+            return (["fake-attachment-bytes"], ["a1"], [])
+
+        monkeypatch.setattr("turnstone.core.attachments.resolve_staged_attachments", fake_resolve)
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        send_result: dict = {}
+
+        def _send() -> None:
+            r = client.post(
+                f"/v1/api/workstreams/{ws_id}/send",
+                json={"message": "with attachment", "attachment_ids": ["a1"]},
+                headers=_auth("user-1"),
+            )
+            send_result["body"] = r.json()
+
+        sender = threading.Thread(target=_send, daemon=True)
+        sender.start()
+        time.sleep(0.3)
+        assert ws.session.sends == []  # still parked
+        gate.set()
+        sender.join(timeout=10)
+        assert not sender.is_alive()
+        assert send_result["body"]["status"] == "ok"
+        assert send_result["body"]["attached_ids"] == ["a1"]
+        text, attachments, _sid = ws.session.sends[0]
+        assert text == "with attachment"
+        assert attachments == ["fake-attachment-bytes"]
+        assert ws.session.queue_calls == []
+
+    def test_send_during_quick_command_window_parks(self, app_client):
+        """The park applies to EVERY command window, not just /compact — a
+        send racing a quick command dispatches after the window with full
+        fidelity instead of entering the interjection queue."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.command_gate = gate
+        cmd_result: dict = {}
+
+        def _cmd() -> None:
+            r = client.post(
+                "/v1/api/command",
+                json={"command": "/skill", "ws_id": ws_id},
+                headers=_auth("user-1"),
+            )
+            cmd_result["body"] = r.json()
+
+        runner = threading.Thread(target=_cmd, daemon=True)
+        runner.start()
+        # Wait until the command worker actually holds the slot.
+        for _ in range(100):
+            if ws._worker_running:
+                break
+            time.sleep(0.02)
+        assert ws._worker_running
+        assert ws.worker_kind == "command"
+        send_result: dict = {}
+
+        def _send() -> None:
+            r = client.post(
+                f"/v1/api/workstreams/{ws_id}/send",
+                json={"message": "mid-command send"},
+                headers=_auth("user-1"),
+            )
+            send_result["body"] = r.json()
+
+        sender = threading.Thread(target=_send, daemon=True)
+        sender.start()
+        time.sleep(0.3)  # long enough for a queue-path regression to show
+        assert ws.session.queue_calls == []
+        assert ws.session.sends == []
+        gate.set()
+        runner.join(timeout=10)
+        sender.join(timeout=10)
+        assert not sender.is_alive()
+        assert cmd_result["body"] == {"status": "ok"}
+        assert send_result["body"]["status"] == "ok"
+        assert [s[0] for s in ws.session.sends] == ["mid-command send"]
+        assert ws.session.queue_calls == []
+
+    def test_clear_ui_rides_the_worker_not_the_endpoint(self, app_client):
+        """The clear_ui follow-up runs on the worker after handle_command —
+        parked after the endpoint's 60s done-wait it was silently skipped
+        for any command that outlived the backstop, leaving every pane
+        rendering a transcript the server no longer holds."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/clear", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        ws = mgr.get(ws_id)
+        ws.worker_thread.join(timeout=5)
+        assert {"type": "clear_ui"} in ws.ui._enqueued
+
+    def _run_abandoned_command(self, client, mgr, ws_id, command="/clear", raises=None):
+        """Dispatch a gated command, force-abandon its worker mid-run, then
+        release the gate so the abandoned thread finishes late.  Returns
+        (endpoint response body, the abandoned worker thread)."""
+        ws = mgr.get(ws_id)
+        gate = threading.Event()
+        ws.session.command_gate = gate
+        ws.session.command_raises = raises
+        result: dict = {}
+
+        def _cmd() -> None:
+            r = client.post(
+                "/v1/api/command",
+                json={"command": command, "ws_id": ws_id},
+                headers=_auth("user-1"),
+            )
+            result["body"] = r.json()
+
+        runner = threading.Thread(target=_cmd, daemon=True)
+        runner.start()
+        for _ in range(100):
+            if ws._worker_running:
+                break
+            time.sleep(0.02)
+        assert ws._worker_running
+        worker = ws.worker_thread
+        # The cancel handler's force path shape: abandon the worker.
+        with ws._lock:
+            ws.worker_thread = None
+            ws._worker_running = False
+        gate.set()  # the wedged command unwedges LATE
+        worker.join(timeout=5)
+        runner.join(timeout=10)
+        assert not worker.is_alive() and not runner.is_alive()
+        return result["body"], worker
+
+    def test_abandoned_command_worker_fires_no_followups(self, app_client):
+        """A force-cancelled wedged command that unwedges minutes later
+        must not fire clear_ui (every pane would wipe its transcript
+        mid-successor-turn) — the owner guard every sibling worker closure
+        applies.  done still fires, so the endpoint never hangs."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        body, _ = self._run_abandoned_command(client, mgr, ws_id, command="/clear")
+        assert not any(e.get("type") == "clear_ui" for e in ws.ui._enqueued)
+        # handle_command genuinely completed, so the (unhung) endpoint's
+        # answer reflects that.
+        assert body["status"] == "ok"
+
+    def test_abandoned_command_worker_swallows_late_error(self, app_client):
+        """The except arm carries the same guard: a stray late 'Command
+        error:' from an abandoned worker must not land mid-successor-turn."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        self._run_abandoned_command(
+            client, mgr, ws_id, command="/skill", raises=RuntimeError("late boom")
+        )
+        assert ws.ui.errors == []
+
+    def test_exit_command_emits_ended_info_and_never_answers(self, app_client):
+        """should_exit commands shut the session down — the worker emits
+        the ended notice and never launches an answering turn (sends
+        during the window park in the /send route and belong to whatever
+        follows the shutdown, not to this worker)."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        ws.session.exit_commands = {"/exit"}
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/exit", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        ws.worker_thread.join(timeout=5)
+        assert ws.session.sends == []
+        assert any("Session ended" in m for m in ws.ui.infos)
+
+    def test_non_compact_command_refused_while_worker_running(self, app_client):
+        """The old inline path was serialized by the event loop itself; the
+        worker-slot dispatch restores that mutual exclusion with an explicit
+        busy answer — /clear can no longer interleave with a live turn or a
+        running compaction."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        with ws._lock:
+            ws._worker_running = True  # a turn / compaction is in flight
+        try:
+            resp = client.post(
+                "/v1/api/command",
+                json={"command": "/clear", "ws_id": ws_id},
+                headers=_auth("user-1"),
+            )
+        finally:
+            with ws._lock:
+                ws._worker_running = False
+        assert resp.status_code == 409
+        assert resp.json()["status"] == "busy"
+        assert ws.session.commands == []

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -1261,6 +1261,19 @@ class TestInteractiveEventsLifted:
 # ---------------------------------------------------------------------------
 
 
+def test_command_backstop_sits_under_console_proxy_timeout() -> None:
+    """The /command ``running`` answer only ever traverses a proxied pane
+    while the node-side completion backstop is STRICTLY under the console
+    proxy's client timeout — two constants in two processes whose
+    inequality used to live in a comment.  This is the enforcement: edit
+    either constant past the other and this fails before a proxied
+    deployment silently loses the degraded answer again."""
+    from turnstone.console.server import _PROXY_CLIENT_TIMEOUT_S
+    from turnstone.server import _COMMAND_RESPONSE_BACKSTOP_S
+
+    assert _COMMAND_RESPONSE_BACKSTOP_S < _PROXY_CLIENT_TIMEOUT_S
+
+
 class TestCompactCommandDispatch:
     """Manual /compact runs on the workstream's worker slot: the event loop
     stays free to stream the compaction progress events, and a concurrent
@@ -2161,6 +2174,123 @@ class TestCompactCommandDispatch:
             {"type": "message_dispatched", "msg_id": second["msg_id"], "folded": True},
         ]
         assert [s[0] for s in ws.session.sends] == ["first"]
+
+    def test_deferred_send_list_saturation_returns_queue_full(self, app_client):
+        """The deferred list is bounded (_PENDING_SENDS_MAX = 10, mirroring
+        the interjection queue's cap): the 11th pending send answers
+        queue_full instead of silently pinning message + attachment bytes
+        per entry for a whole command window and then costing one
+        unattended turn each."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        for i in range(10):
+            r = client.post(
+                f"/v1/api/workstreams/{ws_id}/send",
+                json={"message": f"m{i}"},
+                headers=_auth("user-1"),
+            )
+            assert r.json()["status"] == "queued", i
+        r11 = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "one too many"},
+            headers=_auth("user-1"),
+        )
+        body = r11.json()
+        assert body["status"] == "queue_full"
+        assert "msg_id" not in body  # never acknowledged
+        with ws._lock:
+            assert len(ws._pending_sends) == 10
+        gate.set()
+        wait_until(lambda: len(ws.session.sends) == 10, timeout=8.0)
+        assert [s[0] for s in ws.session.sends] == [f"m{i}" for i in range(10)]
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+
+    def test_drain_spawn_failure_rolls_back_and_answers_queue_full(self, app_client, monkeypatch):
+        """Thread.start failing at the drain-spawn site must not leave a
+        phantom acknowledged-nowhere entry (the 500-after-registration
+        class): entry and slot roll back under the same lock, the client
+        gets the retryable queue_full, and a retry once resources return
+        dispatches exactly once — no duplicate turns."""
+        from turnstone.core import session_routes
+
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+
+        class _ExhaustedThread(threading.Thread):
+            def start(self) -> None:
+                raise RuntimeError("can't start new thread")
+
+        real_factory = session_routes._make_drain_thread
+        monkeypatch.setattr(
+            session_routes,
+            "_make_drain_thread",
+            lambda _ws: _ExhaustedThread(target=lambda: None, daemon=True),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "refused under exhaustion"},
+            headers=_auth("user-1"),
+        )
+        assert r.json()["status"] == "queue_full"
+        with ws._lock:
+            assert ws._pending_sends == []  # rolled back — no phantom
+            assert ws._pending_drain is None
+        # Resources recover: a plain retry defers and dispatches ONCE.
+        monkeypatch.setattr(session_routes, "_make_drain_thread", real_factory)
+        r2 = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "the retry"},
+            headers=_auth("user-1"),
+        )
+        assert r2.json()["status"] == "queued"
+        assert r2.json()["deferred"] is True
+        gate.set()
+        wait_until(lambda: ws.session.sends, timeout=8.0)
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+        assert [s[0] for s in ws.session.sends] == ["the retry"]
+
+    def test_command_spawn_failure_answers_503_not_ok(self, app_client, monkeypatch):
+        """A command worker that never spawned must not answer 200 ok — the
+        endpoint's generic catch-all used to swallow the dispatcher's
+        Thread.start re-raise, telling SDK callers their /clear ran while
+        the context stayed un-cleared."""
+        from turnstone.core import session_worker
+
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+
+        def _exhausted(*_a, **_kw):
+            raise RuntimeError("can't start new thread")
+
+        monkeypatch.setattr(session_worker, "send", _exhausted)
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/clear", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "error"
+        assert ws.session.commands == []  # the command never ran
 
     def test_exit_command_emits_ended_info_and_never_answers(self, app_client):
         """should_exit commands shut the session down — the worker emits

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock
 import pytest
 from starlette.testclient import TestClient
 
+from tests._helpers import wait_until
+
 _TEST_JWT_SECRET = "test-jwt-secret-minimum-32-chars!"
 
 
@@ -1305,16 +1307,11 @@ class TestCompactCommandDispatch:
         # The worker wrapped the run in busy/idle state transitions.
         assert ws.ui.states == ["thinking", "idle"]
 
-    def _wait_for(self, predicate, timeout: float = 8.0) -> bool:
-        """Poll until ``predicate()`` — the deferred-send drain runs on the
-        app's event loop at a 0.25s cadence, so dispatch is asynchronous
-        with respect to the released command worker."""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if predicate():
-                return True
-            time.sleep(0.02)
-        return False
+    # Drain outcomes are polled with tests._helpers.wait_until (flake-
+    # hardened final re-check; raises instead of returning False) at
+    # timeout=8.0 — the drain thread runs at a 0.25s cadence, so dispatch
+    # is asynchronous with respect to the released command worker and the
+    # helper's 5s default is too tight for CI descheduling stalls.
 
     def _drain_idle(self, ws) -> bool:
         """True once the pending-send drain retired itself (list empty,
@@ -1355,6 +1352,9 @@ class TestCompactCommandDispatch:
         assert r.status_code == 200
         body = r.json()
         assert body["status"] == "queued"
+        # The SDK-facing discriminator between "interjection-queued into a
+        # live turn" and "parked on the deferred list" (SendResponse).
+        assert body["deferred"] is True
         assert body["msg_id"]
         assert body["priority"] == "notice"
         # Registered, not dispatched: the window is still open.
@@ -1363,7 +1363,7 @@ class TestCompactCommandDispatch:
         with ws._lock:
             assert len(ws._pending_sends) == 1
         gate.set()  # compaction finishes; the drain dispatches
-        assert self._wait_for(lambda: ws.session.sends)
+        wait_until(lambda: ws.session.sends, timeout=8.0)
         # Full fidelity: the exact 5000-char text, via a normal send (an
         # oversized entry must take the fresh-spawn arm — the interjection
         # fallback would truncate it).
@@ -1372,7 +1372,7 @@ class TestCompactCommandDispatch:
         # The dispatched send carries the deferred msg_id as its send_id,
         # so the client's queued bubble reconciles against the turn.
         assert ws.session.sends[0][2] == body["msg_id"]
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
 
     def test_cancelled_compact_flushes_queue_without_answering(self, app_client):
         """A user-stopped compaction must not auto-run a turn they may no
@@ -1486,13 +1486,13 @@ class TestCompactCommandDispatch:
         assert body["attached_ids"] == ["a1"]
         assert ws.session.sends == []  # still deferred
         gate.set()
-        assert self._wait_for(lambda: ws.session.sends)
+        wait_until(lambda: ws.session.sends, timeout=8.0)
         text, attachments, sid = ws.session.sends[0]
         assert text == "with attachment"
         assert attachments == ["fake-attachment-bytes"]
         assert sid == body["msg_id"]
         assert ws.session.queue_calls == []
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
 
     def test_send_during_quick_command_window_defers(self, app_client):
         """The defer applies to EVERY command window, not just /compact —
@@ -1536,10 +1536,10 @@ class TestCompactCommandDispatch:
         gate.set()
         runner.join(timeout=10)
         assert cmd_result["body"] == {"status": "ok"}
-        assert self._wait_for(lambda: ws.session.sends)
+        wait_until(lambda: ws.session.sends, timeout=8.0)
         assert [s[0] for s in ws.session.sends] == ["mid-command send"]
         assert ws.session.queue_calls == []
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
 
     def test_clear_ui_rides_the_worker_not_the_endpoint(self, app_client):
         """The clear_ui follow-up runs on the worker after handle_command —
@@ -1719,7 +1719,7 @@ class TestCompactCommandDispatch:
         assert d.json() == {"status": "removed"}
         assert ws.session.dequeues == [msg_id]  # fall-through was exercised
         gate.set()
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
         assert ws.session.sends == []
         assert ws.session.queue_calls == []
         # Unknown ids still answer not_found after checking both holders.
@@ -1759,9 +1759,9 @@ class TestCompactCommandDispatch:
         assert first["status"] == second["status"] == "queued"
         assert first["msg_id"] != second["msg_id"]
         gate.set()
-        assert self._wait_for(lambda: len(ws.session.sends) == 2)
+        wait_until(lambda: len(ws.session.sends) == 2, timeout=8.0)
         assert [s[0] for s in ws.session.sends] == ["first", "second"]
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
 
     def test_force_cancel_of_wedged_command_releases_drain(self, app_client):
         """Force-cancelling a wedged command clears the slot flags — the
@@ -1794,12 +1794,12 @@ class TestCompactCommandDispatch:
         )
         assert resp.status_code == 200
         # Dispatch happens while the zombie is STILL wedged on the gate.
-        assert self._wait_for(lambda: ws.session.sends)
+        wait_until(lambda: ws.session.sends, timeout=8.0)
         assert [s[0] for s in ws.session.sends] == ["deferred behind wedge"]
         gate.set()  # let the abandoned thread finish and be joined
         zombie.join(timeout=5)
         assert not zombie.is_alive()
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
 
     def test_ws_close_mid_window_drops_pending_and_drain_exits(self, app_client):
         """A workstream closed with deferred sends outstanding drops them
@@ -1825,7 +1825,7 @@ class TestCompactCommandDispatch:
         with ws._lock:
             ws._closed = True  # the SessionManager.close tombstone shape
         gate.set()
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
         assert ws.session.sends == []
         assert ws.session.queue_calls == []
 
@@ -1855,10 +1855,10 @@ class TestCompactCommandDispatch:
         new_session = _FakeSession(ws_id=ws_id, user_id="user-1")
         ws.session = new_session  # the in-place identity swap
         gate.set()
-        assert self._wait_for(lambda: new_session.sends)
+        wait_until(lambda: new_session.sends, timeout=8.0)
         assert [s[0] for s in new_session.sends] == ["post-swap please"]
         assert old_session.sends == []
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
 
     def test_rejected_deferred_entry_waits_for_slot_then_fresh_spawns(self, app_client):
         """The drain's rejection arm: an entry the interjection fallback
@@ -1893,15 +1893,274 @@ class TestCompactCommandDispatch:
         # Entry 1 spawns fresh and WEDGES in send() on send_gate — a live
         # turn now holds the slot, so entry 2 takes the interjection
         # fallback and is refused (the fake raises cross-user).
-        assert self._wait_for(lambda: ws.session.queue_calls == ["second"])
+        wait_until(lambda: ws.session.queue_calls == ["second"], timeout=8.0)
         assert [s[0] for s in ws.session.sends] == ["first"]
         send_gate.set()  # the turn ends; the slot frees
-        assert self._wait_for(lambda: len(ws.session.sends) == 2)
+        wait_until(lambda: len(ws.session.sends) == 2, timeout=8.0)
         # Entry 2 dispatched as its own fresh turn — exactly one refused
         # queue attempt, then the fresh-spawn arm.
         assert [s[0] for s in ws.session.sends] == ["first", "second"]
         assert ws.session.queue_calls == ["second"]
-        assert self._wait_for(lambda: self._drain_idle(ws))
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+
+    def test_drain_crash_requeues_entry_and_retries(self, app_client):
+        """A crash inside a claimed entry's dispatch attempt (the real-world
+        shape: Thread.start raising under thread exhaustion) must not eat
+        the acknowledged message — the per-iteration handler re-inserts it
+        at head and retries after a backoff, keeping the docstring's
+        no-silent-drop contract."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "survive the crash"},
+            headers=_auth("user-1"),
+        )
+        assert r.json()["status"] == "queued"
+        with ws._lock:
+            entry = ws._pending_sends[0]
+        real_attempt = entry.attempt
+        calls = {"n": 0}
+
+        def crash_once(session):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("simulated Thread.start failure")
+            return real_attempt(session)
+
+        entry.attempt = crash_once
+        gate.set()
+        wait_until(lambda: ws.session.sends, timeout=8.0)
+        assert [s[0] for s in ws.session.sends] == ["survive the crash"]
+        assert calls["n"] == 2  # crashed once, re-queued, dispatched on retry
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+
+    def test_persistently_crashing_entry_is_never_dropped_and_retract_frees_drain(self, app_client):
+        """A persistently crashing attempt keeps the entry alive (retry
+        loop, never a silent drop) — and the user's DELETE still works
+        mid-crash-loop: the re-inserted entry is marked retracted, the
+        loop-top purge drops it, and the drain retires cleanly."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "doomed"},
+            headers=_auth("user-1"),
+        )
+        msg_id = r.json()["msg_id"]
+        with ws._lock:
+            entry = ws._pending_sends[0]
+        calls = {"n": 0}
+
+        def always_crash(_session):
+            calls["n"] += 1
+            raise RuntimeError("persistent dispatch failure")
+
+        entry.attempt = always_crash
+        gate.set()
+        # Two attempts across the ~1s backoff prove the loop survived the
+        # first crash with the entry intact (a dropped entry can't be
+        # re-attempted) and nothing was dispatched behind the user's back.
+        wait_until(lambda: calls["n"] >= 2, timeout=8.0)
+        assert ws.session.sends == []
+        d = client.request(
+            "DELETE",
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"msg_id": msg_id},
+            headers=_auth("user-1"),
+        )
+        assert d.json() == {"status": "removed"}
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+        assert ws.session.sends == []
+
+    def test_fresh_send_defers_behind_claimed_entry(self, app_client):
+        """The order barrier's drain-alive term: a send arriving while the
+        drain has CLAIMED an entry (off the list, dispatch in flight) must
+        defer behind it, not overtake — the pre-fix route dispatched
+        immediately (the list looked empty) and inverted answer order
+        against the acknowledged send."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r1 = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "first"},
+            headers=_auth("user-1"),
+        )
+        assert r1.json()["deferred"] is True
+        with ws._lock:
+            entry = ws._pending_sends[0]
+        real_attempt = entry.attempt
+        claimed = threading.Event()
+        release = threading.Event()
+
+        def gated_attempt(session):
+            claimed.set()
+            assert release.wait(timeout=10)
+            return real_attempt(session)
+
+        entry.attempt = gated_attempt
+        gate.set()  # window closes; the drain claims "first" and blocks
+        wait_until(claimed.is_set, timeout=8.0)
+        with ws._lock:
+            assert ws._pending_sends == []  # claimed — the list alone says "free"
+        big = "y" * 5000  # full-fidelity: can't fold into any live turn
+        r2 = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": big},
+            headers=_auth("user-1"),
+        )
+        # Deferred via the barrier (drain alive), never dispatched directly.
+        assert r2.json()["status"] == "queued"
+        assert r2.json()["deferred"] is True
+        assert ws.session.sends == []
+        release.set()
+        wait_until(lambda: len(ws.session.sends) == 2, timeout=8.0)
+        assert [s[0] for s in ws.session.sends] == ["first", big]
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+
+    def test_drain_exit_re_arms_wake_gate_after_pure_retraction(self, app_client, monkeypatch):
+        """A pending list that empties by RETRACTION never runs a deferred
+        turn, so no worker-exit backstop would re-run the wake gate that
+        yielded to the barrier — the drain's clean exit must re-arm it
+        itself (trigger="drain-exit"), or a nudge parked during the window
+        strands until some unrelated future dispatch."""
+        from turnstone.core import idle_nudge_watcher
+
+        wake_calls: list[str] = []
+        monkeypatch.setattr(
+            idle_nudge_watcher,
+            "wake_workstream_if_pending",
+            lambda ws, *, trigger="unspecified": (wake_calls.append(trigger), False)[1],
+        )
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "will be retracted"},
+            headers=_auth("user-1"),
+        )
+        d = client.request(
+            "DELETE",
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"msg_id": r.json()["msg_id"]},
+            headers=_auth("user-1"),
+        )
+        assert d.json() == {"status": "removed"}
+        gate.set()
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+        wait_until(lambda: "drain-exit" in wake_calls, timeout=8.0)
+        assert ws.session.sends == []
+
+    def test_deferred_dispatch_emits_message_dispatched(self, app_client):
+        """Fresh-spawn arm of the settle protocol: dispatching a deferred
+        entry emits pane-tier ``message_dispatched {msg_id}`` (no
+        ``folded`` key) so the queued chip promotes exactly when the
+        retraction window truly closes."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "settle me"},
+            headers=_auth("user-1"),
+        )
+        msg_id = r.json()["msg_id"]
+        queued_events = [e for e in ws.ui._enqueued if e.get("type") == "message_queued"]
+        assert [e["msg_id"] for e in queued_events] == [msg_id]
+        gate.set()
+        wait_until(
+            lambda: any(e.get("type") == "message_dispatched" for e in ws.ui._enqueued),
+            timeout=8.0,
+        )
+        dispatched = [e for e in ws.ui._enqueued if e.get("type") == "message_dispatched"]
+        assert dispatched == [{"type": "message_dispatched", "msg_id": msg_id}]
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+
+    def test_folded_deferred_dispatch_emits_folded_flag(self, app_client):
+        """Interjection fold-in arm: a deferred entry that dispatches INTO a
+        live turn's queue emits ``folded: true`` — the client must clear
+        only its deferred flag (DELETE still genuinely removes the message
+        from the interjection queue until the seam drains), not promote."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        send_gate = threading.Event()
+        ws.session.compact_gate = gate
+        ws.session.send_gate = send_gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        first = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "first"},
+            headers=_auth("user-1"),
+        ).json()
+        second = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "second"},
+            headers=_auth("user-1"),
+        ).json()
+        gate.set()
+        # "first" spawns fresh and wedges in send() — a live turn holds the
+        # slot, so "second" (small, no attachments) folds into its
+        # interjection queue.
+        wait_until(lambda: ws.session.queue_calls == ["second"], timeout=8.0)
+        send_gate.set()
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+        dispatched = [e for e in ws.ui._enqueued if e.get("type") == "message_dispatched"]
+        assert dispatched == [
+            {"type": "message_dispatched", "msg_id": first["msg_id"]},
+            {"type": "message_dispatched", "msg_id": second["msg_id"], "folded": True},
+        ]
+        assert [s[0] for s in ws.session.sends] == ["first"]
 
     def test_exit_command_emits_ended_info_and_never_answers(self, app_client):
         """should_exit commands shut the session down — the worker emits

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -2176,11 +2176,11 @@ class TestCompactCommandDispatch:
         assert [s[0] for s in ws.session.sends] == ["first"]
 
     def test_deferred_send_list_saturation_returns_queue_full(self, app_client):
-        """The deferred list is bounded (_PENDING_SENDS_MAX = 10, mirroring
-        the interjection queue's cap): the 11th pending send answers
-        queue_full instead of silently pinning message + attachment bytes
-        per entry for a whole command window and then costing one
-        unattended turn each."""
+        """The deferred list is bounded (workstream.PENDING_SENDS_MAX — the
+        shared constant ChatSession._QUEUE_MAX aliases): the 11th pending
+        send answers queue_full instead of silently pinning message +
+        attachment bytes per entry for a whole command window and then
+        costing one unattended turn each."""
         client, mgr = app_client
         ws_id = self._create_ws(client)
         ws = mgr.get(ws_id)
@@ -2291,6 +2291,146 @@ class TestCompactCommandDispatch:
         assert resp.status_code == 503
         assert resp.json()["status"] == "error"
         assert ws.session.commands == []  # the command never ran
+
+    def test_drain_exit_wake_raise_is_contained(self, app_client, monkeypatch, caplog):
+        """A raising drain-exit wake (session_worker.send re-raises
+        Thread.start failures) must stay inside the wake's own guard —
+        it runs AFTER the drain retired its slot, so reaching the
+        last-resort handler would clear a slot this thread no longer
+        owns (a successor drain's live registration)."""
+        import logging
+
+        from turnstone.core import idle_nudge_watcher
+
+        def _raising_gate(ws, *, trigger="unspecified"):
+            if trigger == "drain-exit":
+                raise RuntimeError("can't start new thread")
+            return False
+
+        monkeypatch.setattr(idle_nudge_watcher, "wake_workstream_if_pending", _raising_gate)
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "dispatch me"},
+            headers=_auth("user-1"),
+        )
+        with caplog.at_level(logging.WARNING, logger="turnstone.core.session_routes"):
+            gate.set()
+            wait_until(lambda: ws.session.sends, timeout=8.0)
+            wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+            wait_until(
+                lambda: any("drain_exit_wake_failed" in r.message for r in caplog.records),
+                timeout=8.0,
+            )
+        # The raise was contained by the wake's own guard — never the
+        # last-resort handler (whose log would be a false failure for a
+        # drain that exited cleanly).
+        assert not any("pending_drain_failed" in r.message for r in caplog.records)
+        # The seam stays fully serviceable: another defer cycle works.
+        gate2 = threading.Event()
+        ws.session.compact_gate = gate2
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "and me"},
+            headers=_auth("user-1"),
+        )
+        gate2.set()
+        wait_until(lambda: len(ws.session.sends) == 2, timeout=8.0)
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+
+    def test_closed_drain_exit_runs_no_wake(self, app_client, monkeypatch):
+        """The drain-exit wake backstop belongs to the CLEAN exit only: a
+        closed workstream is torn down, and firing the gate there would
+        be work on a corpse.  (The clean-exit case is pinned by
+        test_drain_exit_re_arms_wake_gate_after_pure_retraction.)"""
+        from turnstone.core import idle_nudge_watcher
+
+        triggers: list[str] = []
+        monkeypatch.setattr(
+            idle_nudge_watcher,
+            "wake_workstream_if_pending",
+            lambda ws, *, trigger="unspecified": (triggers.append(trigger), False)[1],
+        )
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "dies with the ws"},
+            headers=_auth("user-1"),
+        )
+        with ws._lock:
+            ws._closed = True  # tombstone, as SessionManager.close sets it
+        gate.set()
+        wait_until(lambda: self._drain_idle(ws), timeout=8.0)
+        assert "drain-exit" not in triggers
+        assert ws.session.sends == []
+
+    def test_drain_last_resort_clear_is_identity_guarded(self, app_client, monkeypatch, caplog):
+        """Drive the drain's OUTER except (loop machinery failing — here
+        the closed-arm log call) and prove the last-resort slot-clear
+        executes its identity guard: the slot is this drain's own, so it
+        clears; a successor's registration would be left alone (the
+        guard compares thread identity, the sibling exit-seam pattern)."""
+        import logging
+
+        from turnstone.core import session_routes
+
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "stranded by the crash"},
+            headers=_auth("user-1"),
+        )
+
+        def _broken_warning(*_a, **_kw):
+            raise RuntimeError("log backend down")
+
+        monkeypatch.setattr(session_routes.log, "warning", _broken_warning)
+        with ws._lock:
+            ws._closed = True  # closed arm with a pending entry → log.warning
+        with caplog.at_level(logging.ERROR, logger="turnstone.core.session_routes"):
+            gate.set()
+            wait_until(
+                lambda: any("pending_drain_failed" in r.message for r in caplog.records),
+                timeout=8.0,
+            )
+        # The identity-guarded clear ran for the drain's OWN slot.
+        wait_until(lambda: ws._pending_drain is None, timeout=8.0)
+        assert ws.session.sends == []
 
     def test_exit_command_emits_ended_info_and_never_answers(self, app_client):
         """should_exit commands shut the session down — the worker emits

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import queue
 import threading
-import time
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -20,6 +19,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from tests._helpers import wait_until
+from turnstone.core.workstream import INTERJECTION_CAP_CHARS
 
 _TEST_JWT_SECRET = "test-jwt-secret-minimum-32-chars!"
 
@@ -274,7 +274,8 @@ class _FakeSession:
         self.queue_calls.append(text)
         if self.queue_raises is not None:
             raise self.queue_raises
-        cleaned = text[:2000] + "..." if len(text) > 2000 else text
+        cap = INTERJECTION_CAP_CHARS
+        cleaned = text[:cap] + "..." if len(text) > cap else text
         return cleaned, "notice", queue_msg_id or "m1"
 
     def dequeue_message(self, msg_id: str) -> bool:
@@ -1338,9 +1339,9 @@ class TestCompactCommandDispatch:
         IMMEDIATELY (no parked POST — a 30s-bounded caller like the
         coordinator client or console proxy must never lose a message to
         a multi-minute window) and then runs as an ordinary full-fidelity
-        send — never the interjection queue, whose 2000-char cap silently
-        truncated pasted logs/code and whose cross-user guard locked
-        second participants out for the whole compaction."""
+        send — never the interjection queue, whose INTERJECTION_CAP_CHARS
+        cap silently truncated pasted logs/code and whose cross-user guard
+        locked second participants out for the whole compaction."""
         client, mgr = app_client
         ws_id = self._create_ws(client)
         ws = mgr.get(ws_id)
@@ -1531,11 +1532,7 @@ class TestCompactCommandDispatch:
         runner = threading.Thread(target=_cmd, daemon=True)
         runner.start()
         # Wait until the command worker actually holds the slot.
-        for _ in range(100):
-            if ws._worker_running:
-                break
-            time.sleep(0.02)
-        assert ws._worker_running
+        wait_until(lambda: ws._worker_running, timeout=8.0)
         assert ws.worker_kind == "command"
         r = client.post(
             f"/v1/api/workstreams/{ws_id}/send",
@@ -1591,11 +1588,7 @@ class TestCompactCommandDispatch:
 
         runner = threading.Thread(target=_cmd, daemon=True)
         runner.start()
-        for _ in range(100):
-            if ws._worker_running:
-                break
-            time.sleep(0.02)
-        assert ws._worker_running
+        wait_until(lambda: ws._worker_running, timeout=8.0)
         worker = ws.worker_thread
         # The cancel handler's force path shape: abandon the worker.
         with ws._lock:

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -240,12 +240,25 @@ class _FakeSession:
         self.compact_gate: threading.Event | None = None
         self.command_gate: threading.Event | None = None
         self.command_raises: BaseException | None = None
-        # Every queue_message call — the park invariant is that command
+        # Gate for send() — lets a test hold a TURN in flight so a
+        # deferred entry provably lands in (or is refused by) the
+        # interjection fallback at drain time.
+        self.send_gate: threading.Event | None = None
+        # Every queue_message call — the defer invariant is that command
         # windows NEVER reach the interjection queue.
         self.queue_calls: list[str] = []
+        # When set, queue_message records the attempt and then raises it
+        # (e.g. CrossUserInterjectionError for the drain's re-park arm).
+        self.queue_raises: BaseException | None = None
+        # DELETE /send fall-through: ids the route asked this session to
+        # dequeue (the fake never holds interjections, so it returns
+        # False and the route falls through to the deferred-send list).
+        self.dequeues: list[str] = []
 
     def send(self, text: str, *, attachments: Any = None, send_id: Any = None) -> None:
         self.sends.append((text, attachments, send_id))
+        if self.send_gate is not None:
+            self.send_gate.wait(timeout=10)
         if self.send_raises is not None:
             raise self.send_raises
 
@@ -257,8 +270,14 @@ class _FakeSession:
         interjector_user_id: str = "",
     ) -> tuple[str, str, str]:
         self.queue_calls.append(text)
+        if self.queue_raises is not None:
+            raise self.queue_raises
         cleaned = text[:2000] + "..." if len(text) > 2000 else text
         return cleaned, "notice", queue_msg_id or "m1"
+
+    def dequeue_message(self, msg_id: str) -> bool:
+        self.dequeues.append(msg_id)
+        return False
 
     def set_watch_runner(self, *_a: Any, **_kw: Any) -> None:
         pass
@@ -1275,23 +1294,43 @@ class TestCompactCommandDispatch:
         assert ws.session.compacts == 1
         assert ws._worker_running is False
         # The slot was classified as a command window (what the /send
-        # route's park keys on; stale after exit is harmless — every
+        # route's defer keys on; stale after exit is harmless — every
         # reader conjoins _worker_running).
         assert ws.worker_kind == "command"
         # Exit seam: stranded-text backstop flush only — no drain, no
-        # answering send (sends during the window park in the /send route
-        # and dispatch as their own workers afterwards).
+        # answering send (sends during the window defer in the /send
+        # route and dispatch as their own workers afterwards).
         assert ws.session.queued_flushes == 1
         assert ws.session.sends == []
         # The worker wrapped the run in busy/idle state transitions.
         assert ws.ui.states == ["thinking", "idle"]
 
-    def test_send_during_compact_window_parks_then_dispatches_fully(self, app_client):
-        """A /send during a manual /compact PARKS and then runs as an
-        ordinary full-fidelity send — it must never enter the interjection
-        queue, whose 2000-char cap silently truncated pasted logs/code and
-        whose cross-user guard locked second participants out for the
-        whole compaction."""
+    def _wait_for(self, predicate, timeout: float = 8.0) -> bool:
+        """Poll until ``predicate()`` — the deferred-send drain runs on the
+        app's event loop at a 0.25s cadence, so dispatch is asynchronous
+        with respect to the released command worker."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.02)
+        return False
+
+    def _drain_idle(self, ws) -> bool:
+        """True once the pending-send drain retired itself (list empty,
+        single-flight slot cleared) — the leaked-task guard for these
+        tests."""
+        with ws._lock:
+            return not ws._pending_sends and ws._pending_drain is None
+
+    def test_send_during_compact_window_defers_then_dispatches_fully(self, app_client):
+        """A /send during a manual /compact is answered "queued"
+        IMMEDIATELY (no parked POST — a 30s-bounded caller like the
+        coordinator client or console proxy must never lose a message to
+        a multi-minute window) and then runs as an ordinary full-fidelity
+        send — never the interjection queue, whose 2000-char cap silently
+        truncated pasted logs/code and whose cross-user guard locked
+        second participants out for the whole compaction."""
         client, mgr = app_client
         ws_id = self._create_ws(client)
         ws = mgr.get(ws_id)
@@ -1305,35 +1344,35 @@ class TestCompactCommandDispatch:
         )
         assert resp.json() == {"status": "ok"}
         big = "x" * 5000  # over the interjection cap — must survive intact
-        send_result: dict = {}
-
-        def _send() -> None:
-            r = client.post(
-                f"/v1/api/workstreams/{ws_id}/send",
-                json={"message": big},
-                headers=_auth("user-1"),
-            )
-            send_result["status"] = r.status_code
-            send_result["body"] = r.json()
-
-        sender = threading.Thread(target=_send, daemon=True)
-        sender.start()
-        # The send is parked: give it time to have taken the park path,
-        # then prove nothing was dispatched or queued yet.
-        for _ in range(50):
-            if ws.session.queue_calls or ws.session.sends:
-                break
-            time.sleep(0.02)
+        # The response is immediate even though the window is wedged open:
+        # this request runs on the same synchronous test client, so a
+        # parked POST would deadlock the test rather than pass it.
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": big},
+            headers=_auth("user-1"),
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "queued"
+        assert body["msg_id"]
+        assert body["priority"] == "notice"
+        # Registered, not dispatched: the window is still open.
         assert ws.session.sends == []
         assert ws.session.queue_calls == []  # the queue is unreachable
-        gate.set()  # compaction finishes; the park releases
-        sender.join(timeout=10)
-        assert not sender.is_alive()
-        assert send_result["status"] == 200
-        assert send_result["body"]["status"] == "ok"
-        # Full fidelity: the exact 5000-char text, via a normal send.
+        with ws._lock:
+            assert len(ws._pending_sends) == 1
+        gate.set()  # compaction finishes; the drain dispatches
+        assert self._wait_for(lambda: ws.session.sends)
+        # Full fidelity: the exact 5000-char text, via a normal send (an
+        # oversized entry must take the fresh-spawn arm — the interjection
+        # fallback would truncate it).
         assert [s[0] for s in ws.session.sends] == [big]
         assert ws.session.queue_calls == []
+        # The dispatched send carries the deferred msg_id as its send_id,
+        # so the client's queued bubble reconciles against the turn.
+        assert ws.session.sends[0][2] == body["msg_id"]
+        assert self._wait_for(lambda: self._drain_idle(ws))
 
     def test_cancelled_compact_flushes_queue_without_answering(self, app_client):
         """A user-stopped compaction must not auto-run a turn they may no
@@ -1413,10 +1452,10 @@ class TestCompactCommandDispatch:
         assert ws.session.sends == []
         assert ws.ui.states == []
 
-    def test_parked_send_delivers_attachments_after_release(self, app_client, monkeypatch):
-        """Attachments are peek-resolved BEFORE the park (the bytes ride the
-        request closure), so a send parked through a long compaction still
-        delivers them on dispatch — the pre-park refusal
+    def test_deferred_send_delivers_attachments_after_release(self, app_client, monkeypatch):
+        """Attachments are peek-resolved BEFORE the defer (the bytes ride
+        the pending entry), so a send deferred through a long compaction
+        still delivers them on dispatch — the queue-path refusal
         (attachments_busy) must never apply to a command window."""
         client, mgr = app_client
         ws_id = self._create_ws(client)
@@ -1435,34 +1474,31 @@ class TestCompactCommandDispatch:
             json={"command": "/compact", "ws_id": ws_id},
             headers=_auth("user-1"),
         )
-        send_result: dict = {}
-
-        def _send() -> None:
-            r = client.post(
-                f"/v1/api/workstreams/{ws_id}/send",
-                json={"message": "with attachment", "attachment_ids": ["a1"]},
-                headers=_auth("user-1"),
-            )
-            send_result["body"] = r.json()
-
-        sender = threading.Thread(target=_send, daemon=True)
-        sender.start()
-        time.sleep(0.3)
-        assert ws.session.sends == []  # still parked
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "with attachment", "attachment_ids": ["a1"]},
+            headers=_auth("user-1"),
+        )
+        body = r.json()
+        assert body["status"] == "queued"
+        # The attachments are TAKEN by the deferred entry (the client
+        # consumes its chips off this list — a retract discards them).
+        assert body["attached_ids"] == ["a1"]
+        assert ws.session.sends == []  # still deferred
         gate.set()
-        sender.join(timeout=10)
-        assert not sender.is_alive()
-        assert send_result["body"]["status"] == "ok"
-        assert send_result["body"]["attached_ids"] == ["a1"]
-        text, attachments, _sid = ws.session.sends[0]
+        assert self._wait_for(lambda: ws.session.sends)
+        text, attachments, sid = ws.session.sends[0]
         assert text == "with attachment"
         assert attachments == ["fake-attachment-bytes"]
+        assert sid == body["msg_id"]
         assert ws.session.queue_calls == []
+        assert self._wait_for(lambda: self._drain_idle(ws))
 
-    def test_send_during_quick_command_window_parks(self, app_client):
-        """The park applies to EVERY command window, not just /compact — a
-        send racing a quick command dispatches after the window with full
-        fidelity instead of entering the interjection queue."""
+    def test_send_during_quick_command_window_defers(self, app_client):
+        """The defer applies to EVERY command window, not just /compact —
+        a send racing a quick command is answered "queued" and dispatches
+        after the window with full fidelity instead of entering the
+        interjection queue."""
         client, mgr = app_client
         ws_id = self._create_ws(client)
         ws = mgr.get(ws_id)
@@ -1488,29 +1524,22 @@ class TestCompactCommandDispatch:
             time.sleep(0.02)
         assert ws._worker_running
         assert ws.worker_kind == "command"
-        send_result: dict = {}
-
-        def _send() -> None:
-            r = client.post(
-                f"/v1/api/workstreams/{ws_id}/send",
-                json={"message": "mid-command send"},
-                headers=_auth("user-1"),
-            )
-            send_result["body"] = r.json()
-
-        sender = threading.Thread(target=_send, daemon=True)
-        sender.start()
-        time.sleep(0.3)  # long enough for a queue-path regression to show
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "mid-command send"},
+            headers=_auth("user-1"),
+        )
+        send_body = r.json()
+        assert send_body["status"] == "queued"
         assert ws.session.queue_calls == []
         assert ws.session.sends == []
         gate.set()
         runner.join(timeout=10)
-        sender.join(timeout=10)
-        assert not sender.is_alive()
         assert cmd_result["body"] == {"status": "ok"}
-        assert send_result["body"]["status"] == "ok"
+        assert self._wait_for(lambda: ws.session.sends)
         assert [s[0] for s in ws.session.sends] == ["mid-command send"]
         assert ws.session.queue_calls == []
+        assert self._wait_for(lambda: self._drain_idle(ws))
 
     def test_clear_ui_rides_the_worker_not_the_endpoint(self, app_client):
         """The clear_ui follow-up runs on the worker after handle_command —
@@ -1590,10 +1619,294 @@ class TestCompactCommandDispatch:
         )
         assert ws.ui.errors == []
 
+    def test_abandoned_init_worker_still_fires_notify(self, app_client, monkeypatch):
+        """The completion notify is WORKSTREAM-scoped, not slot-scoped:
+        _fire_notify_targets has exactly one call site (the init worker),
+        successor turns never notify, so an owner gate here has no
+        duplicate to prevent — it only converts force-cancel into
+        permanent notification loss for scheduled/unattended workstreams.
+        This pins the un-gated behavior against the tempting symmetry
+        'fix' (the finally's siblings ARE owner-gated, correctly — they
+        mutate live slot/UI state)."""
+        client, mgr = app_client
+        fired: list = []
+        monkeypatch.setattr(
+            "turnstone.server._fire_notify_targets",
+            lambda ws, content: fired.append(ws.id),
+        )
+        gate = threading.Event()
+        started = threading.Event()
+        orig_send = _FakeSession.send
+
+        def wedged_send(self, text, **kwargs):
+            started.set()
+            assert gate.wait(timeout=10)
+            orig_send(self, text, **kwargs)
+
+        monkeypatch.setattr(_FakeSession, "send", wedged_send)
+        resp = client.post(
+            "/v1/api/workstreams/new",
+            json={"name": "sched", "initial_message": "do the thing"},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["ws_id"]
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        assert started.wait(timeout=10)
+        worker = ws.worker_thread
+        with ws._lock:  # the force-cancel abandon shape
+            ws.worker_thread = None
+            ws._worker_running = False
+        gate.set()  # the abandoned init completes LATE
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        assert fired == [ws_id]  # exactly once, despite the abandonment
+
+    def test_compact_on_error_workstream_restores_error_badge(self, app_client):
+        """/compact on an ERROR workstream must exit back to 'error', not
+        stamp 'idle' over the operator's investigatable badge — the
+        compaction neither retried nor resolved the failed turn (mirrors
+        the orphan reaper's ERROR carve-out).  The existing happy-path
+        test pins ['thinking', 'idle'] for an IDLE workstream."""
+        from turnstone.core.workstream import WorkstreamState
+
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        ws.state = WorkstreamState.ERROR  # a prior fatal turn's badge
+        resp = client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        assert resp.json() == {"status": "ok"}
+        ws.worker_thread.join(timeout=5)
+        assert not ws.worker_thread.is_alive()
+        # THINKING during the window is honest (work is happening); the
+        # exit restores the badge instead of clearing it.
+        assert ws.ui.states == ["thinking", "error"]
+
+    def test_retracted_deferred_send_never_dispatches(self, app_client):
+        """DELETE /send with a deferred msg_id retracts the entry before
+        dispatch — the drain must skip it entirely.  The route falls
+        through the session's interjection dequeue (which misses) to the
+        workstream's pending list."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "changed my mind"},
+            headers=_auth("user-1"),
+        )
+        msg_id = r.json()["msg_id"]
+        d = client.request(
+            "DELETE",
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"msg_id": msg_id},
+            headers=_auth("user-1"),
+        )
+        assert d.json() == {"status": "removed"}
+        assert ws.session.dequeues == [msg_id]  # fall-through was exercised
+        gate.set()
+        assert self._wait_for(lambda: self._drain_idle(ws))
+        assert ws.session.sends == []
+        assert ws.session.queue_calls == []
+        # Unknown ids still answer not_found after checking both holders.
+        d2 = client.request(
+            "DELETE",
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"msg_id": "nope"},
+            headers=_auth("user-1"),
+        )
+        assert d2.json() == {"status": "not_found"}
+
+    def test_deferred_sends_dispatch_in_arrival_order(self, app_client):
+        """Two sends deferred behind one window dispatch in arrival order,
+        each as its own full-fidelity turn (the fake's sends complete
+        instantly, so the second never needs the interjection fallback)."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        first = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "first"},
+            headers=_auth("user-1"),
+        ).json()
+        second = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "second"},
+            headers=_auth("user-1"),
+        ).json()
+        assert first["status"] == second["status"] == "queued"
+        assert first["msg_id"] != second["msg_id"]
+        gate.set()
+        assert self._wait_for(lambda: len(ws.session.sends) == 2)
+        assert [s[0] for s in ws.session.sends] == ["first", "second"]
+        assert self._wait_for(lambda: self._drain_idle(ws))
+
+    def test_force_cancel_of_wedged_command_releases_drain(self, app_client):
+        """Force-cancelling a wedged command clears the slot flags — the
+        drain polls the same (_worker_running, worker_kind) pair, so a
+        deferred message dispatches WITHOUT waiting for the abandoned
+        thread to unwedge (the operator's escape hatch keeps working
+        under defer exactly as it did under park)."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        zombie = ws.worker_thread
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "deferred behind wedge"},
+            headers=_auth("user-1"),
+        )
+        assert r.json()["status"] == "queued"
+        resp = client.post(
+            f"/v1/api/workstreams/{ws_id}/cancel",
+            json={"force": True},
+            headers=_auth("user-1"),
+        )
+        assert resp.status_code == 200
+        # Dispatch happens while the zombie is STILL wedged on the gate.
+        assert self._wait_for(lambda: ws.session.sends)
+        assert [s[0] for s in ws.session.sends] == ["deferred behind wedge"]
+        gate.set()  # let the abandoned thread finish and be joined
+        zombie.join(timeout=5)
+        assert not zombie.is_alive()
+        assert self._wait_for(lambda: self._drain_idle(ws))
+
+    def test_ws_close_mid_window_drops_pending_and_drain_exits(self, app_client):
+        """A workstream closed with deferred sends outstanding drops them
+        (documented at-most-once contract) and the drain task retires
+        itself — no leaked task, no dispatch into a closed workstream."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        ws.session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "never delivered"},
+            headers=_auth("user-1"),
+        )
+        assert r.json()["status"] == "queued"
+        with ws._lock:
+            ws._closed = True  # the SessionManager.close tombstone shape
+        gate.set()
+        assert self._wait_for(lambda: self._drain_idle(ws))
+        assert ws.session.sends == []
+        assert ws.session.queue_calls == []
+
+    def test_deferred_send_dispatches_into_post_swap_session(self, app_client):
+        """The drain re-captures ws.session per attempt: a /resume-style
+        identity swap during the window routes the deferred message into
+        the POST-swap session — the same guarantee the park's
+        per-iteration re-capture provided."""
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        old_session = ws.session
+        gate = threading.Event()
+        old_session.compact_gate = gate
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        r = client.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            json={"message": "post-swap please"},
+            headers=_auth("user-1"),
+        )
+        assert r.json()["status"] == "queued"
+        new_session = _FakeSession(ws_id=ws_id, user_id="user-1")
+        ws.session = new_session  # the in-place identity swap
+        gate.set()
+        assert self._wait_for(lambda: new_session.sends)
+        assert [s[0] for s in new_session.sends] == ["post-swap please"]
+        assert old_session.sends == []
+        assert self._wait_for(lambda: self._drain_idle(ws))
+
+    def test_rejected_deferred_entry_waits_for_slot_then_fresh_spawns(self, app_client):
+        """The drain's rejection arm: an entry the interjection fallback
+        refuses (cross-user here; attachments/oversized take the same
+        path) is NOT dropped — it waits for the slot to free and then
+        dispatches as its own fresh turn.  The queued ack must never
+        become a silent drop while the workstream lives."""
+        from turnstone.core.session import CrossUserInterjectionError
+
+        client, mgr = app_client
+        ws_id = self._create_ws(client)
+        ws = mgr.get(ws_id)
+        assert ws is not None
+        gate = threading.Event()
+        send_gate = threading.Event()
+        ws.session.compact_gate = gate
+        ws.session.send_gate = send_gate
+        ws.session.queue_raises = CrossUserInterjectionError("another participant's turn")
+        client.post(
+            "/v1/api/command",
+            json={"command": "/compact", "ws_id": ws_id},
+            headers=_auth("user-1"),
+        )
+        for msg in ("first", "second"):
+            r = client.post(
+                f"/v1/api/workstreams/{ws_id}/send",
+                json={"message": msg},
+                headers=_auth("user-1"),
+            )
+            assert r.json()["status"] == "queued"
+        gate.set()
+        # Entry 1 spawns fresh and WEDGES in send() on send_gate — a live
+        # turn now holds the slot, so entry 2 takes the interjection
+        # fallback and is refused (the fake raises cross-user).
+        assert self._wait_for(lambda: ws.session.queue_calls == ["second"])
+        assert [s[0] for s in ws.session.sends] == ["first"]
+        send_gate.set()  # the turn ends; the slot frees
+        assert self._wait_for(lambda: len(ws.session.sends) == 2)
+        # Entry 2 dispatched as its own fresh turn — exactly one refused
+        # queue attempt, then the fresh-spawn arm.
+        assert [s[0] for s in ws.session.sends] == ["first", "second"]
+        assert ws.session.queue_calls == ["second"]
+        assert self._wait_for(lambda: self._drain_idle(ws))
+
     def test_exit_command_emits_ended_info_and_never_answers(self, app_client):
         """should_exit commands shut the session down — the worker emits
         the ended notice and never launches an answering turn (sends
-        during the window park in the /send route and belong to whatever
+        during the window defer in the /send route and belong to whatever
         follows the shutdown, not to this worker)."""
         client, mgr = app_client
         ws_id = self._create_ws(client)

--- a/tests/test_session_worker.py
+++ b/tests/test_session_worker.py
@@ -146,6 +146,45 @@ def test_enqueue_unexpected_exception_returns_false_logged() -> None:
     assert ws._worker_running is True
 
 
+def test_spawn_failure_releases_slot_and_reraises(monkeypatch) -> None:
+    """``Thread.start`` raising (thread exhaustion, MemoryError) must not
+    wedge the slot: the claim ``(worker_thread, _worker_running)`` taken
+    under the lock is rolled back and the exception propagates.  Without
+    the rollback the flag's only clearer is a finally on a thread that
+    never started — the workstream looks idle forever (no state change
+    ever fired) while every dispatch takes the reuse path into a queue
+    no worker will drain, until an operator force-cancel."""
+    import pytest
+
+    session = _SendSession()
+    ws = _make_ws(session)
+
+    class _ExhaustedThread(threading.Thread):
+        def start(self) -> None:
+            raise RuntimeError("can't start new thread")
+
+    class _ThreadNS:
+        # Shim only what session_worker.send touches; patching the real
+        # threading module's Thread attribute would break every other
+        # test's spawns.
+        Thread = _ExhaustedThread
+        current_thread = staticmethod(threading.current_thread)
+
+    monkeypatch.setattr(session_worker, "threading", _ThreadNS)
+    with pytest.raises(RuntimeError, match="can't start new thread"):
+        _send_message(ws, session, "doomed")
+    assert ws._worker_running is False
+    assert ws.worker_thread is None
+    assert session.send_calls == []
+
+    # The slot is genuinely reusable once resources recover.
+    monkeypatch.setattr(session_worker, "threading", threading)
+    assert _send_message(ws, session, "recovered") is True
+    ws.worker_thread.join(timeout=2.0)
+    assert session.send_calls == ["recovered"]
+    assert ws._worker_running is False
+
+
 def test_closed_workstream_refused_no_spawn() -> None:
     """Authoritative closed-check: ``close()`` sets ``_closed`` under
     ``ws._lock``, so a wake (or send) racing it must be refused HERE —

--- a/tests/test_session_worker.py
+++ b/tests/test_session_worker.py
@@ -146,6 +146,29 @@ def test_enqueue_unexpected_exception_returns_false_logged() -> None:
     assert ws._worker_running is True
 
 
+def test_send_barrier_active_truth_table() -> None:
+    """The two-term order barrier (Workstream.send_barrier_active): list
+    non-empty OR drain alive.  The drain-alive term covers the CLAIMED-
+    entry window (entry popped, dispatch in flight) — the _PendingSend
+    invariant "drain not alive ⇒ nothing claimed" is what makes the pair
+    exhaustive; a one-term copy at any consumer re-opens the wake-jumps-
+    an-acked-send hole."""
+    from types import SimpleNamespace
+
+    ws = _make_ws()
+    assert ws.send_barrier_active() is False  # empty list, no drain
+    ws._pending_sends.append(object())  # type: ignore[arg-type]
+    assert ws.send_barrier_active() is True  # list term
+    ws._pending_drain = SimpleNamespace(is_alive=lambda: True)  # type: ignore[assignment]
+    assert ws.send_barrier_active() is True  # both terms
+    ws._pending_sends.clear()
+    assert ws.send_barrier_active() is True  # drain-alive term alone (claimed window)
+    ws._pending_drain = SimpleNamespace(is_alive=lambda: False)  # type: ignore[assignment]
+    assert ws.send_barrier_active() is False  # dead drain, empty list
+    ws._pending_drain = None
+    assert ws.send_barrier_active() is False
+
+
 def test_spawn_failure_releases_slot_and_reraises(monkeypatch) -> None:
     """``Thread.start`` raising (thread exhaustion, MemoryError) must not
     wedge the slot: the claim ``(worker_thread, _worker_running)`` taken

--- a/tests/test_sse_cursor_resume.py
+++ b/tests/test_sse_cursor_resume.py
@@ -236,6 +236,27 @@ def test_append_system_turn_stamps_row_with_its_sse_event_id(
     assert ui._event_buffer[-1][1]["type"] == "system_turn"
 
 
+def test_system_turn_bool_hook_return_falls_back_to_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A duck-typed ``on_system_turn`` returning ``True`` (bool ⊂ int) must
+    never stamp a boolean into the persisted row: PostgreSQL fails the
+    INSERT after the turn already appended, SQLite stores ``1`` and
+    mis-keys the /history-vs-replay dedupe.  ``_coerce_event_id`` rejects
+    bools at the shared chokepoint and the stamp falls back to the
+    ring-buffer counter (same guard class as ``parse_checkpoint_watermark``)."""
+    session = make_session()
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "turnstone.core.session.save_message",
+        lambda *a, **k: captured.update(event_id=k.get("event_id")),
+    )
+    session.ui.on_system_turn = lambda *_a, **_k: True
+    session._append_system_turn("start", "ground yourself")
+    assert not isinstance(captured["event_id"], bool)
+    assert captured["event_id"] == session._ui_event_id()
+
+
 # ---------------------------------------------------------------------------
 # Storage: event_id round-trip, get_max_event_id, _event_id reseed
 # ---------------------------------------------------------------------------

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -39,8 +39,28 @@ class DequeueRequest(BaseModel):
 
 class SendResponse(BaseModel):
     status: str = Field(
-        description="'ok', 'busy', 'queued', or 'queue_full'",
-        examples=["ok", "busy", "queued", "queue_full"],
+        description=(
+            "'ok' (fresh turn dispatched), 'queued' (folded into the live "
+            "turn's interjection queue, or — when `deferred` is true — "
+            "parked for dispatch after the current command window), "
+            "'queue_full', 'attachments_busy' (attachments can't ride a "
+            "queued turn; retry when idle), or 'cross_user_interjection' "
+            "(another participant's turn is in flight; carried on the 409 "
+            "body)."
+        ),
+        examples=["ok", "queued", "queue_full", "attachments_busy", "cross_user_interjection"],
+    )
+    deferred: bool = Field(
+        default=False,
+        description=(
+            "Set on `queued` responses: the message is parked on the "
+            "workstream's deferred-send list (a slash-command window holds "
+            "the worker slot, or earlier deferred sends are still pending) "
+            "and dispatches as an ordinary full-fidelity send afterwards — "
+            "it is NOT in a live turn's interjection queue. `DELETE .../send` "
+            "retracts it until dispatch. Node-local and in-memory: a node "
+            "restart before dispatch drops it (at-most-once intake)."
+        ),
     )
     attached_ids: list[str] = Field(
         default_factory=list,

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -102,7 +102,9 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "Send a user message",
         request_model=SendRequest,
         response_model=SendResponse,
-        error_codes=[400, 404],
+        # 409: cross_user_interjection (shipped with the multi-user work;
+        # the spec had drifted behind the implementation).
+        error_codes=[400, 404, 409],
         tags=["Chat"],
     ),
     EndpointSpec(
@@ -134,7 +136,7 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "Execute a slash command",
         request_model=CommandRequest,
         response_model=StatusResponse,
-        error_codes=[400, 404],
+        error_codes=[400, 404, 409],
         tags=["Chat"],
     ),
     EndpointSpec(

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -136,7 +136,10 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "Execute a slash command",
         request_model=CommandRequest,
         response_model=StatusResponse,
-        error_codes=[400, 404, 409],
+        # 409 = worker slot busy (deliberate loud refusal); 503 = the
+        # command worker could not be started (thread exhaustion — retry
+        # shortly; the command did NOT run).
+        error_codes=[400, 404, 409, 503],
         tags=["Chat"],
     ),
     EndpointSpec(

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -328,6 +328,68 @@ class TerminalUI(SessionUI):
         sys.stdout.write(f"{YELLOW}[{label}]{RESET} {content}\n")
         sys.stdout.flush()
 
+    def on_compaction(self, payload: dict[str, Any]) -> int | None:
+        """Render compaction lifecycle events as the terminal's classic text
+        lines — the notice, ``part k/N`` progress, and the token-delta +
+        boxed-summary result the CLI printed before these became structured
+        events (the web UI renders the same payloads as a progress card).
+        """
+        phase = payload.get("phase")
+        if phase == "start":
+            # The threshold notice prints only when a threshold actually
+            # fired (pct present — _do_auto_compact).  The overflow-retry
+            # path compacts with auto=True but prints its own "[Context
+            # overflow — auto-compacting and retrying]" line; claiming a
+            # percentage there would fabricate the trigger.  Manual starts
+            # print nothing — the thinking spinner covers it.
+            pct = payload.get("pct")
+            if payload.get("trigger") == "auto" and pct is not None:
+                where = payload.get("where") or ""
+                qualifier = f" {where}" if where else ""
+                self.on_info(
+                    f"\n[Auto-compacting{qualifier}: prompt exceeds {pct}% of context window]"
+                )
+        elif phase == "progress":
+            if payload.get("warning") == "summary_truncated":
+                self.on_info("[Warning: compaction summary was truncated]")
+            elif payload.get("retry_in") is not None:
+                self.on_info(
+                    f"[Compact retrying in {payload['retry_in']:.0f}s: {payload.get('error', '')}]"
+                )
+            else:
+                self.on_info(f"[compacting part {payload.get('part')}/{payload.get('total')}…]")
+        elif phase == "end":
+            if payload.get("ok"):
+                before = payload.get("before_tokens", 0)
+                after = payload.get("after_tokens", 0)
+                self.on_info(f"[compacted: ~{before:,} -> ~{after:,} tokens]")
+                separator = "─" * 60
+                lines = [separator]
+                for line in str(payload.get("summary") or "").splitlines():
+                    lines.append(f"  {line}")
+                lines.append(separator)
+                self.on_info("\n".join(lines))
+            elif payload.get("reason") != "error":
+                # reason="error" already printed through on_error (red) —
+                # the end event is card-teardown for the web panes, not a
+                # second line here.  A cancelled AUTO compaction is also
+                # silent: the surrounding send prints "[Generation
+                # cancelled]" itself, and pre-lifecycle-events one Stop
+                # printed exactly one line.  (A cancelled MANUAL /compact
+                # keeps the message — it's the only line that path prints.)
+                # A SUPERSEDED end is a force-abandoned compaction retiring
+                # late — nobody is waiting on it; narrating it mid-turn
+                # reads as the LIVE work being cancelled.
+                # HAND-SYNCED SIBLING: conversation.js applyCompactionEvent
+                # implements this same three-clause display policy (skip
+                # error-reason / skip superseded / skip cancelled+auto) for
+                # the web panes — change both or they drift.
+                if not payload.get("superseded") and not (
+                    payload.get("reason") == "cancelled" and payload.get("trigger") == "auto"
+                ):
+                    self.on_info(str(payload.get("message") or ""))
+        return None
+
     def on_state_change(self, state: str) -> None:
         pass  # base TerminalUI ignores state changes
 

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -17,7 +17,6 @@ import threading
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
-from turnstone.core.compaction_render import render_compaction_event_as_info
 from turnstone.core.judge import JudgeConfig
 from turnstone.core.session import ChatSession, SessionUI
 from turnstone.core.session_manager import SessionManager
@@ -329,17 +328,12 @@ class TerminalUI(SessionUI):
         sys.stdout.write(f"{YELLOW}[{label}]{RESET} {content}\n")
         sys.stdout.flush()
 
-    def on_compaction(self, payload: dict[str, Any]) -> int | None:
-        """Render compaction lifecycle events as the terminal's classic text
-        lines — the notice, ``part k/N`` progress, and the token-delta +
-        boxed-summary result the CLI printed before these became structured
-        events (the web UI renders the same payloads as a progress card).
-        Shared with :meth:`ChatSession._compaction_event`'s duck-typed
-        fallback so both render identically; failed-end suppression rides
-        the emitter-stamped ``notice`` field (single policy site).
-        """
-        render_compaction_event_as_info(payload, self.on_info)
-        return None
+    # No on_compaction override: TerminalUI subclasses SessionUI
+    # explicitly, and the inherited protocol default body IS the
+    # terminal's classic rendering (render_compaction_event_as_info via
+    # on_info — see SessionUI.on_compaction).  A byte-identical override
+    # here silently forked the policy site: a future change to the
+    # default stopped applying to the CLI.
 
     def on_state_change(self, state: str) -> None:
         pass  # base TerminalUI ignores state changes

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -17,6 +17,7 @@ import threading
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
+from turnstone.core.compaction_render import render_compaction_event_as_info
 from turnstone.core.judge import JudgeConfig
 from turnstone.core.session import ChatSession, SessionUI
 from turnstone.core.session_manager import SessionManager
@@ -333,61 +334,11 @@ class TerminalUI(SessionUI):
         lines — the notice, ``part k/N`` progress, and the token-delta +
         boxed-summary result the CLI printed before these became structured
         events (the web UI renders the same payloads as a progress card).
+        Shared with :meth:`ChatSession._compaction_event`'s duck-typed
+        fallback so both render identically; failed-end suppression rides
+        the emitter-stamped ``notice`` field (single policy site).
         """
-        phase = payload.get("phase")
-        if phase == "start":
-            # The threshold notice prints only when a threshold actually
-            # fired (pct present — _do_auto_compact).  The overflow-retry
-            # path compacts with auto=True but prints its own "[Context
-            # overflow — auto-compacting and retrying]" line; claiming a
-            # percentage there would fabricate the trigger.  Manual starts
-            # print nothing — the thinking spinner covers it.
-            pct = payload.get("pct")
-            if payload.get("trigger") == "auto" and pct is not None:
-                where = payload.get("where") or ""
-                qualifier = f" {where}" if where else ""
-                self.on_info(
-                    f"\n[Auto-compacting{qualifier}: prompt exceeds {pct}% of context window]"
-                )
-        elif phase == "progress":
-            if payload.get("warning") == "summary_truncated":
-                self.on_info("[Warning: compaction summary was truncated]")
-            elif payload.get("retry_in") is not None:
-                self.on_info(
-                    f"[Compact retrying in {payload['retry_in']:.0f}s: {payload.get('error', '')}]"
-                )
-            else:
-                self.on_info(f"[compacting part {payload.get('part')}/{payload.get('total')}…]")
-        elif phase == "end":
-            if payload.get("ok"):
-                before = payload.get("before_tokens", 0)
-                after = payload.get("after_tokens", 0)
-                self.on_info(f"[compacted: ~{before:,} -> ~{after:,} tokens]")
-                separator = "─" * 60
-                lines = [separator]
-                for line in str(payload.get("summary") or "").splitlines():
-                    lines.append(f"  {line}")
-                lines.append(separator)
-                self.on_info("\n".join(lines))
-            elif payload.get("reason") != "error":
-                # reason="error" already printed through on_error (red) —
-                # the end event is card-teardown for the web panes, not a
-                # second line here.  A cancelled AUTO compaction is also
-                # silent: the surrounding send prints "[Generation
-                # cancelled]" itself, and pre-lifecycle-events one Stop
-                # printed exactly one line.  (A cancelled MANUAL /compact
-                # keeps the message — it's the only line that path prints.)
-                # A SUPERSEDED end is a force-abandoned compaction retiring
-                # late — nobody is waiting on it; narrating it mid-turn
-                # reads as the LIVE work being cancelled.
-                # HAND-SYNCED SIBLING: conversation.js applyCompactionEvent
-                # implements this same three-clause display policy (skip
-                # error-reason / skip superseded / skip cancelled+auto) for
-                # the web panes — change both or they drift.
-                if not payload.get("superseded") and not (
-                    payload.get("reason") == "cancelled" and payload.get("trigger") == "auto"
-                ):
-                    self.on_info(str(payload.get("message") or ""))
+        render_compaction_event_as_info(payload, self.on_info)
         return None
 
     def on_state_change(self, state: str) -> None:

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -15,6 +15,7 @@ for the storage-seeded children rebuild.
 
 from __future__ import annotations
 
+import queue
 from typing import TYPE_CHECKING, Any
 
 from turnstone.core import session_worker
@@ -372,6 +373,16 @@ class CoordinatorAdapter:
             # fresh workstream so the catch is defense-in-depth.  Nothing to
             # release: the staged bytes were peeked, not soft-locked, and a
             # rejected enqueue never drained them.
+            if ws.worker_kind == "command":
+                # A slash-command worker (e.g. a minutes-long /compact aimed
+                # at this workstream from the interactive UI) holds the
+                # raced slot: the interjection queue is turn-shaped and must
+                # stay unreachable during command windows — same rule as the
+                # /send route's park.  Fail the dispatch (returns False, the
+                # caller's retryable-backpressure surface) rather than queue
+                # a message that would be capped and could cross a /resume
+                # identity swap.
+                raise queue.Full()
             att_ids = [a.attachment_id for a in _attachments] if _attachments else None
             session.queue_message(
                 message,

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -391,6 +391,25 @@ class CoordinatorAdapter:
                 interjector_user_id=acting_user_id,
             )
 
+        # Order-barrier yield, mirroring the /send route's pre-check: once
+        # deferred sends are pending (or a claimed entry's dispatch is in
+        # flight — the drain-alive term), a spawn here would overtake
+        # messages already acknowledged "queued".  Refuse via the return
+        # value — the adapter's documented backpressure surface, which the
+        # sole call site reports as queue_full/undelivered — NEVER by
+        # raising queue.Full from the body: only enqueue closures may (the
+        # dispatcher catches it there); a body-raise would escape into the
+        # create handler as a crash.  Unreachable today (that caller
+        # dispatches on a freshly created workstream, which cannot have
+        # pending sends); the guard exists for future dispatch callers.
+        drain_t = ws._pending_drain
+        if ws._pending_sends or (drain_t is not None and drain_t.is_alive()):
+            log.warning(
+                "coord_adapter.send_refused_pending_sends ws=%s count=%d",
+                ws.id[:8],
+                len(ws._pending_sends),
+            )
+            return False
         return session_worker.send(
             ws,
             enqueue=_enqueue,

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -378,7 +378,7 @@ class CoordinatorAdapter:
                 # at this workstream from the interactive UI) holds the
                 # raced slot: the interjection queue is turn-shaped and must
                 # stay unreachable during command windows — same rule as the
-                # /send route's park.  Fail the dispatch (returns False, the
+                # /send route's defer.  Fail the dispatch (returns False, the
                 # caller's retryable-backpressure surface) rather than queue
                 # a message that would be capped and could cross a /resume
                 # identity swap.

--- a/turnstone/console/coordinator_adapter.py
+++ b/turnstone/console/coordinator_adapter.py
@@ -393,17 +393,17 @@ class CoordinatorAdapter:
 
         # Order-barrier yield, mirroring the /send route's pre-check: once
         # deferred sends are pending (or a claimed entry's dispatch is in
-        # flight — the drain-alive term), a spawn here would overtake
-        # messages already acknowledged "queued".  Refuse via the return
-        # value — the adapter's documented backpressure surface, which the
-        # sole call site reports as queue_full/undelivered — NEVER by
-        # raising queue.Full from the body: only enqueue closures may (the
-        # dispatcher catches it there); a body-raise would escape into the
-        # create handler as a crash.  Unreachable today (that caller
-        # dispatches on a freshly created workstream, which cannot have
-        # pending sends); the guard exists for future dispatch callers.
-        drain_t = ws._pending_drain
-        if ws._pending_sends or (drain_t is not None and drain_t.is_alive()):
+        # flight — the drain-alive term the shared predicate carries), a
+        # spawn here would overtake messages already acknowledged
+        # "queued".  Refuse via the return value — the adapter's
+        # documented backpressure surface, which the sole call site
+        # reports as queue_full/undelivered — NEVER by raising queue.Full
+        # from the body: only enqueue closures may (the dispatcher
+        # catches it there); a body-raise would escape into the create
+        # handler as a crash.  Unreachable today (that caller dispatches
+        # on a freshly created workstream, which cannot have pending
+        # sends); the guard exists for future dispatch callers.
+        if ws.send_barrier_active():
             log.warning(
                 "coord_adapter.send_refused_pending_sends ws=%s count=%d",
                 ws.id[:8],

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -588,6 +588,14 @@ _CONSOLE_PROXY_STYLE = (
 _VALID_NODE_ID = re.compile(r"^[a-zA-Z0-9._-]+$")
 _VALID_WS_ID_RE = re.compile(r"^[a-f0-9]{1,64}$")
 
+# Client timeout for the REST proxy pool (BOTH constructions: startup and
+# the mTLS re-create).  Node endpoints that answer degraded-but-in-time
+# responses size their backstops strictly UNDER this bound — e.g. the
+# quick-command ``running`` answer (turnstone/server.py
+# _COMMAND_RESPONSE_BACKSTOP_S); a test pins the inequality.  The SSE
+# proxy client's granular Timeout is a separate contract.
+_PROXY_CLIENT_TIMEOUT_S = 30
+
 _PROXY_JWT_EXPIRY_SECONDS = 300  # 5 min — ample for any request round-trip
 
 
@@ -5322,7 +5330,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     _proxy_verify: Any = _proxy_ssl if _proxy_ssl else True
 
     app.state.proxy_client = httpx.AsyncClient(
-        timeout=30,
+        timeout=_PROXY_CLIENT_TIMEOUT_S,
         limits=httpx.Limits(
             max_connections=fan_out + 50,
             max_keepalive_connections=min(fan_out // 4, 100),
@@ -5464,7 +5472,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                 await app.state.proxy_client.aclose()
                 await app.state.proxy_sse_client.aclose()
                 app.state.proxy_client = httpx.AsyncClient(
-                    timeout=30,
+                    timeout=_PROXY_CLIENT_TIMEOUT_S,
                     limits=httpx.Limits(
                         max_connections=app.state.fan_out_limit + 50,
                         max_keepalive_connections=min(app.state.fan_out_limit // 4, 100),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3887,7 +3887,7 @@ def _audit_coordinator_create(
     )
 
 
-def _coord_spawn_metrics(_request: Request, ui: Any) -> None:
+def _coord_spawn_metrics(_request: Request | None, ui: Any) -> None:
     """Per-spawn counter writes for coord — mirrors interactive's pattern.
 
     Wired onto :attr:`SessionEndpointConfig.spawn_metrics`. Increments

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -3895,7 +3895,7 @@ def _audit_coordinator_create(
     )
 
 
-def _coord_spawn_metrics(_request: Request | None, ui: Any) -> None:
+def _coord_spawn_metrics(ui: Any) -> None:
     """Per-spawn counter writes for coord — mirrors interactive's pattern.
 
     Wired onto :attr:`SessionEndpointConfig.spawn_metrics`. Increments

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -28,6 +28,10 @@
 // ---------------------------------------------------------------------------
 import {
   buildWatchResultCard,
+  buildCompactionCard,
+  applyCompactionEvent,
+  resetCompactionHolder,
+  sendAbortMs,
   buildSystemNudgeMarker,
   maxSeverityItem,
   buildConvBatchShell,
@@ -511,6 +515,12 @@ function createCoordinatorPane(root, wsId, opts) {
   // ui/static/app.js's per-pane _renderedSystemEventIds.
   const renderedSystemEventIds = new Set();
 
+  // Compaction lifecycle holder for the shared reducer
+  // (conversation.applyCompactionEvent); `card` is the in-progress card
+  // between start and end, nulled wherever the transcript is wiped — live
+  // events re-create it defensively.
+  const compactionHolder = { card: null, cid: null };
+
   // Cache of judge verdicts keyed by call_id.  intent_verdict and
   // approve_request are async and may arrive in either order; the
   // cache lets each handler apply data to the other without assuming
@@ -600,7 +610,11 @@ function createCoordinatorPane(root, wsId, opts) {
       rows = [parsed];
     }
     if (rows.length === 0) {
-      return "<pre>" + esc(redactCredentials(JSON.stringify(parsed, null, 2))) + "</pre>";
+      return (
+        "<pre>" +
+        esc(redactCredentials(JSON.stringify(parsed, null, 2))) +
+        "</pre>"
+      );
     }
     const lines = rows.map((row) => {
       const safeWs = row.ws_id && WS_ID_RE.test(row.ws_id) ? row.ws_id : null;
@@ -817,6 +831,14 @@ function createCoordinatorPane(root, wsId, opts) {
   // labeled operator bubble.
   function renderSystemTurn(source, content, meta) {
     const m = meta && typeof meta === "object" ? meta : null;
+    // /history projection of a persisted compaction marker — same result
+    // card the live `compaction` end event paints (shared builder).
+    if (source === "compaction") {
+      const card = buildCompactionCard(m, content || "");
+      messagesEl.appendChild(card);
+      _scheduleScroll();
+      return card;
+    }
     if (source === "watch_triggered" && m)
       return appendWatchResult(m, content || "");
     if (source === "output_guard" && m) return appendGuardFinding(m);
@@ -1975,7 +1997,10 @@ function createCoordinatorPane(root, wsId, opts) {
     let sendTimer = null;
     if (sendCtrl) {
       sendInit.signal = sendCtrl.signal;
-      sendTimer = setTimeout(() => sendCtrl.abort(), 15000);
+      // Same policy as the interactive composer: long bound while this
+      // pane's compaction card is live (the send parks server-side for
+      // the command window), wedged-node default otherwise.
+      sendTimer = setTimeout(() => sendCtrl.abort(), sendAbortMs(compactionHolder));
     }
     let sendReq = authFetch(
       "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
@@ -2745,6 +2770,11 @@ function createCoordinatorPane(root, wsId, opts) {
         }
         break;
       case "stream_end":
+        // A live in-progress compaction card here means a FORCE stop
+        // abandoned the compaction worker (the lifecycle wrapper otherwise
+        // always retires the card with an end event before any stream_end
+        // can follow) — remove it instead of leaving a frozen bar.
+        resetCompactionHolder(compactionHolder);
         finishAssistantStream();
         break;
       case "stream_overflow":
@@ -2922,6 +2952,19 @@ function createCoordinatorPane(root, wsId, opts) {
         if (sysEid) renderedSystemEventIds.add(sysEid);
         break;
       }
+      case "compaction":
+        // Context-compaction lifecycle — the shared reducer
+        // (conversation.applyCompactionEvent) is the one state machine for
+        // this viewer and the interactive pane, so the two can't drift.
+        // reason="error" ends render via the paired `error` event (red row);
+        // the reducer emits only the non-error failure notices here.
+        applyCompactionEvent(compactionHolder, ev, {
+          container: messagesEl,
+          renderedIds: renderedSystemEventIds,
+          onNotice: (msg) => appendText("info", msg, { label: "info" }),
+          scroll: () => _scheduleScroll(),
+        });
+        break;
       case "connected":
         // First yield from _coord_events_replay — populates the
         // status bar's model cell before any history arrives.  Also
@@ -5009,6 +5052,7 @@ function createCoordinatorPane(root, wsId, opts) {
     toolRows.clear();
     activeBatch = null;
     renderedSystemEventIds.clear();
+    resetCompactionHolder(compactionHolder);
     if (!hist) return;
     // Fresh-connect fast-forward: when the trailing turn is an executing
     // in-flight tool batch the server can replay, /history returns a

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -45,6 +45,11 @@ import {
 } from "/shared/conversation.js";
 import { redactCredentials } from "/shared/redact_credentials.js";
 import {
+  createQueueController,
+  parsePriority,
+  settleSendResponse,
+} from "/shared/composer_queue.js";
+import {
   OVERFLOW_TRIP_COUNT,
   OVERFLOW_TRIP_WINDOW_MS,
   DEGRADED_COOLDOWN_BASE_MS,
@@ -304,6 +309,9 @@ function createCoordinatorPane(root, wsId, opts) {
     },
   });
   let busy = false;
+  // Provenance of the current busy=true (see setBusy): "server" |
+  // "optimistic" | null when idle.
+  let busySource = null;
   // Acting user (turn initiator) of the in-flight turn, from state_change
   // events; drives the shared-workstream cross-user send gate. Carries the
   // owner id even single-user (the gate just no-ops — it equals this viewer);
@@ -1871,8 +1879,15 @@ function createCoordinatorPane(root, wsId, opts) {
   // caller relies on. queue.onIdleEdge runs only on the actual edge
   // (it's the heavier work — querySelectorAll-driven promote sweep
   // plus the cancel-timer cleanup wired via the onIdle hook above).
-  function setBusy(b) {
+  function setBusy(b, source) {
     const next = !!b;
+    // Who asserted busy: "server" (default — state events and every
+    // existing/future writer) or "optimistic" (ONLY coordSend's pre-POST
+    // flip). The deferred/queue_full settle arms may clear busy solely
+    // while it is still this send's own optimistic flip — a server-
+    // stamped busy is a real turn and must never be clobbered.
+    // Centralized HERE so an unstamped future writer fails safe.
+    busySource = next ? source || "server" : null;
     composer.setBusy(next);
     // Greys out the per-message edit/rewind/retry buttons while a generation
     // is in flight (CSS: [data-busy="true"] .msg-action-btn).
@@ -1957,20 +1972,18 @@ function createCoordinatorPane(root, wsId, opts) {
 
     let queuedEl = null;
     let optimisticEl = null;
-    // Server re-parses the !!! prefix to set queue priority — the
-    // optimistic bubble strips it for display. Parsed outside the busy
-    // branch: the queued+deferred response arm needs it too (an idle
-    // pane's send can defer behind a command window / pending list).
-    let displayText = trimmed;
-    let priority = "notice";
-    if (trimmed.startsWith("!!!")) {
-      displayText = trimmed.slice(3).trimStart();
-      priority = "important";
-    }
-    if (busy) {
+    const isBusy = busy;
+    // Display-only strip of the !!! prefix (the server re-parses it
+    // authoritatively); shared parse so the settle helper's retro-convert
+    // renders the same chip either pane would have built pre-POST.
+    const { displayText, priority } = parsePriority(trimmed);
+    if (isBusy) {
       queuedEl = queue.addQueuedMessage(displayText, priority);
     } else {
-      setBusy(true);
+      // "optimistic": no server state event asserted this — the settle
+      // arms may undo it if the send turns out deferred/refused (see
+      // setBusy's busySource contract).
+      setBusy(true, "optimistic");
       // snap.attachments carries the chip metadata (kind + filename)
       // for every stable chip the composer holds; pass it through so
       // the optimistic user bubble shows the same pill cluster the
@@ -2051,71 +2064,22 @@ function createCoordinatorPane(root, wsId, opts) {
         return r.json();
       })
       .then((data) => {
-        if (data && data.status === "queued" && data.msg_id) {
-          // queuedEl-present: bind() handles the known races. queuedEl-
-          // absent + deferred: the pane thought it was idle but the send
-          // parked on the server's deferred list (command window / order
-          // barrier) — a plain sent bubble would present a parked,
-          // still-retractable, restart-droppable message as delivered, so
-          // replace the optimistic bubble with a real queued chip.
-          // queuedEl-absent + undeferred: plain interjection into a live
-          // turn the client hadn't seen yet (SSE state_change race); keep
-          // the historical small-UX-gap behavior (busy flip only).
-          if (!queuedEl && data.deferred) {
-            if (optimisticEl && optimisticEl.isConnected) optimisticEl.remove();
-            queuedEl = queue.addQueuedMessage(displayText, priority);
-          }
-          if (queuedEl) {
-            queue.bind(queuedEl, data.msg_id, {
-              deferred: !!data.deferred,
-              attachedCount: (data.attached_ids || []).length,
-            });
-          } else setBusy(true);
-          attachments.consume(data.attached_ids, data.dropped_attachment_ids);
-        } else if (data && data.status === "busy") {
-          if (queuedEl) queue.remove(queuedEl);
-          appendText("error", "Server is busy. Please wait.", {
-            label: "error",
-          });
-          if (!queuedEl) setBusy(false);
-        } else if (data && data.status === "queue_full") {
-          if (queuedEl) queue.remove(queuedEl);
-          appendText("error", "Message queue full. Please wait.", {
-            label: "error",
-          });
-        } else if (data && data.status === "attachments_busy") {
-          // Attachments can't ride a queued user turn — server held
-          // the reservations long enough to bounce the request and
-          // released them. Chips stay in the composer; user retries
-          // once the assistant finishes.
-          if (queuedEl) queue.remove(queuedEl);
-          appendText(
-            "error",
-            "Attachments can't be sent while the assistant is working. Send a text-only message now, or wait and resend with attachments.",
-            { label: "error" },
-          );
-        } else if (data && data.status === "cross_user_interjection") {
-          // Another participant's turn is in flight; the server refused the
-          // interjection so it can't run under their credentials or be
-          // misattributed. Reactive fallback for the click-beats-event race
-          // (the send gate normally disables the button first).
-          if (queuedEl) queue.remove(queuedEl);
-          appendText(
-            "error",
-            data.error ||
-              "Another participant's turn is in progress. Wait for it to finish, then send your message.",
-            { label: "error" },
-          );
-          if (!queuedEl) setBusy(false);
-        } else {
-          // Unknown / "ok" status (stale-busy race): settle the optimistic
-          // bubble so a pre-bind × can't strand it in the dismissing state.
-          if (queuedEl) queue.promote(queuedEl);
-          attachments.consume(
-            data && data.attached_ids,
-            data && data.dropped_attachment_ids,
-          );
-        }
+        // The full status dispatch (queued/retro-convert, busy,
+        // queue_full, attachments_busy, cross_user, unknown-ok) lives in
+        // the shared helper — ONE settle matrix for both panes; see
+        // settleSendResponse's contract for the arm semantics.
+        settleSendResponse(queue, data || {}, {
+          queuedEl,
+          optimisticEl,
+          isBusy,
+          displayText,
+          priority,
+          setBusy: (b) => setBusy(b),
+          busyIsOptimistic: () => busy && busySource === "optimistic",
+          renderError: (msg) => appendText("error", msg, { label: "error" }),
+          consumeAttachments: (attached, droppedIds) =>
+            attachments.consume(attached, droppedIds),
+        });
       })
       .catch((e) => {
         if (queuedEl) queue.remove(queuedEl);

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -1956,15 +1956,18 @@ function createCoordinatorPane(root, wsId, opts) {
     const snap = attachments.snapshot();
 
     let queuedEl = null;
+    let optimisticEl = null;
+    // Server re-parses the !!! prefix to set queue priority — the
+    // optimistic bubble strips it for display. Parsed outside the busy
+    // branch: the queued+deferred response arm needs it too (an idle
+    // pane's send can defer behind a command window / pending list).
+    let displayText = trimmed;
+    let priority = "notice";
+    if (trimmed.startsWith("!!!")) {
+      displayText = trimmed.slice(3).trimStart();
+      priority = "important";
+    }
     if (busy) {
-      // Server re-parses the !!! prefix to set queue priority — the
-      // optimistic bubble strips it for display.
-      let displayText = trimmed;
-      let priority = "notice";
-      if (trimmed.startsWith("!!!")) {
-        displayText = trimmed.slice(3).trimStart();
-        priority = "important";
-      }
       queuedEl = queue.addQueuedMessage(displayText, priority);
     } else {
       setBusy(true);
@@ -1972,9 +1975,13 @@ function createCoordinatorPane(root, wsId, opts) {
       // for every stable chip the composer holds; pass it through so
       // the optimistic user bubble shows the same pill cluster the
       // history-replay path renders below.
-      appendUserMessageWithAttachments(trimmed, snap.attachments, {
-        label: "you",
-      });
+      optimisticEl = appendUserMessageWithAttachments(
+        trimmed,
+        snap.attachments,
+        {
+          label: "you",
+        },
+      );
     }
     composer.clear();
 
@@ -2045,21 +2052,24 @@ function createCoordinatorPane(root, wsId, opts) {
       })
       .then((data) => {
         if (data && data.status === "queued" && data.msg_id) {
-          // Race: server returned queued but the client thought it was
-          // idle (SSE state_change hadn't arrived yet on initial load /
-          // reconnect). The optimistic user bubble is already in the
-          // log; we can't bind msg_id to a queued bubble retroactively
-          // without flipping the visual state mid-stream. Flip the busy
-          // flag so any subsequent send takes the queue path correctly,
-          // and accept the small UX gap (no in-UI dismiss for THIS
-          // message). The server still delivers it on worker drain.
+          // queuedEl-present: bind() handles the known races. queuedEl-
+          // absent + deferred: the pane thought it was idle but the send
+          // parked on the server's deferred list (command window / order
+          // barrier) — a plain sent bubble would present a parked,
+          // still-retractable, restart-droppable message as delivered, so
+          // replace the optimistic bubble with a real queued chip.
+          // queuedEl-absent + undeferred: plain interjection into a live
+          // turn the client hadn't seen yet (SSE state_change race); keep
+          // the historical small-UX-gap behavior (busy flip only).
+          if (!queuedEl && data.deferred) {
+            if (optimisticEl && optimisticEl.isConnected) optimisticEl.remove();
+            queuedEl = queue.addQueuedMessage(displayText, priority);
+          }
           if (queuedEl) {
-            // Deferred sends (command-window defer) can carry attachments —
-            // stash the count BEFORE bind (a pre-bind ✕ confirms inside
-            // bind) so the dismiss path can surface the
-            // discarded-attachments consequence.
-            queuedEl._deferredAttachments = (data.attached_ids || []).length;
-            queue.bind(queuedEl, data.msg_id);
+            queue.bind(queuedEl, data.msg_id, {
+              deferred: !!data.deferred,
+              attachedCount: (data.attached_ids || []).length,
+            });
           } else setBusy(true);
           attachments.consume(data.attached_ids, data.dropped_attachment_ids);
         } else if (data && data.status === "busy") {
@@ -3040,6 +3050,14 @@ function createCoordinatorPane(root, wsId, opts) {
         // already showed it; nothing to render here. (Earlier this
         // surfaced an extra info row, which doubled up with the
         // queued bubble once the composer started rendering one.)
+        break;
+      case "message_dispatched":
+        // A deferred send left the parked list: fresh spawn (promote the
+        // chip — the ×'s window is over) or interjection fold-in
+        // (folded: true — only the deferred flag clears; the chip resumes
+        // the normal queued lifecycle). No-op when this tab holds no
+        // matching chip.
+        queue.settleDeferred(ev.msg_id, !!ev.folded);
         break;
       case "busy_error":
         // Worker is still alive after a cancel attempt; re-arm the

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -2076,6 +2076,7 @@ function createCoordinatorPane(root, wsId, opts) {
           priority,
           setBusy: (b) => setBusy(b),
           busyIsOptimistic: () => busy && busySource === "optimistic",
+          paneIsBusy: () => busy,
           renderError: (msg) => appendText("error", msg, { label: "error" }),
           consumeAttachments: (attached, droppedIds) =>
             attachments.consume(attached, droppedIds),

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -31,7 +31,6 @@ import {
   buildCompactionCard,
   applyCompactionEvent,
   resetCompactionHolder,
-  sendAbortMs,
   buildSystemNudgeMarker,
   maxSeverityItem,
   buildConvBatchShell,
@@ -1997,10 +1996,11 @@ function createCoordinatorPane(root, wsId, opts) {
     let sendTimer = null;
     if (sendCtrl) {
       sendInit.signal = sendCtrl.signal;
-      // Same policy as the interactive composer: long bound while this
-      // pane's compaction card is live (the send parks server-side for
-      // the command window), wedged-node default otherwise.
-      sendTimer = setTimeout(() => sendCtrl.abort(), sendAbortMs(compactionHolder));
+      // Same policy as the interactive composer: flat wedged-node bound —
+      // every /send answers within RTT now (dispatched, queued, or
+      // deferred-with-msg_id during a command window; the server parks
+      // nothing against this POST).  Dismissal is bind() → DELETE.
+      sendTimer = setTimeout(() => sendCtrl.abort(), 15000);
     }
     let sendReq = authFetch(
       "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send",
@@ -2053,8 +2053,14 @@ function createCoordinatorPane(root, wsId, opts) {
           // flag so any subsequent send takes the queue path correctly,
           // and accept the small UX gap (no in-UI dismiss for THIS
           // message). The server still delivers it on worker drain.
-          if (queuedEl) queue.bind(queuedEl, data.msg_id);
-          else setBusy(true);
+          if (queuedEl) {
+            // Deferred sends (command-window defer) can carry attachments —
+            // stash the count BEFORE bind (a pre-bind ✕ confirms inside
+            // bind) so the dismiss path can surface the
+            // discarded-attachments consequence.
+            queuedEl._deferredAttachments = (data.attached_ids || []).length;
+            queue.bind(queuedEl, data.msg_id);
+          } else setBusy(true);
           attachments.consume(data.attached_ids, data.dropped_attachment_ids);
         } else if (data && data.status === "busy") {
           if (queuedEl) queue.remove(queuedEl);

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -2068,7 +2068,7 @@ function createCoordinatorPane(root, wsId, opts) {
         // queue_full, attachments_busy, cross_user, unknown-ok) lives in
         // the shared helper — ONE settle matrix for both panes; see
         // settleSendResponse's contract for the arm semantics.
-        settleSendResponse(queue, data || {}, {
+        settleSendResponse(queue, data, {
           queuedEl,
           optimisticEl,
           isBusy,

--- a/turnstone/core/compaction_render.py
+++ b/turnstone/core/compaction_render.py
@@ -1,0 +1,69 @@
+"""Render compaction lifecycle events as classic info-channel text lines.
+
+One implementation, two consumers:
+
+* :class:`turnstone.cli.TerminalUI` — the terminal's native rendering of
+  ``on_compaction`` payloads (the threshold notice, ``part k/N``
+  progress, and the token-delta + boxed-summary result it printed before
+  these became structured events).
+* :meth:`ChatSession._compaction_event`'s duck-typed fallback — a
+  SessionUI implementation that predates the ``on_compaction`` hook gets
+  these same lines through its ``on_info`` instead of silence (an
+  auto-compaction that swaps history with zero announcement).
+
+Display policy: failed ends consult ``payload["notice"]`` — stamped by
+the emitter (:meth:`ChatSession._compaction_event`, the single policy
+site) — never re-derive suppression from reason/trigger/superseded here.
+Superseded OK ends still render: the history swap really committed, and
+suppressing its announcement is exactly the silent-swap failure this
+module exists to prevent.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+
+def render_compaction_event_as_info(
+    payload: dict[str, Any], on_info: Callable[[str], None]
+) -> None:
+    """Print one compaction lifecycle event through ``on_info``."""
+    phase = payload.get("phase")
+    if phase == "start":
+        # The threshold notice prints only when a threshold actually
+        # fired (pct present — _do_auto_compact).  The overflow-retry
+        # path compacts with auto=True but prints its own "[Context
+        # overflow — auto-compacting and retrying]" line; claiming a
+        # percentage there would fabricate the trigger.  Manual starts
+        # print nothing — the caller's own activity display covers it.
+        pct = payload.get("pct")
+        if payload.get("trigger") == "auto" and pct is not None:
+            where = payload.get("where") or ""
+            qualifier = f" {where}" if where else ""
+            on_info(f"\n[Auto-compacting{qualifier}: prompt exceeds {pct}% of context window]")
+    elif phase == "progress":
+        if payload.get("warning") == "summary_truncated":
+            on_info("[Warning: compaction summary was truncated]")
+        elif payload.get("retry_in") is not None:
+            on_info(f"[Compact retrying in {payload['retry_in']:.0f}s: {payload.get('error', '')}]")
+        else:
+            on_info(f"[compacting part {payload.get('part')}/{payload.get('total')}…]")
+    elif phase == "end":
+        if payload.get("ok"):
+            before = payload.get("before_tokens", 0)
+            after = payload.get("after_tokens", 0)
+            on_info(f"[compacted: ~{before:,} -> ~{after:,} tokens]")
+            separator = "─" * 60
+            lines = [separator]
+            for line in str(payload.get("summary") or "").splitlines():
+                lines.append(f"  {line}")
+            lines.append(separator)
+            on_info("\n".join(lines))
+        elif payload.get("notice"):
+            # The emitter stamps ``notice`` on failed ends (suppressing
+            # error-reason ends — already printed red through on_error —
+            # plus superseded and cancelled-auto ends).  A payload without
+            # the field (an event replayed from an older node) stays
+            # silent: these notices are informational, and re-deriving the
+            # suppression here is the cross-runtime drift trap the stamp
+            # exists to kill.
+            on_info(str(payload.get("message") or ""))

--- a/turnstone/core/idle_nudge_watcher.py
+++ b/turnstone/core/idle_nudge_watcher.py
@@ -75,10 +75,12 @@ def wake_workstream_if_pending(ws: Workstream, *, trigger: str = "unspecified") 
       queue at its own seams (``ATTENTION``/``THINKING``/``RUNNING``
       all imply a live worker), and ``ERROR`` stays parked for the
       operator rather than burning inference unattended.
-    * ``ws._pending_sends`` non-empty — deferred sends hold the order
-      barrier; the wake yields and is re-armed by the deferred turns'
+    * ``ws.send_barrier_active()`` — deferred sends hold the order
+      barrier (pending entries, or a claimed entry's dispatch in
+      flight); the wake yields and is re-armed by the deferred turns'
       exit backstops (or the drain's clean exit when everything was
-      retracted).  See the inline comment for the staleness argument.
+      retracted).  See the predicate's docstring for the staleness
+      argument.
     * nothing gate-eligible under ``WAKE_PENDING`` — tool-only/quiet entries
       belong to the next tool-result seam, not a synthetic empty user
       turn (``deliver_wake_nudge_from_queue`` would no-op on them).
@@ -105,19 +107,21 @@ def wake_workstream_if_pending(ws: Workstream, *, trigger: str = "unspecified") 
     session = ws.session
     if session is None or ws._closed or ws.state is not WorkstreamState.IDLE:
         return False
-    if ws._pending_sends:
-        # Order-barrier yield: deferred sends (acknowledged "queued"
-        # during a command window — see _PendingSend) are older than any
-        # nudge, and a wake worker claiming the slot would push them
-        # behind its whole turn.  Lockless peek, benign both ways: a
-        # stale non-empty skips once more (the next exit backstop
-        # converges), a stale empty means the concurrent defer holds no
-        # order contract against this wake anyway.  Convergence is
-        # structural — every path that clears the barrier re-runs this
-        # gate: each deferred turn's exit via ``_retry_pending_wake``,
-        # and the drain's own clean exit (trigger="drain-exit"), which
-        # covers a list that empties by pure retraction and so never
-        # runs a turn.
+    if ws.send_barrier_active():
+        # Order-barrier yield: deferred sends (acknowledged "queued" —
+        # see _PendingSend) are older than any nudge, and a wake worker
+        # claiming the slot would push them behind its whole turn.  The
+        # shared predicate carries BOTH terms — the pending list AND the
+        # drain-alive clause covering a CLAIMED entry (popped, dispatch
+        # in flight but not yet holding the slot); checking the list
+        # alone let a wake jump an acknowledged send in exactly that
+        # window.  Lockless call, benign both ways (staleness ruling in
+        # the predicate's docstring).  Convergence is structural —
+        # every path that clears the barrier re-runs this gate: each
+        # deferred turn's exit via ``_retry_pending_wake``, and the
+        # drain's own clean exit (trigger="drain-exit"), which covers a
+        # list that empties by pure retraction and so never runs a
+        # turn.
         log.info("nudge_wake.yielded_to_pending_sends ws=%s trigger=%s", ws.id[:8], trigger)
         return False
     nudge_queue = getattr(session, "_nudge_queue", None)

--- a/turnstone/core/idle_nudge_watcher.py
+++ b/turnstone/core/idle_nudge_watcher.py
@@ -75,6 +75,10 @@ def wake_workstream_if_pending(ws: Workstream, *, trigger: str = "unspecified") 
       queue at its own seams (``ATTENTION``/``THINKING``/``RUNNING``
       all imply a live worker), and ``ERROR`` stays parked for the
       operator rather than burning inference unattended.
+    * ``ws._pending_sends`` non-empty — deferred sends hold the order
+      barrier; the wake yields and is re-armed by the deferred turns'
+      exit backstops (or the drain's clean exit when everything was
+      retracted).  See the inline comment for the staleness argument.
     * nothing gate-eligible under ``WAKE_PENDING`` — tool-only/quiet entries
       belong to the next tool-result seam, not a synthetic empty user
       turn (``deliver_wake_nudge_from_queue`` would no-op on them).
@@ -100,6 +104,21 @@ def wake_workstream_if_pending(ws: Workstream, *, trigger: str = "unspecified") 
     """
     session = ws.session
     if session is None or ws._closed or ws.state is not WorkstreamState.IDLE:
+        return False
+    if ws._pending_sends:
+        # Order-barrier yield: deferred sends (acknowledged "queued"
+        # during a command window — see _PendingSend) are older than any
+        # nudge, and a wake worker claiming the slot would push them
+        # behind its whole turn.  Lockless peek, benign both ways: a
+        # stale non-empty skips once more (the next exit backstop
+        # converges), a stale empty means the concurrent defer holds no
+        # order contract against this wake anyway.  Convergence is
+        # structural — every path that clears the barrier re-runs this
+        # gate: each deferred turn's exit via ``_retry_pending_wake``,
+        # and the drain's own clean exit (trigger="drain-exit"), which
+        # covers a list that empties by pure retraction and so never
+        # runs a turn.
+        log.info("nudge_wake.yielded_to_pending_sends ws=%s trigger=%s", ws.id[:8], trigger)
         return False
     nudge_queue = getattr(session, "_nudge_queue", None)
     # Gate on WAKE_PENDING, not USER_DRAIN: ``"quiet"`` entries (external

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1150,6 +1150,21 @@ def _is_ctx_overflow(exc: BaseException) -> bool:
     )
 
 
+def _coerce_event_id(value: Any) -> int | None:
+    """Narrow a duck-typed hook return / attribute to a usable event id.
+
+    ``bool`` is an ``int`` subclass, so a bare ``isinstance(value, int)``
+    lets a hook returning ``True`` stamp a boolean into a persisted
+    ``event_id`` — PostgreSQL then fails the INSERT after the state it
+    annotates already committed, and SQLite stores ``1`` and mis-keys
+    the /history-vs-replay dedupe.  Same guard as
+    ``parse_checkpoint_watermark`` (storage/_utils.py); every consumer
+    of a duck-typed event-id source must route through here rather than
+    re-deriving the isinstance chain per site.
+    """
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 class SessionUI(Protocol):
     def on_turn_start(self) -> None: ...
     def on_turn_committed(self) -> None: ...
@@ -1187,8 +1202,22 @@ class SessionUI(Protocol):
         assigns one (see :meth:`on_system_turn`) so the persisted
         compaction marker row can be stamped with the matching resume
         cursor; ``None`` for UIs without an event stream.
+
+        The default body IS the pre-1.8 compat rendering — the classic
+        ``on_info`` lines via the shared renderer.  It must not be a bare
+        ``...`` stub: a Protocol member's body is inherited as a REAL
+        method by explicit subclasses, so a pre-1.8 ``class MyUI(SessionUI)``
+        that never implemented this hook would satisfy the getattr probe
+        in ``_compaction_event`` with a silent no-op and defeat the very
+        fallback built for it — every lifecycle event swallowed, history
+        swapping with zero announcement.  Event-stream UIs override and
+        return the assigned id; a subclass implementing neither hook
+        no-ops through ``on_info``'s own stub (the never-crash floor).
         """
-        ...
+        from turnstone.core.compaction_render import render_compaction_event_as_info
+
+        render_compaction_event_as_info(payload, self.on_info)
+        return None
 
     def on_state_change(self, state: str) -> None: ...
     def on_rename(self, name: str) -> None: ...
@@ -3178,7 +3207,7 @@ class ChatSession:
         available" (the synthetic-snapshot floor).
         """
         eid = getattr(self.ui, "_event_id", None)
-        return eid if isinstance(eid, int) else None
+        return _coerce_event_id(eid)
 
     def _tool_def_chars(self) -> int:
         """Total serialized char size of the active tool definitions (resent on
@@ -5701,7 +5730,9 @@ class ChatSession:
         # event was delivered to double anyway).
         emitted_event_id: int | None = None
         try:
-            emitted_event_id = self.ui.on_system_turn(content, source, meta or None)
+            emitted_event_id = _coerce_event_id(
+                self.ui.on_system_turn(content, source, meta or None)
+            )
         except Exception:
             log.warning("ui.on_system_turn failed; system turn still appended", exc_info=True)
         save_message(
@@ -5709,7 +5740,7 @@ class ChatSession:
             "system",
             content,
             source=source,
-            event_id=emitted_event_id if isinstance(emitted_event_id, int) else self._ui_event_id(),
+            event_id=emitted_event_id if emitted_event_id is not None else self._ui_event_id(),
             meta=meta_json,
         )
 
@@ -7822,7 +7853,13 @@ class ChatSession:
         # getattr-guarded like on_generation_claimed/on_aux_usage: a
         # duck-typed SessionUI predating the hook must not hit an
         # AttributeError that wedges every long session at its first
-        # auto-compaction.
+        # auto-compaction.  This probe only catches DUCK-typed UIs — an
+        # explicit ``class MyUI(SessionUI)`` inherits the protocol
+        # member as a real method and never lands in the None arm, which
+        # is why the protocol default body renders the same classic
+        # lines itself (see SessionUI.on_compaction): both compat routes
+        # converge on render_compaction_event_as_info, policy
+        # single-sited.
         emit = getattr(self.ui, "on_compaction", None)
         if emit is None:
             # Pre-hook UIs get the classic info lines back (an
@@ -7846,8 +7883,9 @@ class ChatSession:
             return None
         result = emit(event)
         # Duck-typed hooks aren't bound to the protocol's return type; the
-        # marker-stamp consumer needs int-or-None, nothing else.
-        return result if isinstance(result, int) else None
+        # marker-stamp consumer needs int-or-None, nothing else (and a
+        # hook returning True must not stamp a bool — see _coerce_event_id).
+        return _coerce_event_id(result)
 
     def _compaction_bailed(
         self,
@@ -9086,15 +9124,6 @@ class ChatSession:
         """
         return self._flush_queued_messages()
 
-    @staticmethod
-    def _combine_queued_items(items: list[tuple[str, str]]) -> str:
-        """Render drained queue items to one text block ([IMPORTANT] framing)."""
-        from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
-
-        return "\n\n".join(
-            f"[IMPORTANT] {msg}" if pri == PRIORITY_IMPORTANT else msg for msg, pri in items
-        )
-
     def compact_now(self) -> bool:
         """Manual compaction with send()'s full generation discipline.
 
@@ -9165,10 +9194,14 @@ class ChatSession:
         Returns ``True`` when any user row was appended (prefix or
         items), ``False`` when both were empty.
         """
+        from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
+
         with self._queued_lock:
             items = list(self._queued_messages.values())
             self._queued_messages.clear()
-        queued_text = self._combine_queued_items(items)
+        queued_text = "\n\n".join(
+            f"[IMPORTANT] {msg}" if pri == PRIORITY_IMPORTANT else msg for msg, pri in items
+        )
         if not queued_text and not prefix:
             return False
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -204,7 +204,11 @@ from turnstone.core.trajectory import (
 )
 from turnstone.core.watch import WATCH_REMINDER_OPTIONAL_KEYS
 from turnstone.core.web import check_ssrf, fetch_with_ssrf_guard, strip_html
-from turnstone.core.workstream import PENDING_SENDS_MAX, WorkstreamKind
+from turnstone.core.workstream import (
+    INTERJECTION_CAP_CHARS,
+    PENDING_SENDS_MAX,
+    WorkstreamKind,
+)
 from turnstone.prompts import (
     INTERACTIVE_CONSENT_CLIENT_TYPES,
     ClientType,
@@ -9130,9 +9134,11 @@ class ChatSession:
             )
 
         cleaned, priority = parse_priority(text)
-        # Cap individual message length to prevent context bloat
-        if len(cleaned) > 2000:
-            cleaned = cleaned[:2000] + "..."
+        # Cap individual message length to prevent context bloat (the
+        # shared bound — the /send defer-fidelity check refuses fold-ins
+        # that could hit this truncation).
+        if len(cleaned) > INTERJECTION_CAP_CHARS:
+            cleaned = cleaned[:INTERJECTION_CAP_CHARS] + "..."
         # Full UUID hex (128 bits) rather than a truncated prefix — this id is
         # the ``send_id`` tracking token threaded through the turn, so the wide
         # space keeps the birthday bound comfortable.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7861,27 +7861,43 @@ class ChatSession:
         # converge on render_compaction_event_as_info, policy
         # single-sited.
         emit = getattr(self.ui, "on_compaction", None)
-        if emit is None:
-            # Pre-hook UIs get the classic info lines back (an
-            # auto-compaction must never swap history with zero
-            # announcement — the pre-1.8 lines reached every UI
-            # unconditionally).  Invoked for superseded events too: a
-            # superseded OK end announces a swap that really committed,
-            # and failed-end staleness is already encoded in ``notice``.
-            # ``on_info`` is getattr-guarded like the hook itself — the
-            # never-crash property is the floor; a UI with neither hook
-            # keeps compacting silently.  Deliberately NOT dual-emitted
-            # for hook-aware UIs or SSE: pre-1.8 SSE/SDK clients that
-            # ignore unknown `compaction` events lose these lines — a
-            # documented 1.8 breaking change (CHANGELOG); dual emission
-            # would double-render on every current client.
-            info = getattr(self.ui, "on_info", None)
-            if info is not None:
-                from turnstone.core.compaction_render import render_compaction_event_as_info
+        try:
+            if emit is None:
+                # Pre-hook UIs get the classic info lines back (an
+                # auto-compaction must never swap history with zero
+                # announcement — the pre-1.8 lines reached every UI
+                # unconditionally).  Invoked for superseded events too: a
+                # superseded OK end announces a swap that really committed,
+                # and failed-end staleness is already encoded in ``notice``.
+                # ``on_info`` is getattr-guarded like the hook itself — the
+                # never-crash property is the floor; a UI with neither hook
+                # keeps compacting silently.  Deliberately NOT dual-emitted
+                # for hook-aware UIs or SSE: pre-1.8 SSE/SDK clients that
+                # ignore unknown `compaction` events lose these lines — a
+                # documented 1.8 breaking change (CHANGELOG); dual emission
+                # would double-render on every current client.
+                info = getattr(self.ui, "on_info", None)
+                if info is not None:
+                    from turnstone.core.compaction_render import render_compaction_event_as_info
 
-                render_compaction_event_as_info(event, info)
+                    render_compaction_event_as_info(event, info)
+                return None
+            result = emit(event)
+        except Exception:
+            # The single raise-proofing site for EVERY lifecycle emission
+            # (both compat routes, all phases): a raising duck-typed hook
+            # must degrade to a lost render, never to a lost EVENT —
+            # unguarded, a raising failed-END emit voided the
+            # exactly-one-end contract through the wrapper backstop
+            # (frozen progress bar on every pane), and a raising SUCCESS
+            # end after the committed swap made the backstop fabricate a
+            # failed end + red row for a compaction that succeeded.  The
+            # cost on raise is only the marker-stamp id — the receiving
+            # hook was broken anyway.  Same policy as this method's own
+            # getattr guard ("must not wedge every long session") and the
+            # same shape as _emit_send_ui.
+            log.debug("compaction lifecycle hook raised; event dropped for this UI", exc_info=True)
             return None
-        result = emit(event)
         # Duck-typed hooks aren't bound to the protocol's return type; the
         # marker-stamp consumer needs int-or-None, nothing else (and a
         # hook returning True must not stamp a bool — see _coerce_event_id).
@@ -7914,7 +7930,17 @@ class ChatSession:
         Handled bails never propagate, so they always emit.
         """
         if reason == "error" and emit_error:
-            self.ui.on_error(message)
+            try:
+                # Guarded like _record_fatal_error's on_error: a raising
+                # duck-typed hook (bounded listener queue.Full) must not
+                # escape BEFORE the end emit below — that voided the
+                # exactly-one-end contract on both bail passes and left
+                # every pane a frozen progress bar.  Order kept
+                # (on_error first): the panes render the red row from it
+                # and treat the end event as card-teardown only.
+                self.ui.on_error(message)
+            except Exception:
+                log.debug("ui.on_error failed during compaction bail", exc_info=True)
         self._compaction_event(
             my_generation,
             {"phase": "end", "ok": False, "reason": reason, "message": message, "trigger": trigger},

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7799,16 +7799,52 @@ class ChatSession:
         not drive the activity-pill restore or animate a successor's card.
         ``my_generation`` is 0 on direct test invocations — falsy, so such
         events are never marked superseded (matching ``_check_cancelled``).
+
+        Failed ends additionally carry ``notice`` — the single display-
+        policy site: renderers show the failure message only when it is
+        true, instead of each re-deriving suppression from reason/trigger/
+        superseded (the cross-runtime drift trap the old hand-synced
+        cli.py/conversation.js clauses documented).  Error-reason ends are
+        suppressed because :meth:`_compaction_bailed` already fired the one
+        red ``on_error`` row; cancelled-auto ends because the surrounding
+        send prints its own "[Generation cancelled]"; superseded ends
+        because nobody is waiting on a force-abandoned compaction and its
+        notice mid-turn reads as the LIVE work being cancelled.
         """
         stale = bool(my_generation and my_generation != self._generation)
+        event: dict[str, Any] = {"compaction_id": my_generation, "superseded": stale, **payload}
+        if payload.get("phase") == "end" and not payload.get("ok"):
+            event["notice"] = (
+                not stale
+                and payload.get("reason") != "error"
+                and not (payload.get("reason") == "cancelled" and payload.get("trigger") == "auto")
+            )
         # getattr-guarded like on_generation_claimed/on_aux_usage: a
-        # duck-typed SessionUI predating the hook gets no compaction events
-        # rather than an AttributeError that wedges every long session at
-        # its first auto-compaction.
+        # duck-typed SessionUI predating the hook must not hit an
+        # AttributeError that wedges every long session at its first
+        # auto-compaction.
         emit = getattr(self.ui, "on_compaction", None)
         if emit is None:
+            # Pre-hook UIs get the classic info lines back (an
+            # auto-compaction must never swap history with zero
+            # announcement — the pre-1.8 lines reached every UI
+            # unconditionally).  Invoked for superseded events too: a
+            # superseded OK end announces a swap that really committed,
+            # and failed-end staleness is already encoded in ``notice``.
+            # ``on_info`` is getattr-guarded like the hook itself — the
+            # never-crash property is the floor; a UI with neither hook
+            # keeps compacting silently.  Deliberately NOT dual-emitted
+            # for hook-aware UIs or SSE: pre-1.8 SSE/SDK clients that
+            # ignore unknown `compaction` events lose these lines — a
+            # documented 1.8 breaking change (CHANGELOG); dual emission
+            # would double-render on every current client.
+            info = getattr(self.ui, "on_info", None)
+            if info is not None:
+                from turnstone.core.compaction_render import render_compaction_event_as_info
+
+                render_compaction_event_as_info(event, info)
             return None
-        result = emit({"compaction_id": my_generation, "superseded": stale, **payload})
+        result = emit(event)
         # Duck-typed hooks aren't bound to the protocol's return type; the
         # marker-stamp consumer needs int-or-None, nothing else.
         return result if isinstance(result, int) else None
@@ -9043,9 +9079,10 @@ class ChatSession:
         queue from BEFORE their window (a dying send worker's closing race)
         — the /compact worker's exit seam is the caller.  Messages sent
         DURING a command window never reach this queue: the /send route
-        parks them while ``worker_kind == "command"`` and dispatches them
-        as ordinary sends afterwards.  Must only be called by the thread
-        that owns the worker slot — it mutates ``self.messages``.
+        defers them (``ws._pending_sends``) while ``worker_kind ==
+        "command"`` and the drain task dispatches them as ordinary sends
+        afterwards.  Must only be called by the thread that owns the
+        worker slot — it mutates ``self.messages``.
         """
         return self._flush_queued_messages()
 
@@ -17338,9 +17375,10 @@ class ChatSession:
 
             # Flush any stranded queued text BEFORE the identity swap so it
             # is persisted into the workstream it was ADDRESSED to.  Sends
-            # during the command window itself park in the /send route and
-            # never queue; this covers only a message stranded by a dying
-            # send worker's closing race before this command started.
+            # during the command window itself defer in the /send route
+            # (ws._pending_sends) and never queue; this covers only a
+            # message stranded by a dying send worker's closing race
+            # before this command started.
             self._flush_queued_messages()
             self.messages.clear()
             self._read_files.clear()

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -204,7 +204,7 @@ from turnstone.core.trajectory import (
 )
 from turnstone.core.watch import WATCH_REMINDER_OPTIONAL_KEYS
 from turnstone.core.web import check_ssrf, fetch_with_ssrf_guard, strip_html
-from turnstone.core.workstream import WorkstreamKind
+from turnstone.core.workstream import PENDING_SENDS_MAX, WorkstreamKind
 from turnstone.prompts import (
     INTERACTIVE_CONSENT_CLIENT_TYPES,
     ClientType,
@@ -1370,7 +1370,11 @@ def _tool_turn_meta(
 
 
 class ChatSession:
-    _QUEUE_MAX = 10
+    # The mid-turn interjection queue's cap — an ALIAS of the shared
+    # per-workstream backpressure bound (see workstream.PENDING_SENDS_MAX):
+    # the deferred-send list refuses at the same size, so busy-window and
+    # command-window sends can never silently diverge on saturation.
+    _QUEUE_MAX = PENDING_SENDS_MAX
 
     def __init__(
         self,
@@ -5409,14 +5413,23 @@ class ChatSession:
         told to break a stale compaction activity latch here — otherwise a
         force-abandoned compaction's latch suppresses the whole successor
         turn's pill writes, re-broadcasting "Compacting context…" through
-        a live turn.  getattr-guarded like ``on_aux_usage``: minimal UI
-        stubs predate the hook and must not crash a claim.
+        a live turn.  getattr-guarded like ``on_aux_usage`` (minimal UI
+        stubs predate the hook) AND call-guarded: this emission sits on
+        send()'s PRE-turn path — before the user turn is appended, before
+        ``_record_fatal_error``'s coverage — so a raising override
+        (``_broadcast_activity`` is a documented override seam) must
+        degrade to a lost latch-break, never to a silently dropped user
+        message.  Same policy as ``_compaction_event``'s dispatch tail;
+        the claim-state writes above stay infallible either way.
         """
         self._generation += 1
         self._cancel_event = threading.Event()
         release = getattr(self.ui, "on_generation_claimed", None)
         if release is not None:
-            release(self._generation)
+            try:
+                release(self._generation)
+            except Exception:
+                log.debug("ui.on_generation_claimed raised; claim proceeds", exc_info=True)
         return self._generation
 
     def _consume_cancel(self, my_generation: int) -> bool:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -308,23 +308,59 @@ class _CancelRef(list[Any]):
     immediately.  If cancellation was already requested before the stream
     was created (e.g. cancel during retry backoff), the stream is closed
     on arrival so the blocked iteration is unblocked.
+
+    ``my_generation`` scopes a ref to one generation (compaction's summary
+    calls pass theirs; the main loop's long-lived shared ref keeps the
+    default 0 = unconditional).  A superseded ref's late-arriving stream —
+    an abandoned compaction that passed its boundary check just before a
+    force-cancel and opened one final zombie call — must neither hijack
+    ``_cancel_stream`` from the successor generation's live stream nor
+    keep burning tokens, so the append skips the registration and closes
+    the stream on arrival.  The generation check and the register are two
+    lockless statements; the residual bytecode-width TOCTOU (successor
+    claims AND registers between them) is accepted — its harm is one
+    delayed Stop (closes a dead handle; the event arm still cancels at the
+    next chunk), not corruption — versus the model-call-width window this
+    closes.
     """
 
-    __slots__ = ("_session",)
+    __slots__ = ("_session", "_my_generation")
 
-    def __init__(self, session: ChatSession) -> None:
+    def __init__(self, session: ChatSession, my_generation: int = 0) -> None:
         super().__init__()
         self._session = session
+        self._my_generation = my_generation
+
+    def _superseded(self) -> bool:
+        gen = self._my_generation
+        return bool(gen and self._session._generation != gen)
 
     def append(self, stream: Any) -> None:
         super().append(stream)
-        self._session._cancel_stream = stream
+        superseded = self._superseded()
+        if not superseded:
+            self._session._cancel_stream = stream
         # If cancel was requested before the first chunk arrived (the worker
         # thread is blocked inside the provider generator waiting for the HTTP
-        # response), close the stream immediately to unblock it.
-        if self._session._cancel_event.is_set():
+        # response), close the stream immediately to unblock it.  Same for a
+        # superseded ref's zombie stream: nobody will consume it.
+        if superseded or self._session._cancel_event.is_set():
             with contextlib.suppress(Exception):
                 stream.close()
+
+    @property
+    def aborted(self) -> bool:
+        """Whether this ref's stream must not be resurrected.
+
+        ``model_turn`` consults ``cancel_ref.aborted`` before re-issuing a
+        request after a mid-drain transport failure (the deadline daemon's
+        :class:`~turnstone.core.deadline.StreamAbortRef` contract): a
+        stream that died because :meth:`ChatSession.cancel` closed it — or
+        because it belongs to a superseded generation — must not be
+        resurrected behind the user's Stop; the failure surfaces and the
+        caller's own cancel check turns it into ``GenerationCancelled``.
+        """
+        return self._session._cancel_event.is_set() or self._superseded()
 
 
 # Image extensions handled as vision content (SVG excluded — it's XML text)
@@ -1139,6 +1175,21 @@ class SessionUI(Protocol):
     def on_system_turn(
         self, content: str, source: str, meta: dict[str, Any] | None = None
     ) -> int | None: ...
+    def on_compaction(self, payload: dict[str, Any]) -> int | None:
+        """Called through the compaction lifecycle.
+
+        ``payload["phase"]`` is ``"start"`` (fields: ``trigger`` =
+        ``"manual"``/``"auto"``, and for auto ``where``/``pct``),
+        ``"progress"`` (``part``/``total``/``depth``, or ``retry_in``/
+        ``error`` for a retry wait), or ``"end"`` (``ok``, and either
+        ``before_tokens``/``after_tokens``/``summary`` or ``reason``/
+        ``message``).  Returns the UI event id when the transport
+        assigns one (see :meth:`on_system_turn`) so the persisted
+        compaction marker row can be stamped with the matching resume
+        cursor; ``None`` for UIs without an event stream.
+        """
+        ...
+
     def on_state_change(self, state: str) -> None: ...
     def on_rename(self, name: str) -> None: ...
     def on_intent_verdict(self, verdict: dict[str, Any], judge_event: object | None = None) -> None:
@@ -3247,29 +3298,27 @@ class ChatSession:
         my_generation: int = 0,
         carry_spill: bool = False,
     ) -> bool:
-        """Emit the auto-compaction notice, compact, and refresh the status
-        line.  Shared by the mid-turn policy (:meth:`_maybe_compact_midturn`)
-        and the end-of-turn check so the notice wording, the percentage, and
-        the post-compaction status refresh stay in lockstep.  ``where`` is an
-        optional qualifier for the notice (e.g. ``"mid-turn"``); ``preserve_tail``
+        """Run an auto-compaction and refresh the status line.  Shared by the
+        mid-turn policy (:meth:`_maybe_compact_midturn`) and the end-of-turn
+        check so the trigger wording, the percentage, and the post-compaction
+        status refresh stay in lockstep.  The auto notice itself rides the
+        ``on_compaction`` start event (via ``where``/``pct``).  ``where`` is an
+        optional qualifier for that notice (e.g. ``"mid-turn"``); ``preserve_tail``
         is forwarded to :meth:`_compact_messages` (e.g. to keep an in-flight
         tool-call turn during compact-before-truncate); ``my_generation`` is
         forwarded so the message swap aborts if a newer send supersedes this one
-        mid-compaction (0 = the manual /compact path, which has no generation);
+        mid-compaction (the manual path claims its own via :meth:`compact_now`);
         ``carry_spill`` is forwarded so the end-of-turn site can copy the
         model's wind-down turn onto the summary verbatim.
         Returns whether a summary was actually produced (False if compaction
         bailed) so callers can avoid acting on a compaction that did not happen."""
-        qualifier = f" {where}" if where else ""
-        pct_display = round(self.auto_compact_pct * 100)
-        self.ui.on_info(
-            f"\n[Auto-compacting{qualifier}: prompt exceeds {pct_display}% of context window]"
-        )
         compacted = self._compact_messages(
             auto=True,
             preserve_tail=preserve_tail,
             my_generation=my_generation,
             carry_spill=carry_spill,
+            where=where,
+            threshold_pct=round(self.auto_compact_pct * 100),
         )
         self._print_status_line()
         return compacted
@@ -4826,6 +4875,7 @@ class ChatSession:
         max_tokens: int = 4096,
         temperature: float | None = None,
         reasoning_effort: str | None = None,
+        cancel_ref: list[Any] | None = None,
     ) -> ModelTurnResult:
         """Run a lightweight internal completion (title gen, compaction,
         extraction) through ``model_turn`` on the session's primary lane.
@@ -4867,6 +4917,13 @@ class ChatSession:
             max_tokens=clamped,
             temperature=self.temperature if temperature is None else temperature,
             reasoning_effort=reasoning_effort,
+            # The abort seam (default None): compaction passes a fresh
+            # per-attempt _CancelRef so a user Stop closes the in-flight
+            # summary HTTP stream instead of waiting it out.  Title-gen
+            # keeps None (not user-cancellable), and web-fetch extraction
+            # MUST keep None — it runs on parallel tool threads and a
+            # registration would clobber the main stream's _cancel_stream.
+            cancel_ref=cancel_ref,
         )
         # Utility completions (title gen, compaction, web-fetch extraction)
         # bypass the streaming on_status path — record their usage so the
@@ -5264,7 +5321,9 @@ class ChatSession:
                 last_err = e
                 delay = self._RETRY_BASE_DELAY * (2**attempt)
                 self.ui.on_info(f"[Retrying in {delay:.0f}s: {ename}]")
-                time.sleep(delay)
+                # Cancel-aware backoff (event arm only — no generation in
+                # scope here, matching the loop-top _check_cancelled()).
+                self._backoff_or_cancelled(delay)
         assert last_err is not None  # unreachable, but satisfies type checker
         raise last_err
 
@@ -5307,6 +5366,65 @@ class ChatSession:
             raise GenerationCancelled()
         if my_generation and my_generation != self._generation:
             raise GenerationCancelled()
+
+    def _claim_generation(self) -> int:
+        """Claim the next generation and install its fresh cancel event.
+
+        The entry half of the per-generation cancel discipline shared by
+        :meth:`send` and :meth:`compact_now`.  The old event object stays
+        set for any abandoned thread — ``_exec_bash`` captures a local
+        reference so subprocesses from old generations are still killed.
+
+        The claim is also the exact moment any prior compaction becomes
+        provably stale (the worker slot serializes turns), so the UI is
+        told to break a stale compaction activity latch here — otherwise a
+        force-abandoned compaction's latch suppresses the whole successor
+        turn's pill writes, re-broadcasting "Compacting context…" through
+        a live turn.  getattr-guarded like ``on_aux_usage``: minimal UI
+        stubs predate the hook and must not crash a claim.
+        """
+        self._generation += 1
+        self._cancel_event = threading.Event()
+        release = getattr(self.ui, "on_generation_claimed", None)
+        if release is not None:
+            release(self._generation)
+        return self._generation
+
+    def _consume_cancel(self, my_generation: int) -> bool:
+        """Clear this generation's cancel signal on exit; report if one landed.
+
+        The exit half of the per-generation discipline: a cancel that
+        targeted THIS generation must not leak into a later idle operation.
+        Only acts while still the active generation — a successor owns a
+        fresh event that must not be cleared from under it.  Returns
+        whether a cancel had been requested (set-but-unraised), so a
+        caller whose body completed anyway can still honor the stop.
+        """
+        if self._generation != my_generation:
+            return False
+        landed = self._cancel_event.is_set()
+        self._cancel_event.clear()
+        return landed
+
+    def _backoff_or_cancelled(self, delay: float, my_generation: int = 0) -> None:
+        """Sleep out a retry backoff, aborting the instant a Stop lands.
+
+        Waits on the CURRENT cancel event rather than ``time.sleep`` so a
+        cancel during a (possibly minutes-long exponential) backoff aborts
+        immediately instead of burning the delay plus one more model call.
+        Two arms, both required: the event object is replaced per
+        generation, so a wait on a superseded generation's old event can
+        time out without ever seeing the successor's cancel — the
+        ``_check_cancelled`` re-check catches that via its generation arm.
+        ``my_generation=0`` callers keep event-arm-only semantics (same
+        default as ``_check_cancelled``).  Raises
+        :class:`GenerationCancelled` — the shared shape for EVERY retry
+        backoff on this class: a hand-rolled ``time.sleep`` backoff is
+        Stop-blind and burns the full delay plus one more model call.
+        """
+        if self._cancel_event.wait(delay):
+            raise GenerationCancelled() from None
+        self._check_cancelled(my_generation)
 
     def _append_user_turn(
         self,
@@ -5734,12 +5852,7 @@ class ChatSession:
         # would otherwise leave the latch set on the long-lived session and
         # trip a premature, advisory-skipping compaction on the next send.
         self._compaction_advised = False
-        self._generation += 1
-        my_generation = self._generation
-        # Fresh cancel event per generation.  The old event object stays
-        # set for any abandoned thread — _exec_bash captures a local
-        # reference so subprocesses from old generations are still killed.
-        self._cancel_event = threading.Event()
+        my_generation = self._claim_generation()
         self._cancelled_partial_msg = None
         # Fresh per-send attachment wire-part memo (see __init__): bounds the
         # heavy rasterized-page parts to one send and picks up any mid-session
@@ -6333,12 +6446,10 @@ class ChatSession:
             # Consume this generation's cancel signal on exit so a cancel that
             # targeted THIS send can't later abort an unrelated idle operation
             # (e.g. a manual /compact between sends would otherwise inherit the
-            # still-set event).  Only when still the active generation — a newer
-            # send owns a fresh event we must not clear out from under it.  This is
-            # why a manual /compact no longer needs to reset the event itself
-            # (which would have disarmed a cancel aimed at a concurrent send).
-            if self._generation == my_generation:
-                self._cancel_event.clear()
+            # still-set event).  A late-landing cancel needs no extra handling
+            # here — send's exits never auto-run further work (queued messages
+            # are flushed, not answered), unlike compact_now's.
+            self._consume_cancel(my_generation)
 
     def _drain_pending_advisories(self) -> None:
         """Drop the abandoned generation's advisory nudges — not external events.
@@ -7438,7 +7549,7 @@ class ChatSession:
             batches.append(current)
         return batches
 
-    def _summarize_once(self, system_prompt: str, body: str) -> str:
+    def _summarize_once(self, system_prompt: str, body: str, my_generation: int = 0) -> str:
         """Run one summary completion over ``body`` and return the cleaned text.
 
         Owns the retry loop (transient errors only, exponential backoff) and the
@@ -7455,25 +7566,51 @@ class ChatSession:
                 result = self._utility_completion(
                     summary_msgs,
                     max_tokens=self._summary_output_tokens(),
+                    # Fresh per-attempt abort seam: _CancelRef.append
+                    # registers the summary HTTP stream in _cancel_stream
+                    # eagerly (and closes on arrival if a Stop already
+                    # landed), so cancel() aborts the blocked read instead
+                    # of waiting out a whole model call — the force-stop
+                    # orphan window collapses from one summary call to the
+                    # next checkpoint.  A fresh instance (never the shared
+                    # self._cancel_ref) keeps the main loop's per-attempt
+                    # clear and [0]-fallback semantics untouched, and the
+                    # boundary checks in _summarize_batch/_backoff guarantee
+                    # a superseded compaction makes no further calls — so
+                    # it can never clobber a successor's registration.
+                    cancel_ref=_CancelRef(self, my_generation),
                 )
                 break
             except Exception as e:
+                # A closed-by-cancel stream surfaces as a provider error —
+                # map it to the cancel BEFORE the retry policy reads it, so
+                # a Stop on the final attempt ends the compaction as
+                # cancelled, never as a red "Compaction failed" (the main
+                # drain path makes the same closed-stream→GenerationCancelled
+                # translation).
+                self._check_cancelled(my_generation)
                 ename = type(e).__name__
                 if self._stop_retrying(e, attempt, self._provider):
                     # Overflow is deterministic — let _summarize_batch subdivide
                     # instead of retrying an identical oversized call.
                     raise
                 delay = self._RETRY_BASE_DELAY * (2**attempt)
-                self.ui.on_info(f"[Compact retrying in {delay:.0f}s: {ename}]")
-                time.sleep(delay)
+                self._compaction_event(
+                    my_generation, {"phase": "progress", "retry_in": delay, "error": ename}
+                )
+                self._backoff_or_cancelled(delay, my_generation)
         assert result is not None
         # Strip any <think>/<reasoning> tags the summarizer may emit
         summary = self._strip_reasoning(result.content or "")
         if result.finish_reason == "length":
-            self.ui.on_info("[Warning: compaction summary was truncated]")
+            self._compaction_event(
+                my_generation, {"phase": "progress", "warning": "summary_truncated"}
+            )
         return summary
 
-    def _summarize_blocks(self, blocks: list[str], *, depth: int = 0) -> str:
+    def _summarize_blocks(
+        self, blocks: list[str], *, depth: int = 0, my_generation: int = 0
+    ) -> str:
         """Summarize ``blocks`` into one dense summary, chunking + recursing so no
         single model call exceeds the model window.
 
@@ -7502,7 +7639,7 @@ class ChatSession:
             raise _CompactionIrreducibleError
         batches = self._pack_blocks(blocks, self._summary_input_budget_chars())
         if len(batches) == 1:
-            return self._summarize_batch(system_prompt, batches[0], depth)
+            return self._summarize_batch(system_prompt, batches[0], depth, my_generation)
 
         # More than one batch: recurse-merge the per-batch summaries.  A block-count
         # guard would be wrong here — _summarize_batch's binary subdivision can
@@ -7511,11 +7648,18 @@ class ChatSession:
         total = len(batches)
         summaries: list[str] = []
         for k, batch in enumerate(batches, start=1):
-            self.ui.on_info(f"[compacting part {k}/{total}…]")
-            summaries.append(self._summarize_batch(system_prompt, batch, depth))
-        return self._summarize_blocks(summaries, depth=depth + 1)
+            # depth 0 = summarizing transcript batches; depth > 0 = merging
+            # partial summaries.  The web card renders depth 0 as a
+            # determinate part-k-of-N bar and deeper levels as a merge note.
+            self._compaction_event(
+                my_generation, {"phase": "progress", "part": k, "total": total, "depth": depth}
+            )
+            summaries.append(self._summarize_batch(system_prompt, batch, depth, my_generation))
+        return self._summarize_blocks(summaries, depth=depth + 1, my_generation=my_generation)
 
-    def _summarize_batch(self, system_prompt: str, batch: list[str], depth: int) -> str:
+    def _summarize_batch(
+        self, system_prompt: str, batch: list[str], depth: int, my_generation: int = 0
+    ) -> str:
         """Summarize one packed batch, subdividing on a token-window overflow.
 
         The char budget that produced ``batch`` is only an estimate, so the model
@@ -7533,10 +7677,13 @@ class ChatSession:
         # Cooperative cancellation: a cancel mid-compaction aborts here.  It raises
         # GenerationCancelled (a BaseException), so _compact_messages' ``except
         # Exception`` can't swallow it and the message-swap below never runs — the
-        # history is left untouched.
-        self._check_cancelled()
+        # history is left untouched.  my_generation matters for the force-cancel
+        # orphan: a successor's claim REPLACES the cancel event, so the event arm
+        # alone would let an abandoned compaction keep issuing summary calls —
+        # the generation arm is what retires it at the next batch boundary.
+        self._check_cancelled(my_generation)
         try:
-            return self._summarize_once(system_prompt, "\n\n".join(batch))
+            return self._summarize_once(system_prompt, "\n\n".join(batch), my_generation)
         except Exception as e:
             if not _is_ctx_overflow(e):
                 raise
@@ -7547,9 +7694,11 @@ class ChatSession:
                 # as fits — a wide over-window batch costs ~log2(N) calls, not one
                 # model call per block.
                 mid = len(batch) // 2
-                left = self._summarize_batch(system_prompt, batch[:mid], depth)
-                right = self._summarize_batch(system_prompt, batch[mid:], depth)
-                return self._summarize_blocks([left, right], depth=depth + 1)
+                left = self._summarize_batch(system_prompt, batch[:mid], depth, my_generation)
+                right = self._summarize_batch(system_prompt, batch[mid:], depth, my_generation)
+                return self._summarize_blocks(
+                    [left, right], depth=depth + 1, my_generation=my_generation
+                )
             # A lone block overflows by itself: the char budget over-estimated how
             # many tokens it holds.  Shrink progressively — halve the truncation
             # budget and retry, keeping as much of the message as the real window
@@ -7561,7 +7710,7 @@ class ChatSession:
             while True:
                 try:
                     return self._summarize_once(
-                        system_prompt, self._truncate_block(batch[0], budget)
+                        system_prompt, self._truncate_block(batch[0], budget), my_generation
                     )
                 except Exception as e2:
                     if not _is_ctx_overflow(e2):
@@ -7571,6 +7720,134 @@ class ChatSession:
                     budget = max(self._MIN_SUMMARY_BUDGET_CHARS, budget // 2)
 
     def _compact_messages(
+        self,
+        auto: bool = False,
+        preserve_tail: int = 0,
+        my_generation: int = 0,
+        carry_spill: bool = False,
+        where: str = "",
+        threshold_pct: int | None = None,
+    ) -> bool:
+        """Compact conversation history — the lifecycle-event wrapper.
+
+        Owns the cooperative-latch clear and the ``on_compaction`` lifecycle
+        contract: exactly one ``start`` event, then exactly one ``end`` event
+        on EVERY exit — the handled bails inside
+        :meth:`_compact_messages_impl` emit their own failed ``end`` (with a
+        per-site reason), and this wrapper backstops the raising exits
+        (``GenerationCancelled`` from a cancel mid-summary, unexpected
+        errors) so a UI that painted an in-progress card on ``start`` can
+        never be left with a stuck progress bar.  ``where`` is the auto
+        trigger's qualifier (``"mid-turn"`` …) and ``threshold_pct`` the
+        auto-compact percentage — both ride the ``start`` event, and only
+        :meth:`_do_auto_compact` passes the pct: the context-overflow retry
+        path also compacts with ``auto=True`` but never evaluated the
+        threshold, so a pct there would fabricate a trigger explanation
+        contradicting the overflow notice printed a line above it.
+        """
+        # Clear the cooperative latch on every compaction *attempt*, ahead of
+        # the early-return guards in the impl — a bailed compaction (too few/
+        # large messages, summary error) must fall back to the advisory grace
+        # state next cycle rather than retry-storm on the same over-soft
+        # estimate.
+        self._compaction_advised = False
+        trigger = "auto" if auto else "manual"
+        start_payload: dict[str, Any] = {"phase": "start", "trigger": trigger}
+        if auto:
+            start_payload["where"] = where
+            if threshold_pct is not None:
+                start_payload["pct"] = threshold_pct
+        self._compaction_event(my_generation, start_payload)
+        try:
+            return self._compact_messages_impl(auto, preserve_tail, my_generation, carry_spill)
+        except BaseException as e:
+            # GenerationCancelled is a BaseException — the except above the
+            # message swap lets it propagate so history stays untouched; the
+            # UIs still need the end event to retire the in-progress card.
+            # Any OTHER non-Exception BaseException (KeyboardInterrupt at
+            # the CLI, SystemExit) is a deliberate abort too, not a
+            # compaction failure — report cancelled, never a red error row
+            # (str(KeyboardInterrupt()) is "" and would render "Compaction
+            # failed: ").
+            cancelled = isinstance(e, GenerationCancelled) or not isinstance(e, Exception)
+            message = "Compaction cancelled." if cancelled else f"Compaction failed: {e}"
+            # _compaction_bailed is the single failed-end emitter.  The
+            # error notification is trigger-scoped: AUTO raising exits
+            # propagate into send()'s fatal handler, which fires the one
+            # on_error — emitting here too doubled the red rows and the
+            # error metric.  MANUAL raising exits have no downstream
+            # emitter (the web compact worker's runner only logs; the CLI
+            # REPL suppresses below), so the wrapper's is the one red row.
+            self._compaction_bailed(
+                "cancelled" if cancelled else "error",
+                message,
+                trigger=trigger,
+                my_generation=my_generation,
+                emit_error=(trigger == "manual"),
+            )
+            raise
+
+    def _compaction_event(self, my_generation: int, payload: dict[str, Any]) -> int | None:
+        """Emit one compaction lifecycle event stamped with its owning id.
+
+        ``compaction_id`` (the owning generation) ties every progress/end
+        event to the compaction that started it, and ``superseded`` marks
+        events from a generation that is no longer current (a
+        force-abandoned worker running out its last summary call).
+        :meth:`SessionUIBase.on_compaction <turnstone.core.session_ui_base.SessionUIBase.on_compaction>`
+        consumes ``superseded`` (never enqueued): a superseded event must
+        not drive the activity-pill restore or animate a successor's card.
+        ``my_generation`` is 0 on direct test invocations — falsy, so such
+        events are never marked superseded (matching ``_check_cancelled``).
+        """
+        stale = bool(my_generation and my_generation != self._generation)
+        # getattr-guarded like on_generation_claimed/on_aux_usage: a
+        # duck-typed SessionUI predating the hook gets no compaction events
+        # rather than an AttributeError that wedges every long session at
+        # its first auto-compaction.
+        emit = getattr(self.ui, "on_compaction", None)
+        if emit is None:
+            return None
+        result = emit({"compaction_id": my_generation, "superseded": stale, **payload})
+        # Duck-typed hooks aren't bound to the protocol's return type; the
+        # marker-stamp consumer needs int-or-None, nothing else.
+        return result if isinstance(result, int) else None
+
+    def _compaction_bailed(
+        self,
+        reason: str,
+        message: str,
+        *,
+        trigger: str,
+        my_generation: int,
+        emit_error: bool = True,
+    ) -> bool:
+        """Emit a failed-compaction ``end`` event and return ``False``.
+
+        The single failed-end emitter: :meth:`_compact_messages_impl`'s
+        handled bails AND the wrapper's raising backstop both route here —
+        each carries a machine ``reason`` (drives the web card's failure
+        state) and the human ``message``.  ``reason="error"``
+        additionally fires :meth:`on_error` — the typed error event and the
+        Prometheus error counter this path fed before the lifecycle events
+        existed; the panes render the red row from THAT and treat the end
+        event as card-teardown only, so the text isn't shown twice.
+
+        ``emit_error=False`` is the RAISING backstop's auto-trigger arm:
+        those exceptions propagate into ``send()``'s fatal handler, whose
+        ``_record_fatal_error`` fires the single on_error — a second one
+        here doubled every pane's red rows and the node's error metric.
+        Handled bails never propagate, so they always emit.
+        """
+        if reason == "error" and emit_error:
+            self.ui.on_error(message)
+        self._compaction_event(
+            my_generation,
+            {"phase": "end", "ok": False, "reason": reason, "message": message, "trigger": trigger},
+        )
+        return False
+
+    def _compact_messages_impl(
         self,
         auto: bool = False,
         preserve_tail: int = 0,
@@ -7603,14 +7880,16 @@ class ChatSession:
         the summarizer also reads the spill, but its paraphrase must not be
         the only survivor.
         """
-        # Clear the cooperative latch on every compaction *attempt*, ahead of
-        # the early-return guards below — a bailed compaction (too few/large
-        # messages, summary error) must fall back to the advisory grace state
-        # next cycle rather than retry-storm on the same over-soft estimate.
-        self._compaction_advised = False
+        # Presentation label derived from the one semantic flag — deriving
+        # locally makes an auto=True/trigger="manual" drift impossible.
+        trigger = "auto" if auto else "manual"
         if len(self.messages) < 2:
-            self.ui.on_info("Not enough messages to compact.")
-            return False
+            return self._compaction_bailed(
+                "not_enough_messages",
+                "Not enough messages to compact.",
+                trigger=trigger,
+                my_generation=my_generation,
+            )
 
         # Optionally keep the last ``preserve_tail`` messages verbatim — e.g. an
         # in-flight assistant tool-call whose results are about to be appended, or
@@ -7645,24 +7924,37 @@ class ChatSession:
         to_summarize_dicts = dicts_from_turns(to_summarize)
         blocks = self._summary_blocks(to_summarize_dicts)
         if not blocks:
-            self.ui.on_info("Not enough messages to compact.")
-            return False
+            return self._compaction_bailed(
+                "not_enough_messages",
+                "Not enough messages to compact.",
+                trigger=trigger,
+                my_generation=my_generation,
+            )
 
         self.ui.on_thinking_start()
         try:
-            summary = self._summarize_blocks(blocks)
+            summary = self._summarize_blocks(blocks, my_generation=my_generation)
         except _CompactionIrreducibleError:
-            self.ui.on_info("Messages too large to fit in summary context.")
-            return False
+            return self._compaction_bailed(
+                "irreducible",
+                "Messages too large to fit in summary context.",
+                trigger=trigger,
+                my_generation=my_generation,
+            )
         except Exception as e:
-            self.ui.on_error(f"Compaction failed: {e}")
-            return False
+            return self._compaction_bailed(
+                "error", f"Compaction failed: {e}", trigger=trigger, my_generation=my_generation
+            )
         finally:
             self.ui.on_thinking_stop()
 
         if not summary.strip():
-            self.ui.on_info("Compaction produced an empty summary; keeping history.")
-            return False
+            return self._compaction_bailed(
+                "empty_summary",
+                "Compaction produced an empty summary; keeping history.",
+                trigger=trigger,
+                my_generation=my_generation,
+            )
 
         # The verbatim carries: the wind-down spill and the continuation-hint
         # quote of the ask.  Both can fire on the SAME compaction (the
@@ -7772,14 +8064,20 @@ class ChatSession:
                 "total_tokens": after_tokens,
             }
 
-        self.ui.on_info(f"[compacted: ~{before_tokens:,} -> ~{after_tokens:,} tokens]")
-        separator = "\u2500" * 60
-        lines = [separator]
-        for line in summary.splitlines():
-            lines.append(f"  {line}")
-        lines.append(separator)
-        self.ui.on_info("\n".join(lines))
-
+        # The successful end event carries everything a UI needs to paint the
+        # result card (token delta + the summary text); its id stamps the
+        # marker row below so /history and the live stream stay aligned.
+        end_event_id = self._compaction_event(
+            my_generation,
+            {
+                "phase": "end",
+                "ok": True,
+                "trigger": trigger,
+                "before_tokens": before_tokens,
+                "after_tokens": after_tokens,
+                "summary": summary,
+            },
+        )
         # Persist a compaction checkpoint so a reopen rehydrates [summary]+[tail]
         # instead of the full transcript — which, on a long session or one switched
         # to a smaller-context model, can exceed the window and deadlock the first
@@ -7792,13 +8090,27 @@ class ChatSession:
         if self._ws_id:
             watermark = get_compaction_watermark(self._ws_id, preserve_tail)
             if watermark is not None:
+                # ``before_tokens``/``after_tokens``/``trigger`` are display
+                # additions for the /history compaction card; the resume
+                # slice reads only ``watermark`` (parse_checkpoint_watermark
+                # ignores the extra keys).  The row is stamped with the end
+                # event's id so a fresh-connect cursor computed from /history
+                # sits at-or-past the live event — repaint and replay can't
+                # both render the card.
                 save_message(
                     self._ws_id,
                     "assistant",
                     summary,
                     source=COMPACTION_SOURCE,
-                    meta=json.dumps({"watermark": watermark}),
-                    event_id=self._ui_event_id(),
+                    meta=json.dumps(
+                        {
+                            "watermark": watermark,
+                            "before_tokens": before_tokens,
+                            "after_tokens": after_tokens,
+                            "trigger": trigger,
+                        }
+                    ),
+                    event_id=end_event_id if end_event_id is not None else self._ui_event_id(),
                     producer=self._provider.provider_name if self._provider else None,
                 )
         return True
@@ -8724,6 +9036,79 @@ class ChatSession:
             popped = self._queued_messages.pop(msg_id, None)
         return popped is not None
 
+    def flush_queued_messages(self) -> bool:
+        """Drain queued messages into a combined user turn (public seam).
+
+        Defensive backstop for workers that can find text stranded in the
+        queue from BEFORE their window (a dying send worker's closing race)
+        — the /compact worker's exit seam is the caller.  Messages sent
+        DURING a command window never reach this queue: the /send route
+        parks them while ``worker_kind == "command"`` and dispatches them
+        as ordinary sends afterwards.  Must only be called by the thread
+        that owns the worker slot — it mutates ``self.messages``.
+        """
+        return self._flush_queued_messages()
+
+    @staticmethod
+    def _combine_queued_items(items: list[tuple[str, str]]) -> str:
+        """Render drained queue items to one text block ([IMPORTANT] framing)."""
+        from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
+
+        return "\n\n".join(
+            f"[IMPORTANT] {msg}" if pri == PRIORITY_IMPORTANT else msg for msg, pri in items
+        )
+
+    def compact_now(self) -> bool:
+        """Manual compaction with send()'s full generation discipline.
+
+        The web /compact worker path.  Mirrors send()'s entry — claim the
+        next generation and install a fresh cancel event — so:
+
+        * an abandoned (force-cancelled) compaction can never swap history
+          under a successor turn: the successor's claim makes this
+          generation stale and the pre-swap ``_check_cancelled`` raises
+          (send() prevents the identical race the identical way);
+        * a cancel that landed while idle (a Stop click between turns)
+          can't instantly abort the next /compact — the stale set event is
+          replaced here, exactly as send() replaces it per generation;
+        * a cancel aimed at THIS compaction is consumed on exit (while
+          still the active generation), so it can't leak into a later idle
+          operation — previously nothing cleared it until the next send,
+          which bricked every /compact retry as instantly \"cancelled\".
+
+        Raises :class:`GenerationCancelled` (after consuming the event) so
+        the caller can distinguish a user stop from a bail; returns whether
+        a summary was produced otherwise.  That raise ALSO covers a Stop
+        that lands after the impl's last cancel check (the swap /
+        marker-persist tail) or during a retry backoff that then bails:
+        the compaction outcome stands, but an explicit Stop must never be
+        silently eaten — the caller must not auto-run anything on the
+        user's behalf after one.  The CLI's ``handle_command`` route
+        delegates here too — the REPL is single-threaded so the discipline
+        is redundant there, but one path means one behaviour.
+        """
+        my_generation = self._claim_generation()
+        cancel_landed = False
+        try:
+            compacted = self._compact_messages(my_generation=my_generation)
+        finally:
+            # Consume this generation's cancel signal (send()'s exit does
+            # the same).  A body raise propagates past this; the landed
+            # flag matters only on the completed-anyway paths below.
+            cancel_landed = self._consume_cancel(my_generation)
+        if compacted:
+            # Refresh the status line/context pill so the freed window is
+            # visible immediately — parity with _do_auto_compact.  BEFORE
+            # honoring a tail-landing Stop: the compaction genuinely
+            # happened (swap + marker + OK card), so the pill must reflect
+            # it either way — the raise below only suppresses follow-up
+            # work, it must not leave the pill claiming a full context
+            # next to a "context compacted" card.
+            self._print_status_line()
+        if cancel_landed:
+            raise GenerationCancelled()
+        return compacted
+
     def _flush_queued_messages(self, prefix: str = "") -> bool:
         """Drain queued messages into a single combined user turn.
 
@@ -8743,21 +9128,19 @@ class ChatSession:
         Returns ``True`` when any user row was appended (prefix or
         items), ``False`` when both were empty.
         """
-        from turnstone.core.tool_advisory import PRIORITY_IMPORTANT
-
         with self._queued_lock:
             items = list(self._queued_messages.values())
             self._queued_messages.clear()
-        if not items and not prefix:
+        queued_text = self._combine_queued_items(items)
+        if not queued_text and not prefix:
             return False
 
-        parts = [f"[IMPORTANT] {msg}" if pri == PRIORITY_IMPORTANT else msg for msg, pri in items]
-        if prefix and parts:
-            content = prefix + "\n\n" + "\n\n".join(parts)
+        if prefix and queued_text:
+            content = prefix + "\n\n" + queued_text
         elif prefix:
             content = prefix
         else:
-            content = "\n\n".join(parts)
+            content = queued_text
         self._append_user_turn(content, ())
         return True
 
@@ -15212,7 +15595,9 @@ class ChatSession:
                     last_err = e
                     delay = self._RETRY_BASE_DELAY * (2**attempt)
                     self.ui.on_info(f"[{label} retrying in {delay:.0f}s: {ename}]")
-                    time.sleep(delay)
+                    # Cancel-aware backoff: a Stop mid-agent-retry aborts
+                    # the run instead of burning the delay + one more call.
+                    self._backoff_or_cancelled(delay)
             assert last_err is not None  # unreachable
             raise last_err
 
@@ -16174,7 +16559,10 @@ class ChatSession:
                         max_retries=self._NOTIFY_MAX_RETRIES,
                         retry_delay=delay,
                     )
-                    time.sleep(delay)
+                    # Cancel-aware: notify runs as an in-turn tool, so a
+                    # Stop aborts pending delivery retries with the turn
+                    # (the batch synthesizes the cancelled tool_result).
+                    self._backoff_or_cancelled(delay)
                     continue
                 log.warning("notify.no_services_exhausted")
                 msg = "Error: no channel gateway services available"
@@ -16223,7 +16611,8 @@ class ChatSession:
                     gateway_count=len(services),
                     retry_delay=delay,
                 )
-                time.sleep(delay)
+                # Same cancel-aware backoff as the no-services arm above.
+                self._backoff_or_cancelled(delay)
             else:
                 log.warning(
                     "notify.delivery_failed",
@@ -16947,6 +17336,12 @@ class ChatSession:
         elif cmd == "/new":
             from turnstone.core.memory import register_workstream
 
+            # Flush any stranded queued text BEFORE the identity swap so it
+            # is persisted into the workstream it was ADDRESSED to.  Sends
+            # during the command window itself park in the /send route and
+            # never queue; this covers only a message stranded by a dying
+            # send worker's closing race before this command started.
+            self._flush_queued_messages()
             self.messages.clear()
             self._read_files.clear()
             self._repeat_detector.clear()
@@ -17009,6 +17404,10 @@ class ChatSession:
                 elif target_id == self._ws_id:
                     self.ui.on_info("Already in that workstream.")
                 else:
+                    # Same pre-swap flush as /new: stranded queued text is
+                    # persisted into the CURRENT workstream before resume()
+                    # swaps this session's identity to the target.
+                    self._flush_queued_messages()
                     try:
                         resumed: bool | None = self.resume(target_id)
                     except ValueError as exc:
@@ -17159,13 +17558,17 @@ class ChatSession:
                     self.ui.on_info(f"Invalid. Choose from: {', '.join(valid)}")
 
         elif cmd == "/compact":
-            try:
-                self._compact_messages()
-            except GenerationCancelled:
-                # Ctrl-C during a manual compaction aborts cleanly — the message
-                # swap never ran (the cancel-check precedes it), so history is
-                # intact, exactly like cancelling a send.
-                self.ui.on_info("Compaction cancelled.")
+            # Ctrl-C during a manual compaction aborts cleanly — the message
+            # swap never ran (the cancel-check precedes it), so history is
+            # intact, exactly like cancelling a send.  The lifecycle wrapper
+            # already emitted the cancelled end event, so every UI has been
+            # told; nothing more to print here.  Unexpected errors are also
+            # swallowed: the wrapper's manual-trigger backstop already fired
+            # on_error (the red row), and the CLI REPL calls handle_command
+            # with no try/except — re-raising would crash the whole REPL on
+            # a compaction failure (history is untouched on raising exits).
+            with contextlib.suppress(GenerationCancelled, Exception):
+                self.compact_now()
 
         elif cmd == "/creative":
             # Recognized but decommissioned: print a live migration pointer

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from starlette.routing import BaseRoute
 
     from turnstone.core.attachments import UploadRejection
+    from turnstone.core.session import ChatSession
     from turnstone.core.session_manager import SessionManager
     from turnstone.core.session_ui_base import SessionUIBase
     from turnstone.core.workstream import Workstream, WorkstreamKind
@@ -1365,6 +1366,18 @@ def make_cancel_handler(
                 # ``session_worker.send`` documents this invariant:
                 # "readers gating on either flag see a coherent
                 # (worker_thread, _worker_running) pair."
+                #
+                # Documented bet — force-cancelling a wedged QUICK command
+                # (worker_kind == "command", e.g. /resume stuck in storage
+                # I/O): clearing the flag releases any parked /send, whose
+                # fresh worker can then run while the abandoned command
+                # thread finishes its in-place mutation — quick commands
+                # have no generation checkpoints to retire them (compact_now
+                # does).  Same blast radius as force-abandoning a send
+                # worker mid-tool; accepted because force-cancel is the
+                # operator escape hatch for an already-wedged session, not a
+                # routine path.  Revisit if commands ever gain generation
+                # discipline.
                 with ws._lock:
                     ws.worker_thread = None
                     ws._worker_running = False
@@ -3444,9 +3457,17 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         cursor: int | None = None
         if storage is not None:
             try:
-                # repair=False — display read; see reconstruct_messages docstring.
+                # repair=False — display read; include_compaction=True so a
+                # persisted compaction marker projects as an in-place
+                # source="compaction" system row and the UI re-renders its
+                # compaction card after a reload.  See the
+                # reconstruct_messages docstring for both flags.
                 messages = await asyncio.to_thread(
-                    storage.load_messages, ws_id, limit=limit, repair=False
+                    storage.load_messages,
+                    ws_id,
+                    limit=limit,
+                    repair=False,
+                    include_compaction=True,
                 )
             except Exception:
                 log.debug("ws.history.load_failed ws=%s", ws_id[:8], exc_info=True)
@@ -4072,32 +4093,96 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         if ws.session is None:
             return JSONResponse({"error": "No session"}, status_code=500)
 
-        session = ws.session
-        # Captured by ``_enqueue`` only when the dispatcher takes the
-        # live-worker reuse path. Empty after a fresh-spawn dispatch.
-        queue_outcome: dict[str, Any] = {}
+        def _dispatch_once(session: ChatSession) -> tuple[bool, dict[str, Any]]:
+            """One atomic queue-or-spawn attempt bound to ONE session capture.
 
-        def _enqueue() -> None:
-            try:
-                cleaned, priority, msg_id = session.queue_message(
-                    message,
-                    attachment_ids=list(ordered_taken),
-                    queue_msg_id=send_id or None,
-                    interjector_user_id=acting_uid,
-                )
-            except AttachmentsNotQueueableError:
-                queue_outcome["rejected"] = "attachments_busy"
-                return
-            except CrossUserInterjectionError:
-                # A different authenticated participant tried to interject into
-                # someone else's in-flight turn; folding it in would borrow the
-                # initiator's credentials and misattribute the message. Reject
-                # so they resend as a fresh turn once the worker idles.
-                queue_outcome["rejected"] = "cross_user_interjection"
-                return
-            queue_outcome["cleaned"] = cleaned
-            queue_outcome["priority"] = priority
-            queue_outcome["msg_id"] = msg_id
+            The park loop below re-captures ``ws.session`` before every
+            attempt — a /resume or /new that ran while we parked swaps the
+            session's workstream identity in place, and closures bound to
+            the pre-swap capture would send the user's message into the
+            wrong workstream's transcript.  Binding happens here, in one
+            place, per attempt.  ``queue_outcome`` is written only when the
+            dispatcher takes the live-worker reuse path; empty after a
+            fresh-spawn dispatch.
+            """
+            queue_outcome: dict[str, Any] = {}
+
+            def _enqueue() -> None:
+                # Runs under ``ws._lock`` (session_worker.send calls it
+                # inside the same acquisition that reads _worker_running),
+                # so this worker_kind read cannot race the spawn write.  A
+                # command window must NEVER reach queue_message — its cap
+                # and cross-user guard are turn semantics — so refuse and
+                # let the route loop back to the park.
+                if ws.worker_kind == "command":
+                    queue_outcome["rejected"] = "command_window"
+                    return
+                try:
+                    cleaned, priority, msg_id = session.queue_message(
+                        message,
+                        attachment_ids=list(ordered_taken),
+                        queue_msg_id=send_id or None,
+                        interjector_user_id=acting_uid,
+                    )
+                except AttachmentsNotQueueableError:
+                    queue_outcome["rejected"] = "attachments_busy"
+                    return
+                except CrossUserInterjectionError:
+                    # A different authenticated participant tried to interject into
+                    # someone else's in-flight turn; folding it in would borrow the
+                    # initiator's credentials and misattribute the message. Reject
+                    # so they resend as a fresh turn once the worker idles.
+                    queue_outcome["rejected"] = "cross_user_interjection"
+                    return
+                queue_outcome["cleaned"] = cleaned
+                queue_outcome["priority"] = priority
+                queue_outcome["msg_id"] = msg_id
+
+            def _run() -> None:
+                me = threading.current_thread()
+                try:
+                    kwargs: dict[str, Any] = {}
+                    if resolved_atts:
+                        kwargs["attachments"] = resolved_atts
+                    if send_id:
+                        kwargs["send_id"] = send_id
+                    # Fresh turn: rebind per-user MCP credentials to the
+                    # authenticated sender. Bound here (not via a send()
+                    # kwarg) so per-kind session stubs with explicit send
+                    # signatures keep working; getattr-guarded for the same
+                    # reason. The queue path above never rebinds.
+                    bind = getattr(session, "bind_acting_user", None)
+                    if acting_uid and callable(bind):
+                        bind(acting_uid)
+                    session.send(message, **kwargs)
+                except GenerationCancelled:
+                    # Safety net — send() normally handles this internally.
+                    # If this thread was force-abandoned, ws.worker_thread
+                    # was set to None — don't emit spurious events.
+                    if ws.worker_thread is me:
+                        _emit_ui("on_stream_end")
+                        _emit_ui("on_state_change", "idle")
+                except Exception:
+                    # Undrained staged uploads aren't locked (the buffer is a peek,
+                    # not a reservation) — they expire on the buffer TTL — so the
+                    # only cleanup owed here is the UI streaming hook.
+                    if ws.worker_thread is me:
+                        # ``session.send()`` already fired ``on_error``
+                        # (with sanitized text), persisted ``last_error``,
+                        # and emitted ``state='error'`` via
+                        # :meth:`ChatSession._record_fatal_error` before
+                        # re-raising.  The route handler only needs the
+                        # streaming-cleanup hook the worker contract owes
+                        # the UI listeners.
+                        _emit_ui("on_stream_end")
+
+            ok = session_worker.send(
+                ws,
+                enqueue=_enqueue,
+                run=_run,
+                thread_name=f"send-worker-{ws.id[:8]}",
+            )
+            return ok, queue_outcome
 
         def _emit_ui(hook_name: str, *args: Any) -> None:
             """Best-effort UI hook dispatch.
@@ -4105,7 +4190,9 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             Each call is wrapped in try/except so a failure in one
             hook (e.g. listener-queue full → on_error raises) doesn't
             suppress the others. Mirrors the pre-P1.5
-            coord_adapter.send per-hook defense.
+            coord_adapter.send per-hook defense.  Defined after
+            ``_dispatch_once`` but resolved late (when a worker runs) —
+            every dispatch happens strictly below this line.
             """
             if ui is None:
                 return
@@ -4122,50 +4209,48 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                     exc_info=True,
                 )
 
-        def _run() -> None:
-            me = threading.current_thread()
-            try:
-                kwargs: dict[str, Any] = {}
-                if resolved_atts:
-                    kwargs["attachments"] = resolved_atts
-                if send_id:
-                    kwargs["send_id"] = send_id
-                # Fresh turn: rebind per-user MCP credentials to the
-                # authenticated sender. Bound here (not via a send()
-                # kwarg) so per-kind session stubs with explicit send
-                # signatures keep working; getattr-guarded for the same
-                # reason. The queue path above never rebinds.
-                bind = getattr(session, "bind_acting_user", None)
-                if acting_uid and callable(bind):
-                    bind(acting_uid)
-                session.send(message, **kwargs)
-            except GenerationCancelled:
-                # Safety net — send() normally handles this internally.
-                # If this thread was force-abandoned, ws.worker_thread
-                # was set to None — don't emit spurious events.
-                if ws.worker_thread is me:
-                    _emit_ui("on_stream_end")
-                    _emit_ui("on_state_change", "idle")
-            except Exception:
-                # Undrained staged uploads aren't locked (the buffer is a peek,
-                # not a reservation) — they expire on the buffer TTL — so the
-                # only cleanup owed here is the UI streaming hook.
-                if ws.worker_thread is me:
-                    # ``session.send()`` already fired ``on_error``
-                    # (with sanitized text), persisted ``last_error``,
-                    # and emitted ``state='error'`` via
-                    # :meth:`ChatSession._record_fatal_error` before
-                    # re-raising.  The route handler only needs the
-                    # streaming-cleanup hook the worker contract owes
-                    # the UI listeners.
-                    _emit_ui("on_stream_end")
-
-        ok = session_worker.send(
-            ws,
-            enqueue=_enqueue,
-            run=_run,
-            thread_name=f"send-worker-{ws.id[:8]}",
-        )
+        # Park-then-dispatch.  While a slash-command worker holds the slot
+        # (a manual /compact can hold it for MINUTES), a send must not take
+        # the interjection-queue path — its 2000-char cap and cross-user
+        # guard are mid-TURN semantics, and a queued message would cross a
+        # /resume//new identity swap into the wrong workstream.  Parking
+        # reproduces the pre-worker-dispatch observable behavior (the
+        # request waited out the then-blocked event loop, then ran as a
+        # normal full-fidelity send under the sender's own identity) with
+        # the loop free: SSE keeps streaming the compaction progress card
+        # while we wait.  The inner park is deliberately unbounded — the
+        # composer bounds its POST at ~15s and aborts, and we poll
+        # ``is_disconnected`` because starlette does NOT cancel a running
+        # handler on client disconnect: dispatching after the client gave
+        # up would surprise the user with a duplicate turn when they
+        # resend.  The outer bound only caps command-window FLAPPING
+        # (back-to-back commands re-claiming the slot between our park
+        # exit and dispatch).
+        ok = False
+        queue_outcome: dict[str, Any] = {}
+        for _ in range(20):
+            while ws._worker_running and ws.worker_kind == "command":
+                if await request.is_disconnected():
+                    # Client abandoned the send mid-park; the response is
+                    # discarded — the status is for the access log only.
+                    return JSONResponse({"status": "abandoned"})
+                await asyncio.sleep(0.25)
+            session_now = ws.session
+            if session_now is None:
+                return JSONResponse({"error": "No session"}, status_code=500)
+            ok, queue_outcome = _dispatch_once(session_now)
+            if queue_outcome.get("rejected") != "command_window":
+                break
+        else:
+            # 20 consecutive command-window collisions — surface the same
+            # retryable backpressure shape as a saturated queue.
+            return JSONResponse(
+                {
+                    "status": "queue_full",
+                    "attached_ids": [],
+                    "dropped_attachment_ids": list(requested_ids),
+                }
+            )
         if not ok:
             if ws._closed:
                 # ``send`` refused because the workstream closed between our

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -40,7 +40,11 @@ from starlette.routing import Route
 
 from turnstone.core.log import get_logger
 from turnstone.core.session_ui_base import AutoApproveReason
-from turnstone.core.workstream import PENDING_SENDS_MAX, _PendingSend
+from turnstone.core.workstream import (
+    INTERJECTION_CAP_CHARS,
+    PENDING_SENDS_MAX,
+    _PendingSend,
+)
 
 if TYPE_CHECKING:
     import threading
@@ -104,12 +108,12 @@ AttachmentOwnerResolver = Callable[
     ["Request", str, "SessionManager"],
     tuple[str, "JSONResponse | None"],
 ]
-# (request, ui) — kind's spawn-time bookkeeping. Interactive bumps
+# (ui) — kind's spawn-time bookkeeping. Interactive bumps
 # ``_metrics.record_message_sent`` + per-UI message counters; coord
-# has no analog and wires ``None``.  The request is ``None`` when the
-# pending-send drain dispatches a deferred entry (no live request
-# exists by then) — both installed impls ignore the argument.
-SpawnMetricsHook = Callable[["Request | None", Any], None]
+# wires its per-UI-counter analog.  Deliberately request-free: the
+# pending-send drain dispatches deferred entries with no live request,
+# and no impl ever needed one.
+SpawnMetricsHook = Callable[[Any], None]
 
 
 class CancelForensics(Protocol):
@@ -346,7 +350,7 @@ class SessionEndpointConfig:
     - ``spawn_metrics``: optional bookkeeping hook fired once per
       ``send`` that spawns a fresh worker (queue-reuse path skips it).
       Interactive wires its WebUI per-conversation counters; coord
-      wires ``None``.
+      wires its per-UI-counter analog.
     - ``emit_message_queued``: when ``True`` and the dispatcher takes
       the live-worker enqueue path, the lifted body emits a
       ``message_queued`` event onto the workstream's listener queue
@@ -4015,7 +4019,6 @@ def _make_dispatch_attempt(
     ordered_taken: list[str],
     send_id: str,
     acting_uid: str,
-    request: Request | None,
     defer_fidelity: bool = False,
 ) -> Callable[[ChatSession], tuple[bool, dict[str, Any]]]:
     """Build one atomic queue-or-spawn attempt bound to ONE session capture.
@@ -4036,17 +4039,15 @@ def _make_dispatch_attempt(
 
     ``defer_fidelity=True`` marks a deferred entry's attempt: it was
     answered "queued" under the full-fidelity defer contract, so the
-    interjection fallback — which truncates at ``queue_message``'s
-    2000-char cap and cannot carry attachments — is refused for
+    interjection fallback — which truncates at ``queue_message``'s cap
+    (``workstream.INTERJECTION_CAP_CHARS``) and cannot carry
+    attachments — is refused for
     oversized or attachment-bearing entries (the drain waits for the
     slot and retries into the fresh-spawn arm instead).  The refusal
     happens inside the enqueue callback, under the same ``ws._lock``
     acquisition as the queue-vs-spawn decision, so a turn claiming the
     slot between the drain's poll and this dispatch can never route the
     entry into truncation.
-
-    ``request`` is ``None`` for drain-side attempts; the spawn-metrics
-    hook tolerates it (both installed impls ignore the argument).
     """
     import threading
 
@@ -4070,7 +4071,14 @@ def _make_dispatch_attempt(
             if ws.worker_kind == "command":
                 queue_outcome["rejected"] = "command_window"
                 return
-            if defer_fidelity and (resolved_atts or len(message) > 2000):
+            # Measures the RAW message while queue_message caps the
+            # post-!!!-strip CLEANED text — deliberate: parse_priority
+            # only strips, so raw >= cleaned and the raw measure can
+            # only ever OVER-refuse (a borderline fold-in costs one
+            # full-fidelity fresh spawn, never a truncation); measuring
+            # cleaned here would run parse_priority twice per dispatch
+            # for zero safety gain.
+            if defer_fidelity and (resolved_atts or len(message) > INTERJECTION_CAP_CHARS):
                 queue_outcome["rejected"] = "defer_full_fidelity"
                 return
             try:
@@ -4141,7 +4149,7 @@ def _make_dispatch_attempt(
             # Fresh spawn — the kind's per-turn metrics fire exactly once,
             # from the shared attempt so the drain's dispatches count too.
             try:
-                cfg.spawn_metrics(request, ui)
+                cfg.spawn_metrics(ui)
             except Exception:
                 log.debug(
                     "ws.send.spawn_metrics_failed ws=%s",
@@ -4384,8 +4392,8 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
       ``True`` post-P1.5; the flag exists so a kind that hasn't
       lit up its UI surface yet can defer.
     - ``spawn_metrics``: when set, fires once on the spawn path with
-      ``(request, ui)``. Interactive wires its WebUI per-conversation
-      counters here; coord wires ``None``.
+      ``(ui)``. Interactive wires its WebUI per-conversation counters
+      here; coord wires its per-UI-counter analog.
     - ``emit_message_queued``: when ``True``, the queue-reuse path
       pushes a ``message_queued`` event onto the listener queue.
 
@@ -4523,8 +4531,9 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
 
         # Defer-and-drain.  While a slash-command worker holds the slot (a
         # manual /compact can hold it for MINUTES), a send must not take
-        # the interjection-queue path — its 2000-char cap and cross-user
-        # guard are mid-TURN semantics, and a queued message would cross a
+        # the interjection-queue path — its INTERJECTION_CAP_CHARS cap and
+        # cross-user guard are mid-TURN semantics, and a queued message
+        # would cross a
         # /resume//new identity swap into the wrong workstream.  Instead
         # of parking THIS request until the window closes (which encoded
         # "client disconnected" as "message retracted" — deterministic
@@ -4608,7 +4617,6 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                         ordered_taken=ordered_taken,
                         send_id=pending_msg_id,
                         acting_uid=acting_uid,
-                        request=None,
                         defer_fidelity=True,
                     ),
                 )
@@ -4705,7 +4713,6 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             ordered_taken=ordered_taken,
             send_id=send_id,
             acting_uid=acting_uid,
-            request=request,
         )
         session_now = ws.session
         if session_now is None:

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -40,8 +40,11 @@ from starlette.routing import Route
 
 from turnstone.core.log import get_logger
 from turnstone.core.session_ui_base import AutoApproveReason
+from turnstone.core.workstream import _PendingSend
 
 if TYPE_CHECKING:
+    import threading
+
     from starlette.background import BackgroundTask
     from starlette.requests import Request
     from starlette.responses import Response
@@ -3948,54 +3951,40 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
 
 
 # ---------------------------------------------------------------------------
-# Deferred sends (command windows)
+# Deferred sends (command windows / order barrier)
 # ---------------------------------------------------------------------------
 
+# The dataclass and the order-barrier predicate live with the Workstream
+# fields they annotate (turnstone.core.workstream): _PendingSend carries
+# the "drain not alive ⇒ nothing claimed" invariant (imported at module
+# top), and Workstream.send_barrier_active() is the ONE definition of
+# the two-term barrier every dispatch surface consults.
 
-@dataclass
-class _PendingSend:
-    """One send deferred during a command window.
+# Saturation bound for ws._pending_sends — restores the backpressure
+# contract the interjection queue (ChatSession._QUEUE_MAX, same value)
+# enforced for every busy-window send before the defer seam replaced it.
+# Each accepted entry pins its full message text plus materialized
+# attachment bytes for the length of a command window and then costs one
+# unattended turn, so acceptance must be bounded; callers get the
+# standard retryable ``queue_full``.
+_PENDING_SENDS_MAX = 10
 
-    A /send that lands while a slash-command worker holds the slot
-    (``ws.worker_kind == "command"`` — a manual /compact can hold it for
-    minutes) is answered ``{"status": "queued", "msg_id": ...}``
-    immediately and registered here; :func:`_drain_pending_sends`
-    dispatches it full-fidelity when the window closes.  This replaces
-    the parked-POST design, which encoded "client disconnected" as
-    "message retracted" — true only for the web composers' ✕-abort;
-    every bounded caller (the coordinator client and the console proxy
-    at timeout=30, SDKs, curl) times out instead, and its message was
-    deliberately dropped for the whole window.
 
-    ``attempt`` is the prebuilt one-session-capture dispatch closure
-    (:func:`_make_dispatch_attempt` with ``defer_fidelity=True``), so
-    the drain stays endpoint-agnostic — everything kind-specific
-    (attachments, spawn metrics, UI hooks) was captured at defer time.
-    ``retracted`` is flipped under ``ws._lock`` by the DELETE dequeue
-    fall-through; the drain never dispatches a retracted entry.
+def _make_drain_thread(ws: Workstream) -> threading.Thread:
+    """Construct (never start) the pending-send drain thread for *ws*.
 
-    Durability contract (documented in the API reference): node-local
-    and in-memory, the interjection queue's lifetime — entries die with
-    the workstream or the process, so "queued" is at-most-once intake,
-    not durable acceptance.
-
-    Invariant both the route's order barrier and the drain depend on:
-    **drain not alive ⇒ nothing claimed.**  The drain pops an entry only
-    while it lives and re-inserts it at head on ANY non-dispatch outcome
-    (rejection or crash), so a dead/absent drain means every accepted
-    entry is on this list — the route's barrier term pair
-    (``_pending_sends`` non-empty OR drain alive) therefore covers the
-    claimed-entry window with no third state.
-
-    (No ``priority`` field: dispatch is strictly FIFO — arrival order is
-    the contract — and the queued response/event use the route's parsed
-    local.  A deferred entry's ``!!!`` prefix still reaches the model:
-    the full text dispatches as an ordinary send.)
+    A module-level seam so tests can inject spawn failure without
+    touching the global ``threading`` module; ``_defer_send`` owns the
+    slot write, the ``start()`` call, and the rollback discipline.
     """
+    import threading  # matches the file's handler-scope import style
 
-    msg_id: str
-    attempt: Callable[[ChatSession], tuple[bool, dict[str, Any]]]
-    retracted: bool = False
+    return threading.Thread(
+        target=_drain_pending_sends,
+        args=(ws,),
+        name=f"pending-drain-{ws.id[:8]}",
+        daemon=True,
+    )
 
 
 def _emit_send_ui(ws: Workstream, ui: Any, hook_name: str, *args: Any) -> None:
@@ -4394,15 +4383,19 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
       emits the pane-tier ``message_dispatched`` settle event (see
       :func:`_make_dispatch_attempt`).
     - 200 ``{"status": "queue_full", "attached_ids",
-      "dropped_attachment_ids"}`` — live worker's queue at
-      capacity; reservations released. Caller should retry. The
-      ``attached_ids`` list is always empty here (the dispatch
-      didn't take ownership of any reservations).
+      "dropped_attachment_ids"}`` — the send was refused with
+      retry-shortly semantics: the live worker's interjection queue is
+      at capacity, the deferred-send list hit its saturation bound
+      (``_PENDING_SENDS_MAX`` — the same backpressure contract), or the
+      drain thread could not be started under resource exhaustion (the
+      entry is rolled back, never phantom-parked). Reservations
+      released; caller should retry. The ``attached_ids`` list is
+      always empty here (the dispatch didn't take ownership of any
+      reservations).
     - 4xx / 500 — auth / not-found / no-session per the usual
       :class:`SessionEndpointConfig` semantics.
     """
     import asyncio
-    import threading
     import uuid
 
     from turnstone.core.tool_advisory import parse_priority
@@ -4529,59 +4522,131 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         # command-window trigger re-acquires for its append, which is safe
         # because that rejection was reported under the lock the attempt
         # itself held.
-        def _defer_send(*, require_barrier: bool) -> Response | None:
-            # ``send_id`` is minted only when attachments are enabled —
-            # the deferred entry needs a truthy id regardless: it is the
-            # client's dismiss/bind handle and the drain's
-            # queue_msg_id/send_id thread.
-            pending_msg_id = send_id or uuid.uuid4().hex
-            cleaned_display, pending_priority = parse_priority(message)
-            entry = _PendingSend(
-                msg_id=pending_msg_id,
-                attempt=_make_dispatch_attempt(
-                    ws,
-                    cfg,
-                    ui,
-                    message=message,
-                    resolved_atts=resolved_atts,
-                    ordered_taken=ordered_taken,
-                    send_id=pending_msg_id,
-                    acting_uid=acting_uid,
-                    request=None,
-                    defer_fidelity=True,
-                ),
+        def _queue_full_response() -> Response:
+            # Shared refusal shape (see the not-ok arm below for the
+            # rationale): retry-shortly semantics, no ownership taken.
+            return JSONResponse(
+                {
+                    "status": "queue_full",
+                    "attached_ids": [],
+                    "dropped_attachment_ids": list(requested_ids),
+                }
             )
+
+        def _defer_send(*, require_barrier: bool) -> Response | None:
             with ws._lock:
-                if require_barrier:
-                    drain_t = ws._pending_drain
-                    if not ws._pending_sends and not (drain_t is not None and drain_t.is_alive()):
-                        return None  # no barrier — caller dispatches directly
+                # Probe FIRST, before constructing anything: in the
+                # overwhelmingly common no-barrier case this costs two
+                # field reads instead of a discarded closure tree +
+                # parse_priority per ordinary send.
+                if require_barrier and not ws.send_barrier_active():
+                    return None  # no barrier — caller dispatches directly
                 if ws._closed:
                     # Mirror the dispatch-refusal 404 below: a "queued"
                     # answer for a workstream whose next resolution 404s
                     # would promise a dispatch that can never happen.
                     return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+                if len(ws._pending_sends) >= _PENDING_SENDS_MAX:
+                    # Saturation backpressure — restores the contract the
+                    # interjection queue enforced for every busy-window
+                    # send before the defer seam replaced it
+                    # (ChatSession._QUEUE_MAX, session.py): without a
+                    # bound, each acked entry pins its message text plus
+                    # materialized attachment bytes for a whole command
+                    # window and then costs one unattended turn — an
+                    # automated caller could OOM the node with 200s.
+                    # len() deliberately counts retract-marked husks
+                    # awaiting the drain's loop-top purge (DELETE only
+                    # marks): a live-only count would let park/retract
+                    # churn re-open the unbounded-growth hole.  Transient
+                    # over-refusal self-heals at the next purge.
+                    return _queue_full_response()
+                # ``send_id`` is minted only when attachments are enabled
+                # — the deferred entry needs a truthy id regardless: it
+                # is the client's dismiss/bind handle and the drain's
+                # queue_msg_id/send_id thread.  Constructed INSIDE the
+                # lock: closure creation is microsecond-cheap (the same
+                # argument session_worker.send makes for Thread()), and
+                # it keeps probe→append atomic.
+                pending_msg_id = send_id or uuid.uuid4().hex
+                cleaned_display, pending_priority = parse_priority(message)
+                entry = _PendingSend(
+                    msg_id=pending_msg_id,
+                    attempt=_make_dispatch_attempt(
+                        ws,
+                        cfg,
+                        ui,
+                        message=message,
+                        resolved_atts=resolved_atts,
+                        ordered_taken=ordered_taken,
+                        send_id=pending_msg_id,
+                        acting_uid=acting_uid,
+                        request=None,
+                        defer_fidelity=True,
+                    ),
+                )
                 ws._pending_sends.append(entry)
                 drain = ws._pending_drain
                 if drain is None or not drain.is_alive():
-                    # Single drain-spawn site — also the recovery path for
-                    # a drain that died in its last-resort handler.
-                    t = threading.Thread(
-                        target=_drain_pending_sends,
-                        args=(ws,),
-                        name=f"pending-drain-{ws.id[:8]}",
-                        daemon=True,
-                    )
+                    # Single drain-spawn site — also the recovery path
+                    # for a drain that died in its last-resort handler.
+                    # ``t.start()`` stays INSIDE this lock acquisition,
+                    # deliberately unlike session_worker.send's
+                    # outside-lock start (d3028234): that site's readers
+                    # gate on the ``_worker_running`` flag, which is
+                    # valid before start — this slot's only liveness
+                    # signal is ``Thread.is_alive()``, which reads False
+                    # for a constructed-but-unstarted thread, so an
+                    # outside-lock start would let a concurrent defer's
+                    # eligibility check see the pending drain as dead
+                    # and spawn a SECOND dispatcher (FIFO inversion; the
+                    # drain's exit slot-clears are single-flight-only).
+                    # Holding the lock through start makes that state
+                    # unobservable and keeps single-flight structural;
+                    # the cost is thread-spawn latency (~100µs) on a
+                    # cold path.
+                    t = _make_drain_thread(ws)
                     ws._pending_drain = t
-                    t.start()
-            if cfg.emit_message_queued and hasattr(ui, "_enqueue"):
-                ui._enqueue(
+                    try:
+                        t.start()
+                    except Exception:
+                        # Thread creation failed (exhaustion,
+                        # MemoryError).  Roll back BOTH writes — the
+                        # lock was held throughout, so the entry is
+                        # provably the tail and the slot is provably
+                        # ``t`` — and refuse with queue_full: the SDK's
+                        # existing retry-shortly vocabulary.  Never a
+                        # 500 after registration (a phantom entry the
+                        # client can't retract that dispatches later as
+                        # a duplicate), and never a queued ack (it would
+                        # promise a dispatch whose only revival trigger
+                        # is a FUTURE send).  Entries acked by earlier
+                        # successful defers stay parked under the
+                        # next-send-re-ensures policy — no respawn
+                        # attempt here under the same exhaustion that
+                        # just failed.
+                        ws._pending_sends.pop()
+                        ws._pending_drain = None
+                        log.exception(
+                            "ws.send.pending_drain_spawn_failed ws=%s — send refused",
+                            ws.id[:8],
+                        )
+                        return _queue_full_response()
+            # Best-effort ack event — a raising UI hook must not convert
+            # an ACCEPTED deferred send into a 500 (the client would
+            # retry and deliver twice); same never-mask-acceptance rule
+            # as message_dispatched.
+            if cfg.emit_message_queued:
+                _emit_send_ui(
+                    ws,
+                    ui,
+                    "_enqueue",
                     {
                         "type": "message_queued",
                         "message": cleaned_display,
                         "priority": pending_priority,
                         "msg_id": pending_msg_id,
-                    }
+                    },
                 )
             return JSONResponse(
                 {
@@ -4632,7 +4697,9 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 # resolution 404s.  Mirror the resolution miss instead.
                 return JSONResponse({"error": cfg.not_found_label}, status_code=404)
             # queue.Full or session-disappeared race — surface as
-            # queue_full so clients retry rather than 500. ``attached_ids``
+            # queue_full so clients retry rather than 500 (the same shape
+            # _defer_send answers for its saturation cap and drain-spawn
+            # failure). ``attached_ids``
             # is always empty on this path (the dispatch never took
             # ownership); the empty arrays preserve the response-shape
             # guarantee so SDK consumers don't branch on status.
@@ -4677,15 +4744,21 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
 
         dropped = [aid for aid in requested_ids if aid not in taken_set]
         if queue_outcome:
-            # Reused a live worker; ``queue_message`` succeeded.
-            if cfg.emit_message_queued and hasattr(ui, "_enqueue"):
-                ui._enqueue(
+            # Reused a live worker; ``queue_message`` succeeded.  Best-
+            # effort like the defer arm's ack: the message is already
+            # accepted, so a raising UI hook must not 500 this into a
+            # client retry (duplicate delivery).
+            if cfg.emit_message_queued:
+                _emit_send_ui(
+                    ws,
+                    ui,
+                    "_enqueue",
                     {
                         "type": "message_queued",
                         "message": queue_outcome["cleaned"],
                         "priority": queue_outcome["priority"],
                         "msg_id": queue_outcome["msg_id"],
-                    }
+                    },
                 )
             return JSONResponse(
                 {

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3978,10 +3978,22 @@ class _PendingSend:
     and in-memory, the interjection queue's lifetime — entries die with
     the workstream or the process, so "queued" is at-most-once intake,
     not durable acceptance.
+
+    Invariant both the route's order barrier and the drain depend on:
+    **drain not alive ⇒ nothing claimed.**  The drain pops an entry only
+    while it lives and re-inserts it at head on ANY non-dispatch outcome
+    (rejection or crash), so a dead/absent drain means every accepted
+    entry is on this list — the route's barrier term pair
+    (``_pending_sends`` non-empty OR drain alive) therefore covers the
+    claimed-entry window with no third state.
+
+    (No ``priority`` field: dispatch is strictly FIFO — arrival order is
+    the contract — and the queued response/event use the route's parsed
+    local.  A deferred entry's ``!!!`` prefix still reaches the model:
+    the full text dispatches as an ordinary send.)
     """
 
     msg_id: str
-    priority: str
     attempt: Callable[[ChatSession], tuple[bool, dict[str, Any]]]
     retracted: bool = False
 
@@ -4152,6 +4164,25 @@ def _make_dispatch_attempt(
                     ws.id[:8] if ws.id else "",
                     exc_info=True,
                 )
+        if ok and defer_fidelity and "rejected" not in queue_outcome and cfg.emit_message_queued:
+            # A deferred entry actually dispatched — the settle signal the
+            # panes' queued chips wait on (the busy→idle sweep skips
+            # deferred chips: "idle ⇒ drained" is untrue for them).  Lives
+            # HERE, not in the drain, which is endpoint-agnostic by design:
+            # this arm has ``cfg``/``ui`` in scope and fires for BOTH
+            # dispatch shapes.  ``folded`` marks the interjection fold-in
+            # (non-empty outcome): the message moved to the live turn's
+            # queue where DELETE still genuinely removes it, so the client
+            # clears only its deferred flag and lets the chip resume the
+            # normal interjection lifecycle — a flat promote there would
+            # strip the ✕ while retraction is still honored.  Pane-tier
+            # like ``message_queued`` (not SDK-typed); best-effort via
+            # _emit_send_ui — an emission failure must not look like a
+            # dispatch failure (the drain would re-insert and DOUBLE-send).
+            event: dict[str, Any] = {"type": "message_dispatched", "msg_id": send_id}
+            if queue_outcome:
+                event["folded"] = True
+            _emit_send_ui(ws, ui, "_enqueue", event)
         return ok, queue_outcome
 
     return attempt
@@ -4182,13 +4213,27 @@ def _drain_pending_sends(ws: Workstream) -> None:
     fresh-spawn arm.
 
     Claim discipline: an entry is popped under ``ws._lock`` immediately
-    before its dispatch attempt and re-inserted on rejection, so the
-    DELETE fall-through (which marks only in-list entries) can never
-    "remove" a message whose dispatch already left the station — a
-    claimed entry answers ``not_found`` ("already sent"), which its
-    eventual dispatch makes true.
+    before its dispatch attempt and re-inserted at head on ANY
+    non-dispatch outcome — rejection or a crash inside the attempt — so
+    the DELETE fall-through (which marks only in-list entries) can never
+    "remove" a message whose dispatch already left the station, and the
+    :class:`_PendingSend` invariant (drain not alive ⇒ nothing claimed)
+    holds on every exit path.  A claimed entry answers ``not_found``
+    ("already sent"), which its eventual dispatch makes true.
+
+    Clean-exit wake backstop: the drain's retirement is the moment the
+    /send order barrier clears, and a list that empties by RETRACTION
+    never runs a deferred turn — so no worker exit would ever re-run the
+    wake gate that yielded to us (see the pending-sends yield in
+    :func:`~turnstone.core.idle_nudge_watcher.wake_workstream_if_pending`).
+    Re-running the gate here, outside ``ws._lock`` (session_worker's
+    exit-backstop discipline), closes that strand; when entries DID
+    dispatch, it's a cheap no-op re-check after the last turn's own exit
+    backstop.
     """
     import time
+
+    from turnstone.core.idle_nudge_watcher import wake_workstream_if_pending
 
     try:
         while True:
@@ -4208,7 +4253,7 @@ def _drain_pending_sends(ws: Workstream) -> None:
                     return
                 if not pending:
                     ws._pending_drain = None
-                    return
+                    break  # clean exit — wake backstop below, outside the lock
                 entry = pending[0]
             if ws._worker_running and ws.worker_kind == "command":
                 # The park, relocated server-side: the poll cadence
@@ -4221,14 +4266,34 @@ def _drain_pending_sends(ws: Workstream) -> None:
                 # check terminates this if it's a close in progress.
                 time.sleep(0.25)
                 continue
-            with ws._lock:
-                if not ws._pending_sends or ws._pending_sends[0] is not entry:
-                    continue  # list reshaped under us — re-evaluate
-                if entry.retracted:
-                    ws._pending_sends.pop(0)
-                    continue
-                ws._pending_sends.pop(0)  # claim
-            ok, outcome = entry.attempt(session_now)
+            claimed = False
+            try:
+                with ws._lock:
+                    if not ws._pending_sends or ws._pending_sends[0] is not entry:
+                        continue  # list reshaped under us — re-evaluate
+                    if entry.retracted:
+                        ws._pending_sends.pop(0)
+                        continue
+                    ws._pending_sends.pop(0)  # claim
+                    claimed = True
+                ok, outcome = entry.attempt(session_now)
+            except Exception:
+                # An entry acknowledged "queued" must never be eaten by a
+                # crash (Thread.start under thread exhaustion, MemoryError
+                # in the dispatch path): restore the claim, back off, and
+                # retry — the docstring's no-give-up contract.  ``claimed``
+                # gates the re-insert so a claim-section failure can't
+                # duplicate the head entry.
+                log.exception(
+                    "ws.send.pending_dispatch_crashed ws=%s msg_id=%s — entry retained",
+                    ws.id[:8] if ws.id else "",
+                    entry.msg_id,
+                )
+                if claimed:
+                    with ws._lock:
+                        ws._pending_sends.insert(0, entry)
+                time.sleep(1.0)
+                continue
             if not ok or outcome.get("rejected") in (
                 "command_window",
                 "defer_full_fidelity",
@@ -4239,16 +4304,45 @@ def _drain_pending_sends(ws: Workstream) -> None:
                 # live turn holds the slot against a full-fidelity entry,
                 # the interjection queue is saturated
                 # (session_worker.send → False on queue.Full), or the ws
-                # closed (resolved at the loop top).  Unclaim and wait.
+                # closed (resolved at the loop top).  Unclaim, pace, wait.
                 with ws._lock:
                     ws._pending_sends.insert(0, entry)
                 time.sleep(0.25)
+                if outcome.get("rejected") != "command_window":
+                    # Every non-window rejection is stable for the CURRENT
+                    # worker (cross-user / attachments / full-fidelity are
+                    # per-turn structural; queue.Full clears only at the
+                    # turn's drain seams and the entry is already acked, so
+                    # turn-bounded delay is contract-legal) — wait on the
+                    # cheap flags instead of re-running the full dispatch
+                    # machinery against ``ws._lock`` at 4 Hz for the length
+                    # of a turn.  Lockless reads: DELETE only MARKS
+                    # ``retracted`` (the loop-top purge under the lock is
+                    # authoritative), a ``worker_kind`` flip to "command"
+                    # exits into the window arm above, and force-cancel's
+                    # flag-clear releases this exactly as it released the
+                    # old park.  One dispatch attempt per slot-state change.
+                    while (
+                        ws._worker_running
+                        and ws.worker_kind != "command"
+                        and not entry.retracted
+                        and not ws._closed
+                    ):
+                        time.sleep(0.25)
                 continue
             # Dispatched: fresh spawn (empty outcome) or interjection
-            # fallback (msg_id preserved) — this entry is done.
+            # fallback (msg_id preserved) — this entry is done.  The
+            # settle event (message_dispatched) fired inside the attempt.
+        wake_workstream_if_pending(ws, trigger="drain-exit")
     except Exception:
         # Never die holding the single-flight slot — a wedged drain would
-        # strand every future deferred send for this workstream.
+        # strand every future deferred send for this workstream.  With the
+        # per-iteration handler above, reaching here means the loop
+        # machinery itself failed; entries stay on the list and the
+        # route's barrier arm re-ensures a drain on the next /send
+        # (deliberately NO successor spawn here: Thread.start fails under
+        # the same exhaustion that gets you here, and the route staying
+        # the single spawn site is what makes single-flight structural).
         log.exception("ws.send.pending_drain_failed ws=%s", ws.id[:8] if ws.id else "")
         with ws._lock:
             ws._pending_drain = None
@@ -4290,12 +4384,15 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
       reservation race losses).
     - 200 ``{"status": "queued", "priority", "msg_id", "attached_ids",
       "dropped_attachment_ids"}`` — reused live worker (queued for
-      injection at the next tool-result seam), OR deferred during a
-      slash-command window (registered on ``ws._pending_sends`` and
-      dispatched full-fidelity by :func:`_drain_pending_sends` when the
-      window closes — see :class:`_PendingSend` for the durability
-      contract).  ``DELETE {prefix}/{ws_id}/send`` with the ``msg_id``
-      retracts either kind before dispatch.
+      injection at the next tool-result seam), OR — with ``"deferred":
+      true`` — parked on ``ws._pending_sends`` (a slash-command window
+      holds the slot, or earlier deferred sends hold the order barrier)
+      and dispatched full-fidelity by :func:`_drain_pending_sends` when
+      the slot frees — see :class:`_PendingSend` for the durability
+      contract.  ``DELETE {prefix}/{ws_id}/send`` with the ``msg_id``
+      retracts either kind before dispatch; a deferred dispatch also
+      emits the pane-tier ``message_dispatched`` settle event (see
+      :func:`_make_dispatch_attempt`).
     - 200 ``{"status": "queue_full", "attached_ids",
       "dropped_attachment_ids"}`` — live worker's queue at
       capacity; reservations released. Caller should retry. The
@@ -4402,8 +4499,6 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 await asyncio.sleep(0.1)
                 if not ws._worker_running:
                     break
-        if ws.session is None:
-            return JSONResponse({"error": "No session"}, status_code=500)
 
         # Defer-and-drain.  While a slash-command worker holds the slot (a
         # manual /compact can hold it for MINUTES), a send must not take
@@ -4416,26 +4511,25 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         # and console proxy time out at 30s, and the web composers' long
         # abort bound raced the compaction card), the send is answered
         # "queued" immediately and registered on ``ws._pending_sends``;
-        # the per-workstream drain task dispatches it full-fidelity when
+        # the per-workstream drain thread dispatches it full-fidelity when
         # the window closes.  Dismissal is the same DELETE /send
         # {msg_id} the interjection queue uses — server-confirmed, no
         # POST-abort side channel.
-        attempt = _make_dispatch_attempt(
-            ws,
-            cfg,
-            ui,
-            message=message,
-            resolved_atts=resolved_atts,
-            ordered_taken=ordered_taken,
-            send_id=send_id,
-            acting_uid=acting_uid,
-            request=request,
-        )
-        session_now = ws.session
-        if session_now is None:
-            return JSONResponse({"error": "No session"}, status_code=500)
-        ok, queue_outcome = attempt(session_now)
-        if queue_outcome.get("rejected") == "command_window":
+        #
+        # Two triggers share ``_defer_send`` below: the command-window
+        # rejection (the attempt's enqueue closure reports it), and the
+        # ORDER BARRIER — once entries are pending (or a claimed entry's
+        # dispatch is in flight: the drain-alive term, backed by the
+        # _PendingSend invariant), the pending list is the order
+        # authority, and a fresh send lines up behind it instead of
+        # overtaking messages already acknowledged "queued".  The barrier
+        # check and the append happen under ONE ``ws._lock`` acquisition —
+        # ws._lock is not reentrant and session_worker.send takes it, so
+        # the lock is always released before any dispatch attempt; the
+        # command-window trigger re-acquires for its append, which is safe
+        # because that rejection was reported under the lock the attempt
+        # itself held.
+        def _defer_send(*, require_barrier: bool) -> Response | None:
             # ``send_id`` is minted only when attachments are enabled —
             # the deferred entry needs a truthy id regardless: it is the
             # client's dismiss/bind handle and the drain's
@@ -4444,7 +4538,6 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             cleaned_display, pending_priority = parse_priority(message)
             entry = _PendingSend(
                 msg_id=pending_msg_id,
-                priority=pending_priority,
                 attempt=_make_dispatch_attempt(
                     ws,
                     cfg,
@@ -4459,6 +4552,10 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 ),
             )
             with ws._lock:
+                if require_barrier:
+                    drain_t = ws._pending_drain
+                    if not ws._pending_sends and not (drain_t is not None and drain_t.is_alive()):
+                        return None  # no barrier — caller dispatches directly
                 if ws._closed:
                     # Mirror the dispatch-refusal 404 below: a "queued"
                     # answer for a workstream whose next resolution 404s
@@ -4467,6 +4564,8 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 ws._pending_sends.append(entry)
                 drain = ws._pending_drain
                 if drain is None or not drain.is_alive():
+                    # Single drain-spawn site — also the recovery path for
+                    # a drain that died in its last-resort handler.
                     t = threading.Thread(
                         target=_drain_pending_sends,
                         args=(ws,),
@@ -4487,6 +4586,11 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             return JSONResponse(
                 {
                     "status": "queued",
+                    # Parked on ws._pending_sends, NOT in a live turn's
+                    # interjection queue: the panes keep the chip's ✕ past
+                    # the busy→idle edge until message_dispatched settles
+                    # it.  See SendResponse for the SDK-facing contract.
+                    "deferred": True,
                     "priority": pending_priority,
                     "msg_id": pending_msg_id,
                     "attached_ids": list(ordered_taken),
@@ -4495,6 +4599,31 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                     ],
                 }
             )
+
+        barrier_resp = _defer_send(require_barrier=True)
+        if barrier_resp is not None:
+            return barrier_resp
+
+        attempt = _make_dispatch_attempt(
+            ws,
+            cfg,
+            ui,
+            message=message,
+            resolved_atts=resolved_atts,
+            ordered_taken=ordered_taken,
+            send_id=send_id,
+            acting_uid=acting_uid,
+            request=request,
+        )
+        session_now = ws.session
+        if session_now is None:
+            return JSONResponse({"error": "No session"}, status_code=500)
+        ok, queue_outcome = attempt(session_now)
+        if queue_outcome.get("rejected") == "command_window":
+            window_resp = _defer_send(require_barrier=False)
+            if window_resp is None:  # unreachable: only the barrier probe returns None
+                return JSONResponse({"error": "defer failed"}, status_code=500)
+            return window_resp
         if not ok:
             if ws._closed:
                 # ``send`` refused because the workstream closed between our

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -40,7 +40,7 @@ from starlette.routing import Route
 
 from turnstone.core.log import get_logger
 from turnstone.core.session_ui_base import AutoApproveReason
-from turnstone.core.workstream import _PendingSend
+from turnstone.core.workstream import PENDING_SENDS_MAX, _PendingSend
 
 if TYPE_CHECKING:
     import threading
@@ -3954,20 +3954,15 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
 # Deferred sends (command windows / order barrier)
 # ---------------------------------------------------------------------------
 
-# The dataclass and the order-barrier predicate live with the Workstream
-# fields they annotate (turnstone.core.workstream): _PendingSend carries
-# the "drain not alive ⇒ nothing claimed" invariant (imported at module
-# top), and Workstream.send_barrier_active() is the ONE definition of
-# the two-term barrier every dispatch surface consults.
-
-# Saturation bound for ws._pending_sends — restores the backpressure
-# contract the interjection queue (ChatSession._QUEUE_MAX, same value)
-# enforced for every busy-window send before the defer seam replaced it.
-# Each accepted entry pins its full message text plus materialized
-# attachment bytes for the length of a command window and then costs one
-# unattended turn, so acceptance must be bounded; callers get the
-# standard retryable ``queue_full``.
-_PENDING_SENDS_MAX = 10
+# The dataclass, the order-barrier predicate, and the saturation bound
+# all live with the Workstream fields they annotate
+# (turnstone.core.workstream, imported at module top): _PendingSend
+# carries the "drain not alive ⇒ nothing claimed" invariant,
+# Workstream.send_barrier_active() is the ONE definition of the two-term
+# barrier every dispatch surface consults, and PENDING_SENDS_MAX is the
+# shared backpressure bound ChatSession._QUEUE_MAX aliases — one
+# constant, structurally incapable of diverging between the interjection
+# queue and the deferred list.
 
 
 def _make_drain_thread(ws: Workstream) -> threading.Thread:
@@ -4220,10 +4215,18 @@ def _drain_pending_sends(ws: Workstream) -> None:
     dispatch, it's a cheap no-op re-check after the last turn's own exit
     backstop.
     """
+    # Function-local imports (file style): ``threading`` is NEEDED here —
+    # the module-top import is TYPE_CHECKING-only, and the except arm's
+    # identity guard below would otherwise NameError at runtime inside
+    # the last-resort handler (masking the original exception and leaving
+    # the slot permanently held — the exact wedge the handler prevents);
+    # mypy can't catch that because the type-only import satisfies it.
+    import threading
     import time
 
     from turnstone.core.idle_nudge_watcher import wake_workstream_if_pending
 
+    clean_exit = False
     try:
         while True:
             with ws._lock:
@@ -4242,7 +4245,8 @@ def _drain_pending_sends(ws: Workstream) -> None:
                     return
                 if not pending:
                     ws._pending_drain = None
-                    break  # clean exit — wake backstop below, outside the lock
+                    clean_exit = True
+                    break  # clean exit — wake backstop AFTER the try block
                 entry = pending[0]
             if ws._worker_running and ws.worker_kind == "command":
                 # The park, relocated server-side: the poll cadence
@@ -4322,7 +4326,6 @@ def _drain_pending_sends(ws: Workstream) -> None:
             # Dispatched: fresh spawn (empty outcome) or interjection
             # fallback (msg_id preserved) — this entry is done.  The
             # settle event (message_dispatched) fired inside the attempt.
-        wake_workstream_if_pending(ws, trigger="drain-exit")
     except Exception:
         # Never die holding the single-flight slot — a wedged drain would
         # strand every future deferred send for this workstream.  With the
@@ -4334,7 +4337,32 @@ def _drain_pending_sends(ws: Workstream) -> None:
         # the single spawn site is what makes single-flight structural).
         log.exception("ws.send.pending_drain_failed ws=%s", ws.id[:8] if ws.id else "")
         with ws._lock:
-            ws._pending_drain = None
+            # Identity-guarded, like every sibling exit seam: on paths
+            # that already RELEASED the slot before raising, an
+            # unconditional clear here would null a SUCCESSOR drain's
+            # live registration (two drains servicing one list — FIFO
+            # inversion, and the barrier reads inactive while the
+            # survivor holds a claimed entry).  The guard makes any
+            # future post-release statement inside the try safe by
+            # construction.
+            if ws._pending_drain is threading.current_thread():
+                ws._pending_drain = None
+        return
+    # Clean-exit wake backstop — AFTER the try/except, deliberately: this
+    # runs once the drain has already retired its slot, so a raise out of
+    # the wake (session_worker.send re-raises Thread.start failures) must
+    # not reach the last-resort handler above and mutate state this
+    # thread no longer owns.  Own guard, mirroring _retry_pending_wake's
+    # discipline around the same gate.  Not run on the closed arm (the
+    # workstream is torn down) nor after the except (entries remain, the
+    # barrier still holds — the gate would just yield).
+    if clean_exit:
+        try:
+            wake_workstream_if_pending(ws, trigger="drain-exit")
+        except Exception:
+            log.warning(
+                "ws.send.drain_exit_wake_failed ws=%s", ws.id[:8] if ws.id else "", exc_info=True
+            )
 
 
 def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
@@ -4386,7 +4414,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
       "dropped_attachment_ids"}`` — the send was refused with
       retry-shortly semantics: the live worker's interjection queue is
       at capacity, the deferred-send list hit its saturation bound
-      (``_PENDING_SENDS_MAX`` — the same backpressure contract), or the
+      (``PENDING_SENDS_MAX`` — the shared backpressure bound), or the
       drain thread could not be started under resource exhaustion (the
       entry is rolled back, never phantom-parked). Reservations
       released; caller should retry. The ``attached_ids`` list is
@@ -4546,15 +4574,14 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                     # answer for a workstream whose next resolution 404s
                     # would promise a dispatch that can never happen.
                     return JSONResponse({"error": cfg.not_found_label}, status_code=404)
-                if len(ws._pending_sends) >= _PENDING_SENDS_MAX:
-                    # Saturation backpressure — restores the contract the
-                    # interjection queue enforced for every busy-window
-                    # send before the defer seam replaced it
-                    # (ChatSession._QUEUE_MAX, session.py): without a
-                    # bound, each acked entry pins its message text plus
-                    # materialized attachment bytes for a whole command
-                    # window and then costs one unattended turn — an
-                    # automated caller could OOM the node with 200s.
+                if len(ws._pending_sends) >= PENDING_SENDS_MAX:
+                    # Saturation backpressure — the SHARED bound
+                    # (workstream.PENDING_SENDS_MAX, which the
+                    # interjection queue's _QUEUE_MAX aliases): without
+                    # a bound, each acked entry pins its message text
+                    # plus materialized attachment bytes for a whole
+                    # command window and then costs one unattended turn
+                    # — an automated caller could OOM the node with 200s.
                     # len() deliberately counts retract-marked husks
                     # awaiting the drain's loop-top purge (DELETE only
                     # marks): a live-only count would let park/retract
@@ -4697,19 +4724,11 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 # resolution 404s.  Mirror the resolution miss instead.
                 return JSONResponse({"error": cfg.not_found_label}, status_code=404)
             # queue.Full or session-disappeared race — surface as
-            # queue_full so clients retry rather than 500 (the same shape
-            # _defer_send answers for its saturation cap and drain-spawn
-            # failure). ``attached_ids``
+            # queue_full so clients retry rather than 500.  ``attached_ids``
             # is always empty on this path (the dispatch never took
             # ownership); the empty arrays preserve the response-shape
             # guarantee so SDK consumers don't branch on status.
-            return JSONResponse(
-                {
-                    "status": "queue_full",
-                    "attached_ids": [],
-                    "dropped_attachment_ids": list(requested_ids),
-                }
-            )
+            return _queue_full_response()
 
         if queue_outcome.get("rejected") == "attachments_busy":
             # Attachments can't ride a queued user turn (see

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -103,8 +103,10 @@ AttachmentOwnerResolver = Callable[
 ]
 # (request, ui) — kind's spawn-time bookkeeping. Interactive bumps
 # ``_metrics.record_message_sent`` + per-UI message counters; coord
-# has no analog and wires ``None``.
-SpawnMetricsHook = Callable[["Request", Any], None]
+# has no analog and wires ``None``.  The request is ``None`` when the
+# pending-send drain dispatches a deferred entry (no live request
+# exists by then) — both installed impls ignore the argument.
+SpawnMetricsHook = Callable[["Request | None", Any], None]
 
 
 class CancelForensics(Protocol):
@@ -1369,13 +1371,16 @@ def make_cancel_handler(
                 #
                 # Documented bet — force-cancelling a wedged QUICK command
                 # (worker_kind == "command", e.g. /resume stuck in storage
-                # I/O): clearing the flag releases any parked /send, whose
-                # fresh worker can then run while the abandoned command
-                # thread finishes its in-place mutation — quick commands
-                # have no generation checkpoints to retire them (compact_now
-                # does).  Same blast radius as force-abandoning a send
-                # worker mid-tool; accepted because force-cancel is the
-                # operator escape hatch for an already-wedged session, not a
+                # I/O): clearing the flag releases the pending-send
+                # drain's park (_drain_pending_sends polls the same
+                # (_worker_running, worker_kind) pair the parked /send
+                # used to), so a deferred message's fresh worker can then
+                # run while the abandoned command thread finishes its
+                # in-place mutation — quick commands have no generation
+                # checkpoints to retire them (compact_now does).  Same
+                # blast radius as force-abandoning a send worker
+                # mid-tool; accepted because force-cancel is the operator
+                # escape hatch for an already-wedged session, not a
                 # routine path.  Revisit if commands ever gain generation
                 # discipline.
                 with ws._lock:
@@ -3942,6 +3947,313 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
     return detail
 
 
+# ---------------------------------------------------------------------------
+# Deferred sends (command windows)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PendingSend:
+    """One send deferred during a command window.
+
+    A /send that lands while a slash-command worker holds the slot
+    (``ws.worker_kind == "command"`` — a manual /compact can hold it for
+    minutes) is answered ``{"status": "queued", "msg_id": ...}``
+    immediately and registered here; :func:`_drain_pending_sends`
+    dispatches it full-fidelity when the window closes.  This replaces
+    the parked-POST design, which encoded "client disconnected" as
+    "message retracted" — true only for the web composers' ✕-abort;
+    every bounded caller (the coordinator client and the console proxy
+    at timeout=30, SDKs, curl) times out instead, and its message was
+    deliberately dropped for the whole window.
+
+    ``attempt`` is the prebuilt one-session-capture dispatch closure
+    (:func:`_make_dispatch_attempt` with ``defer_fidelity=True``), so
+    the drain stays endpoint-agnostic — everything kind-specific
+    (attachments, spawn metrics, UI hooks) was captured at defer time.
+    ``retracted`` is flipped under ``ws._lock`` by the DELETE dequeue
+    fall-through; the drain never dispatches a retracted entry.
+
+    Durability contract (documented in the API reference): node-local
+    and in-memory, the interjection queue's lifetime — entries die with
+    the workstream or the process, so "queued" is at-most-once intake,
+    not durable acceptance.
+    """
+
+    msg_id: str
+    priority: str
+    attempt: Callable[[ChatSession], tuple[bool, dict[str, Any]]]
+    retracted: bool = False
+
+
+def _emit_send_ui(ws: Workstream, ui: Any, hook_name: str, *args: Any) -> None:
+    """Best-effort UI hook dispatch for send-worker closures.
+
+    Each call is wrapped in try/except so a failure in one hook (e.g.
+    listener-queue full → on_error raises) doesn't suppress the others.
+    Mirrors the pre-P1.5 coord_adapter.send per-hook defense.
+    """
+    if ui is None:
+        return
+    method = getattr(ui, hook_name, None)
+    if method is None:
+        return
+    try:
+        method(*args)
+    except Exception:
+        log.debug(
+            "ws.send.ui_hook_failed ws=%s hook=%s",
+            ws.id[:8] if ws.id else "",
+            hook_name,
+            exc_info=True,
+        )
+
+
+def _make_dispatch_attempt(
+    ws: Workstream,
+    cfg: SessionEndpointConfig,
+    ui: Any,
+    *,
+    message: str,
+    resolved_atts: list[Any],
+    ordered_taken: list[str],
+    send_id: str,
+    acting_uid: str,
+    request: Request | None,
+    defer_fidelity: bool = False,
+) -> Callable[[ChatSession], tuple[bool, dict[str, Any]]]:
+    """Build one atomic queue-or-spawn attempt bound to ONE session capture.
+
+    The single dispatch implementation shared by the /send route's
+    immediate path and :func:`_drain_pending_sends` — session re-capture
+    across /resume//new identity swaps, the cross-user and attachment
+    queue guards, ``send_id`` threading (the queue path reuses it as
+    ``queue_msg_id`` so the client's DELETE targets one id either way),
+    and the spawn-path metrics all live here, once.  Callers re-capture
+    ``ws.session`` before every attempt and pass it in: closures bound
+    to a pre-swap capture would send the user's message into the wrong
+    workstream's transcript.
+
+    ``queue_outcome`` (second element of the return) is written only
+    when the dispatcher takes the live-worker reuse path; empty after a
+    fresh-spawn dispatch.
+
+    ``defer_fidelity=True`` marks a deferred entry's attempt: it was
+    answered "queued" under the full-fidelity defer contract, so the
+    interjection fallback — which truncates at ``queue_message``'s
+    2000-char cap and cannot carry attachments — is refused for
+    oversized or attachment-bearing entries (the drain waits for the
+    slot and retries into the fresh-spawn arm instead).  The refusal
+    happens inside the enqueue callback, under the same ``ws._lock``
+    acquisition as the queue-vs-spawn decision, so a turn claiming the
+    slot between the drain's poll and this dispatch can never route the
+    entry into truncation.
+
+    ``request`` is ``None`` for drain-side attempts; the spawn-metrics
+    hook tolerates it (both installed impls ignore the argument).
+    """
+    import threading
+
+    from turnstone.core import session_worker
+    from turnstone.core.session import (
+        AttachmentsNotQueueableError,
+        CrossUserInterjectionError,
+        GenerationCancelled,
+    )
+
+    def attempt(session: ChatSession) -> tuple[bool, dict[str, Any]]:
+        queue_outcome: dict[str, Any] = {}
+
+        def _enqueue() -> None:
+            # Runs under ``ws._lock`` (session_worker.send calls it inside
+            # the same acquisition that reads _worker_running), so this
+            # worker_kind read cannot race the spawn write.  A command
+            # window must NEVER reach queue_message — its cap and
+            # cross-user guard are turn semantics — so report it and let
+            # the route defer (or the drain re-park).
+            if ws.worker_kind == "command":
+                queue_outcome["rejected"] = "command_window"
+                return
+            if defer_fidelity and (resolved_atts or len(message) > 2000):
+                queue_outcome["rejected"] = "defer_full_fidelity"
+                return
+            try:
+                cleaned, priority, msg_id = session.queue_message(
+                    message,
+                    attachment_ids=list(ordered_taken),
+                    queue_msg_id=send_id or None,
+                    interjector_user_id=acting_uid,
+                )
+            except AttachmentsNotQueueableError:
+                queue_outcome["rejected"] = "attachments_busy"
+                return
+            except CrossUserInterjectionError:
+                # A different authenticated participant tried to interject
+                # into someone else's in-flight turn; folding it in would
+                # borrow the initiator's credentials and misattribute the
+                # message.  Reject so they resend as a fresh turn once the
+                # worker idles (the drain instead waits and re-attempts).
+                queue_outcome["rejected"] = "cross_user_interjection"
+                return
+            queue_outcome["cleaned"] = cleaned
+            queue_outcome["priority"] = priority
+            queue_outcome["msg_id"] = msg_id
+
+        def _run() -> None:
+            me = threading.current_thread()
+            try:
+                kwargs: dict[str, Any] = {}
+                if resolved_atts:
+                    kwargs["attachments"] = resolved_atts
+                if send_id:
+                    kwargs["send_id"] = send_id
+                # Fresh turn: rebind per-user MCP credentials to the
+                # authenticated sender. Bound here (not via a send()
+                # kwarg) so per-kind session stubs with explicit send
+                # signatures keep working; getattr-guarded for the same
+                # reason. The queue path above never rebinds.
+                bind = getattr(session, "bind_acting_user", None)
+                if acting_uid and callable(bind):
+                    bind(acting_uid)
+                session.send(message, **kwargs)
+            except GenerationCancelled:
+                # Safety net — send() normally handles this internally.
+                # If this thread was force-abandoned, ws.worker_thread
+                # was set to None — don't emit spurious events.
+                if ws.worker_thread is me:
+                    _emit_send_ui(ws, ui, "on_stream_end")
+                    _emit_send_ui(ws, ui, "on_state_change", "idle")
+            except Exception:
+                # Undrained staged uploads aren't locked (the buffer is a
+                # peek, not a reservation) — they expire on the buffer TTL
+                # — so the only cleanup owed here is the UI streaming
+                # hook: ``session.send()`` already fired ``on_error``
+                # (with sanitized text), persisted ``last_error``, and
+                # emitted ``state='error'`` via
+                # :meth:`ChatSession._record_fatal_error` before
+                # re-raising.
+                if ws.worker_thread is me:
+                    _emit_send_ui(ws, ui, "on_stream_end")
+
+        ok = session_worker.send(
+            ws,
+            enqueue=_enqueue,
+            run=_run,
+            thread_name=f"send-worker-{ws.id[:8]}",
+        )
+        if ok and not queue_outcome and cfg.spawn_metrics is not None:
+            # Fresh spawn — the kind's per-turn metrics fire exactly once,
+            # from the shared attempt so the drain's dispatches count too.
+            try:
+                cfg.spawn_metrics(request, ui)
+            except Exception:
+                log.debug(
+                    "ws.send.spawn_metrics_failed ws=%s",
+                    ws.id[:8] if ws.id else "",
+                    exc_info=True,
+                )
+        return ok, queue_outcome
+
+    return attempt
+
+
+def _drain_pending_sends(ws: Workstream) -> None:
+    """Dispatch a workstream's deferred sends once its command window closes.
+
+    Per-workstream single-flight (``ws._pending_drain``), started by the
+    /send route when it defers an entry and run on a small daemon thread
+    (the dispatch machinery is synchronous and thread-shaped like every
+    other worker here, and a thread's lifetime is independent of any
+    event loop's — the request loop owes this drain nothing once the
+    route has answered).  It owns the waiting the parked POST used to do
+    — but server-side, so a client timeout or abort can no longer become
+    message loss.  Entries dispatch in arrival order via their prebuilt
+    attempt closures, re-capturing ``ws.session`` per attempt (a /resume
+    or /new that swapped the session mid-window routes the message into
+    the post-swap session, exactly as the park did).
+
+    Terminal outcomes per entry: dispatched (fresh spawn — or, for a
+    queue-shaped entry, the interjection fallback into a live turn,
+    msg_id preserved so the client's DELETE still targets it),
+    retracted (dismissed before dispatch), or dropped because the
+    workstream closed.  There is deliberately no give-up bound: an entry
+    acknowledged "queued" is never silently dropped while the workstream
+    lives — rejections wait for the slot to free and retry into the
+    fresh-spawn arm.
+
+    Claim discipline: an entry is popped under ``ws._lock`` immediately
+    before its dispatch attempt and re-inserted on rejection, so the
+    DELETE fall-through (which marks only in-list entries) can never
+    "remove" a message whose dispatch already left the station — a
+    claimed entry answers ``not_found`` ("already sent"), which its
+    eventual dispatch makes true.
+    """
+    import time
+
+    try:
+        while True:
+            with ws._lock:
+                pending = ws._pending_sends
+                while pending and pending[0].retracted:
+                    pending.pop(0)
+                if ws._closed:
+                    if pending:
+                        log.warning(
+                            "ws.send.pending_dropped_on_close ws=%s count=%d",
+                            ws.id[:8],
+                            len(pending),
+                        )
+                        pending.clear()
+                    ws._pending_drain = None
+                    return
+                if not pending:
+                    ws._pending_drain = None
+                    return
+                entry = pending[0]
+            if ws._worker_running and ws.worker_kind == "command":
+                # The park, relocated server-side: the poll cadence
+                # matches the old request-handler loop's.
+                time.sleep(0.25)
+                continue
+            session_now = ws.session
+            if session_now is None:
+                # Mid-swap / partial-construction gap; the loop-top close
+                # check terminates this if it's a close in progress.
+                time.sleep(0.25)
+                continue
+            with ws._lock:
+                if not ws._pending_sends or ws._pending_sends[0] is not entry:
+                    continue  # list reshaped under us — re-evaluate
+                if entry.retracted:
+                    ws._pending_sends.pop(0)
+                    continue
+                ws._pending_sends.pop(0)  # claim
+            ok, outcome = entry.attempt(session_now)
+            if not ok or outcome.get("rejected") in (
+                "command_window",
+                "defer_full_fidelity",
+                "attachments_busy",
+                "cross_user_interjection",
+            ):
+                # Window re-claimed between the poll and the dispatch, a
+                # live turn holds the slot against a full-fidelity entry,
+                # the interjection queue is saturated
+                # (session_worker.send → False on queue.Full), or the ws
+                # closed (resolved at the loop top).  Unclaim and wait.
+                with ws._lock:
+                    ws._pending_sends.insert(0, entry)
+                time.sleep(0.25)
+                continue
+            # Dispatched: fresh spawn (empty outcome) or interjection
+            # fallback (msg_id preserved) — this entry is done.
+    except Exception:
+        # Never die holding the single-flight slot — a wedged drain would
+        # strand every future deferred send for this workstream.
+        log.exception("ws.send.pending_drain_failed ws=%s", ws.id[:8] if ws.id else "")
+        with ws._lock:
+            ws._pending_drain = None
+
+
 def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
     """Lifted body for ``POST {prefix}/{ws_id}/send`` — message dispatch.
 
@@ -3977,8 +4289,13 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
       requested attachments that landed (may be a strict subset on
       reservation race losses).
     - 200 ``{"status": "queued", "priority", "msg_id", "attached_ids",
-      "dropped_attachment_ids"}`` — reused live worker; queued for
-      injection at the next tool-result seam.
+      "dropped_attachment_ids"}`` — reused live worker (queued for
+      injection at the next tool-result seam), OR deferred during a
+      slash-command window (registered on ``ws._pending_sends`` and
+      dispatched full-fidelity by :func:`_drain_pending_sends` when the
+      window closes — see :class:`_PendingSend` for the durability
+      contract).  ``DELETE {prefix}/{ws_id}/send`` with the ``msg_id``
+      retracts either kind before dispatch.
     - 200 ``{"status": "queue_full", "attached_ids",
       "dropped_attachment_ids"}`` — live worker's queue at
       capacity; reservations released. Caller should retry. The
@@ -3991,12 +4308,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
     import threading
     import uuid
 
-    from turnstone.core import session_worker
-    from turnstone.core.session import (
-        AttachmentsNotQueueableError,
-        CrossUserInterjectionError,
-        GenerationCancelled,
-    )
+    from turnstone.core.tool_advisory import parse_priority
     from turnstone.core.web_helpers import auth_user_id, read_json_or_400
 
     async def send(request: Request) -> Response:
@@ -4093,162 +4405,94 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         if ws.session is None:
             return JSONResponse({"error": "No session"}, status_code=500)
 
-        def _dispatch_once(session: ChatSession) -> tuple[bool, dict[str, Any]]:
-            """One atomic queue-or-spawn attempt bound to ONE session capture.
-
-            The park loop below re-captures ``ws.session`` before every
-            attempt — a /resume or /new that ran while we parked swaps the
-            session's workstream identity in place, and closures bound to
-            the pre-swap capture would send the user's message into the
-            wrong workstream's transcript.  Binding happens here, in one
-            place, per attempt.  ``queue_outcome`` is written only when the
-            dispatcher takes the live-worker reuse path; empty after a
-            fresh-spawn dispatch.
-            """
-            queue_outcome: dict[str, Any] = {}
-
-            def _enqueue() -> None:
-                # Runs under ``ws._lock`` (session_worker.send calls it
-                # inside the same acquisition that reads _worker_running),
-                # so this worker_kind read cannot race the spawn write.  A
-                # command window must NEVER reach queue_message — its cap
-                # and cross-user guard are turn semantics — so refuse and
-                # let the route loop back to the park.
-                if ws.worker_kind == "command":
-                    queue_outcome["rejected"] = "command_window"
-                    return
-                try:
-                    cleaned, priority, msg_id = session.queue_message(
-                        message,
-                        attachment_ids=list(ordered_taken),
-                        queue_msg_id=send_id or None,
-                        interjector_user_id=acting_uid,
-                    )
-                except AttachmentsNotQueueableError:
-                    queue_outcome["rejected"] = "attachments_busy"
-                    return
-                except CrossUserInterjectionError:
-                    # A different authenticated participant tried to interject into
-                    # someone else's in-flight turn; folding it in would borrow the
-                    # initiator's credentials and misattribute the message. Reject
-                    # so they resend as a fresh turn once the worker idles.
-                    queue_outcome["rejected"] = "cross_user_interjection"
-                    return
-                queue_outcome["cleaned"] = cleaned
-                queue_outcome["priority"] = priority
-                queue_outcome["msg_id"] = msg_id
-
-            def _run() -> None:
-                me = threading.current_thread()
-                try:
-                    kwargs: dict[str, Any] = {}
-                    if resolved_atts:
-                        kwargs["attachments"] = resolved_atts
-                    if send_id:
-                        kwargs["send_id"] = send_id
-                    # Fresh turn: rebind per-user MCP credentials to the
-                    # authenticated sender. Bound here (not via a send()
-                    # kwarg) so per-kind session stubs with explicit send
-                    # signatures keep working; getattr-guarded for the same
-                    # reason. The queue path above never rebinds.
-                    bind = getattr(session, "bind_acting_user", None)
-                    if acting_uid and callable(bind):
-                        bind(acting_uid)
-                    session.send(message, **kwargs)
-                except GenerationCancelled:
-                    # Safety net — send() normally handles this internally.
-                    # If this thread was force-abandoned, ws.worker_thread
-                    # was set to None — don't emit spurious events.
-                    if ws.worker_thread is me:
-                        _emit_ui("on_stream_end")
-                        _emit_ui("on_state_change", "idle")
-                except Exception:
-                    # Undrained staged uploads aren't locked (the buffer is a peek,
-                    # not a reservation) — they expire on the buffer TTL — so the
-                    # only cleanup owed here is the UI streaming hook.
-                    if ws.worker_thread is me:
-                        # ``session.send()`` already fired ``on_error``
-                        # (with sanitized text), persisted ``last_error``,
-                        # and emitted ``state='error'`` via
-                        # :meth:`ChatSession._record_fatal_error` before
-                        # re-raising.  The route handler only needs the
-                        # streaming-cleanup hook the worker contract owes
-                        # the UI listeners.
-                        _emit_ui("on_stream_end")
-
-            ok = session_worker.send(
-                ws,
-                enqueue=_enqueue,
-                run=_run,
-                thread_name=f"send-worker-{ws.id[:8]}",
-            )
-            return ok, queue_outcome
-
-        def _emit_ui(hook_name: str, *args: Any) -> None:
-            """Best-effort UI hook dispatch.
-
-            Each call is wrapped in try/except so a failure in one
-            hook (e.g. listener-queue full → on_error raises) doesn't
-            suppress the others. Mirrors the pre-P1.5
-            coord_adapter.send per-hook defense.  Defined after
-            ``_dispatch_once`` but resolved late (when a worker runs) —
-            every dispatch happens strictly below this line.
-            """
-            if ui is None:
-                return
-            method = getattr(ui, hook_name, None)
-            if method is None:
-                return
-            try:
-                method(*args)
-            except Exception:
-                log.debug(
-                    "ws.send.ui_hook_failed ws=%s hook=%s",
-                    ws.id[:8] if ws.id else "",
-                    hook_name,
-                    exc_info=True,
-                )
-
-        # Park-then-dispatch.  While a slash-command worker holds the slot
-        # (a manual /compact can hold it for MINUTES), a send must not take
+        # Defer-and-drain.  While a slash-command worker holds the slot (a
+        # manual /compact can hold it for MINUTES), a send must not take
         # the interjection-queue path — its 2000-char cap and cross-user
         # guard are mid-TURN semantics, and a queued message would cross a
-        # /resume//new identity swap into the wrong workstream.  Parking
-        # reproduces the pre-worker-dispatch observable behavior (the
-        # request waited out the then-blocked event loop, then ran as a
-        # normal full-fidelity send under the sender's own identity) with
-        # the loop free: SSE keeps streaming the compaction progress card
-        # while we wait.  The inner park is deliberately unbounded — the
-        # composer bounds its POST at ~15s and aborts, and we poll
-        # ``is_disconnected`` because starlette does NOT cancel a running
-        # handler on client disconnect: dispatching after the client gave
-        # up would surprise the user with a duplicate turn when they
-        # resend.  The outer bound only caps command-window FLAPPING
-        # (back-to-back commands re-claiming the slot between our park
-        # exit and dispatch).
-        ok = False
-        queue_outcome: dict[str, Any] = {}
-        for _ in range(20):
-            while ws._worker_running and ws.worker_kind == "command":
-                if await request.is_disconnected():
-                    # Client abandoned the send mid-park; the response is
-                    # discarded — the status is for the access log only.
-                    return JSONResponse({"status": "abandoned"})
-                await asyncio.sleep(0.25)
-            session_now = ws.session
-            if session_now is None:
-                return JSONResponse({"error": "No session"}, status_code=500)
-            ok, queue_outcome = _dispatch_once(session_now)
-            if queue_outcome.get("rejected") != "command_window":
-                break
-        else:
-            # 20 consecutive command-window collisions — surface the same
-            # retryable backpressure shape as a saturated queue.
+        # /resume//new identity swap into the wrong workstream.  Instead
+        # of parking THIS request until the window closes (which encoded
+        # "client disconnected" as "message retracted" — deterministic
+        # message loss for every bounded caller: the coordinator client
+        # and console proxy time out at 30s, and the web composers' long
+        # abort bound raced the compaction card), the send is answered
+        # "queued" immediately and registered on ``ws._pending_sends``;
+        # the per-workstream drain task dispatches it full-fidelity when
+        # the window closes.  Dismissal is the same DELETE /send
+        # {msg_id} the interjection queue uses — server-confirmed, no
+        # POST-abort side channel.
+        attempt = _make_dispatch_attempt(
+            ws,
+            cfg,
+            ui,
+            message=message,
+            resolved_atts=resolved_atts,
+            ordered_taken=ordered_taken,
+            send_id=send_id,
+            acting_uid=acting_uid,
+            request=request,
+        )
+        session_now = ws.session
+        if session_now is None:
+            return JSONResponse({"error": "No session"}, status_code=500)
+        ok, queue_outcome = attempt(session_now)
+        if queue_outcome.get("rejected") == "command_window":
+            # ``send_id`` is minted only when attachments are enabled —
+            # the deferred entry needs a truthy id regardless: it is the
+            # client's dismiss/bind handle and the drain's
+            # queue_msg_id/send_id thread.
+            pending_msg_id = send_id or uuid.uuid4().hex
+            cleaned_display, pending_priority = parse_priority(message)
+            entry = _PendingSend(
+                msg_id=pending_msg_id,
+                priority=pending_priority,
+                attempt=_make_dispatch_attempt(
+                    ws,
+                    cfg,
+                    ui,
+                    message=message,
+                    resolved_atts=resolved_atts,
+                    ordered_taken=ordered_taken,
+                    send_id=pending_msg_id,
+                    acting_uid=acting_uid,
+                    request=None,
+                    defer_fidelity=True,
+                ),
+            )
+            with ws._lock:
+                if ws._closed:
+                    # Mirror the dispatch-refusal 404 below: a "queued"
+                    # answer for a workstream whose next resolution 404s
+                    # would promise a dispatch that can never happen.
+                    return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+                ws._pending_sends.append(entry)
+                drain = ws._pending_drain
+                if drain is None or not drain.is_alive():
+                    t = threading.Thread(
+                        target=_drain_pending_sends,
+                        args=(ws,),
+                        name=f"pending-drain-{ws.id[:8]}",
+                        daemon=True,
+                    )
+                    ws._pending_drain = t
+                    t.start()
+            if cfg.emit_message_queued and hasattr(ui, "_enqueue"):
+                ui._enqueue(
+                    {
+                        "type": "message_queued",
+                        "message": cleaned_display,
+                        "priority": pending_priority,
+                        "msg_id": pending_msg_id,
+                    }
+                )
             return JSONResponse(
                 {
-                    "status": "queue_full",
-                    "attached_ids": [],
-                    "dropped_attachment_ids": list(requested_ids),
+                    "status": "queued",
+                    "priority": pending_priority,
+                    "msg_id": pending_msg_id,
+                    "attached_ids": list(ordered_taken),
+                    "dropped_attachment_ids": [
+                        aid for aid in requested_ids if aid not in taken_set
+                    ],
                 }
             )
         if not ok:
@@ -4324,16 +4568,9 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                 }
             )
 
-        # Spawned a fresh worker — kind's metrics fire once per turn.
-        if cfg.spawn_metrics is not None:
-            try:
-                cfg.spawn_metrics(request, ui)
-            except Exception:
-                log.debug(
-                    "ws.send.spawn_metrics_failed ws=%s",
-                    ws_id[:8] if ws_id else "",
-                    exc_info=True,
-                )
+        # Spawned a fresh worker — the kind's per-turn metrics fired inside
+        # the shared attempt (see _make_dispatch_attempt), where the drain
+        # task's dispatches fire them too.
         return JSONResponse(
             {
                 "status": "ok",
@@ -4633,12 +4870,17 @@ def make_attachment_handlers(cfg: SessionEndpointConfig) -> AttachmentHandlers:
 def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
     """Lifted body for ``DELETE {prefix}/{ws_id}/send`` — cancel a queued message.
 
-    Removes a previously-queued message identified by ``msg_id`` from
-    the workstream's pending queue. Returns ``status: removed`` when
-    the queue had the entry and ``status: not_found`` otherwise.
-    Queued messages don't carry attachments (see
-    :class:`AttachmentsNotQueueableError`), so there's no reservation
-    side-effect to undo here.
+    Removes a previously-queued message identified by ``msg_id`` —
+    first from the session's interjection queue, then (fall-through)
+    from the workstream's deferred-send list (``ws._pending_sends``,
+    sends answered "queued" during a command window).  Returns
+    ``status: removed`` when either held the entry and
+    ``status: not_found`` otherwise.  Interjection-queued messages
+    don't carry attachments (see :class:`AttachmentsNotQueueableError`)
+    and a deferred entry's resolved attachments die with it (the staged
+    bytes were peeked, not reserved — they expire on the buffer TTL),
+    so there's no reservation side-effect to undo here; the client
+    surfaces the discarded-attachments consequence to the user.
     """
     from turnstone.core.web_helpers import read_json_or_400
 
@@ -4677,6 +4919,21 @@ def make_dequeue_handler(cfg: SessionEndpointConfig) -> Handler:
         if ws.session is None:
             return JSONResponse({"error": "No session"}, status_code=400)
         removed = ws.session.dequeue_message(msg_id)
+        if not removed:
+            # Fall through to the deferred-send list: a send answered
+            # "queued" during a command window lives on the workstream
+            # (see _PendingSend), not in the session's interjection
+            # queue.  Marked under the same lock the drain claims under,
+            # so a retracted entry can never dispatch; an entry the
+            # drain already claimed is gone from the list and correctly
+            # answers not_found ("already sent" — its dispatch is in
+            # flight).
+            with ws._lock:
+                for entry in ws._pending_sends:
+                    if entry.msg_id == msg_id and not entry.retracted:
+                        entry.retracted = True
+                        removed = True
+                        break
         return JSONResponse({"status": "removed" if removed else "not_found"})
 
     return dequeue

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -587,6 +587,19 @@ class SessionUIBase:
         # Activity tracking for dashboard ("thinking" / "tool" / "").
         self._ws_current_activity: str = ""
         self._ws_activity_state: str = ""
+        # Compaction pill window: while True, on_thinking_start leaves the
+        # activity alone (the impl's own thinking wrap would otherwise
+        # clobber "Compacting context…" with "Thinking…" milliseconds after
+        # the start event set it, for the whole summarize phase).  The end
+        # event restores the pre-compaction pair, so a bail can't strand a
+        # stale "Compacting context…" on an idle workstream either.
+        self._compaction_activity_live: bool = False
+        self._pre_compaction_activity: tuple[str, str] = ("", "")
+        # Which compaction owns the latch (its ``compaction_id``): a
+        # force-abandoned compaction's LATE end event must not restore a
+        # stale pill pair over — or unlatch — a successor compaction that
+        # has since taken the latch over.
+        self._compaction_activity_owner: int = 0
         # Turn-content accumulator: assistant tokens piggybacked onto
         # the ``ws_state:idle`` broadcast so the dashboard renders the
         # turn without an extra storage round-trip. Cleared on IDLE /
@@ -2970,10 +2983,17 @@ class SessionUIBase:
             self._reset_inflight_buffers_locked()
 
     def on_thinking_start(self) -> None:
-        """Track that the model is thinking; broadcast activity + enqueue."""
+        """Track that the model is thinking; broadcast activity + enqueue.
+
+        Inside a compaction window the activity write is skipped —
+        :meth:`on_compaction` owns the pill there ("Compacting context…"
+        must survive the summarize phase's own thinking wrap); the
+        ``thinking_start`` event still flows for the spinner UIs.
+        """
         with self._ws_lock:
-            self._ws_current_activity = "Thinking…"
-            self._ws_activity_state = "thinking"
+            if not self._compaction_activity_live:
+                self._ws_current_activity = "Thinking…"
+                self._ws_activity_state = "thinking"
         self._broadcast_activity()
         self._enqueue({"type": "thinking_start"})
 
@@ -3254,6 +3274,137 @@ class SessionUIBase:
         return self._enqueue(
             {"type": "system_turn", "content": content, "source": source, "meta": meta or None}
         )
+
+    def on_compaction(self, payload: dict[str, Any]) -> int | None:
+        """Surface one compaction lifecycle event (``phase`` = start/progress/end).
+
+        The transcript affordance for context compaction: ``start`` paints
+        the in-progress card, ``progress`` drives its bar (chunked
+        summarization emits ``part``/``total``/``depth``), and ``end``
+        replaces it with the result card (or the failure notice).  The
+        successful ``end`` event's id is returned so ``_compact_messages``
+        stamps the persisted compaction marker row with the matching
+        resume cursor — the same live-event/history-row alignment
+        :meth:`on_system_turn` provides for operator turns, which is what
+        keeps a ``/history`` repaint and an SSE replay from double-rendering
+        the result card.
+
+        Inside a task agent the events are dropped (same rule as
+        :meth:`on_info`): a sub-agent's compaction is progress chatter that
+        carries no ``call_id``, so it cannot nest under the task card and
+        must not paint a top-level compaction card on the pane.
+
+        ``superseded`` (stamped by ``ChatSession._compaction_event``) marks
+        events from a force-abandoned compaction whose generation a
+        successor has since claimed.  Its start/progress events are
+        swallowed — animating a card for a dead compaction, or re-creating
+        one via the panes' defensive-create, is pure corruption — but its
+        END flows WITH the flag on the wire: the pane needs the event to
+        retire the card the abandoned compaction painted while it was
+        live, and the flag to know its failure notice would narrate a
+        compaction nobody is waiting on (a superseded OK end still renders
+        the result card — the history swap really happened).  On the latch
+        side a superseded end unlatches (so the live turn's thinking
+        writes resume) without restoring — its saved pair predates the
+        successor turn and would overwrite the live pill.
+        """
+        if _agent_scope_var.get() > 0:
+            return None
+        payload = dict(payload)
+        superseded = bool(payload.pop("superseded", False))
+        cid = int(payload.get("compaction_id") or 0)
+        phase = payload.get("phase")
+        if phase == "end":
+            # Ends carry the flag on the wire (typed in both SDKs);
+            # start/progress never do — the live ones are by definition
+            # not superseded and the stale ones are swallowed below.
+            payload["superseded"] = superseded
+        if phase == "start" and not superseded:
+            # The activity pill mirrors on_thinking_start's mechanics but
+            # names the actual work — the summarize calls can run for a
+            # while and "Thinking…" undersells what the session is doing.
+            # Save the prior pair for the end-side restore, and latch the
+            # window so the impl's own on_thinking_start can't clobber it.
+            with self._ws_lock:
+                if not self._compaction_activity_live:
+                    # A stale (abandoned) compaction may still hold the
+                    # latch — keep ITS saved pair as the restore target
+                    # rather than capturing the "Compacting context…" it
+                    # wrote.
+                    self._pre_compaction_activity = (
+                        self._ws_current_activity,
+                        self._ws_activity_state,
+                    )
+                self._ws_current_activity = "Compacting context…"
+                self._ws_activity_state = "thinking"
+                self._compaction_activity_live = True
+                self._compaction_activity_owner = cid
+            self._broadcast_activity()
+        elif phase == "end":
+            # Restore whatever the pill showed before the compaction — a
+            # mid-turn auto-compaction hands back to the send loop (whose
+            # next thinking/tool write overwrites anyway); a manual bail
+            # returns the idle session's blank pair instead of stranding
+            # "Compacting context…" on an idle workstream.  Owner-gated:
+            # an abandoned compaction's late end must leave a successor's
+            # latch (and pill) alone.
+            changed = False
+            with self._ws_lock:
+                if self._compaction_activity_live and self._compaction_activity_owner == cid:
+                    # A superseded owner-end only unlatches: its saved pair
+                    # predates the successor turn and must not overwrite the
+                    # live pill (the latch itself isn't in the broadcast
+                    # snapshot, so unlatch-only is also broadcast-free).
+                    changed = self._release_compaction_latch_locked(restore=not superseded)
+            if changed:
+                self._broadcast_activity()
+        if superseded and phase != "end":
+            return None
+        return self._enqueue({"type": "compaction", **payload})
+
+    def _release_compaction_latch_locked(self, *, restore: bool) -> bool:
+        """Unlatch the compaction pill window; optionally restore the pair.
+
+        The shared release half of the latch invariant — called under
+        ``_ws_lock`` by the owner-gated ``end`` arm of :meth:`on_compaction`
+        (restore unless superseded) and by :meth:`on_generation_claimed`
+        (always restore).  Returns whether the broadcast snapshot — the
+        ``(activity, state)`` pair — actually changed.
+        """
+        self._compaction_activity_live = False
+        if restore:
+            (
+                self._ws_current_activity,
+                self._ws_activity_state,
+            ) = self._pre_compaction_activity
+            return True
+        return False
+
+    def on_generation_claimed(self, generation: int) -> None:
+        """Break a stale compaction activity latch at a new generation claim.
+
+        Called by ``ChatSession._claim_generation`` (getattr-guarded, like
+        ``on_aux_usage``).  The claim is the exact moment any live latch is
+        provably stale — the worker slot serializes turns, so a latch held
+        at claim time belongs to a force-abandoned compaction whose late
+        events may be a full summary call away.  Without this, the whole
+        successor turn's ``on_thinking_start`` writes are suppressed and
+        the pill re-broadcasts "Compacting context…" over a live turn.
+
+        Unlatch AND restore the saved pre-compaction pair: restoring keeps
+        ``_pre_compaction_activity`` coherent for a successor compaction's
+        own start (which saves the CURRENT pair as its restore target — a
+        leftover "Compacting context…" here would get re-stranded on an
+        idle workstream after that successor completes).  A send claimer's
+        first thinking/tool write overwrites the restored pair within
+        milliseconds either way.
+        """
+        changed = False
+        with self._ws_lock:
+            if self._compaction_activity_live and self._compaction_activity_owner != generation:
+                changed = self._release_compaction_latch_locked(restore=True)
+        if changed:
+            self._broadcast_activity()
 
     # ------------------------------------------------------------------
     # Broadcast hooks — kind-specific transport.

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -93,6 +93,7 @@ def send(
     enqueue: Callable[[], None],
     run: Callable[[], None],
     thread_name: str | None = None,
+    worker_kind: str = "turn",
 ) -> bool:
     """Dispatch work onto a workstream's worker thread.
 
@@ -105,6 +106,31 @@ def send(
     Both callbacks are no-arg closures — callers close over the
     ``ChatSession`` they want to drive, so the worker can't be racing a
     concurrent ``ws.session`` swap.
+
+    ``worker_kind`` classifies what the slot holds — ``"turn"`` (send /
+    retry / wake / init, the default) or ``"command"`` (slash-command
+    workers, including the minutes-long manual /compact).  Written to
+    ``ws.worker_kind`` in the same lock acquisition as the
+    ``(worker_thread, _worker_running)`` pair.  This is the ONLY site
+    that sets ``_worker_running=True``, so the classification cannot be
+    bypassed by a new dispatch caller.  The /send route parks while a
+    command holds the slot instead of taking the interjection-queue
+    path (whose length cap / cross-user guard are turn semantics); an
+    ``enqueue`` callback that can fire during a command window (the
+    coordinator adapter's, the init race's) must refuse rather than
+    queue — see the command-window refusals at those closures.
+
+    The refusal is DELIBERATELY not centralized here despite the three
+    hand-written guards: each surface needs a different refusal channel
+    (the /send route signals "re-park" via its ``queue_outcome`` flag;
+    the coordinator adapter and the init race raise ``queue.Full`` into
+    their existing backpressure statuses), and a central refusal inside
+    this function can only return ``False`` — indistinguishable from
+    queue-full/closed for the route's re-park decision and mislabeled by
+    the init path's status derivation.  Making it distinguishable means
+    a tri-state contract change across every dispatch caller, which is
+    more surface than three four-line guards.  If you add a NEW enqueue
+    closure that can queue turn work, copy the guard.
 
     Returns:
         ``True`` on successful enqueue (existing worker accepted) or
@@ -196,6 +222,7 @@ def send(
         # lock-window cost is dominated by the spawn branch's identity
         # write either way.
         ws._worker_running = True
+        ws.worker_kind = worker_kind
         t = threading.Thread(target=_runner, name=name, daemon=True)
         ws.worker_thread = t
     # ``t.start()`` may run user code (worker body) before returning;

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -145,6 +145,12 @@ def send(
         caller surfaces 429) or any other exception (logged). Falling
         through to spawn a second worker on a full queue would corrupt
         ChatSession state.
+
+    Raises:
+        Whatever ``Thread.start()`` raised when the spawn itself fails
+        (thread exhaustion, ``MemoryError``) — the slot claim is rolled
+        back first, so the workstream stays dispatchable once resources
+        recover instead of wedging behind a flag no thread will clear.
     """
     name = thread_name or f"session-worker-{ws.id[:8]}"
 
@@ -233,5 +239,27 @@ def send(
     # ``t.start()`` may run user code (worker body) before returning;
     # keep it outside the lock to avoid pinning ``ws._lock`` for the
     # full thread-creation cost.
-    t.start()
+    try:
+        t.start()
+    except Exception:
+        # Thread creation failed (RuntimeError under thread exhaustion,
+        # MemoryError): the slot was claimed under the lock above, but the
+        # flag's normal clearer is ``_runner``'s finally — on a thread
+        # that will never run.  Without this release, ``_worker_running``
+        # stays True forever on a workstream that LOOKS idle (the worker
+        # never fired a state change), every future dispatch takes the
+        # reuse path into a queue with no consumer, and only an operator
+        # force-cancel unwedges it.  Identity-guarded like ``_runner``'s
+        # clear: a concurrent force-cancel may already have cleared or
+        # replaced the slot, and this must not clobber a live successor.
+        # Re-raise rather than return False: callers' crash paths (the
+        # deferred-send drain's per-iteration handler with its backoff)
+        # are shaped for exceptions, and a False here would masquerade as
+        # queue-full backpressure.
+        with ws._lock:
+            if ws.worker_thread is t:
+                ws.worker_thread = None
+                ws._worker_running = False
+        log.exception("session_worker.spawn_failed ws=%s — slot released", ws.id[:8])
+        raise
     return True

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -113,24 +113,29 @@ def send(
     ``ws.worker_kind`` in the same lock acquisition as the
     ``(worker_thread, _worker_running)`` pair.  This is the ONLY site
     that sets ``_worker_running=True``, so the classification cannot be
-    bypassed by a new dispatch caller.  The /send route parks while a
+    bypassed by a new dispatch caller.  The /send route DEFERS while a
     command holds the slot instead of taking the interjection-queue
-    path (whose length cap / cross-user guard are turn semantics); an
-    ``enqueue`` callback that can fire during a command window (the
-    coordinator adapter's, the init race's) must refuse rather than
-    queue — see the command-window refusals at those closures.
+    path (whose length cap / cross-user guard are turn semantics): its
+    enqueue closure reports the window and the route registers the send
+    on ``ws._pending_sends`` for the drain task to dispatch when the
+    window closes.  An ``enqueue`` callback that can fire during a
+    command window (the coordinator adapter's, the init race's) must
+    refuse rather than queue — see the command-window refusals at those
+    closures.
 
-    The refusal is DELIBERATELY not centralized here despite the three
+    The refusal is DELIBERATELY not centralized here despite the
     hand-written guards: each surface needs a different refusal channel
-    (the /send route signals "re-park" via its ``queue_outcome`` flag;
-    the coordinator adapter and the init race raise ``queue.Full`` into
-    their existing backpressure statuses), and a central refusal inside
-    this function can only return ``False`` — indistinguishable from
-    queue-full/closed for the route's re-park decision and mislabeled by
-    the init path's status derivation.  Making it distinguishable means
-    a tri-state contract change across every dispatch caller, which is
-    more surface than three four-line guards.  If you add a NEW enqueue
-    closure that can queue turn work, copy the guard.
+    (the /send route's closure signals "command window" via its
+    ``queue_outcome`` flag — the defer trigger; the coordinator adapter
+    and the init race raise ``queue.Full`` into their existing
+    backpressure statuses), and a central refusal inside this function
+    can only return ``False`` — indistinguishable from queue-full/closed
+    exactly where the route must distinguish "defer this" from "drop
+    this".  Making it distinguishable means a tri-state contract change
+    across every dispatch caller — more surface than the guards it
+    replaces.  (A check inside this function's locked section would be
+    race-free; the cost is the contract change, not atomicity.)  If you
+    add a NEW enqueue closure that can queue turn work, copy the guard.
 
     Returns:
         ``True`` on successful enqueue (existing worker accepted) or

--- a/turnstone/core/session_worker.py
+++ b/turnstone/core/session_worker.py
@@ -47,7 +47,7 @@ from turnstone.core.log import get_logger
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from turnstone.core.workstream import Workstream
+    from turnstone.core.workstream import WorkerKind, Workstream
 
 log = get_logger(__name__)
 
@@ -93,7 +93,7 @@ def send(
     enqueue: Callable[[], None],
     run: Callable[[], None],
     thread_name: str | None = None,
-    worker_kind: str = "turn",
+    worker_kind: WorkerKind = "turn",
 ) -> bool:
     """Dispatch work onto a workstream's worker thread.
 

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -480,10 +480,17 @@ class PostgreSQLBackend:
         return msg_rows, (attachments or None)
 
     def load_messages(
-        self, ws_id: str, *, limit: int | None = None, repair: bool = True
+        self,
+        ws_id: str,
+        *,
+        limit: int | None = None,
+        repair: bool = True,
+        include_compaction: bool = False,
     ) -> list[dict[str, Any]]:
         msg_rows, attachments = self._conversation_rows(ws_id, limit)
-        return _reconstruct_messages(msg_rows, ws_id, attachments, repair=repair)
+        return _reconstruct_messages(
+            msg_rows, ws_id, attachments, repair=repair, include_compaction=include_compaction
+        )
 
     def load_message_turns(self, ws_id: str, *, checkpointed: bool = True) -> list[Turn]:
         """Load the conversation as canonical ``Turn``s (unresolved AttachmentRef)

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -227,7 +227,12 @@ class StorageBackend(Protocol):
         ...
 
     def load_messages(
-        self, ws_id: str, *, limit: int | None = None, repair: bool = True
+        self,
+        ws_id: str,
+        *,
+        limit: int | None = None,
+        repair: bool = True,
+        include_compaction: bool = False,
     ) -> list[dict[str, Any]]:
         """Load messages for a workstream and reconstruct OpenAI message format.
 
@@ -251,6 +256,13 @@ class StorageBackend(Protocol):
         Attachments are resolved to inline content parts (the materialized
         bytes a display/export consumer needs); :meth:`load_message_turns` is
         the unresolved, by-reference counterpart for resume.
+
+        ``include_compaction`` (default False) surfaces persisted compaction
+        checkpoint markers as in-place ``role="system"`` display rows
+        (``_source="compaction"``, ``meta`` = watermark/token counts) instead
+        of dropping them — the ``/history`` display path passes True so the
+        UI can re-render its compaction card after a reload; export/search
+        keep the unannotated transcript.
         """
         ...
 

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -538,10 +538,17 @@ class SQLiteBackend:
         return msg_rows, (attachments or None)
 
     def load_messages(
-        self, ws_id: str, *, limit: int | None = None, repair: bool = True
+        self,
+        ws_id: str,
+        *,
+        limit: int | None = None,
+        repair: bool = True,
+        include_compaction: bool = False,
     ) -> list[dict[str, Any]]:
         msg_rows, attachments = self._conversation_rows(ws_id, limit)
-        return _reconstruct_messages(msg_rows, ws_id, attachments, repair=repair)
+        return _reconstruct_messages(
+            msg_rows, ws_id, attachments, repair=repair, include_compaction=include_compaction
+        )
 
     def load_message_turns(self, ws_id: str, *, checkpointed: bool = True) -> list[Turn]:
         """Load the conversation as canonical ``Turn``s (unresolved AttachmentRef).

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -909,6 +909,7 @@ def reconstruct_messages(
     attachments_by_msg: dict[int, list[dict[str, Any]]] | None = None,
     *,
     repair: bool = True,
+    include_compaction: bool = False,
 ) -> list[dict[str, Any]]:
     """Reconstruct OpenAI message format from stored conversation rows.
 
@@ -946,12 +947,21 @@ def reconstruct_messages(
     the user sees the actual partial state — refreshing during tool execution
     otherwise silently drops the trailing turn from the UI.
     """
-    # Drop compaction checkpoint markers: they are resume-only artifacts (the
-    # persisted summary that lets a reopened session rehydrate a bounded context,
-    # see reconstruct_turns_checkpointed), not real conversation turns, so
-    # /history, export, and search show the true transcript without an injected
-    # summary.
-    rows = [r for r in rows if not _is_compaction_marker(r)]
+    # Compaction checkpoint markers are resume artifacts (the persisted summary
+    # that lets a reopened session rehydrate a bounded context, see
+    # reconstruct_turns_checkpointed), not real conversation turns — dropped by
+    # default so export and search show the true transcript without an injected
+    # summary.  ``include_compaction=True`` (the /history display path) instead
+    # re-rows each marker as a first-class ``system`` row IN PLACE: assistant
+    # rows drop ``_source``/``meta`` on reconstruction, but a system row keeps
+    # both, so the marker flows through the standard operator-context
+    # projection (``_source="compaction"`` + ``meta`` = watermark/token
+    # counts) and the frontend renders its compaction card at the point in
+    # the transcript where the compaction actually happened.
+    if include_compaction:
+        rows = [(r[0], "system", *r[2:]) if _is_compaction_marker(r) else r for r in rows]
+    else:
+        rows = [r for r in rows if not _is_compaction_marker(r)]
     turns = reconstruct_turns(rows, ws_id, attachments_by_msg)
     if repair:
         turns = recover_trajectory(turns)

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -139,6 +139,18 @@ class Workstream:
     # racing ``Thread.is_alive()``. Used by both interactive and
     # coordinator paths since Stage 2 P1.
     _worker_running: bool = field(default=False, repr=False)
+    # What KIND of work the current worker slot holds: "turn" (a send /
+    # retry / wake — the default) or "command" (a slash-command worker,
+    # including the minutes-long manual /compact).  Written under
+    # ``_lock`` by ``session_worker.send`` in the same acquisition that
+    # sets ``worker_thread``/``_worker_running``, so readers gating on
+    # the running flag see a coherent triple.  A stale value after the
+    # worker exits is harmless — every reader conjoins
+    # ``_worker_running``.  The /send route parks (never queues) while
+    # this reads "command": the mid-turn interjection queue is
+    # turn-shaped (length cap, cross-user guard) and must be
+    # unreachable during command windows.
+    worker_kind: str = field(default="", repr=False)
     # True once ``SessionManager.commit_create`` (or the non-deferred
     # path through ``SessionManager.create``) has fired the lifecycle
     # ``emit_created`` event for this workstream. Used by

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -13,10 +13,18 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from turnstone.core.session import ChatSession, SessionUI
+
+# What KIND of work a worker slot holds.  A Literal (not a free-form str)
+# so a typo'd comparison or a new dispatch caller passing "commands" is a
+# type error instead of a silently never-firing command-window guard —
+# the /send defer keys on exactly these values.
+WorkerKind = Literal["", "turn", "command"]
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +105,61 @@ BULK_CLOSE_STATE_VALUES: frozenset[str] = frozenset(
 
 
 # ---------------------------------------------------------------------------
+# Deferred sends
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PendingSend:
+    """One send deferred while the /send order barrier holds.
+
+    A /send that lands while a slash-command worker holds the slot
+    (``ws.worker_kind == "command"`` — a manual /compact can hold it for
+    minutes) or while earlier deferred entries are still pending is
+    answered ``{"status": "queued", "deferred": true, "msg_id": ...}``
+    immediately and registered here;
+    :func:`turnstone.core.session_routes._drain_pending_sends` dispatches
+    it full-fidelity when the slot frees.  This replaces the parked-POST
+    design, which encoded "client disconnected" as "message retracted" —
+    true only for the web composers' ✕-abort; every bounded caller (the
+    coordinator client and the console proxy at timeout=30, SDKs, curl)
+    times out instead, and its message was deliberately dropped for the
+    whole window.
+
+    ``attempt`` is the prebuilt one-session-capture dispatch closure
+    (:func:`turnstone.core.session_routes._make_dispatch_attempt` with
+    ``defer_fidelity=True``), so the drain stays endpoint-agnostic —
+    everything kind-specific (attachments, spawn metrics, UI hooks) was
+    captured at defer time.  ``retracted`` is flipped under ``ws._lock``
+    by the DELETE dequeue fall-through; the drain never dispatches a
+    retracted entry.
+
+    Durability contract (documented in the API reference): node-local
+    and in-memory, the interjection queue's lifetime — entries die with
+    the workstream or the process, so "queued" is at-most-once intake,
+    not durable acceptance.
+
+    Invariant both the route's order barrier and the drain depend on
+    (and the second term of :meth:`Workstream.send_barrier_active`
+    exists to honor): **drain not alive ⇒ nothing claimed.**  The drain
+    pops an entry only while it lives and re-inserts it at head on ANY
+    non-dispatch outcome (rejection or crash), so a dead/absent drain
+    means every accepted entry is on the list — the barrier term pair
+    (list non-empty OR drain alive) therefore covers the claimed-entry
+    window with no third state.
+
+    (No ``priority`` field: dispatch is strictly FIFO — arrival order is
+    the contract — and the queued response/event use the route's parsed
+    local.  A deferred entry's ``!!!`` prefix still reaches the model:
+    the full text dispatches as an ordinary send.)
+    """
+
+    msg_id: str
+    attempt: Callable[[ChatSession], tuple[bool, dict[str, Any]]]
+    retracted: bool = False
+
+
+# ---------------------------------------------------------------------------
 # Workstream dataclass
 # ---------------------------------------------------------------------------
 
@@ -151,19 +214,19 @@ class Workstream:
     # turn-shaped (length cap, cross-user guard) and must be
     # unreachable during command windows — deferred entries live on
     # ``_pending_sends`` below.
-    worker_kind: str = field(default="", repr=False)
-    # Sends deferred during a command window (full-fidelity pending
-    # entries — see ``session_routes._PendingSend``), dispatched in
-    # arrival order by the per-workstream drain task when the window
-    # closes.  Appends, retract-marks and claims all happen under
+    worker_kind: WorkerKind = field(default="", repr=False)
+    # Sends deferred while the order barrier holds (full-fidelity
+    # pending entries — see :class:`_PendingSend` above), dispatched in
+    # arrival order by the per-workstream drain thread when the slot
+    # frees.  Appends, retract-marks and claims all happen under
     # ``_lock``.  Node-local and in-memory: entries die with the
     # workstream or the process (the interjection queue's lifetime) —
     # the /send contract documents the at-most-once consequence.
-    _pending_sends: list[Any] = field(default_factory=list, repr=False)
+    _pending_sends: list[_PendingSend] = field(default_factory=list, repr=False)
     # Single-flight guard for the drain (a daemon ``threading.Thread``
     # while one is live).  Written under ``_lock``; the drain clears it
     # before exiting so a later deferred send starts a fresh one.
-    _pending_drain: Any = field(default=None, repr=False)
+    _pending_drain: threading.Thread | None = field(default=None, repr=False)
     # True once ``SessionManager.commit_create`` (or the non-deferred
     # path through ``SessionManager.create``) has fired the lifecycle
     # ``emit_created`` event for this workstream. Used by
@@ -183,3 +246,35 @@ class Workstream:
     def __post_init__(self) -> None:
         if not self.name:
             self.name = f"ws-{self.id[:4]}"
+
+    def send_barrier_active(self) -> bool:
+        """True while the /send order barrier holds — the ONE definition.
+
+        The barrier is a two-term pair, and every dispatch surface that
+        must not overtake acknowledged sends consults it here (the /send
+        route's defer probe, ``CoordinatorAdapter.send``'s refusal, the
+        queued-nudge wake gate) instead of hand-copying the terms:
+
+        * ``_pending_sends`` non-empty — acknowledged entries are waiting
+          (retract-marked husks count until the drain's loop-top purge:
+          they still occupy their arrival slot).
+        * the drain is alive — an entry may be CLAIMED (popped, dispatch
+          in flight); the :class:`_PendingSend` invariant ("drain not
+          alive ⇒ nothing claimed") is what makes these two terms
+          exhaustive, with no third state.  The pair also covers the
+          drain-spawn window because ``_defer_send`` appends the entry
+          and starts the thread under one ``_lock`` acquisition — the
+          list term is always set before a not-yet-started drain could
+          be observed.
+
+        Lockless callers (the wake gate, the coordinator adapter) get
+        benign staleness in both directions: a stale True skips once
+        more and the next barrier-clearing path re-runs the gate (every
+        deferred turn's exit backstop, plus the drain's own clean exit);
+        a stale False means the concurrent defer holds no order contract
+        against the caller anyway.  Callers that need the answer atomic
+        with a mutation (the route's probe-then-append) hold ``_lock``
+        around the call.
+        """
+        drain = self._pending_drain
+        return bool(self._pending_sends) or (drain is not None and drain.is_alive())

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -119,6 +119,15 @@ BULK_CLOSE_STATE_VALUES: frozenset[str] = frozenset(
 # turn, so acceptance must be bounded.
 PENDING_SENDS_MAX = 10
 
+# The interjection queue's per-message character cap, shared by its TWO
+# consumers so they cannot drift: ``ChatSession.queue_message`` truncates
+# the cleaned text at this bound, and the /send defer-fidelity check
+# refuses the interjection fold-in for any deferred entry whose text
+# could hit it (routing the entry to a full-fidelity fresh spawn
+# instead).  A drift between those sites is exactly the silent-truncation
+# bug the defer contract exists to prevent.
+INTERJECTION_CAP_CHARS = 2000
+
 
 @dataclass
 class _PendingSend:

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -108,6 +108,17 @@ BULK_CLOSE_STATE_VALUES: frozenset[str] = frozenset(
 # Deferred sends
 # ---------------------------------------------------------------------------
 
+# Per-workstream backpressure bound shared by BOTH message-acceptance
+# surfaces: the deferred-send list below refuses appends at this size
+# (the 11th answers the retryable ``queue_full``), and
+# ``ChatSession._QUEUE_MAX`` aliases it for the mid-turn interjection
+# queue — one constant, so busy-window and command-window sends can
+# never silently diverge on saturation behavior.  Each accepted deferred
+# entry pins its full message text plus materialized attachment bytes
+# for the length of a command window and then costs one unattended
+# turn, so acceptance must be bounded.
+PENDING_SENDS_MAX = 10
+
 
 @dataclass
 class _PendingSend:

--- a/turnstone/core/workstream.py
+++ b/turnstone/core/workstream.py
@@ -13,7 +13,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from turnstone.core.session import ChatSession, SessionUI
@@ -146,11 +146,24 @@ class Workstream:
     # sets ``worker_thread``/``_worker_running``, so readers gating on
     # the running flag see a coherent triple.  A stale value after the
     # worker exits is harmless — every reader conjoins
-    # ``_worker_running``.  The /send route parks (never queues) while
+    # ``_worker_running``.  The /send route defers (never queues) while
     # this reads "command": the mid-turn interjection queue is
     # turn-shaped (length cap, cross-user guard) and must be
-    # unreachable during command windows.
+    # unreachable during command windows — deferred entries live on
+    # ``_pending_sends`` below.
     worker_kind: str = field(default="", repr=False)
+    # Sends deferred during a command window (full-fidelity pending
+    # entries — see ``session_routes._PendingSend``), dispatched in
+    # arrival order by the per-workstream drain task when the window
+    # closes.  Appends, retract-marks and claims all happen under
+    # ``_lock``.  Node-local and in-memory: entries die with the
+    # workstream or the process (the interjection queue's lifetime) —
+    # the /send contract documents the at-most-once consequence.
+    _pending_sends: list[Any] = field(default_factory=list, repr=False)
+    # Single-flight guard for the drain (a daemon ``threading.Thread``
+    # while one is live).  Written under ``_lock``; the drain clears it
+    # before exiting so a later deferred send starts a fresh one.
+    _pending_drain: Any = field(default=None, repr=False)
     # True once ``SessionManager.commit_create`` (or the non-deferred
     # path through ``SessionManager.create``) has fired the lifecycle
     # ``emit_created`` event for this workstream. Used by

--- a/turnstone/eval/core.py
+++ b/turnstone/eval/core.py
@@ -132,6 +132,9 @@ class NullUI:
     def on_system_turn(self, content: str, source: str, meta: dict[str, Any] | None = None) -> None:
         pass
 
+    def on_compaction(self, payload: dict[str, Any]) -> int | None:
+        return None
+
     def on_state_change(self, state: str) -> None:
         pass
 

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -297,6 +297,47 @@ class OutputWarningEvent(ServerEvent):
     judge_model: str = ""
 
 
+@dataclass
+class CompactionEvent(ServerEvent):
+    """Context-compaction lifecycle (``phase`` = start / progress / end).
+
+    ``start`` carries ``trigger`` (``"manual"`` / ``"auto"``; auto adds
+    ``where`` + ``pct``); ``progress`` carries chunked-summarization
+    ``part``/``total``/``depth`` (or ``retry_in``/``error`` for a retry
+    wait); ``end`` carries ``ok`` plus either the result
+    (``before_tokens``/``after_tokens``/``summary``) or the failure
+    ``reason``/``message`` — failure ends carry ``trigger`` too.  The
+    successful end's summary is also persisted as a compaction marker
+    row and replays from ``/history`` as a ``role="system"``,
+    ``source="compaction"`` entry.  ``compaction_id`` correlates every
+    event of one compaction run (0 from internal/legacy emitters).  End
+    events additionally carry ``superseded``: True marks a force-abandoned
+    compaction retiring after a successor generation took over — clients
+    should skip failure notices for those (an OK end's result still
+    stands; the history swap happened).
+    """
+
+    type: str = "compaction"
+    phase: str = ""
+    compaction_id: int = 0
+    superseded: bool = False
+    trigger: str = ""
+    where: str = ""
+    pct: int | None = None
+    part: int | None = None
+    total: int | None = None
+    depth: int | None = None
+    retry_in: float | None = None
+    error: str = ""
+    warning: str = ""
+    ok: bool | None = None
+    reason: str = ""
+    message: str = ""
+    before_tokens: int | None = None
+    after_tokens: int | None = None
+    summary: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Server global events  (/v1/api/events/global)
 # ---------------------------------------------------------------------------
@@ -473,6 +514,7 @@ _SERVER_REGISTRY: dict[str, type[ServerEvent]] = {
         CancelledEvent,
         IntentVerdictEvent,
         OutputWarningEvent,
+        CompactionEvent,
         WsStateEvent,
         WsActivityEvent,
         WsRenameEvent,

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -314,13 +314,17 @@ class CompactionEvent(ServerEvent):
     events additionally carry ``superseded``: True marks a force-abandoned
     compaction retiring after a successor generation took over — clients
     should skip failure notices for those (an OK end's result still
-    stands; the history swap happened).
+    stands; the history swap happened).  Failed ends carry ``notice``:
+    the emitter-computed display verdict — show ``message`` only when it
+    is True, instead of re-deriving suppression from
+    reason/trigger/superseded client-side.
     """
 
     type: str = "compaction"
     phase: str = ""
     compaction_id: int = 0
     superseded: bool = False
+    notice: bool = False
     trigger: str = ""
     where: str = ""
     pct: int | None = None

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1715,23 +1715,190 @@ async def command(request: Request) -> JSONResponse:
                 status_code=400,
             )
 
-        should_exit = ws.session.handle_command(cmd)
-        if should_exit:
-            ui.on_info("Session ended. You can close this tab.")
-        # Handle UI updates for workstream-changing commands
-        if cmd_word in ("/clear", "/new"):
-            ui._enqueue({"type": "clear_ui"})
-        elif cmd_word == "/resume":
-            # clear_ui signals the frontend to re-fetch history via REST.
-            ui._enqueue({"type": "clear_ui"})
-        # Sync in-memory workstream name after any command that can change it.
-        # This ensures /api/workstreams and future page loads see the right name.
-        if cmd_word in ("/name", "/resume"):
-            from turnstone.core.memory import get_workstream_display_name
+        from turnstone.core import session_worker
 
-            updated_name = get_workstream_display_name(ws.session.ws_id) if ws.session else None
-            if updated_name:
-                ws.name = updated_name
+        session = ws.session
+        cmd_ui = ui
+        busy_hit = {"hit": False}
+
+        def _reject_busy() -> None:
+            # Worker already running (a turn or another command is in
+            # flight).  Commands aren't queueable work — surface "busy"
+            # instead.  Server-side mirror of the composer's client guard,
+            # and a strict improvement for API callers: the old inline path
+            # let /clear & co. mutate the session mid-turn.
+            busy_hit["hit"] = True
+
+        def _dispatch_command(
+            run: Callable[[], None], thread_name: str, busy_hint: str
+        ) -> JSONResponse | None:
+            """Dispatch a command worker; return the refusal response or None.
+
+            One envelope for both command branches: the unknown-workstream
+            404 and the busy refusal differ only in the retry hint.  The
+            worker slot is claimed with ``worker_kind="command"`` — the
+            /send route PARKS (never queues) while that kind holds the
+            slot, so the mid-turn interjection queue and its turn-shaped
+            semantics (length cap, cross-user guard) are unreachable for
+            the whole command window; messages sent mid-command dispatch
+            as ordinary full-fidelity sends when the window closes.
+            """
+            dispatched = session_worker.send(
+                ws,
+                enqueue=_reject_busy,
+                run=run,
+                thread_name=thread_name,
+                worker_kind="command",
+            )
+            if not dispatched:
+                return JSONResponse({"error": "Unknown workstream"}, status_code=404)
+            if busy_hit["hit"]:
+                # 409, not 200: the refusal is deliberate (mutual exclusion
+                # replaced the old inline mid-turn interleave) but it must
+                # be LOUD — a status-code-only SDK caller treats a 200 as
+                # "command ran" and silently loses the rename/clear/config
+                # change.  Same shape as /send's cross-user 409.
+                return JSONResponse(
+                    {
+                        "status": "busy",
+                        "error": (
+                            "Session is busy — wait for the current turn to "
+                            f"finish, then {busy_hint}."
+                        ),
+                    },
+                    status_code=409,
+                )
+            return None
+
+        if cmd_word == "/compact":
+            # Manual compaction runs LLM summary calls — seconds to minutes.
+            # It gets the send path's worker dispatch instead of an inline
+            # call so (a) the event loop stays free to stream the compaction
+            # progress events this very command produces (inline, they only
+            # flushed in one burst after the blocking call returned — the
+            # "no visible indicator" bug), and (b) a message sent
+            # mid-compaction takes the existing queue path instead of racing
+            # the history swap on a second worker.  compact_now() carries
+            # send()'s generation discipline, so a force-abandoned compact
+            # thread goes stale instead of swapping history under a
+            # successor, and a cancel aimed at it is consumed on exit.
+            # Fire-and-forget: the response returns as soon as the worker is
+            # dispatched and NO completion bound applies — a large context
+            # can legitimately compact for many minutes; progress streams
+            # over SSE and Stop cancels it.  (The 60s wait below is for the
+            # quick commands only.)
+
+            def _run_compact() -> None:
+                me = threading.current_thread()
+                try:
+                    cmd_ui.on_state_change("thinking")
+                    session.compact_now()
+                except GenerationCancelled:
+                    # User stopped it — including a Stop that landed in the
+                    # completion tail, which compact_now re-raises after
+                    # consuming.
+                    pass
+                finally:
+                    # Abandoned-worker guard — mirrors the send/retry
+                    # closures: a force-cancelled compact thread must not
+                    # touch state a successor worker now owns.
+                    if ws.worker_thread is me:
+                        try:
+                            # Backstop only: sends during the command window
+                            # PARK in the /send route (they cannot reach the
+                            # interjection queue — see _dispatch_command), so
+                            # anything found here predates the window (a
+                            # message stranded by a dying send worker's
+                            # closing race).  Record it in the transcript
+                            # rather than leaving it invisible.
+                            if session.flush_queued_messages():
+                                log.warning("ws.compact.stranded_queue_flushed ws=%s", ws.id[:8])
+                        except Exception:
+                            log.exception("ws.compact.exit_seam_failed ws=%s", ws.id[:8])
+                        cmd_ui.on_state_change("idle")
+
+            refusal = _dispatch_command(
+                _run_compact, f"compact-worker-{ws.id[:8]}", "run /compact again"
+            )
+            if refusal is not None:
+                return refusal
+            return JSONResponse({"status": "ok"})
+
+        # Every other command ALSO runs on the workstream's worker slot —
+        # the inline call this replaced was serialized by the event loop
+        # itself (nothing else could interleave with it); to_thread alone
+        # would let /clear & co. race a running /compact worker, a live
+        # send, or another command.  The slot restores that mutual
+        # exclusion with an explicit busy answer, and the endpoint awaits
+        # completion off-loop so the response still reflects the outcome.
+        loop = asyncio.get_running_loop()
+        done = asyncio.Event()
+
+        def _run_cmd() -> None:
+            me = threading.current_thread()
+            try:
+                should_exit = session.handle_command(cmd)
+                # Post-command follow-ups run HERE, on the worker, not
+                # after the endpoint's done-wait: past the 60s backstop the
+                # endpoint has already answered {"status": "running"}, and
+                # follow-ups parked there were silently skipped — a >60s
+                # /resume left every pane rendering the pre-resume
+                # transcript against a session whose history had changed,
+                # and the workstream list kept the stale name.
+                # Abandoned-worker guard, mirroring every sibling closure:
+                # a force-cancelled wedged command that unwedges minutes
+                # later must not fire clear_ui into a successor turn's live
+                # stream (every pane would wipe mid-answer) nor write a
+                # post-swap name from a stale session read.
+                if ws.worker_thread is me:
+                    if should_exit:
+                        cmd_ui.on_info("Session ended. You can close this tab.")
+                    if cmd_word in ("/clear", "/new", "/resume"):
+                        # clear_ui signals the frontend to re-fetch history
+                        # via REST.
+                        cmd_ui._enqueue({"type": "clear_ui"})
+                    if cmd_word in ("/name", "/resume"):
+                        # Sync the in-memory workstream name after any
+                        # command that can change it, so /api/workstreams
+                        # and future page loads see the right name.
+                        from turnstone.core.memory import get_workstream_display_name
+
+                        updated_name = get_workstream_display_name(session.ws_id)
+                        if updated_name:
+                            ws.name = updated_name
+            except Exception as e:
+                # Same guard: a late "Command error:" from an abandoned
+                # worker would land mid-successor-turn.
+                if ws.worker_thread is me:
+                    cmd_ui.on_error(f"Command error: {e}")
+            finally:
+                # Unblock the endpoint response.  Suppress the loop-closed
+                # RuntimeError (process shutdown mid-command): nobody is
+                # waiting anymore.  No queue drain here: sends during the
+                # command window PARK in the /send route (the interjection
+                # queue is unreachable while worker_kind == "command"), so
+                # they dispatch as ordinary sends when this worker exits —
+                # the stranded-message backstop lives on the /compact seam,
+                # the only command window long enough to matter.
+                with contextlib.suppress(RuntimeError):
+                    loop.call_soon_threadsafe(done.set)
+
+        refusal = _dispatch_command(_run_cmd, f"command-worker-{ws.id[:8]}", "retry the command")
+        if refusal is not None:
+            return refusal
+        # Commands are quick (the long-runner, /compact, took the branch
+        # above); the bound is a backstop so a wedged command can't hold
+        # this request open forever — the worker keeps running, its output
+        # reaches the pane via SSE, and the post-command follow-ups run on
+        # the worker itself, so a late completion still refreshes the
+        # panes.  Loop-native wait (call_soon_threadsafe from the worker's
+        # finally): a thread parked in Event.wait via to_thread would hold
+        # a shared default-executor slot for up to 60s per wedged command.
+        try:
+            async with asyncio.timeout(60):
+                await done.wait()
+        except TimeoutError:
+            return JSONResponse({"status": "running"})
     except Exception as e:
         ui.on_error(f"Command error: {e}")
 
@@ -2275,6 +2442,7 @@ async def _interactive_create_post_install(
             resolved_atts, staged_ord, _drop = _resolve_staged(attachment_ids, ws.id, uid)
 
         def _run_initial() -> None:
+            me = threading.current_thread()
             try:
                 session.send(
                     initial_message,
@@ -2282,15 +2450,23 @@ async def _interactive_create_post_install(
                     send_id=send_id if resolved_atts else None,
                 )
             except (Exception, GenerationCancelled):
-                if isinstance(ws.ui, WebUI):
+                # Abandoned-worker guard (sibling of _run_cmd/_run_compact/
+                # the send closures): a force-cancelled init that unwedges
+                # late must not stamp idle over — or emit stream_end into —
+                # a successor turn.
+                if ws.worker_thread is me and isinstance(ws.ui, WebUI):
                     ws.ui.on_stream_end()
                     ws.ui.on_state_change("idle")
             finally:
-                try:
-                    last_content = _extract_last_assistant_content(session)
-                    _fire_notify_targets(ws, last_content)
-                except Exception:
-                    log.warning("notify_completion.hook_error", ws_id=ws.id, exc_info=True)
+                # Owner only — an abandoned init's late notify would
+                # duplicate the successor's.  (Guard, not early-return: a
+                # return in a finally silences in-flight exceptions.)
+                if ws.worker_thread is me:
+                    try:
+                        last_content = _extract_last_assistant_content(session)
+                        _fire_notify_targets(ws, last_content)
+                    except Exception:
+                        log.warning("notify_completion.hook_error", ws_id=ws.id, exc_info=True)
 
         init_enqueued = False
 
@@ -2311,6 +2487,15 @@ async def _interactive_create_post_install(
             # message were delivered.
             nonlocal init_enqueued
             init_enqueued = True
+            if ws.worker_kind == "command":
+                # A command worker (e.g. a minutes-long /compact) holds the
+                # raced slot: the interjection queue is turn-shaped (length
+                # cap, and the text would cross a /resume identity swap) and
+                # must stay unreachable during command windows — same rule
+                # as the /send route's park.  queue.Full is the existing
+                # backpressure surface: the create reports the first message
+                # as undelivered (``queue_full``) and the client retries.
+                raise queue.Full()
             session.queue_message(initial_message)
             if resolved_atts:
                 log.warning(

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -698,6 +698,14 @@ def _interactive_dispatch_retry(ws: Workstream, user_msg: str) -> None:
     the pre-lift inline behaviour). The shared dispatcher owns the
     ``_worker_running`` lifecycle, so the ``run`` closure needs no
     ``finally`` flag-clear of its own.
+
+    Deliberately NOT gated on the /send order barrier
+    (``ws._pending_sends``): a retry is an explicit user action that
+    rewinds a COMPLETED turn — dispatching it ahead of deferred sends is
+    an accepted overtake (the user just asked for exactly that turn to
+    run again), not the silent send-vs-send inversion the barrier exists
+    to prevent.  Deferred entries dispatch after it, order among
+    themselves preserved.
     """
     from turnstone.core import session_worker
 
@@ -1787,7 +1795,7 @@ async def command(request: Request) -> JSONResponse:
             # Fire-and-forget: the response returns as soon as the worker is
             # dispatched and NO completion bound applies — a large context
             # can legitimately compact for many minutes; progress streams
-            # over SSE and Stop cancels it.  (The 60s wait below is for the
+            # over SSE and Stop cancels it.  (The 25s wait below is for the
             # quick commands only.)
 
             def _run_compact() -> None:
@@ -1852,9 +1860,9 @@ async def command(request: Request) -> JSONResponse:
             try:
                 should_exit = session.handle_command(cmd)
                 # Post-command follow-ups run HERE, on the worker, not
-                # after the endpoint's done-wait: past the 60s backstop the
+                # after the endpoint's done-wait: past the 25s backstop the
                 # endpoint has already answered {"status": "running"}, and
-                # follow-ups parked there were silently skipped — a >60s
+                # follow-ups parked there were silently skipped — a slow
                 # /resume left every pane rendering the pre-resume
                 # transcript against a session whose history had changed,
                 # and the workstream list kept the stale name.
@@ -1907,9 +1915,15 @@ async def command(request: Request) -> JSONResponse:
         # the worker itself, so a late completion still refreshes the
         # panes.  Loop-native wait (call_soon_threadsafe from the worker's
         # finally): a thread parked in Event.wait via to_thread would hold
-        # a shared default-executor slot for up to 60s per wedged command.
+        # a shared default-executor slot for the whole wait per wedged
+        # command.  25s: strictly under the console proxy's 30s client
+        # timeout (console/server.py proxy_client) so the degraded
+        # ``running`` answer can actually traverse a proxied pane — at 60s
+        # the proxy aborted first, the pane's dispatch swallowed the 5xx,
+        # and the user saw nothing at all (the same bounded-caller
+        # reasoning that redesigned /send's command-window path).
         try:
-            async with asyncio.timeout(60):
+            async with asyncio.timeout(25):
                 await done.wait()
         except TimeoutError:
             return JSONResponse({"status": "running"})
@@ -2537,6 +2551,9 @@ async def _interactive_create_post_install(
         # creation) unless a caller-supplied ws_id is raced — hence
         # ``_enqueue_init`` preserves the message and leaves the staged
         # attachments recoverable instead of assuming the branch is dead.
+        # No /send order-barrier pre-check for the same by-construction
+        # reason: a freshly created workstream cannot have deferred sends
+        # pending (``ws._pending_sends`` only ever grows via that route).
         init_ok = session_worker.send(
             ws,
             enqueue=_enqueue_init,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4563,7 +4563,7 @@ def create_app(
         magic-mocked ``ws.user_id``."""
         return _require_ws_access(request, ws_id)
 
-    def _interactive_spawn_metrics(_request: Request | None, ui: Any) -> None:
+    def _interactive_spawn_metrics(ui: Any) -> None:
         """Per-conversation metrics fired once per send that spawns a
         fresh worker. Coord wires its own
         :func:`turnstone.console.server._coord_spawn_metrics` (the

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1624,6 +1624,15 @@ async def metrics_endpoint(request: Request) -> Response:
     return Response(content, media_type="text/plain; version=0.0.4; charset=utf-8")
 
 
+# Quick-command completion backstop.  MUST stay strictly below the
+# console proxy's client timeout (console/server.py
+# _PROXY_CLIENT_TIMEOUT_S = 30) or the degraded ``running`` answer can
+# never traverse a proxied pane — the proxy aborts first, the pane's
+# dispatch swallows the 5xx, and the caller sees nothing at all.  The
+# inequality is pinned by a test importing both constants.
+_COMMAND_RESPONSE_BACKSTOP_S = 25
+
+
 def _capture_cancel_forensics(session: Any, ui: Any, *, was_running: bool) -> dict[str, Any]:
     """Snapshot in-flight session state for the cancel response.
 
@@ -1727,7 +1736,7 @@ async def command(request: Request) -> JSONResponse:
 
         session = ws.session
         cmd_ui = ui
-        busy_hit = {"hit": False}
+        busy_hit = False
 
         def _reject_busy() -> None:
             # Worker already running (a turn or another command is in
@@ -1735,7 +1744,8 @@ async def command(request: Request) -> JSONResponse:
             # instead.  Server-side mirror of the composer's client guard,
             # and a strict improvement for API callers: the old inline path
             # let /clear & co. mutate the session mid-turn.
-            busy_hit["hit"] = True
+            nonlocal busy_hit
+            busy_hit = True
 
         def _dispatch_command(
             run: Callable[[], None], thread_name: str, busy_hint: str
@@ -1753,16 +1763,33 @@ async def command(request: Request) -> JSONResponse:
             full-fidelity sends by the pending-send drain when the window
             closes.
             """
-            dispatched = session_worker.send(
-                ws,
-                enqueue=_reject_busy,
-                run=run,
-                thread_name=thread_name,
-                worker_kind="command",
-            )
+            try:
+                dispatched = session_worker.send(
+                    ws,
+                    enqueue=_reject_busy,
+                    run=run,
+                    thread_name=thread_name,
+                    worker_kind="command",
+                )
+            except Exception:
+                # Thread.start failed (exhaustion, MemoryError) — the
+                # dispatcher rolled the slot claim back and re-raised.
+                # Answer 503, NOT the endpoint's generic 200-ok arm: a
+                # command worker that never spawned must be as loud as
+                # the busy 409 below — a status-code-only SDK caller
+                # would otherwise believe its /clear//name//resume
+                # applied and silently run against un-changed state.
+                log.exception("command.worker_spawn_failed ws=%s", ws.id[:8])
+                return JSONResponse(
+                    {
+                        "status": "error",
+                        "error": "Command worker could not be started — retry shortly.",
+                    },
+                    status_code=503,
+                )
             if not dispatched:
                 return JSONResponse({"error": "Unknown workstream"}, status_code=404)
-            if busy_hit["hit"]:
+            if busy_hit:
                 # 409, not 200: the refusal is deliberate (mutual exclusion
                 # replaced the old inline mid-turn interleave) but it must
                 # be LOUD — a status-code-only SDK caller treats a 200 as
@@ -1916,14 +1943,14 @@ async def command(request: Request) -> JSONResponse:
         # panes.  Loop-native wait (call_soon_threadsafe from the worker's
         # finally): a thread parked in Event.wait via to_thread would hold
         # a shared default-executor slot for the whole wait per wedged
-        # command.  25s: strictly under the console proxy's 30s client
-        # timeout (console/server.py proxy_client) so the degraded
+        # command.  The bound (_COMMAND_RESPONSE_BACKSTOP_S) sits strictly
+        # under the console proxy's client timeout so the degraded
         # ``running`` answer can actually traverse a proxied pane — at 60s
         # the proxy aborted first, the pane's dispatch swallowed the 5xx,
         # and the user saw nothing at all (the same bounded-caller
         # reasoning that redesigned /send's command-window path).
         try:
-            async with asyncio.timeout(25):
+            async with asyncio.timeout(_COMMAND_RESPONSE_BACKSTOP_S):
                 await done.wait()
         except TimeoutError:
             return JSONResponse({"status": "running"})

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1737,11 +1737,13 @@ async def command(request: Request) -> JSONResponse:
             One envelope for both command branches: the unknown-workstream
             404 and the busy refusal differ only in the retry hint.  The
             worker slot is claimed with ``worker_kind="command"`` — the
-            /send route PARKS (never queues) while that kind holds the
+            /send route DEFERS (never queues) while that kind holds the
             slot, so the mid-turn interjection queue and its turn-shaped
             semantics (length cap, cross-user guard) are unreachable for
-            the whole command window; messages sent mid-command dispatch
-            as ordinary full-fidelity sends when the window closes.
+            the whole command window; messages sent mid-command are
+            answered ``queued`` immediately and dispatched as ordinary
+            full-fidelity sends by the pending-send drain when the window
+            closes.
             """
             dispatched = session_worker.send(
                 ws,
@@ -1790,6 +1792,15 @@ async def command(request: Request) -> JSONResponse:
 
             def _run_compact() -> None:
                 me = threading.current_thread()
+                # Snapshot for the exit restore: with the slot free to
+                # claim, only IDLE or ERROR are reachable here (the live
+                # states imply a held slot and _dispatch_command refuses
+                # busy).  ERROR is the user-investigatable badge (same
+                # carve-out the orphan reaper honors) and /compact neither
+                # retries nor resolves the failed turn — the old inline
+                # /compact never touched ws.state — so the badge must
+                # survive the window; everything else exits to idle.
+                prev_state = ws.state
                 try:
                     cmd_ui.on_state_change("thinking")
                     session.compact_now()
@@ -1805,7 +1816,7 @@ async def command(request: Request) -> JSONResponse:
                     if ws.worker_thread is me:
                         try:
                             # Backstop only: sends during the command window
-                            # PARK in the /send route (they cannot reach the
+                            # DEFER in the /send route (they cannot reach the
                             # interjection queue — see _dispatch_command), so
                             # anything found here predates the window (a
                             # message stranded by a dying send worker's
@@ -1815,7 +1826,9 @@ async def command(request: Request) -> JSONResponse:
                                 log.warning("ws.compact.stranded_queue_flushed ws=%s", ws.id[:8])
                         except Exception:
                             log.exception("ws.compact.exit_seam_failed ws=%s", ws.id[:8])
-                        cmd_ui.on_state_change("idle")
+                        cmd_ui.on_state_change(
+                            "error" if prev_state is WorkstreamState.ERROR else "idle"
+                        )
 
             refusal = _dispatch_command(
                 _run_compact, f"compact-worker-{ws.id[:8]}", "run /compact again"
@@ -1875,11 +1888,12 @@ async def command(request: Request) -> JSONResponse:
                 # Unblock the endpoint response.  Suppress the loop-closed
                 # RuntimeError (process shutdown mid-command): nobody is
                 # waiting anymore.  No queue drain here: sends during the
-                # command window PARK in the /send route (the interjection
+                # command window DEFER in the /send route (the interjection
                 # queue is unreachable while worker_kind == "command"), so
-                # they dispatch as ordinary sends when this worker exits —
-                # the stranded-message backstop lives on the /compact seam,
-                # the only command window long enough to matter.
+                # the pending-send drain dispatches them as ordinary sends
+                # when this worker exits — the stranded-message backstop
+                # lives on the /compact seam, the only command window long
+                # enough to matter.
                 with contextlib.suppress(RuntimeError):
                     loop.call_soon_threadsafe(done.set)
 
@@ -2458,15 +2472,23 @@ async def _interactive_create_post_install(
                     ws.ui.on_stream_end()
                     ws.ui.on_state_change("idle")
             finally:
-                # Owner only — an abandoned init's late notify would
-                # duplicate the successor's.  (Guard, not early-return: a
-                # return in a finally silences in-flight exceptions.)
-                if ws.worker_thread is me:
-                    try:
-                        last_content = _extract_last_assistant_content(session)
-                        _fire_notify_targets(ws, last_content)
-                    except Exception:
-                        log.warning("notify_completion.hook_error", ws_id=ws.id, exc_info=True)
+                # Deliberately NOT owner-gated, unlike the except arm above
+                # and the _run_cmd/_run_compact follow-ups: those mutate
+                # live slot/UI state a successor now owns, while the notify
+                # is workstream-scoped — an outward signal that this
+                # workstream's initial turn ran to completion and its
+                # answer is in the transcript.  _fire_notify_targets has
+                # exactly ONE call site (here); successor turns never
+                # notify, so there is no successor duplicate for an owner
+                # gate to prevent — gating it turned force-cancel into
+                # permanent notification loss for scheduled/unattended
+                # workstreams (the empty-content fallback covers the
+                # error/cancel exits, as it always did).
+                try:
+                    last_content = _extract_last_assistant_content(session)
+                    _fire_notify_targets(ws, last_content)
+                except Exception:
+                    log.warning("notify_completion.hook_error", ws_id=ws.id, exc_info=True)
 
         init_enqueued = False
 
@@ -2492,7 +2514,7 @@ async def _interactive_create_post_install(
                 # raced slot: the interjection queue is turn-shaped (length
                 # cap, and the text would cross a /resume identity swap) and
                 # must stay unreachable during command windows — same rule
-                # as the /send route's park.  queue.Full is the existing
+                # as the /send route's defer.  queue.Full is the existing
                 # backpressure surface: the create reports the first message
                 # as undelivered (``queue_full``) and the client retries.
                 raise queue.Full()
@@ -4497,7 +4519,7 @@ def create_app(
         magic-mocked ``ws.user_id``."""
         return _require_ws_access(request, ws_id)
 
-    def _interactive_spawn_metrics(_request: Request, ui: Any) -> None:
+    def _interactive_spawn_metrics(_request: Request | None, ui: Any) -> None:
         """Per-conversation metrics fired once per send that spawns a
         fresh worker. Coord wires its own
         :func:`turnstone.console.server._coord_spawn_metrics` (the

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -994,6 +994,108 @@
   margin-top: 6px;
 }
 
+/* Compaction card — both the in-progress state (``.compaction-running``, with
+   the progress bar) and the settled result (token delta + summary fold).
+   Built by ``buildCompactionProgressCard`` / ``buildCompactionCard``
+   (shared conversation.js) for the interactive pane AND the coord viewer.
+   Magenta accent: a memory/infrastructure operation — distinct from the cyan
+   tool surface, the yellow operator bubbles, and the amber user turns. */
+.msg.compaction-card {
+  border-left-color: var(--magenta);
+  background: var(--panel);
+  padding: 8px 12px;
+  margin: 6px 0;
+  width: 100%;
+}
+.msg.compaction-card .msg-compaction-header {
+  color: var(--magenta);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: lowercase;
+}
+.msg.compaction-card .msg-compaction-detail {
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin-top: 4px;
+}
+.msg.compaction-card .msg-compaction-note {
+  color: var(--ink-3);
+  font-size: 11px;
+  margin-top: 6px;
+}
+.msg.compaction-card .msg-compaction-bar {
+  position: relative;
+  height: 4px;
+  margin-top: 8px;
+  border-radius: 2px;
+  background: var(--magenta-glow);
+  overflow: hidden;
+}
+.msg.compaction-card .msg-compaction-bar-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 2px;
+  background: var(--magenta);
+  transition: width 300ms ease;
+}
+/* Indeterminate state — a single-batch summarization emits no part-k/N
+   progress, so the bar sweeps until the end event settles it. */
+.msg.compaction-card .msg-compaction-bar.indeterminate .msg-compaction-bar-fill {
+  width: 40%;
+  animation: compaction-sweep 1.4s ease-in-out infinite;
+}
+@keyframes compaction-sweep {
+  0% {
+    margin-left: -40%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .msg.compaction-card .msg-compaction-bar.indeterminate .msg-compaction-bar-fill {
+    animation: none;
+    width: 100%;
+    opacity: 0.4;
+  }
+  .msg.compaction-card .msg-compaction-bar-fill {
+    transition: none;
+  }
+}
+.msg.compaction-card .msg-compaction-fold {
+  margin-top: 6px;
+}
+.msg.compaction-card .msg-compaction-fold > summary {
+  color: var(--ink-3);
+  font-size: 11px;
+  cursor: pointer;
+  user-select: none;
+  text-transform: lowercase;
+}
+.msg.compaction-card .msg-compaction-body {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  margin: 6px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg-dim);
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* Slash-command echo — control-plane input, not a conversational turn.
+   Prompt-styled mono line (the leading "/" is the glyph), quieter than a
+   user bubble so command chatter doesn't read as trajectory. */
+.msg.command-echo {
+  border-left-color: var(--fg-dim);
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 4px 12px;
+}
+
 /* Guard-finding card — the ``output_guard`` operator-context system turn.  The
    inner warning element (``.output-warning`` interactive / ``.coord-tool-row-
    warning`` coord) carries the risk colour + flags + redaction; this wrapper

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -998,17 +998,20 @@
    the progress bar) and the settled result (token delta + summary fold).
    Built by ``buildCompactionProgressCard`` / ``buildCompactionCard``
    (shared conversation.js) for the interactive pane AND the coord viewer.
-   Magenta accent: a memory/infrastructure operation — distinct from the cyan
-   tool surface, the yellow operator bubbles, and the amber user turns. */
+   Blue accent: a system/infrastructure-info operation — distinct from the
+   cyan tool surface, the yellow operator bubbles, and the amber user turns.
+   NOT magenta: that accent is reserved for the MCP surface (.scope-mcp and
+   the admin scope chips); blue's other uses are admin-surface only (model
+   status dots, provider chips) and never co-render with transcript cards. */
 .msg.compaction-card {
-  border-left-color: var(--magenta);
+  border-left-color: var(--blue);
   background: var(--panel);
   padding: 8px 12px;
   margin: 6px 0;
   width: 100%;
 }
 .msg.compaction-card .msg-compaction-header {
-  color: var(--magenta);
+  color: var(--blue);
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 600;
@@ -1030,14 +1033,14 @@
   height: 4px;
   margin-top: 8px;
   border-radius: 2px;
-  background: var(--magenta-glow);
+  background: var(--blue-glow);
   overflow: hidden;
 }
 .msg.compaction-card .msg-compaction-bar-fill {
   height: 100%;
   width: 0;
   border-radius: 2px;
-  background: var(--magenta);
+  background: var(--blue);
   transition: width 300ms ease;
 }
 /* Indeterminate state — a single-batch summarization emits no part-k/N

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -297,6 +297,11 @@ export function createQueueController(opts) {
     if (el.getAttribute("aria-busy") === "true") return;
     el.dataset.dismissAttempted = "1";
     _setDismissing(el, true);
+    // A send whose POST is still in flight (parked server-side during a
+    // command window — possibly for minutes) attaches an abort hook: the ×
+    // must kill the request itself, or the dismissed message dispatches
+    // anyway when the window closes.  Post-response the hook is a no-op.
+    if (typeof el._sendAbort === "function") el._sendAbort();
     var msgId = el.dataset.msgId;
     if (!msgId) {
       // Pre-bind: bind() confirms once the server returns the msg_id (it

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -265,6 +265,16 @@ export function createQueueController(opts) {
         var status = data && data.status;
         if (status === "removed") {
           el.remove();
+          // A deferred send (command-window defer) can carry attachments;
+          // retracting it discards them — the chips were consumed when the
+          // send was accepted and a retract does not re-stage the bytes.
+          // Say so instead of letting the files silently expire.
+          if (el._deferredAttachments > 0 && onNotice)
+            onNotice(
+              "Message removed. Its " +
+                el._deferredAttachments +
+                " attachment(s) were discarded — re-attach them to send again.",
+            );
           // `removed` is the only verdict that mutated server-side queue
           // state, so it's the only one worth re-syncing composer state for.
           if (onAfterDequeue) onAfterDequeue();
@@ -297,11 +307,6 @@ export function createQueueController(opts) {
     if (el.getAttribute("aria-busy") === "true") return;
     el.dataset.dismissAttempted = "1";
     _setDismissing(el, true);
-    // A send whose POST is still in flight (parked server-side during a
-    // command window — possibly for minutes) attaches an abort hook: the ×
-    // must kill the request itself, or the dismissed message dispatches
-    // anyway when the window closes.  Post-response the hook is a no-op.
-    if (typeof el._sendAbort === "function") el._sendAbort();
     var msgId = el.dataset.msgId;
     if (!msgId) {
       // Pre-bind: bind() confirms once the server returns the msg_id (it

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -544,7 +544,15 @@ export function parsePriority(text) {
 //   busy / attachments_busy / cross_user_interjection / unknown-ok —
 //     the panes' historical shapes, verbatim.
 export function settleSendResponse(queue, data, ctx) {
-  var status = data && data.status;
+  // Normalize a null / non-object 2xx body once, here at the shared
+  // chokepoint, so neither pane's call site has to guard it (interactive
+  // passed bare `data`, the coordinator passed `data || {}` — the divergence
+  // this helper exists to erase).  In-tree /send always returns an object, so
+  // this only hardens against a misbehaving proxy answering e.g. `200 null`;
+  // without it the unknown/"ok" fall-through below would deref
+  // data.attached_ids and surface a delivered message as a connection error.
+  data = data || {};
+  var status = data.status;
   if (status === "queued" && data.msg_id) {
     var queuedEl = ctx.queuedEl;
     if (!queuedEl && data.deferred) {

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -1,7 +1,7 @@
 /* composer_queue.js — shared optimistic-queue UI for the chat composer.
  *
  * Used by both:
- *   - turnstone/ui/static/app.js (interactive Pane)
+ *   - turnstone/shared_static/interactive.js (interactive Pane)
  *   - turnstone/console/static/coordinator/coordinator.js (coord IIFE)
  *
  * What this owns:
@@ -444,8 +444,11 @@ export function createQueueController(opts) {
       // Unbound chips (no msg_id — the POST round-trip is still in
       // flight): a quick command window can close inside the round-trip,
       // firing this edge before bind() could stamp the deferred flag.
-      // Every response arm (bind/promote/remove/catch) settles unbound
-      // chips, so the sweep never needs them.
+      // Every response arm settles unbound chips — including the edge
+      // this sweep just consumed without them: settleSendResponse's
+      // post-bind missed-edge promote catches a non-deferred chip whose
+      // busy→idle edge passed mid-round-trip — so the sweep never needs
+      // them.
       if (!el.dataset.msgId) return;
       _promote(el);
     });
@@ -518,6 +521,8 @@ export function parsePriority(text) {
 //   busyIsOptimistic(): true iff the pane's CURRENT busy came from this
 //                 send flow's optimistic flip and no server state event
 //                 has since asserted it (see the panes' busySource stamp)
+//   paneIsBusy(): the pane's LIVE busy flag (not the send-time snapshot)
+//                 — drives the missed-edge settle below
 //   renderError(msg): pane error row
 //   consumeAttachments(attached_ids, dropped_ids): composer chip sync
 //
@@ -528,7 +533,9 @@ export function parsePriority(text) {
 //     delivered). For deferred sends the optimistic busy flip is then a
 //     lie — no worker exists for this send — so busy clears under the
 //     busyIsOptimistic guard, AFTER bind() so the false-edge idle sweep
-//     sees dataset.deferred and skips the new chip.
+//     sees dataset.deferred and skips the new chip. A non-deferred chip
+//     binding onto an ALREADY-idle pane missed its only sweep — the
+//     post-bind settle promotes it (see the inline contract).
 //   queue_full — the send was NEVER accepted (interjection cap, deferred-
 //     list saturation, or drain-spawn failure): remove the optimistic
 //     bubble too — leaving it renders loss as delivery — and restore busy
@@ -551,11 +558,39 @@ export function settleSendResponse(queue, data, ctx) {
         attachedCount: (data.attached_ids || []).length,
       });
       if (data.deferred && ctx.busyIsOptimistic()) ctx.setBusy(false);
+      // Missed-edge settle: if the busy→idle edge already passed during
+      // the POST round-trip, this chip's only sweep skipped it (unbound
+      // then) and — for non-deferred sends — no message_dispatched will
+      // ever fire, so without this the pane keeps a retractable "queued"
+      // bubble for a delivered message forever.  Keyed on the POST-BIND
+      // chip state, not the wire flag: bind's pre-bind-settle
+      // reconciliation may have just cleared a raced folded settle's
+      // deferred flag, and that chip needs the same catch-up.  Skips
+      // dismiss-in-flight chips (aria-busy — _confirmDequeue's verdict
+      // settles those, the sweep's own discipline) and still-deferred
+      // chips (message_dispatched owns them).  Carries the same bet the
+      // old edge-promote made: idle can precede the final flush; a
+      // DELETE racing delivery resolves via the not_found → "already
+      // sent" arm as ever.
+      if (
+        queuedEl.isConnected &&
+        queuedEl.classList.contains("msg-queued") &&
+        !queuedEl.dataset.deferred &&
+        !queuedEl.hasAttribute("aria-busy") &&
+        !ctx.paneIsBusy()
+      ) {
+        queue.promote(queuedEl);
+      }
     } else {
       // Non-deferred queuedEl-absent: the client thought it was idle but
       // a live worker interjection-queued the message (SSE state_change
-      // race). A worker provably exists, so its idle edge will arrive —
-      // keep the historical busy flip.
+      // race) — keep the historical busy flip.  KNOWN residual (the
+      // missed-edge sibling of the chip arm above): if that worker
+      // exited during the POST round-trip, no further state event
+      // arrives and this flip strands an idle pane busy until the next
+      // real activity; pre-branch behavior, preserved verbatim —
+      // ctx.paneIsBusy() is the instrument if a future round promotes
+      // this from residual to fix.
       ctx.setBusy(true);
     }
     ctx.consumeAttachments(data.attached_ids, data.dropped_attachment_ids);
@@ -603,8 +638,3 @@ export function settleSendResponse(queue, data, ctx) {
   if (ctx.queuedEl) queue.promote(ctx.queuedEl);
   ctx.consumeAttachments(data.attached_ids, data.dropped_attachment_ids);
 }
-
-// --- Legacy window bridge ---------------------------------------------------
-// Still-classic consumers reach this as a global at event/boot time (after
-// this deferred module evaluated).  New module code imports instead.
-window.createQueueController = createQueueController;

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -57,20 +57,40 @@
  * Returned controller surface:
  *   addQueuedMessage(text, priority) -> el
  *       priority: "important" | anything-else (treated as "notice")
- *   bind(el, msgId)
+ *   bind(el, msgId, opts)
  *       Server returned status:queued + msg_id. Stamps msgId so the × can
  *       dequeue; if the user already clicked × (pre-bind) runs the
  *       confirming delete now; if the idle sweep already promoted the
  *       bubble (already delivered), leaves it untouched.
+ *       opts (optional): { deferred, attachedCount } from the send
+ *       response — deferred chips are skipped by the idle sweep (they
+ *       settle via settleDeferred instead), and attachedCount feeds the
+ *       discarded-attachments notice on a confirmed retract. This is the
+ *       ONLY channel for both facts; consumers must not stash expandos
+ *       on the element.
  *   promote(el)
  *       Settle an optimistic bubble as a normal sent message — used by the
  *       consumer when the send response wasn't "queued" (e.g. an "ok"
  *       stale-busy race) so a pre-bind × can't strand the card.
  *   remove(el)
  *       Drop the bubble (busy / queue_full / connection-error path).
+ *   settleDeferred(msgId, folded)
+ *       Consume a `message_dispatched` pane event: the deferred send left
+ *       the parked list. folded=false → fresh turn spawned; promote (the
+ *       ×'s window is over — a late DELETE resolves via not_found).
+ *       folded=true → interjection fold-in; clear ONLY the deferred flag
+ *       so the chip resumes the normal queued lifecycle (DELETE still
+ *       genuinely removes it until the seam drains; the idle sweep
+ *       promotes it at the turn edge). No-op when no live chip carries
+ *       msgId (other tabs, replays) or a dismiss is in flight.
  *   onIdleEdge()
  *       Caller invokes once per busy → idle transition. Promotes every
  *       not-in-flight queued bubble and then fires the onIdle hook.
+ *       Skips deferred chips ("idle ⇒ drained" is untrue for them — they
+ *       dispatch when the server-side drain runs, possibly minutes later)
+ *       and unbound chips (POST round-trip still in flight — a quick
+ *       command window can close inside it; the response arms settle
+ *       every unbound chip, so the sweep never needs to).
  */
 export function createQueueController(opts) {
   if (!opts || !opts.messagesEl)
@@ -98,6 +118,14 @@ export function createQueueController(opts) {
   // Live queued bubbles — the idle sweep iterates this instead of querying
   // the whole messages container (see onIdleEdge).
   var _liveQueued = new Set();
+  // Settles that arrived before bind() could stamp the chip: the order
+  // barrier lets a deferred entry dispatch within milliseconds of its ack,
+  // so the SSE message_dispatched can beat the POST response's .then —
+  // without this, the chip would stay flagged deferred and the idle sweep
+  // would skip it forever. bind() reconciles and deletes; capped small
+  // because chip-absent settles (other tabs, replays) also land here and
+  // never get consumed.
+  var _preBindSettles = new Map(); // msgId -> folded
   // Upper bound on the dequeue DELETE so a wedged proxied node (the exact
   // case this flow targets) can't leave a card stuck "dismissing" forever.
   var DELETE_TIMEOUT_MS = 15000;
@@ -268,11 +296,13 @@ export function createQueueController(opts) {
           // A deferred send (command-window defer) can carry attachments;
           // retracting it discards them — the chips were consumed when the
           // send was accepted and a retract does not re-stage the bytes.
-          // Say so instead of letting the files silently expire.
-          if (el._deferredAttachments > 0 && onNotice)
+          // Say so instead of letting the files silently expire. The count
+          // rides bind()'s opts (dataset), never an element expando.
+          var nAtt = parseInt(el.dataset.attachedCount || "0", 10);
+          if (nAtt > 0 && onNotice)
             onNotice(
               "Message removed. Its " +
-                el._deferredAttachments +
+                nAtt +
                 " attachment(s) were discarded — re-attach them to send again.",
             );
           // `removed` is the only verdict that mutated server-side queue
@@ -317,16 +347,34 @@ export function createQueueController(opts) {
   }
 
   // Server returned status:queued + msg_id.
-  function bind(el, msgId) {
+  function bind(el, msgId, opts) {
     if (!el || !msgId) return;
     // Idle sweep already promoted the bubble (worker drained mid-POST): the
-    // message is on its way, so leave it as a sent bubble. We deliberately do
-    // NOT delete here — idle can be emitted before the worker actually drains,
-    // so a delete could cancel a still-queued message; and a dismissed card
-    // never reaches this branch (onIdleEdge skips aria-busy cards), so doing
-    // nothing is the safe action.
+    // message is on its way, so leave it as a sent bubble. Dead-but-harmless
+    // since the sweep skips unbound chips; kept as the safe action for any
+    // promote path we didn't enumerate. We deliberately do NOT delete here —
+    // a delete could cancel a still-queued message; and a dismissed card
+    // never reaches this branch (onIdleEdge skips aria-busy cards).
     if (!el.classList.contains("msg-queued")) return;
     el.dataset.msgId = msgId;
+    if (opts && opts.deferred) el.dataset.deferred = "1";
+    if (opts && opts.attachedCount > 0)
+      el.dataset.attachedCount = String(opts.attachedCount);
+    // A settle raced ahead of this bind (see _preBindSettles): apply it
+    // now. Fresh-spawn settle → the dispatch already happened, promote
+    // (fires "already sent" if the × was clicked — the dispatch won);
+    // fold-in settle → clear the flag, the chip is a normal queued
+    // interjection from here.
+    if (el.dataset.deferred && _preBindSettles.has(msgId)) {
+      var racedFolded = _preBindSettles.get(msgId);
+      _preBindSettles.delete(msgId);
+      if (racedFolded) {
+        delete el.dataset.deferred;
+      } else {
+        _promote(el);
+        return;
+      }
+    }
     // User clicked × before the id arrived → confirm the delete now
     // (removes only on a confirmed `removed`; promotes on not_found).
     if (el.dataset.dismissAttempted) _confirmDequeue(el, msgId);
@@ -348,6 +396,8 @@ export function createQueueController(opts) {
     var attempted = el.dataset.dismissAttempted;
     el.classList.remove("msg-queued", "msg-queued-important");
     delete el.dataset.msgId;
+    delete el.dataset.deferred;
+    delete el.dataset.attachedCount;
     delete el.dataset.dismissAttempted;
     el.removeAttribute("role");
     el.removeAttribute("aria-label");
@@ -378,9 +428,47 @@ export function createQueueController(opts) {
         return;
       }
       if (el.hasAttribute("aria-busy")) return; // mid-dequeue — let it settle
+      // Deferred sends outlive the busy→idle edge: they dispatch when the
+      // server-side drain runs (message_dispatched → settleDeferred), and
+      // promoting here would strip the × while DELETE still genuinely
+      // retracts — presenting a parked message as sent, which on a node
+      // restart before dispatch becomes loss disguised as delivery.
+      if (el.dataset.deferred) return;
+      // Unbound chips (no msg_id — the POST round-trip is still in
+      // flight): a quick command window can close inside the round-trip,
+      // firing this edge before bind() could stamp the deferred flag.
+      // Every response arm (bind/promote/remove/catch) settles unbound
+      // chips, so the sweep never needs them.
+      if (!el.dataset.msgId) return;
       _promote(el);
     });
     if (onIdle) onIdle();
+  }
+
+  // Consume a `message_dispatched {msg_id, folded}` pane event — see the
+  // header contract. Promote on a fresh spawn; on a fold-in clear only the
+  // deferred flag so the chip re-enters the normal interjection lifecycle.
+  function settleDeferred(msgId, folded) {
+    if (!msgId) return;
+    var target = null;
+    _liveQueued.forEach(function (el) {
+      if (el.isConnected && el.dataset.msgId === msgId) target = el;
+    });
+    if (!target) {
+      // No bound chip yet: either another tab's message (never consumed —
+      // hence the cap) or this tab's bind() is still in the POST
+      // round-trip; park the settle for bind() to reconcile.
+      _preBindSettles.set(msgId, !!folded);
+      if (_preBindSettles.size > 8)
+        _preBindSettles.delete(_preBindSettles.keys().next().value);
+      return;
+    }
+    if (target.hasAttribute("aria-busy")) return; // dismiss in flight — let it settle
+    if (folded) {
+      delete target.dataset.deferred;
+      return;
+    }
+    _promote(target);
   }
 
   return {
@@ -388,6 +476,7 @@ export function createQueueController(opts) {
     bind: bind,
     promote: _promote,
     remove: remove,
+    settleDeferred: settleDeferred,
     onIdleEdge: onIdleEdge,
   };
 }

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -122,10 +122,17 @@ export function createQueueController(opts) {
   // barrier lets a deferred entry dispatch within milliseconds of its ack,
   // so the SSE message_dispatched can beat the POST response's .then —
   // without this, the chip would stay flagged deferred and the idle sweep
-  // would skip it forever. bind() reconciles and deletes; capped small
-  // because chip-absent settles (other tabs, replays) also land here and
-  // never get consumed.
-  var _preBindSettles = new Map(); // msgId -> folded
+  // would skip it forever. bind() reconciles and deletes. Expiry is
+  // TTL-based, NOT a size cap: when a window closes with many deferred
+  // sends, the drain settles them FIFO in one burst — this tab's own
+  // raced settle parks FIRST and a count cap would evict exactly it as
+  // the foreign settles (other tabs' messages, which never get consumed
+  // here) pile in behind. 30s dominates every path that can still
+  // consume an entry: bind() runs off the send POST, client-aborted at
+  // 15s in both panes. Growth is rate-bounded (settle frequency × TTL);
+  // stale foreign entries expire on the next insert's purge.
+  var PRE_BIND_SETTLE_TTL_MS = 30000;
+  var _preBindSettles = new Map(); // msgId -> {folded, at}
   // Upper bound on the dequeue DELETE so a wedged proxied node (the exact
   // case this flow targets) can't leave a card stuck "dismissing" forever.
   var DELETE_TIMEOUT_MS = 15000;
@@ -366,9 +373,9 @@ export function createQueueController(opts) {
     // fold-in settle → clear the flag, the chip is a normal queued
     // interjection from here.
     if (el.dataset.deferred && _preBindSettles.has(msgId)) {
-      var racedFolded = _preBindSettles.get(msgId);
+      var raced = _preBindSettles.get(msgId);
       _preBindSettles.delete(msgId);
-      if (racedFolded) {
+      if (raced.folded) {
         delete el.dataset.deferred;
       } else {
         _promote(el);
@@ -456,11 +463,13 @@ export function createQueueController(opts) {
     });
     if (!target) {
       // No bound chip yet: either another tab's message (never consumed —
-      // hence the cap) or this tab's bind() is still in the POST
+      // hence the TTL expiry) or this tab's bind() is still in the POST
       // round-trip; park the settle for bind() to reconcile.
-      _preBindSettles.set(msgId, !!folded);
-      if (_preBindSettles.size > 8)
-        _preBindSettles.delete(_preBindSettles.keys().next().value);
+      var now = Date.now();
+      _preBindSettles.forEach(function (v, k) {
+        if (now - v.at > PRE_BIND_SETTLE_TTL_MS) _preBindSettles.delete(k);
+      });
+      _preBindSettles.set(msgId, { folded: !!folded, at: now });
       return;
     }
     if (target.hasAttribute("aria-busy")) return; // dismiss in flight — let it settle
@@ -479,6 +488,120 @@ export function createQueueController(opts) {
     settleDeferred: settleDeferred,
     onIdleEdge: onIdleEdge,
   };
+}
+
+// --- Send-response settle (shared by both panes) -----------------------------
+
+// Strip the "!!!" priority prefix for the optimistic bubble — the server
+// re-parses it authoritatively; this is display-only. Exported here because
+// priority is this module's vocabulary (it feeds addQueuedMessage's badge)
+// and both panes need the identical parse pre-POST.
+export function parsePriority(text) {
+  if (text.startsWith("!!!")) {
+    return { displayText: text.slice(3).trimStart(), priority: "important" };
+  }
+  return { displayText: text, priority: "notice" };
+}
+
+// Settle a parsed /send response against the pane's optimistic state — the
+// ONE implementation of the status dispatch both panes share (the
+// applyCompactionEvent hooks pattern: everything pane-specific arrives via
+// ctx). The fetch-stage concerns (409 pre-parse, network .catch) stay
+// per-pane; this owns everything after a parsed 2xx/handled body.
+//
+// ctx:
+//   queuedEl:     the pre-POST queued chip (busy pane) or null
+//   optimisticEl: the pre-POST sent bubble (idle pane) or null
+//   isBusy:       the pane's busy flag AT SEND TIME
+//   displayText/priority: parsePriority() of the sent text
+//   setBusy(b):   pane busy setter
+//   busyIsOptimistic(): true iff the pane's CURRENT busy came from this
+//                 send flow's optimistic flip and no server state event
+//                 has since asserted it (see the panes' busySource stamp)
+//   renderError(msg): pane error row
+//   consumeAttachments(attached_ids, dropped_ids): composer chip sync
+//
+// Status arms:
+//   queued — bind the chip (retro-converting the idle pane's optimistic
+//     bubble into a REAL queued chip when deferred: a parked,
+//     still-retractable, restart-droppable message must not render as
+//     delivered). For deferred sends the optimistic busy flip is then a
+//     lie — no worker exists for this send — so busy clears under the
+//     busyIsOptimistic guard, AFTER bind() so the false-edge idle sweep
+//     sees dataset.deferred and skips the new chip.
+//   queue_full — the send was NEVER accepted (interjection cap, deferred-
+//     list saturation, or drain-spawn failure): remove the optimistic
+//     bubble too — leaving it renders loss as delivery — and restore busy
+//     under the same guard (no worker and no drain may exist to ever emit
+//     a state event; leaving busy strands the composer in Stop mode).
+//   busy / attachments_busy / cross_user_interjection / unknown-ok —
+//     the panes' historical shapes, verbatim.
+export function settleSendResponse(queue, data, ctx) {
+  var status = data && data.status;
+  if (status === "queued" && data.msg_id) {
+    var queuedEl = ctx.queuedEl;
+    if (!queuedEl && data.deferred) {
+      if (ctx.optimisticEl && ctx.optimisticEl.isConnected)
+        ctx.optimisticEl.remove();
+      queuedEl = queue.addQueuedMessage(ctx.displayText, ctx.priority);
+    }
+    if (queuedEl) {
+      queue.bind(queuedEl, data.msg_id, {
+        deferred: !!data.deferred,
+        attachedCount: (data.attached_ids || []).length,
+      });
+      if (data.deferred && ctx.busyIsOptimistic()) ctx.setBusy(false);
+    } else {
+      // Non-deferred queuedEl-absent: the client thought it was idle but
+      // a live worker interjection-queued the message (SSE state_change
+      // race). A worker provably exists, so its idle edge will arrive —
+      // keep the historical busy flip.
+      ctx.setBusy(true);
+    }
+    ctx.consumeAttachments(data.attached_ids, data.dropped_attachment_ids);
+    return;
+  }
+  if (status === "busy") {
+    if (ctx.queuedEl) queue.remove(ctx.queuedEl);
+    ctx.renderError("Server is busy. Please wait.");
+    if (!ctx.isBusy) ctx.setBusy(false);
+    return;
+  }
+  if (status === "queue_full") {
+    if (ctx.queuedEl) {
+      queue.remove(ctx.queuedEl);
+    } else {
+      if (ctx.optimisticEl && ctx.optimisticEl.isConnected)
+        ctx.optimisticEl.remove();
+      if (ctx.busyIsOptimistic()) ctx.setBusy(false);
+    }
+    ctx.renderError("Message queue full. Please wait.");
+    return;
+  }
+  if (status === "attachments_busy") {
+    if (ctx.queuedEl) queue.remove(ctx.queuedEl);
+    ctx.renderError(
+      "Attachments can't be sent while the assistant is working. " +
+        "Send a text-only message now, or wait and resend with attachments.",
+    );
+    return;
+  }
+  if (status === "cross_user_interjection") {
+    if (ctx.queuedEl) queue.remove(ctx.queuedEl);
+    ctx.renderError(
+      data.error ||
+        "Another participant's turn is in progress. Wait for it to " +
+          "finish, then send your message.",
+    );
+    if (!ctx.isBusy) ctx.setBusy(false);
+    return;
+  }
+  // Unknown / "ok" status (e.g. the stale-busy race: the client
+  // optimistically queued but the server ran the send on a fresh worker).
+  // Settle the optimistic chip as a normal sent message so a pre-bind ×
+  // can't strand it; promote() notifies "already sent" if it was dismissed.
+  if (ctx.queuedEl) queue.promote(ctx.queuedEl);
+  ctx.consumeAttachments(data.attached_ids, data.dropped_attachment_ids);
 }
 
 // --- Legacy window bridge ---------------------------------------------------

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -73,6 +73,257 @@ export function buildWatchResultCard(meta, content) {
   return el;
 }
 
+// Compaction result card — the settled state of a context compaction.  Renders
+// from BOTH sources of the same fact: the live `compaction` end event and the
+// `/history` projection of the persisted marker row (role="system",
+// source="compaction"), so a reload paints the identical card.  `meta` carries
+// the structured fields ({before_tokens, after_tokens, trigger}); `summary` is
+// the produced summary text, offered behind a <details> fold rather than
+// inline — it exists for provenance, not for re-reading every visit.
+export function buildCompactionCard(meta, summary) {
+  const m = meta && typeof meta === "object" ? meta : {};
+  const el = document.createElement("div");
+  el.className = "msg compaction-card";
+  el.setAttribute("role", "article");
+  el.setAttribute("data-ts-role", "compaction");
+  el.setAttribute("aria-label", "context compacted");
+  const header = document.createElement("div");
+  header.className = "msg-compaction-header";
+  header.textContent =
+    "context compacted" + (m.trigger === "auto" ? " · auto" : "");
+  el.appendChild(header);
+  const before = Number(m.before_tokens);
+  const after = Number(m.after_tokens);
+  if (Number.isFinite(before) && Number.isFinite(after) && before > 0) {
+    const detail = document.createElement("div");
+    detail.className = "msg-compaction-detail";
+    detail.textContent =
+      "~" +
+      before.toLocaleString() +
+      " → ~" +
+      after.toLocaleString() +
+      " tokens";
+    el.appendChild(detail);
+  }
+  const text = String(summary == null ? "" : summary).trim();
+  if (text) {
+    const fold = document.createElement("details");
+    fold.className = "msg-compaction-fold";
+    const label = document.createElement("summary");
+    label.textContent = "summary";
+    fold.appendChild(label);
+    const body = document.createElement("pre");
+    body.className = "msg-compaction-body";
+    body.textContent = text;
+    fold.appendChild(body);
+    el.appendChild(fold);
+  }
+  return el;
+}
+
+// In-progress compaction card — the transient affordance between the
+// `compaction` start and end events.  Starts with an indeterminate bar
+// (a single-batch summarization emits no progress events); the first
+// part-k-of-N progress event flips it determinate via
+// updateCompactionProgress.  The end event replaces the card with
+// buildCompactionCard (or a failure notice).
+export function buildCompactionProgressCard(isAuto) {
+  const el = document.createElement("div");
+  el.className = "msg compaction-card compaction-running";
+  el.setAttribute("role", "status");
+  el.setAttribute("data-ts-role", "compaction");
+  el.setAttribute("aria-label", "compacting context");
+  const header = document.createElement("div");
+  header.className = "msg-compaction-header";
+  header.textContent = "compacting context…" + (isAuto ? " · auto" : "");
+  el.appendChild(header);
+  const bar = document.createElement("div");
+  bar.className = "msg-compaction-bar indeterminate";
+  const fill = document.createElement("div");
+  fill.className = "msg-compaction-bar-fill";
+  bar.appendChild(fill);
+  el.appendChild(bar);
+  const note = document.createElement("div");
+  note.className = "msg-compaction-note";
+  note.textContent = "summarizing conversation…";
+  el.appendChild(note);
+  return el;
+}
+
+// Advance an in-progress compaction card from a `compaction` progress event.
+// Depth 0 = summarizing transcript batches (determinate part k of N); deeper
+// levels merge partial summaries — those update the note ONLY, never the bar:
+// an over-window depth-0 batch subdivides mid-loop (emitting depth>0 events
+// between depth-0 parts), so any width a merge event wrote would snap
+// backwards when the outer loop resumed.  The depth-0 width itself is
+// monotonic (max with the current fill) for the same reason.  A retry wait
+// ({retry_in, error}) and the truncated-summary warning annotate the note
+// without touching the bar.
+export function updateCompactionProgress(el, evt) {
+  const bar = el.querySelector(".msg-compaction-bar");
+  const fill = el.querySelector(".msg-compaction-bar-fill");
+  const note = el.querySelector(".msg-compaction-note");
+  if (!bar || !fill || !note) return;
+  if (evt.warning === "summary_truncated") {
+    note.textContent = "summary was truncated — continuing…";
+    return;
+  }
+  if (evt.retry_in != null) {
+    note.textContent =
+      "retrying in " +
+      Math.round(Number(evt.retry_in)) +
+      "s (" +
+      String(evt.error || "error") +
+      ")…";
+    return;
+  }
+  const part = Number(evt.part);
+  const total = Number(evt.total);
+  if (!Number.isFinite(part) || !Number.isFinite(total) || total < 1) return;
+  if (Number(evt.depth) > 0) {
+    note.textContent = "merging summaries (" + part + " of " + total + ")…";
+    return;
+  }
+  bar.classList.remove("indeterminate");
+  // part is emitted BEFORE its batch summarizes — show the k-1 completed
+  // fraction so the bar never claims work that hasn't happened yet.
+  const pct = Math.max(0, Math.min(100, ((part - 1) / total) * 100));
+  const current = parseFloat(fill.style.width) || 0;
+  fill.style.width = Math.max(current, pct) + "%";
+  note.textContent = "summarizing part " + part + " of " + total + "…";
+}
+
+// Shared compaction-lifecycle reducer — ONE state machine for the
+// interactive pane and the coordinator viewer (each previously carried a
+// hand-synced copy, and they drifted within their first diff).  `holder` is
+// the pane's mutable `{card}` slot (nulled wherever the transcript DOM is
+// wiped); `hooks` supplies the pane-specific seams:
+//   container      — the transcript element to append into
+//   renderedIds    — the pane's rendered-event-id Set (dedups the ok-end
+//                    card against the /history-projected marker row)
+//   onNotice(msg)  — render a non-error failure notice (info styling)
+//   scroll(force)  — the pane's scroll-to-bottom
+// reason="error" ends render NO notice here: the backend pairs them with a
+// typed `error` event, which each pane's existing error handler styles red
+// (and which feeds the node's error metrics) — emitting here too would show
+// the message twice.
+export function applyCompactionEvent(holder, evt, hooks) {
+  // Lifecycle ownership: events carry the backend's compaction_id and the
+  // holder remembers which compaction painted the live card, so a stale
+  // event — a force-abandoned compaction retiring after a successor
+  // started — can't animate or tear down the successor's card.  The id
+  // gates only while a live card exists (with no card there is nothing to
+  // protect), and a missing id on either side matches everything so
+  // replays from older backends keep working.
+  const owns =
+    !holder.card ||
+    holder.cid == null ||
+    evt.compaction_id == null ||
+    String(evt.compaction_id) === holder.cid;
+  if (evt.phase === "start") {
+    if (holder.card) holder.card.remove();
+    holder.card = buildCompactionProgressCard(evt.trigger === "auto");
+    holder.cid = evt.compaction_id != null ? String(evt.compaction_id) : null;
+    hooks.container.appendChild(holder.card);
+    hooks.scroll(true);
+    return;
+  }
+  if (evt.phase === "progress") {
+    if (!owns) return;
+    // Defensive create: a fresh connect mid-compaction (dead replay
+    // buffer) can see a progress event with no preceding start.  The
+    // `false` is deliberate: progress events carry no trigger field, so
+    // this card cannot know it should wear the "· auto" suffix —
+    // cosmetic, and threading trigger through the summarize stack for it
+    // is disproportionate.
+    if (!holder.card) {
+      holder.card = buildCompactionProgressCard(false);
+      holder.cid = evt.compaction_id != null ? String(evt.compaction_id) : null;
+      hooks.container.appendChild(holder.card);
+    }
+    updateCompactionProgress(holder.card, evt);
+    hooks.scroll(false);
+    return;
+  }
+  if (evt.phase === "end") {
+    if (owns && holder.card) {
+      holder.card.remove();
+      holder.card = null;
+      holder.cid = null;
+    }
+    if (evt.ok) {
+      // The persisted marker row is stamped with THIS event's id, so
+      // whichever of /history repaint or live/replayed event renders
+      // first wins.  Rendered even for a non-owning end: a completed
+      // compaction's result is real regardless of whose card is live.
+      const eid = evt._event_id != null ? String(evt._event_id) : null;
+      if (eid && hooks.renderedIds.has(eid)) return;
+      hooks.container.appendChild(
+        buildCompactionCard(
+          {
+            before_tokens: evt.before_tokens,
+            after_tokens: evt.after_tokens,
+            trigger: evt.trigger,
+          },
+          evt.summary || "",
+        ),
+      );
+      if (eid) hooks.renderedIds.add(eid);
+    } else if (
+      owns &&
+      !evt.superseded &&
+      evt.reason !== "error" &&
+      !(evt.reason === "cancelled" && evt.trigger === "auto")
+    ) {
+      // cancelled / not_enough_messages / irreducible / empty_summary —
+      // informational, not an error state.  Three suppressions: a stale
+      // end's notice would narrate a dead compaction underneath a live
+      // one; a superseded end (a force-abandoned compaction retiring
+      // late, flagged by the backend) is one nobody is waiting on — its
+      // notice mid-turn reads as the LIVE work being cancelled; and an
+      // auto-compaction's cancel is just part of cancelling the
+      // surrounding turn — the send loop emits its own "[Generation
+      // cancelled]" info line, so a second line here stacked two notices
+      // for one Stop click.  (A superseded OK end above still renders
+      // its result card — the history swap really happened.)
+      // HAND-SYNCED SIBLING: cli.py TerminalUI.on_compaction implements
+      // this same three-clause policy for the terminal — change both or
+      // they drift (two runtimes, no shared code path).
+      hooks.onNotice(evt.message || "Compaction skipped.");
+    }
+    hooks.scroll(true);
+  }
+}
+
+// Send-POST abort bound for a pane, selected off its compaction holder.
+// Sends during a slash-command window PARK server-side and dispatch when
+// the window closes — a manual /compact legitimately runs for minutes, so
+// while ITS progress card is live the composer must not abort the parked
+// POST at the wedged-node default (~15s) and silently drop the message.
+// The card is the one cross-tab signal that a long window is in progress
+// (SSE-driven via applyCompactionEvent); with no card the short default
+// stands — a WEDGED quick command past 15s should fail loudly, not hang
+// the composer for 10 minutes.  Deployment note: reverse proxies bound
+// the effective park at their own read timeout (documented in the API
+// reference).  Shared by the interactive composer and the coordinator
+// viewer so the policy can't drift between panes.
+export function sendAbortMs(holder) {
+  return holder && holder.card ? 600000 : 15000;
+}
+
+// Retire a pane's in-progress compaction card (if any) and clear the
+// holder.  The teardown half of the lifecycle the reducer above owns —
+// exported so the panes' stream_end handlers (force-stop abandons the
+// compaction worker without an end event in flight) and transcript-wipe
+// sites share ONE implementation instead of four hand-synced copies.
+// Element.remove() on an already-detached node (a wipe that
+// replaceChildren()'d the transcript) is a harmless no-op.
+export function resetCompactionHolder(holder) {
+  if (holder.card) holder.card.remove();
+  holder.card = null;
+  holder.cid = null;
+}
+
 // Thin `.msg.user.system-nudge` marker — the visible-but-subtle anchor a
 // wake-driven empty user turn renders, so the operator-context `system` turns
 // that follow it land in the right place.  The caller handles empty-state

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -169,12 +169,16 @@ export function updateCompactionProgress(el, evt) {
     return;
   }
   if (evt.retry_in != null) {
+    // retry_in is a server-emitted backoff (seconds) coerced with Number();
+    // validate it the way part/total below are, so a malformed value can't
+    // render "retrying in NaNs".  The error text is the load-bearing half —
+    // keep it whether or not the duration parses.
+    const secs = Number(evt.retry_in);
+    const err = String(evt.error || "error");
     note.textContent =
-      "retrying in " +
-      Math.round(Number(evt.retry_in)) +
-      "s (" +
-      String(evt.error || "error") +
-      ")…";
+      Number.isFinite(secs) && secs >= 0
+        ? "retrying in " + Math.round(secs) + "s (" + err + ")…"
+        : "retrying (" + err + ")…";
     return;
   }
   const part = Number(evt.part);

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -246,11 +246,7 @@ export function applyCompactionEvent(holder, evt, hooks) {
     return;
   }
   if (evt.phase === "end") {
-    if (owns && holder.card) {
-      holder.card.remove();
-      holder.card = null;
-      holder.cid = null;
-    }
+    if (owns) resetCompactionHolder(holder);
     if (evt.ok) {
       // The persisted marker row is stamped with THIS event's id, so
       // whichever of /history repaint or live/replayed event renders
@@ -269,46 +265,25 @@ export function applyCompactionEvent(holder, evt, hooks) {
         ),
       );
       if (eid) hooks.renderedIds.add(eid);
-    } else if (
-      owns &&
-      !evt.superseded &&
-      evt.reason !== "error" &&
-      !(evt.reason === "cancelled" && evt.trigger === "auto")
-    ) {
+    } else if (owns && evt.notice) {
       // cancelled / not_enough_messages / irreducible / empty_summary —
-      // informational, not an error state.  Three suppressions: a stale
-      // end's notice would narrate a dead compaction underneath a live
-      // one; a superseded end (a force-abandoned compaction retiring
-      // late, flagged by the backend) is one nobody is waiting on — its
-      // notice mid-turn reads as the LIVE work being cancelled; and an
-      // auto-compaction's cancel is just part of cancelling the
-      // surrounding turn — the send loop emits its own "[Generation
-      // cancelled]" info line, so a second line here stacked two notices
-      // for one Stop click.  (A superseded OK end above still renders
-      // its result card — the history swap really happened.)
-      // HAND-SYNCED SIBLING: cli.py TerminalUI.on_compaction implements
-      // this same three-clause policy for the terminal — change both or
-      // they drift (two runtimes, no shared code path).
+      // informational, not an error state.  Whether the message is shown
+      // is the emitter's call: the backend stamps `notice` on failed ends
+      // (suppressing error-reason / superseded / cancelled-auto ends —
+      // see ChatSession._compaction_event, the single policy site), so
+      // this arm stays mechanical.  `owns` is the one pane-local clause
+      // the emitter cannot compute — card ownership via compaction_id vs
+      // holder.cid — and it guards a reachable divergence: a /resume
+      // swaps sessions and restarts generation counters, so an abandoned
+      // old-session end can arrive superseded=false against the new
+      // session's live card.  An end without the field (replayed from an
+      // older node) stays silent — these notices are informational.
+      // (A superseded OK end above still renders its result card — the
+      // history swap really happened.)
       hooks.onNotice(evt.message || "Compaction skipped.");
     }
     hooks.scroll(true);
   }
-}
-
-// Send-POST abort bound for a pane, selected off its compaction holder.
-// Sends during a slash-command window PARK server-side and dispatch when
-// the window closes — a manual /compact legitimately runs for minutes, so
-// while ITS progress card is live the composer must not abort the parked
-// POST at the wedged-node default (~15s) and silently drop the message.
-// The card is the one cross-tab signal that a long window is in progress
-// (SSE-driven via applyCompactionEvent); with no card the short default
-// stands — a WEDGED quick command past 15s should fail loudly, not hang
-// the composer for 10 minutes.  Deployment note: reverse proxies bound
-// the effective park at their own read timeout (documented in the API
-// reference).  Shared by the interactive composer and the coordinator
-// viewer so the policy can't drift between panes.
-export function sendAbortMs(holder) {
-  return holder && holder.card ? 600000 : 15000;
 }
 
 // Retire a pane's in-progress compaction card (if any) and clear the

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -265,6 +265,7 @@ export function applyCompactionEvent(holder, evt, hooks) {
         ),
       );
       if (eid) hooks.renderedIds.add(eid);
+      hooks.scroll(true);
     } else if (owns && evt.notice) {
       // cancelled / not_enough_messages / irreducible / empty_summary —
       // informational, not an error state.  Whether the message is shown
@@ -281,8 +282,12 @@ export function applyCompactionEvent(holder, evt, hooks) {
       // (A superseded OK end above still renders its result card — the
       // history swap really happened.)
       hooks.onNotice(evt.message || "Compaction skipped.");
+      hooks.scroll(true);
     }
-    hooks.scroll(true);
+    // No follow-scroll on the remaining paths: a non-owning failed end
+    // renders nothing (scrolling would yank the view with zero visual
+    // change — the round-7 finding), and an owning teardown only REMOVES
+    // the progress card, which needs no scroll chase.
   }
 }
 

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -23,6 +23,10 @@
 import {
   stripAnsi,
   buildWatchResultCard,
+  buildCompactionCard,
+  applyCompactionEvent,
+  resetCompactionHolder,
+  sendAbortMs,
   buildSystemNudgeMarker,
   buildConvBatchShell,
   buildConvRow,
@@ -261,6 +265,10 @@ class Pane {
     this._scrollPinPending = false;
     this._scrollPinForce = false;
     this._thinkingEl = null;
+    // Compaction lifecycle holder for the shared reducer
+    // (conversation.applyCompactionEvent); `card` is the in-progress card
+    // between start and end, nulled wherever the transcript DOM is wiped.
+    this._compaction = { card: null, cid: null };
     this._retryHolderEl = null;
     this._toolRowIndex = new Map();
     this._streamElIndex = new Map();
@@ -458,6 +466,7 @@ class Pane {
     // Instance ref, not a container query: removeThinkingIndicator runs on
     // EVERY content/reasoning delta, and a class-selector miss walks the
     // whole transcript subtree — O(N) per streamed token at 5000 messages.
+    if (this._compaction.card) return; // the compaction card owns the affordance
     if (this._thinkingEl) return;
     const el = document.createElement("div");
     el.className = "thinking-indicator";
@@ -492,6 +501,15 @@ class Pane {
     // carries structured `meta` (watch_name / command / poll counters) → the
     // richer `.msg.watch-result` card instead of the plain operator bubble.
     this.removeEmptyState();
+    // The /history projection of a persisted compaction marker (an in-place
+    // source="compaction" system row) — render the same result card the live
+    // `compaction` end event paints, so a reload reproduces the transcript.
+    if (source === "compaction") {
+      const card = buildCompactionCard(meta, content || "");
+      this.messagesEl.appendChild(card);
+      this.scrollToBottom(true);
+      return card;
+    }
     if (source === "watch_triggered" && meta && typeof meta === "object") {
       const card = buildWatchResultCard(meta, content || "");
       this.messagesEl.appendChild(card);
@@ -529,6 +547,40 @@ class Pane {
     body.appendChild(labelEl);
     body.appendChild(textEl);
     el.appendChild(body);
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom(true);
+    return el;
+  }
+
+  handleCompactionEvent(evt) {
+    // Shared reducer (conversation.applyCompactionEvent) — one lifecycle
+    // state machine for this pane and the coordinator viewer.  The dedup
+    // set is the same one the system_turn path uses: the persisted marker
+    // row is stamped with the ok-end event's id, so whichever of /history
+    // repaint or live/replayed event renders first wins.  reason="error"
+    // ends render through the paired `error` event (red row), not here.
+    this.removeEmptyState();
+    if (!this._renderedSystemEventIds) {
+      this._renderedSystemEventIds = new Set();
+    }
+    applyCompactionEvent(this._compaction, evt, {
+      container: this.messagesEl,
+      renderedIds: this._renderedSystemEventIds,
+      onNotice: (msg) => this.addInfoMessage(msg),
+      scroll: (force) => this.scrollToBottom(force),
+    });
+  }
+
+  addCommandEcho(text) {
+    // A slash command is control-plane input, not a conversational turn —
+    // echo it as a distinct command chip (styled like a prompt line), not a
+    // user bubble.  It is deliberately NOT persisted: commands don't join
+    // the trajectory, so a bubble that vanished on reload was a lie.
+    this.removeEmptyState();
+    const el = document.createElement("div");
+    el.className = "msg command-echo";
+    el.setAttribute("aria-label", "command");
+    el.textContent = text;
     this.messagesEl.appendChild(el);
     this.scrollToBottom(true);
     return el;
@@ -1643,6 +1695,13 @@ class Pane {
           clearTimeout(this._forceTimeout);
           this._forceTimeout = null;
         }
+        // A live in-progress compaction card at stream_end means a FORCE
+        // stop abandoned the compaction worker (the lifecycle wrapper
+        // otherwise always retires the card with an end event before any
+        // stream_end can follow) — remove it now instead of leaving a
+        // frozen bar until the abandoned worker notices at its next
+        // checkpoint.
+        resetCompactionHolder(this._compaction);
         // Reset the segment state BEFORE the finalize render, and guard the
         // render with a plain-text fallback (mirrors coordinator.js).  With
         // the old order a finalize throw skipped these clears, so every
@@ -1878,6 +1937,13 @@ class Pane {
         }
         break;
       }
+
+      case "compaction":
+        // Context-compaction lifecycle: start paints the in-progress card,
+        // progress drives its bar, end swaps it for the result card (or a
+        // failure notice).  See handleCompactionEvent.
+        this.handleCompactionEvent(evt);
+        break;
 
       case "message_queued":
         // Confirmation from server that a queued message was accepted.
@@ -2657,6 +2723,9 @@ class Pane {
     this.currentAssistantBodyEl = null;
     this.currentReasoningEl = null;
     this.contentBuffer = "";
+    // In-progress compaction card: the transcript wipe orphaned it; live
+    // events re-create it defensively (see handleCompactionEvent).
+    resetCompactionHolder(this._compaction);
     // Approval cycles + announce shells point into the wiped subtree too;
     // the replayed history / detail snapshot re-registers live ones.
     this.approvalCycles = new Map();
@@ -3606,7 +3675,11 @@ class Pane {
     if (!text) return;
 
     if (text.startsWith("/")) {
-      if (this.busy) return; // commands not allowed while busy
+      if (this.busy) {
+        // Was a silent return — say why nothing happened.
+        this.addInfoMessage("Session is busy — commands can't run mid-turn.");
+        return;
+      }
       // /rewind and /retry were lifted to path-keyed endpoints (#549);
       // reroute hand-typed ones so they don't 400 against /command.
       const parts = text.split(/\s+/);
@@ -3633,8 +3706,27 @@ class Pane {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ command: text, ws_id: this.wsId }),
-      });
-      this.addUserMessage(text);
+      })
+        .then((r) =>
+          r.json().then(
+            (b) => b || {},
+            () => ({}),
+          ),
+        )
+        .then((body) => {
+          // /compact dispatched onto an already-busy worker reports
+          // {status: "busy"} — surface it (the optimistic busy guard
+          // above can lose that race).
+          if (body.status === "busy") {
+            this.addInfoMessage(
+              body.error || "Session is busy — try again shortly.",
+            );
+          }
+        })
+        .catch(() => {});
+      // Echo as a command chip, not addUserMessage — a slash command is
+      // control-plane input, not a conversational user turn.
+      this.addCommandEcho(text);
       this.composer.clear();
       return;
     }
@@ -3677,7 +3769,17 @@ class Pane {
     let sendTimer = null;
     if (sendCtrl) {
       sendInit.signal = sendCtrl.signal;
-      sendTimer = setTimeout(() => sendCtrl.abort(), 15000);
+      // Long bound while a compaction card is live (the send is parked
+      // server-side for the command window); wedged-node default
+      // otherwise — see sendAbortMs.
+      sendTimer = setTimeout(
+        () => sendCtrl.abort(),
+        sendAbortMs(this._compaction),
+      );
+      // An × on the queued bubble BEFORE the response arrives (pre-bind)
+      // must also kill the parked POST — otherwise the dismissed message
+      // dispatches anyway when the command window closes, minutes later.
+      if (queuedEl) queuedEl._sendAbort = () => sendCtrl.abort();
     }
     let sendReq = authFetch(
       this._base +

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -640,6 +640,9 @@ class Pane {
     this._addUserMsgActions(el, text);
     this.messagesEl.appendChild(el);
     this.scrollToBottom(true);
+    // Returned so the send flow can retro-convert the optimistic bubble
+    // into a queued chip when the server answers queued+deferred.
+    return el;
   }
 
   // --- Approval-cycle bookkeeping -----------------------------------------
@@ -1942,6 +1945,15 @@ class Pane {
       case "message_queued":
         // Confirmation from server that a queued message was accepted.
         // The UI already showed the message optimistically in addQueuedMessage.
+        break;
+
+      case "message_dispatched":
+        // A deferred send left the parked list: fresh spawn (promote the
+        // chip — the ×'s window is over) or interjection fold-in
+        // (folded: true — only the deferred flag clears; the chip resumes
+        // the normal queued lifecycle). No-op when this tab holds no
+        // matching chip.
+        this.queue.settleDeferred(evt.msg_id, !!evt.folded);
         break;
 
       case "busy_error":
@@ -3715,6 +3727,14 @@ class Pane {
             this.addInfoMessage(
               body.error || "Session is busy — try again shortly.",
             );
+          } else if (body.status === "running") {
+            // The command outlived the endpoint's 25s completion backstop
+            // (kept under the console proxy's 30s bound precisely so this
+            // answer can traverse a proxied pane). The worker is still
+            // going; its output and pane refreshes arrive over SSE.
+            this.addInfoMessage(
+              "Command is still running — results will appear here when it finishes.",
+            );
           }
         })
         .catch(() => {});
@@ -3727,22 +3747,26 @@ class Pane {
 
     const isBusy = this.busy;
     let queuedEl = null;
+    let optimisticEl = null;
     const snap = this.attachments.snapshot();
 
+    // Server re-parses the !!! prefix to set queue priority — the
+    // optimistic bubble strips it for display. Parsed outside the busy
+    // branch: the queued+deferred response arm needs it too (an idle
+    // pane's send can defer behind a command window / pending list).
+    let displayText = text;
+    let priority = "notice";
+    if (text.startsWith("!!!")) {
+      displayText = text.slice(3).trimStart();
+      priority = "important";
+    }
+
     if (isBusy) {
-      // Server re-parses the !!! prefix to set queue priority — the
-      // optimistic bubble strips it for display.
-      let displayText = text;
-      let priority = "notice";
-      if (text.startsWith("!!!")) {
-        displayText = text.slice(3).trimStart();
-        priority = "important";
-      }
       this.removeEmptyState();
       queuedEl = this.queue.addQueuedMessage(displayText, priority);
     } else {
       this.setBusy(true);
-      this.addUserMessage(text, snap.attachments);
+      optimisticEl = this.addUserMessage(text, snap.attachments);
     }
     this.composer.clear();
 
@@ -3819,20 +3843,23 @@ class Pane {
         if (data.status === "queued" && data.msg_id) {
           // queuedEl-present path: bind() handles the three known races
           // (pre-bind dismiss, promote sweep raced ahead, normal accept).
-          // queuedEl-absent path: client thought it was idle but the
-          // server saw a live worker (SSE state_change hadn't arrived
-          // yet). Flip busy so subsequent sends queue correctly; the
-          // optimistic user bubble is already in the log and the server
-          // still delivers the message on worker drain — accept the
-          // small UX gap (no in-UI dismiss for THIS message).
+          // queuedEl-absent + deferred: the pane thought it was idle but
+          // the send parked on the server's deferred list (command window
+          // / order barrier) — a plain sent bubble would present a parked,
+          // still-retractable, restart-droppable message as delivered, so
+          // replace the optimistic bubble with a real queued chip carrying
+          // the dismiss affordance. queuedEl-absent + undeferred: plain
+          // interjection into a live turn the client hadn't seen yet;
+          // keep the historical small-UX-gap behavior (busy flip only).
+          if (!queuedEl && data.deferred) {
+            if (optimisticEl && optimisticEl.isConnected) optimisticEl.remove();
+            queuedEl = this.queue.addQueuedMessage(displayText, priority);
+          }
           if (queuedEl) {
-            // A deferred send (command-window defer) can carry
-            // attachments — stash the count BEFORE bind (a pre-bind ✕
-            // confirms inside bind) so the dismiss path can tell the
-            // user the attachments were discarded: the chips are
-            // consumed below and a retract does not re-stage them.
-            queuedEl._deferredAttachments = (data.attached_ids || []).length;
-            this.queue.bind(queuedEl, data.msg_id);
+            this.queue.bind(queuedEl, data.msg_id, {
+              deferred: !!data.deferred,
+              attachedCount: (data.attached_ids || []).length,
+            });
           } else this.setBusy(true);
           this.attachments.consume(
             data.attached_ids,

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -26,7 +26,6 @@ import {
   buildCompactionCard,
   applyCompactionEvent,
   resetCompactionHolder,
-  sendAbortMs,
   buildSystemNudgeMarker,
   buildConvBatchShell,
   buildConvRow,
@@ -269,6 +268,12 @@ class Pane {
     // (conversation.applyCompactionEvent); `card` is the in-progress card
     // between start and end, nulled wherever the transcript DOM is wiped.
     this._compaction = { card: null, cid: null };
+    // Rendered-event-id dedup for system turns and compaction markers
+    // (/history repaint vs live/replayed event — whichever renders first
+    // wins).  replayHistory assigns a FRESH Set on every transcript wipe
+    // so pre-wipe ids can't suppress re-painted rows; this is the
+    // first-load init.
+    this._renderedSystemEventIds = new Set();
     this._retryHolderEl = null;
     this._toolRowIndex = new Map();
     this._streamElIndex = new Map();
@@ -560,9 +565,6 @@ class Pane {
     // repaint or live/replayed event renders first wins.  reason="error"
     // ends render through the paired `error` event (red row), not here.
     this.removeEmptyState();
-    if (!this._renderedSystemEventIds) {
-      this._renderedSystemEventIds = new Set();
-    }
     applyCompactionEvent(this._compaction, evt, {
       container: this.messagesEl,
       renderedIds: this._renderedSystemEventIds,
@@ -1918,11 +1920,7 @@ class Pane {
         // the resume-cursor fix this shouldn't recur, but the guard keeps the
         // /history+replay seam idempotent for system turns regardless.
         const sysEid = evt._event_id != null ? String(evt._event_id) : null;
-        if (
-          sysEid &&
-          this._renderedSystemEventIds &&
-          this._renderedSystemEventIds.has(sysEid)
-        ) {
+        if (sysEid && this._renderedSystemEventIds.has(sysEid)) {
           break;
         }
         this.addSystemContext(
@@ -1930,11 +1928,7 @@ class Pane {
           evt.source || "",
           evt.meta || null,
         );
-        if (sysEid) {
-          if (!this._renderedSystemEventIds)
-            this._renderedSystemEventIds = new Set();
-          this._renderedSystemEventIds.add(sysEid);
-        }
+        if (sysEid) this._renderedSystemEventIds.add(sysEid);
         break;
       }
 
@@ -3769,17 +3763,12 @@ class Pane {
     let sendTimer = null;
     if (sendCtrl) {
       sendInit.signal = sendCtrl.signal;
-      // Long bound while a compaction card is live (the send is parked
-      // server-side for the command window); wedged-node default
-      // otherwise — see sendAbortMs.
-      sendTimer = setTimeout(
-        () => sendCtrl.abort(),
-        sendAbortMs(this._compaction),
-      );
-      // An × on the queued bubble BEFORE the response arrives (pre-bind)
-      // must also kill the parked POST — otherwise the dismissed message
-      // dispatches anyway when the command window closes, minutes later.
-      if (queuedEl) queuedEl._sendAbort = () => sendCtrl.abort();
+      // Flat wedged-node bound: every /send answers within RTT now —
+      // dispatched, queued, or deferred-with-msg_id during a command
+      // window (the server parks nothing against this POST), so a
+      // response slower than this means a wedged node, not a long
+      // command.  Dismissal is bind() → DELETE, never a POST abort.
+      sendTimer = setTimeout(() => sendCtrl.abort(), 15000);
     }
     let sendReq = authFetch(
       this._base +
@@ -3836,8 +3825,15 @@ class Pane {
           // optimistic user bubble is already in the log and the server
           // still delivers the message on worker drain — accept the
           // small UX gap (no in-UI dismiss for THIS message).
-          if (queuedEl) this.queue.bind(queuedEl, data.msg_id);
-          else this.setBusy(true);
+          if (queuedEl) {
+            // A deferred send (command-window defer) can carry
+            // attachments — stash the count BEFORE bind (a pre-bind ✕
+            // confirms inside bind) so the dismiss path can tell the
+            // user the attachments were discarded: the chips are
+            // consumed below and a retract does not re-stage them.
+            queuedEl._deferredAttachments = (data.attached_ids || []).length;
+            this.queue.bind(queuedEl, data.msg_id);
+          } else this.setBusy(true);
           this.attachments.consume(
             data.attached_ids,
             data.dropped_attachment_ids,

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -47,7 +47,11 @@ import {
   createAttachmentController,
   kindIcon,
 } from "./composer_attachments.js";
-import { createQueueController } from "./composer_queue.js";
+import {
+  createQueueController,
+  parsePriority,
+  settleSendResponse,
+} from "./composer_queue.js";
 import { StatusBar } from "./status_bar.js";
 import { streamingRender, streamingRenderFinalize } from "./renderer.js";
 import { setMarkdown, operatorSourceLabel } from "./utils.js";
@@ -218,6 +222,9 @@ class Pane {
     this.currentReasoningEl = null;
     this.contentBuffer = "";
     this.busy = false;
+    // Provenance of the current busy=true (see setBusy): "server" |
+    // "optimistic" | null when idle.
+    this.busySource = null;
     this.isThinking = false;
     // Acting user (turn initiator) of the in-flight turn, from state_change
     // events; drives the shared-workstream cross-user send gate. Carries the
@@ -385,8 +392,15 @@ class Pane {
   // reset). queue.onIdleEdge runs only on the actual edge — it carries
   // the heavier work (querySelectorAll-driven promote sweep + cancel-
   // timer cleanup wired via the queue's onIdle hook).
-  setBusy(b) {
+  setBusy(b, source) {
     const next = !!b;
+    // Who asserted busy: "server" (default — state events, thinking_start,
+    // every existing/future writer) or "optimistic" (ONLY the send flow's
+    // pre-POST flip). The deferred/queue_full settle arms may clear busy
+    // solely when it is still this send's own optimistic flip — a server-
+    // stamped busy is a real turn and must never be clobbered. Centralized
+    // HERE so an unstamped future writer fails safe as "server".
+    this.busySource = next ? source || "server" : null;
     this.composer.setBusy(next);
     this.messagesEl.dataset.busy = next ? "true" : "false";
     const edge = next !== this.busy;
@@ -2041,6 +2055,14 @@ class Pane {
             this._pendingEditSend = null;
             this.setBusy(true);
             this.addUserMessage(editText);
+            // Known settle gap (deliberately deferred, pre-branch path):
+            // this POST consumes only the .catch — a queued/deferred/
+            // queue_full body is silently dropped, so a /compact window
+            // opened from another tab in exactly this instant leaves the
+            // resent message parked with no chip and busy stranded
+            // "server". Narrow (rewind just ran; the slot was ours) and
+            // original-strata; route through settleSendResponse when
+            // this flow is next touched.
             authFetch(
               this._base +
                 "/v1/api/workstreams/" +
@@ -3728,12 +3750,19 @@ class Pane {
               body.error || "Session is busy — try again shortly.",
             );
           } else if (body.status === "running") {
-            // The command outlived the endpoint's 25s completion backstop
-            // (kept under the console proxy's 30s bound precisely so this
-            // answer can traverse a proxied pane). The worker is still
-            // going; its output and pane refreshes arrive over SSE.
+            // The command outlived the endpoint's completion backstop
+            // (kept under the console proxy's client bound precisely so
+            // this answer can traverse a proxied pane). The worker is
+            // still going; its output and pane refreshes arrive over SSE.
             this.addInfoMessage(
               "Command is still running — results will appear here when it finishes.",
+            );
+          } else if (body.status === "error") {
+            // 503: the command worker could not be started (thread
+            // exhaustion) — the command did NOT run. Loud, like the busy
+            // arm: silence here reads as success.
+            this.addErrorMessage(
+              body.error || "Command failed to start — retry shortly.",
             );
           }
         })
@@ -3750,22 +3779,19 @@ class Pane {
     let optimisticEl = null;
     const snap = this.attachments.snapshot();
 
-    // Server re-parses the !!! prefix to set queue priority — the
-    // optimistic bubble strips it for display. Parsed outside the busy
-    // branch: the queued+deferred response arm needs it too (an idle
-    // pane's send can defer behind a command window / pending list).
-    let displayText = text;
-    let priority = "notice";
-    if (text.startsWith("!!!")) {
-      displayText = text.slice(3).trimStart();
-      priority = "important";
-    }
+    // Display-only strip of the !!! prefix (the server re-parses it
+    // authoritatively); shared parse so the settle helper's retro-convert
+    // renders the same chip either pane would have built pre-POST.
+    const { displayText, priority } = parsePriority(text);
 
     if (isBusy) {
       this.removeEmptyState();
       queuedEl = this.queue.addQueuedMessage(displayText, priority);
     } else {
-      this.setBusy(true);
+      // "optimistic": no server state event asserted this — the settle
+      // arms may undo it if the send turns out deferred/refused (see
+      // setBusy's busySource contract).
+      this.setBusy(true, "optimistic");
       optimisticEl = this.addUserMessage(text, snap.attachments);
     }
     this.composer.clear();
@@ -3840,72 +3866,22 @@ class Pane {
         return r.json();
       })
       .then((data) => {
-        if (data.status === "queued" && data.msg_id) {
-          // queuedEl-present path: bind() handles the three known races
-          // (pre-bind dismiss, promote sweep raced ahead, normal accept).
-          // queuedEl-absent + deferred: the pane thought it was idle but
-          // the send parked on the server's deferred list (command window
-          // / order barrier) — a plain sent bubble would present a parked,
-          // still-retractable, restart-droppable message as delivered, so
-          // replace the optimistic bubble with a real queued chip carrying
-          // the dismiss affordance. queuedEl-absent + undeferred: plain
-          // interjection into a live turn the client hadn't seen yet;
-          // keep the historical small-UX-gap behavior (busy flip only).
-          if (!queuedEl && data.deferred) {
-            if (optimisticEl && optimisticEl.isConnected) optimisticEl.remove();
-            queuedEl = this.queue.addQueuedMessage(displayText, priority);
-          }
-          if (queuedEl) {
-            this.queue.bind(queuedEl, data.msg_id, {
-              deferred: !!data.deferred,
-              attachedCount: (data.attached_ids || []).length,
-            });
-          } else this.setBusy(true);
-          this.attachments.consume(
-            data.attached_ids,
-            data.dropped_attachment_ids,
-          );
-        } else if (data.status === "busy") {
-          if (queuedEl) this.queue.remove(queuedEl);
-          this.addErrorMessage("Server is busy. Please wait.");
-          if (!isBusy) this.setBusy(false);
-        } else if (data.status === "queue_full") {
-          if (queuedEl) this.queue.remove(queuedEl);
-          this.addErrorMessage("Message queue full. Please wait.");
-        } else if (data.status === "attachments_busy") {
-          // Attachments can't ride a queued user turn — server held the
-          // chips' reservations long enough to bounce the request and
-          // released them. Surface to the user; chips stay in the
-          // composer so they can retry once the assistant finishes.
-          if (queuedEl) this.queue.remove(queuedEl);
-          this.addErrorMessage(
-            "Attachments can't be sent while the assistant is working. " +
-              "Send a text-only message now, or wait and resend with attachments.",
-          );
-        } else if (data.status === "cross_user_interjection") {
-          // Another participant's turn is in flight; the server refused the
-          // interjection so it can't run under their credentials or be
-          // misattributed. The send gate normally disables the button first;
-          // this handles the race where the click beat the state_change.
-          if (queuedEl) this.queue.remove(queuedEl);
-          this.addErrorMessage(
-            data.error ||
-              "Another participant's turn is in progress. Wait for it to " +
-                "finish, then send your message.",
-          );
-          if (!isBusy) this.setBusy(false);
-        } else {
-          // Unknown / "ok" status (e.g. the stale-busy race: the client
-          // optimistically queued but the server ran the send on a fresh
-          // worker). Settle the optimistic bubble as a normal sent message
-          // so a pre-bind × can't strand it in the dismissing state;
-          // promote() notifies "already sent" if it was dismissed.
-          if (queuedEl) this.queue.promote(queuedEl);
-          this.attachments.consume(
-            data.attached_ids,
-            data.dropped_attachment_ids,
-          );
-        }
+        // The full status dispatch (queued/retro-convert, busy,
+        // queue_full, attachments_busy, cross_user, unknown-ok) lives in
+        // the shared helper — ONE settle matrix for both panes; see
+        // settleSendResponse's contract for the arm semantics.
+        settleSendResponse(this.queue, data, {
+          queuedEl,
+          optimisticEl,
+          isBusy,
+          displayText,
+          priority,
+          setBusy: (b) => this.setBusy(b),
+          busyIsOptimistic: () => this.busy && this.busySource === "optimistic",
+          renderError: (msg) => this.addErrorMessage(msg),
+          consumeAttachments: (attached, droppedIds) =>
+            this.attachments.consume(attached, droppedIds),
+        });
       })
       .catch((err) => {
         if (queuedEl) this.queue.remove(queuedEl);

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -3736,12 +3736,16 @@ class Pane {
         body: JSON.stringify({ command: text, ws_id: this.wsId }),
       })
         .then((r) =>
+          // Thread {ok, status} alongside the parsed body — the loud
+          // arms below ride NON-2xx codes (busy = 409, error = 503), so
+          // an /send-style throw-on-!ok pre-gate would wrongly reroute
+          // them into the transport catch.
           r.json().then(
-            (b) => b || {},
-            () => ({}),
+            (b) => ({ ok: r.ok, status: r.status, body: b || {} }),
+            () => ({ ok: r.ok, status: r.status, body: {} }),
           ),
         )
-        .then((body) => {
+        .then(({ ok, status, body }) => {
           // /compact dispatched onto an already-busy worker reports
           // {status: "busy"} — surface it (the optimistic busy guard
           // above can lose that race).
@@ -3764,9 +3768,21 @@ class Pane {
             this.addErrorMessage(
               body.error || "Command failed to start — retry shortly.",
             );
+          } else if (!ok) {
+            // Status-less non-2xx (404 unknown workstream, proxy 502
+            // HTML): the same silence-reads-as-success rule as the arms
+            // above. Rendered directly — not thrown into the catch,
+            // which would double-prefix the message.
+            this.addErrorMessage(
+              body.error || "Command failed (HTTP " + status + ")",
+            );
           }
         })
-        .catch(() => {});
+        .catch((err) => {
+          // Transport failure (network drop, abort): the command-echo
+          // chip is already rendered — say the command did not run.
+          this.addErrorMessage("Command failed: " + err.message);
+        });
       // Echo as a command chip, not addUserMessage — a slash command is
       // control-plane input, not a conversational user turn.
       this.addCommandEcho(text);
@@ -3878,6 +3894,7 @@ class Pane {
           priority,
           setBusy: (b) => this.setBusy(b),
           busyIsOptimistic: () => this.busy && this.busySource === "optimistic",
+          paneIsBusy: () => this.busy,
           renderError: (msg) => this.addErrorMessage(msg),
           consumeAttachments: (attached, droppedIds) =>
             this.attachments.consume(attached, droppedIds),


### PR DESCRIPTION
## Summary

Adds end-to-end visibility for compaction and, in the process, hardens the
message-send path it runs through into an explicit **defer-and-drain send
subsystem**. Compaction now emits an SSE lifecycle (`compaction` start →
progress → end/error), the web UI renders a progress card in both the
interactive and coordinator panes, `/compact` dispatches on a worker instead of
blocking the event loop, and `/history` re-renders a compaction marker.

## Why this touches the send path

Surfacing compaction progress meant a message could arrive while a worker slot
was mid-transition (compaction spawns/retires workers). The old "just enqueue"
path had no defined behavior for "send while the slot is between owners," so the
progress work exposed a set of latent ordering and ownership races on the
busiest path in the system. Rather than paper over them under the progress card,
this branch gives that path an explicit contract: bounded intake, single-owner
slot, and an order barrier that every send observes.

## What changed (by seam)

- **Compaction lifecycle + progress card** — `compaction` SSE events; web
  progress card (interactive + coordinator); `/history` marker projection.
- **`/compact` worker dispatch** — moves compaction off the event loop so the
  pane stays live while it runs; the ERROR badge survives a `/compact`.
- **Defer-and-drain send subsystem** — one lock acquisition per send:
  barrier-probe → closed-check → cap-check → append → ensure-drain, with the
  drain thread started **inside** the lock (the slot is `is_alive()`-gated) and
  rolled back on spawn failure. Bounded at-most-once intake
  (`PENDING_SENDS_MAX`), backpressure via `409`/`503`, and settle events.
- **Order barrier** — `Workstream.send_barrier_active()` is the single order
  authority (pending non-empty OR drain alive); idle-nudge and coordinator-body
  gates consult it instead of raising.
- **Chip settle** — a single shared `settleSendResponse` matrix drives both
  panes (queued/retro-convert, busy, `queue_full`, attachments, cross-user,
  unknown-ok), with a missed-edge promote keyed on post-bind chip state and a
  TTL-bounded pre-bind settle buffer.
- **Compaction events leave `info`** *(Breaking, 1.8)* — compaction is now its
  own SSE type rather than an `info` line; see CHANGELOG.

## Load-bearing invariants (for review)

1. **Slot single-ownership** — a worker/drain claims the slot; `t.start()`
   failure rolls the claim back (route mirrors `session_worker`'s discipline;
   the route starts inside the lock deliberately — an outside-lock start opens a
   double-drain window the flag-gated worker path doesn't have).
2. **Drain not alive ⇒ nothing claimed** — the `_PendingSend` contract; a dead
   drain never leaves an entry mid-flight.
3. **Order authority** — every barrier-clearing path re-runs the wake gate
   (turn exits + drain clean exit, `trigger="drain-exit"`).
4. **Bounded at-most-once intake** — `PENDING_SENDS_MAX`; spawn failure →
   rollback + `queue_full`, never a silent drop or a double-enqueue.
5. **Chip settle** — one settle matrix + sweep skips (aria-busy / deferred /
   unbound) + `message_dispatched` + TTL pre-bind buffer + missed-edge promote.

## Review campaign

Landed through 11 unprimed, full-surface review rounds. Confirmed-correctness
trend across rounds: **15 / 6 / 6 / 4 / 4 / 6 / 7 / 7 / 3 / 0 / 0**. The final
two rounds were correctness-clean — round 10 and round 11 under **different
models** (cross-model confirmation) — which is the convergence gate this branch
was held to (two consecutive zero-correctness rounds). Every fix round was run
through a fix-plan sanity pass before implementation to avoid the "fix
manufactures the next finding" cascade.

## Testing

- Full non-live suite green (`pytest -m "not live"`, ~9.5k tests).
- ruff / ruff-format / mypy / `tsc` (SDK) clean; control-char byte-scan clean.
- Send-subsystem drain matrix covered in `test_server_authz.py`
  (cap-saturation, spawn-failure rollback + recovery, claimed-window barrier,
  drain-exit re-arm, wake-raise containment, identity-guard).
- Chip settle covered by a node behavioral harness executing
  `settleSendResponse` directly; the null-body case is teeth-checked (red
  without the fix).

## Reviewing this

This branch concentrates in a sensitive area (worker-slot ownership, drain
lifecycle, SSE ordering). A reviewer's brief with risk tiers and the residuals
list is available on request. Suggested focus order: the single-lock send path
in `session_routes.py`, then `Workstream.send_barrier_active()` and its
consumers, then the `settleSendResponse` matrix.
