### PR TITLE
chore(sdk): sync openapi-console.json with build_console_spec()

### DIFF
--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "turnstone Console API",
-    "version": "1.7.0rc1",
+    "version": "1.8.0a2",
     "description": "Cluster-wide visibility and control across all turnstone nodes."
   },
   "paths": {
@@ -7791,6 +7791,12 @@
             "title": "Persona",
             "type": "string"
           },
+          "project_id": {
+            "default": "",
+            "description": "Project to attach the workstream to (validated against membership, empty = none)",
+            "title": "Project Id",
+            "type": "string"
+          },
           "resume_ws": {
             "default": "",
             "description": "Workstream ID to resume (loads previous conversation)",
@@ -8496,6 +8502,18 @@
             "title": "Skill",
             "type": "string"
           },
+          "persona": {
+            "default": "",
+            "description": "Persona slug (empty = kind default)",
+            "title": "Persona",
+            "type": "string"
+          },
+          "project_id": {
+            "default": "",
+            "description": "Project to attach the workstream to",
+            "title": "Project Id",
+            "type": "string"
+          },
           "notify_targets": {
             "description": "Notification targets on completion (channel_type + channel_id/user_id)",
             "items": {
@@ -8659,6 +8677,30 @@
             "default": null,
             "title": "Skill"
           },
+          "persona": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Persona"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project Id"
+          },
           "notify_targets": {
             "anyOf": [
               {
@@ -8752,6 +8794,16 @@
           "skill": {
             "default": "",
             "title": "Skill",
+            "type": "string"
+          },
+          "persona": {
+            "default": "",
+            "title": "Persona",
+            "type": "string"
+          },
+          "project_id": {
+            "default": "",
+            "title": "Project Id",
             "type": "string"
           },
           "notify_targets": {


### PR DESCRIPTION
## Summary

Regenerates `sdk/typescript/openapi-console.json`, which had drifted from
`build_console_spec()`. The committed file was last generated at `1.7.0rc1`;
running `sdk/typescript/scripts/generate-types.py` resyncs it.

The drift is entirely already-shipped backend surface that the reference spec
never picked up:

- the `persona` workstream-creation field (Personas, 1.7)
- the `project_id` workstream-creation field (Projects, 1.7)
- the `info.version` bump `1.7.0rc1` → `1.8.0a2`

Spec-only — no console API behavior change. `openapi-server.json` was already
current (the generator produced no diff for it), so this touches only the
console spec.

This is the deferred follow-up split out of the compaction-visibility branch,
which reverted the console-spec regeneration throughout to keep that PR scoped.
