### PR TITLE
fix(ui): paint composer project/persona pickers from warm cache (no FOUC)

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2407,15 +2407,10 @@ def test_new_ws_modal_paints_project_and_persona_from_cache_synchronously() -> N
     these guards pin only that a synchronous populate precedes it."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function showNewWsModal(")
-    # The FIRST _populateProjectSelect(projSelect, …) is the sync paint; it must
-    # precede the refreshProjects().then(…) async repaint.
-    sync_proj = fn.find("_populateProjectSelect(projSelect")
-    async_proj = fn.find("refreshProjects().then")
-    assert sync_proj >= 0, "the modal must paint the project picker from cache synchronously"
-    assert async_proj >= 0, "the modal must keep refreshProjects().then (catches remote changes)"
-    assert sync_proj < async_proj, (
-        "the synchronous project paint must precede the async refreshProjects().then "
-        "repaint — otherwise the picker flashes empty on every open"
+    # Project is painted via the shared _paintProjectPicker helper (fork-gated);
+    # the sync-before-async pattern is pinned in test_paint_project_picker_syncs.
+    assert "_paintProjectPicker(projSelect" in fn, (
+        "the modal must paint the project picker via the shared _paintProjectPicker helper"
     )
     sync_persona = fn.find("_populatePersonaSelect(personaSelect")
     async_persona = fn.find("refreshPersonas().then")
@@ -2434,12 +2429,9 @@ def test_dashboard_paints_project_and_persona_from_cache_synchronously() -> None
     from requireProject() synchronously, matching the new-ws modal."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function _loadDashboardOptionsLists(")
-    sync_proj = fn.find("_populateProjectSelect(projSel")
-    async_proj = fn.find("refreshProjects().then")
-    assert sync_proj >= 0, "the dashboard must paint the project picker from cache synchronously"
-    assert async_proj >= 0, "the dashboard must keep refreshProjects().then"
-    assert sync_proj < async_proj, (
-        "the synchronous dashboard project paint must precede the async refresh repaint"
+    # Project is painted via the shared _paintProjectPicker helper.
+    assert "_paintProjectPicker(projSel" in fn, (
+        "the dashboard must paint the project picker via the shared _paintProjectPicker helper"
     )
     sync_persona = fn.find("_populatePersonaSelect(personaSel")
     async_persona = fn.find("refreshPersonas().then")
@@ -2455,10 +2447,7 @@ def test_dashboard_paints_project_and_persona_from_cache_synchronously() -> None
     assert 'class="label-hint"' in html[lbl : lbl + 120], (
         "the dashboard Project label must carry a .label-hint span (required/optional cue)"
     )
-    sync_hint = fn.find("projHint.textContent")
-    assert 0 <= sync_hint < async_proj, (
-        "the dashboard project label hint must be seeded synchronously (before the refresh)"
-    )
+    # The hint is seeded synchronously inside _paintProjectPicker (asserted there).
 
 
 def test_console_launcher_paints_project_and_persona_from_cache_synchronously() -> None:
@@ -2484,4 +2473,26 @@ def test_console_launcher_paints_project_and_persona_from_cache_synchronously() 
     assert async_persona >= 0, "the launcher must keep refreshPersonas().then"
     assert sync_persona < async_persona, (
         "the synchronous launcher persona paint must precede the async refresh repaint"
+    )
+
+
+def test_paint_project_picker_syncs_before_refresh() -> None:
+    """The shared _paintProjectPicker (used by BOTH the modal and dashboard, so
+    the two can't drift and silently re-introduce the FOUC) seeds the required/
+    optional hint + paints the picker via _populateProjectSelect SYNCHRONOUSLY,
+    then refreshes-and-repaints.  It skips a fork, and both paints route through
+    the same _populateProjectSelect (preserving the #867 strict-picker invariant)."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function _paintProjectPicker(")
+    assert "_populateProjectSelect(" in fn, (
+        "_paintProjectPicker must paint via _populateProjectSelect"
+    )
+    assert "hint.textContent" in fn, "_paintProjectPicker must seed the required/optional hint"
+    assert "opts.fork" in fn, "_paintProjectPicker must skip for a fork"
+    sync_call = fn.find("paint();")
+    async_refresh = fn.find("refreshProjects().then")
+    assert async_refresh >= 0, "_paintProjectPicker must keep refreshProjects().then"
+    assert 0 <= sync_call < async_refresh, (
+        "_paintProjectPicker must paint synchronously (paint()) BEFORE the async "
+        "refreshProjects().then repaint"
     )

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2353,7 +2353,135 @@ def test_strict_picker_requires_explicit_pick() -> None:
     assert "Select a project" in body, (
         "strict picker must offer an explicit 'Select a project…' prompt"
     )
-    m = re.search(r"function _reconcileRequiredProjectSelection\(sel\)\s*\{(.*?)\n\}", body, re.S)
+    m = re.search(
+        r"function _reconcileRequiredProjectSelection\(sel, choices\)\s*\{(.*?)\n\}",
+        body,
+        re.S,
+    )
     assert m is not None, "could not locate _reconcileRequiredProjectSelection"
     fn = m.group(1)
     assert "real[0]" not in fn, "strict picker must not auto-select the first project"
+    # §6b polish: _populateProjectSelect threads its already-computed choices into
+    # reconcile rather than forcing a second projectChoices() recompute (the onClose
+    # creator caller still passes none and reconcile recomputes for it).
+    assert "_reconcileRequiredProjectSelection(sel, choices)" in body, (
+        "the populate helper must thread its computed choices into reconcile "
+        "(avoids a redundant projectChoices() recompute)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composer selector FOUC — sync-paint-then-refresh guards
+# ---------------------------------------------------------------------------
+#
+# The project + persona composer selectors are painted from the warm shared
+# client cache (window.TurnstoneProjects / window.TurnstonePersonas, warmed by
+# the rail at startup) SYNCHRONOUSLY on open, BEFORE the deliberate async
+# refresh-and-repaint that catches items created elsewhere.  Pre-fix they were
+# painted only inside the refresh().then callback, so every open flashed an
+# empty dropdown for a network round-trip even when the data was already in
+# memory.  These guards pin the ordering — a synchronous populate must precede
+# the refresh().then — for all three composer surfaces (new-ws modal, dashboard
+# Options, console launcher).  Model/skill selectors are a separate later pass
+# and intentionally NOT covered here.
+
+
+def _slice_top_level_fn(body: str, header: str) -> str:
+    """Slice a top-level ``function`` body from ``header`` to the next
+    column-0 ``function`` declaration (or EOF).  Unlike
+    ``_slice_balanced_body`` this has no fixed-size window, so it is safe
+    for large functions like ``showNewWsModal``.  Nested (indented)
+    ``function () {…}`` expressions never match the ``\\nfunction `` bound,
+    so the slice stops at the next top-level function."""
+    start = body.index(header)
+    nxt = body.find("\nfunction ", start + 1)
+    return body[start:] if nxt < 0 else body[start:nxt]
+
+
+def test_new_ws_modal_paints_project_and_persona_from_cache_synchronously() -> None:
+    """FOUC fix: the new-ws modal's project + persona pickers paint from the warm
+    shared cache SYNCHRONOUSLY on open, BEFORE the async refresh-and-repaint — so a
+    warm-cache open (the common case; the rail warms the caches at startup) shows
+    the populated dropdowns immediately instead of flashing empty for a network
+    round-trip.  The refresh-on-open is KEPT (it catches items created elsewhere);
+    these guards pin only that a synchronous populate precedes it."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function showNewWsModal(")
+    # The FIRST _populateProjectSelect(projSelect, …) is the sync paint; it must
+    # precede the refreshProjects().then(…) async repaint.
+    sync_proj = fn.find("_populateProjectSelect(projSelect")
+    async_proj = fn.find("refreshProjects().then")
+    assert sync_proj >= 0, "the modal must paint the project picker from cache synchronously"
+    assert async_proj >= 0, "the modal must keep refreshProjects().then (catches remote changes)"
+    assert sync_proj < async_proj, (
+        "the synchronous project paint must precede the async refreshProjects().then "
+        "repaint — otherwise the picker flashes empty on every open"
+    )
+    sync_persona = fn.find("_populatePersonaSelect(personaSelect")
+    async_persona = fn.find("refreshPersonas().then")
+    assert sync_persona >= 0, "the modal must paint the persona picker from cache synchronously"
+    assert async_persona >= 0, "the modal must keep refreshPersonas().then"
+    assert sync_persona < async_persona, (
+        "the synchronous persona paint must precede the async refreshPersonas().then repaint"
+    )
+
+
+def test_dashboard_paints_project_and_persona_from_cache_synchronously() -> None:
+    """FOUC fix (dashboard composer twin of the modal): the dashboard Options
+    project + persona pickers paint synchronously from the warm cache before the
+    async refresh.  Also pins the deferred require_project polish — the dashboard
+    Project label carries a ``.label-hint`` span seeded ``required``/``optional``
+    from requireProject() synchronously, matching the new-ws modal."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function _loadDashboardOptionsLists(")
+    sync_proj = fn.find("_populateProjectSelect(projSel")
+    async_proj = fn.find("refreshProjects().then")
+    assert sync_proj >= 0, "the dashboard must paint the project picker from cache synchronously"
+    assert async_proj >= 0, "the dashboard must keep refreshProjects().then"
+    assert sync_proj < async_proj, (
+        "the synchronous dashboard project paint must precede the async refresh repaint"
+    )
+    sync_persona = fn.find("_populatePersonaSelect(personaSel")
+    async_persona = fn.find("refreshPersonas().then")
+    assert sync_persona >= 0, "the dashboard must paint the persona picker from cache synchronously"
+    assert async_persona >= 0, "the dashboard must keep refreshPersonas().then"
+    assert sync_persona < async_persona, (
+        "the synchronous dashboard persona paint must precede the async refresh repaint"
+    )
+    # require_project label-hint parity: the dashboard Project label gained a
+    # .label-hint span, seeded synchronously from requireProject() like the modal.
+    html = _INDEX_HTML.read_text(encoding="utf-8")
+    lbl = html.index('for="dashboard-project"')
+    assert 'class="label-hint"' in html[lbl : lbl + 120], (
+        "the dashboard Project label must carry a .label-hint span (required/optional cue)"
+    )
+    sync_hint = fn.find("projHint.textContent")
+    assert 0 <= sync_hint < async_proj, (
+        "the dashboard project label hint must be seeded synchronously (before the refresh)"
+    )
+
+
+def test_console_launcher_paints_project_and_persona_from_cache_synchronously() -> None:
+    """FOUC fix (console launcher composer): the launcher's project + persona
+    pickers paint synchronously from the warm shared cache before the async
+    refresh-and-repaint, mirroring the standalone app.  The console launcher keeps
+    its ungated 'No project' semantics (§8); this only adds the sync pre-paint."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    proj_fn = _slice_top_level_fn(body, "function _refreshAndPopulateProjects(")
+    # The bare _populateHomeProjectDropdown() call is the sync paint; the refresh's
+    # .then argument has no parens, so this matches only the standalone sync call.
+    sync_proj = proj_fn.find("_populateHomeProjectDropdown()")
+    async_proj = proj_fn.find("refreshProjects().then")
+    assert sync_proj >= 0, "the launcher must paint the project picker from cache synchronously"
+    assert async_proj >= 0, "the launcher must keep refreshProjects().then"
+    assert sync_proj < async_proj, (
+        "the synchronous launcher project paint must precede the async refresh repaint"
+    )
+    persona_fn = _slice_top_level_fn(body, "function _refreshAndPopulatePersonas(")
+    sync_persona = persona_fn.find("_populateHomePersonaDropdown()")
+    async_persona = persona_fn.find("refreshPersonas().then")
+    assert sync_persona >= 0, "the launcher must paint the persona picker from cache synchronously"
+    assert async_persona >= 0, "the launcher must keep refreshPersonas().then"
+    assert sync_persona < async_persona, (
+        "the synchronous launcher persona paint must precede the async refresh repaint"
+    )

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1489,6 +1489,12 @@ function _ensureHomeComposerInit() {
 function _refreshAndPopulatePersonas() {
   const TP = window.TurnstonePersonas;
   if (!TP) return;
+  // Paint from the warm cache SYNCHRONOUSLY first so the Persona picker isn't
+  // empty for the refresh round-trip (the rail warms personas at startup), then
+  // refresh-and-repaint to catch a persona created elsewhere. _populateHome-
+  // PersonaDropdown preserves a mid-window pick and only applies the kind default
+  // when nothing valid is selected, so the second paint can't clobber a choice.
+  _populateHomePersonaDropdown();
   TP.refreshPersonas().then(_populateHomePersonaDropdown);
 }
 
@@ -1523,6 +1529,12 @@ function _populateHomePersonaDropdown() {
 function _refreshAndPopulateProjects() {
   const TP = window.TurnstoneProjects;
   if (!TP) return;
+  // Sync paint from the warm cache first (the launcher keeps its "No project"
+  // placeholder when cold), then refresh-and-repaint to catch a project created
+  // elsewhere. _populateHomeProjectDropdown preserves a mid-window pick. The
+  // console launcher intentionally does NOT gate on requireProject() (§8) — the
+  // node create endpoint is the authoritative gate.
+  _populateHomeProjectDropdown();
   TP.refreshProjects().then(_populateHomeProjectDropdown);
 }
 

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -424,6 +424,15 @@ function showNewWsModal(forkFromWsId) {
       : "optional";
   }
   if (projSelect && !_forkFromWsId && window.TurnstoneProjects) {
+    // Paint from the warm cache SYNCHRONOUSLY first so the picker isn't empty for
+    // the (redundant) refresh round-trip — the rail warms projects at startup and
+    // projectChoices()/requireProject() are sync. On a cold cache projectChoices()
+    // is [] and this is a no-op the async fills, so it's never worse than before.
+    // BOTH paints route through the SAME _populateProjectSelect, so the #867
+    // strict-picker invariant (never auto-select a real project) holds identically.
+    _populateProjectSelect(projSelect, {
+      requireProject: !!window.TurnstoneProjects.requireProject(),
+    });
     window.TurnstoneProjects.refreshProjects().then(function () {
       const strict = !!window.TurnstoneProjects.requireProject();
       // Honest label: under require_project a fresh create must resolve to a real
@@ -440,6 +449,11 @@ function showNewWsModal(forkFromWsId) {
   if (personaLabel) personaLabel.hidden = !!_forkFromWsId;
   if (personaSelect) personaSelect.hidden = !!_forkFromWsId;
   if (personaSelect && !_forkFromWsId && window.TurnstonePersonas) {
+    // Sync paint from the warm cache first, then refresh-and-repaint to catch a
+    // persona created elsewhere. _populatePersonaSelect preserves a mid-window
+    // pick and only applies the kind default when nothing valid is selected, so
+    // the second (async) paint can't clobber the user's choice.
+    _populatePersonaSelect(personaSelect);
     window.TurnstonePersonas.refreshPersonas().then(function () {
       _populatePersonaSelect(personaSelect);
     });
@@ -598,7 +612,9 @@ function _populateProjectSelect(sel, opts) {
   if (previous && previous !== _PROJECT_NEW && _optionExists(sel, previous)) {
     sel.value = previous;
   }
-  _reconcileRequiredProjectSelection(sel);
+  // Reuse the choices we already built — reconcile needs the same real-project
+  // list and would otherwise recompute projectChoices() a second time.
+  _reconcileRequiredProjectSelection(sel, choices);
 }
 
 // Under require_project the picker keeps a VALID selection — an already-chosen
@@ -607,13 +623,16 @@ function _populateProjectSelect(sel, opts) {
 // must NOT auto-select a real project the user didn't choose — that silently
 // files a required chat under a possibly-shared project. No-op when the gate is
 // off.  Idempotent — only sets the SELECTION, never adds options.
-function _reconcileRequiredProjectSelection(sel) {
+function _reconcileRequiredProjectSelection(sel, choices) {
   if (!sel) return;
   const mode = sel._projMode || {};
   if (!mode.requireProject) return;
-  const real = window.TurnstoneProjects
-    ? window.TurnstoneProjects.projectChoices()
-    : [];
+  // _populateProjectSelect threads in the projectChoices() list it already built;
+  // the inline "+ New project…" creator's onClose caller passes none, so recompute
+  // from the cache in that case.
+  const real =
+    choices ||
+    (window.TurnstoneProjects ? window.TurnstoneProjects.projectChoices() : []);
   if (real.length === 0) {
     sel.value = ""; // the disabled "No projects available" notice
     return;
@@ -1493,24 +1512,41 @@ function _loadDashboardOptionsLists() {
       });
   }
 
-  // Project picker — refresh the shared cache then repaint (also feeds the
-  // rail's group-by-project).  Re-fetched each time the options open so a
-  // project created elsewhere appears without a page reload.
+  // Project picker — paint from the warm cache then refresh-and-repaint (also
+  // feeds the rail's group-by-project).  Re-fetched each time the options open so
+  // a project created elsewhere appears without a page reload.
   const projSel = document.getElementById("dashboard-project");
+  const projLabel = document.querySelector('label[for="dashboard-project"]');
+  const projHint = projLabel ? projLabel.querySelector(".label-hint") : null;
   if (projSel && window.TurnstoneProjects) {
+    // Seed the "required"/"optional" label hint + paint the picker from the warm
+    // cache SYNCHRONOUSLY (mirrors showNewWsModal) so a fresh open isn't empty or
+    // mislabeled for the refresh round-trip; the async refresh below re-affirms
+    // both to catch a project created elsewhere. Dashboard quick-create is ALWAYS
+    // a fresh create (never a fork); the mode is passed explicitly so the shared
+    // helper never reads the fork-only global.
+    if (projHint) {
+      projHint.textContent = window.TurnstoneProjects.requireProject()
+        ? "required"
+        : "optional";
+    }
+    _populateProjectSelect(projSel, {
+      requireProject: !!window.TurnstoneProjects.requireProject(),
+    });
     window.TurnstoneProjects.refreshProjects().then(function () {
-      // Dashboard quick-create is ALWAYS a fresh create (never a fork); pass the
-      // mode explicitly so the shared helper never reads the fork-only global.
-      _populateProjectSelect(projSel, {
-        requireProject: !!window.TurnstoneProjects.requireProject(),
-      });
+      const strict = !!window.TurnstoneProjects.requireProject();
+      if (projHint) projHint.textContent = strict ? "required" : "optional";
+      _populateProjectSelect(projSel, { requireProject: strict });
     });
   }
 
-  // Persona picker — same refresh-on-open policy; kind default preselected
-  // so a zero-touch launch behaves exactly like today.
+  // Persona picker — same paint-from-cache-then-refresh policy; kind default
+  // preselected so a zero-touch launch behaves exactly like today.
   const personaSel = document.getElementById("dashboard-persona");
   if (personaSel && window.TurnstonePersonas) {
+    // Sync paint first, then refresh-and-repaint; the helper preserves a mid-
+    // window pick and only applies the kind default when nothing valid is chosen.
+    _populatePersonaSelect(personaSel);
     window.TurnstonePersonas.refreshPersonas().then(function () {
       _populatePersonaSelect(personaSel);
     });

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -414,33 +414,11 @@ function showNewWsModal(forkFromWsId) {
   const projHint = projLabel ? projLabel.querySelector(".label-hint") : null;
   if (projLabel) projLabel.hidden = !!_forkFromWsId;
   if (projSelect) projSelect.hidden = !!_forkFromWsId;
-  // Seed the hint from the warm cache SYNCHRONOUSLY so a fresh create isn't
-  // mislabeled "optional" for the duration of the (redundant) refresh round-trip
-  // — requireProject() reads a cache the rail warms at startup. The refresh below
-  // re-affirms it for the rare cold-cache open.
-  if (projHint && !_forkFromWsId && window.TurnstoneProjects) {
-    projHint.textContent = window.TurnstoneProjects.requireProject()
-      ? "required"
-      : "optional";
-  }
-  if (projSelect && !_forkFromWsId && window.TurnstoneProjects) {
-    // Paint from the warm cache SYNCHRONOUSLY first so the picker isn't empty for
-    // the (redundant) refresh round-trip — the rail warms projects at startup and
-    // projectChoices()/requireProject() are sync. On a cold cache projectChoices()
-    // is [] and this is a no-op the async fills, so it's never worse than before.
-    // BOTH paints route through the SAME _populateProjectSelect, so the #867
-    // strict-picker invariant (never auto-select a real project) holds identically.
-    _populateProjectSelect(projSelect, {
-      requireProject: !!window.TurnstoneProjects.requireProject(),
-    });
-    window.TurnstoneProjects.refreshProjects().then(function () {
-      const strict = !!window.TurnstoneProjects.requireProject();
-      // Honest label: under require_project a fresh create must resolve to a real
-      // project, so the static "optional" hint must not claim otherwise.
-      if (projHint) projHint.textContent = strict ? "required" : "optional";
-      _populateProjectSelect(projSelect, { requireProject: strict });
-    });
-  }
+  // Paint the picker + its required/optional hint from the warm cache, then
+  // refresh-and-repaint — shared with the dashboard via _paintProjectPicker so
+  // the two can't drift; skips for a fork (its picker is hidden above,
+  // inheritance is server-enforced).
+  _paintProjectPicker(projSelect, projHint, { fork: !!_forkFromWsId });
 
   // Persona picker — hidden when forking (a fork resumes the source's
   // stamped persona; the create handler skips resolution on resume_ws).
@@ -569,6 +547,24 @@ function _optionExists(sel, val) {
     if (sel.options[i].value === val) return true;
   }
   return false;
+}
+
+// Paint a FRESH-create project picker (+ its required/optional label hint) from
+// the warm cache SYNCHRONOUSLY, then refresh-and-repaint.  Shared by the new-ws
+// modal and the dashboard composer so the two paths can't drift and silently
+// re-introduce the empty-dropdown / mislabel FOUC this exists to prevent.  A fork
+// skips entirely (a fork inherits its source's project server-side; the modal
+// hides the picker for forks).  Both paints reuse _populateProjectSelect, so the
+// #867 strict-picker invariant (never auto-select a real project) holds on each.
+function _paintProjectPicker(sel, hint, opts) {
+  if ((opts && opts.fork) || !sel || !window.TurnstoneProjects) return;
+  const paint = function () {
+    const strict = !!window.TurnstoneProjects.requireProject();
+    if (hint) hint.textContent = strict ? "required" : "optional";
+    _populateProjectSelect(sel, { requireProject: strict });
+  };
+  paint(); // sync from the warm cache (no-op when cold; the async fills it)
+  window.TurnstoneProjects.refreshProjects().then(paint);
 }
 
 // Fill a project <select> from the shared projects cache.  The picker MODE is
@@ -1513,32 +1509,12 @@ function _loadDashboardOptionsLists() {
   }
 
   // Project picker — paint from the warm cache then refresh-and-repaint (also
-  // feeds the rail's group-by-project).  Re-fetched each time the options open so
-  // a project created elsewhere appears without a page reload.
+  // feeds the rail's group-by-project). Dashboard quick-create is ALWAYS a fresh
+  // create (never a fork); shared with the modal via _paintProjectPicker.
   const projSel = document.getElementById("dashboard-project");
   const projLabel = document.querySelector('label[for="dashboard-project"]');
   const projHint = projLabel ? projLabel.querySelector(".label-hint") : null;
-  if (projSel && window.TurnstoneProjects) {
-    // Seed the "required"/"optional" label hint + paint the picker from the warm
-    // cache SYNCHRONOUSLY (mirrors showNewWsModal) so a fresh open isn't empty or
-    // mislabeled for the refresh round-trip; the async refresh below re-affirms
-    // both to catch a project created elsewhere. Dashboard quick-create is ALWAYS
-    // a fresh create (never a fork); the mode is passed explicitly so the shared
-    // helper never reads the fork-only global.
-    if (projHint) {
-      projHint.textContent = window.TurnstoneProjects.requireProject()
-        ? "required"
-        : "optional";
-    }
-    _populateProjectSelect(projSel, {
-      requireProject: !!window.TurnstoneProjects.requireProject(),
-    });
-    window.TurnstoneProjects.refreshProjects().then(function () {
-      const strict = !!window.TurnstoneProjects.requireProject();
-      if (projHint) projHint.textContent = strict ? "required" : "optional";
-      _populateProjectSelect(projSel, { requireProject: strict });
-    });
-  }
+  _paintProjectPicker(projSel, projHint, { fork: false });
 
   // Persona picker — same paint-from-cache-then-refresh policy; kind default
   // preselected so a zero-touch launch behaves exactly like today.

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -169,7 +169,9 @@
             <select id="dashboard-skill">
               <option value="">Use defaults</option>
             </select>
-            <label for="dashboard-project">Project</label>
+            <label for="dashboard-project"
+              >Project <span class="label-hint">optional</span></label
+            >
             <select id="dashboard-project">
               <option value="">No project</option>
             </select>


### PR DESCRIPTION
## What

The new-workstream **modal**, the **dashboard** composer, and the **console launcher** painted their project and persona `<select>`s only inside the async `refresh().then(...)` callback, so each open flashed an empty/stale dropdown for a network round-trip -- even though the client caches (`window.TurnstoneProjects` / `window.TurnstonePersonas`) are already warmed at startup by the rail.

This paints each **synchronously from the warm cache first, then refreshes-and-repaints** (still catches items created elsewhere). On a cold cache the sync paint is a no-op the async fills -- never worse than before.

## Safety

Both project paints route through the **same** `_populateProjectSelect` + `_reconcileRequiredProjectSelection`, so the #867 strict-picker invariant (under `require_project`, never auto-select a real project into a possibly-shared one) is unchanged. Persona reuses `_populatePersonaSelect`, which preserves a mid-window pick and only applies the kind default when nothing valid is selected.

## Also (deferred #867 polish, same code)

- Dashboard Project label now shows the "required"/"optional" hint (parity with the modal).
- `_reconcileRequiredProjectSelection` reuses the `projectChoices()` list its caller already built instead of recomputing it.

## Scope

Project + persona only. The **models/skills** selectors are a separate follow-up -- they have no client cache today (and the model endpoint returns two different schemas per app), so they need their own `models.js` / `skills.js` cache bridges.

## Tests

`tests/test_app_js.py`: 3 new guards pinning that each project/persona composer surface paints synchronously before the async refresh (non-tautological -- removing a sync paint flips the ordering and fails the guard), plus the updated strict-picker guard for the new reconcile signature. 91 pass; `node --check` + control-byte scan clean.
