### PR TITLE
refactor(ui): shared list-cache core + models/skills caches

### DIFF
--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2446,39 +2446,44 @@ def test_dashboard_paints_project_and_persona_from_cache_synchronously() -> None
 
 
 def test_console_launcher_paints_project_and_persona_from_cache_synchronously() -> None:
-    """FOUC fix (console launcher composer): the launcher's project + persona
-    pickers paint synchronously from the warm shared cache before the async
-    refresh-and-repaint, mirroring the standalone app.  The console launcher keeps
-    its ungated 'No project' semantics (§8); this only adds the sync pre-paint."""
+    """FOUC fix (console launcher composer): the project + persona wrappers route
+    through the _paintHomeFromCache chokepoint — sync paint from the warm cache,
+    then refresh(callOpts)-and-repaint; the ordering discipline is asserted ONCE
+    on the helper (in the model/skill twin test).  Each wrapper must pair its OWN
+    bridge refresh with its OWN populate helper.  Also pins the persona
+    kind-default revert: _populateHomePersonaDropdown must fall back to
+    defaultPersona(kind) when the previous pick is no longer a valid choice (the
+    interactive/coordinator persona shelves are disjoint), or a kind toggle
+    silently degrades the picker to a bare placeholder."""
     body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
     proj_fn = _slice_top_level_fn(body, "function _refreshAndPopulateProjects(")
-    # The bare _populateHomeProjectDropdown() call is the sync paint; the refresh's
-    # .then argument has no parens, so this matches only the standalone sync call.
-    sync_proj = proj_fn.find("_populateHomeProjectDropdown()")
-    async_proj = proj_fn.find("refreshProjects(callOpts).then")
-    assert sync_proj >= 0, "the launcher must paint the project picker from cache synchronously"
-    assert async_proj >= 0, "the launcher must keep refreshProjects(callOpts).then"
-    assert sync_proj < async_proj, (
-        "the synchronous launcher project paint must precede the async refresh repaint"
-    )
+    assert re.search(
+        r"_paintHomeFromCache\(\s*TP && TP\.refreshProjects,\s*_populateHomeProjectDropdown",
+        proj_fn,
+    ), "the launcher project wrapper must pair its bridge refresh + populate via the chokepoint"
     persona_fn = _slice_top_level_fn(body, "function _refreshAndPopulatePersonas(")
-    sync_persona = persona_fn.find("_populateHomePersonaDropdown()")
-    async_persona = persona_fn.find("refreshPersonas(callOpts).then")
-    assert sync_persona >= 0, "the launcher must paint the persona picker from cache synchronously"
-    assert async_persona >= 0, "the launcher must keep refreshPersonas(callOpts).then"
-    assert sync_persona < async_persona, (
-        "the synchronous launcher persona paint must precede the async refresh repaint"
+    assert re.search(
+        r"_paintHomeFromCache\(\s*TP && TP\.refreshPersonas,\s*_populateHomePersonaDropdown",
+        persona_fn,
+    ), "the launcher persona wrapper must pair its bridge refresh + populate via the chokepoint"
+    pop = _slice_top_level_fn(body, "function _populateHomePersonaDropdown(")
+    assert '_restorePick("persona"' in pop, (
+        "the persona populate must restore a still-valid pick via _restorePick"
+    )
+    assert "defaultPersona(_launcherKind)" in pop, (
+        "the persona populate must revert to the kind default when the pick is gone"
     )
 
 
 def test_paint_project_picker_syncs_before_refresh() -> None:
     """The shared _paintProjectPicker (used by BOTH the modal and dashboard, so
     the two can't drift and silently re-introduce the FOUC) seeds the required/
-    optional hint + paints the picker via _populateProjectSelect SYNCHRONOUSLY,
-    then refreshes-and-repaints.  It skips a fork, and both paints route through
-    the same _populateProjectSelect (preserving the #867 strict-picker invariant).
-    The sync paint passes freshOnOpen; the async repaint MUST pass fresh=false, or
-    it clobbers a project the user picked mid-refresh (require_project -> 400)."""
+    optional hint + paints via _populateProjectSelect, and routes its
+    sync-then-refresh tail through the _paintFromCache chokepoint — where the
+    sync-before-async + always-fresh:false discipline is asserted once.  Its
+    fork/absent-bridge path returns a resolved promise so the dashboard's chained
+    Options-chip recompute still runs.  Both paints reuse _populateProjectSelect
+    (preserving the #867 strict-picker invariant)."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function _paintProjectPicker(")
     assert "_populateProjectSelect(" in fn, (
@@ -2486,15 +2491,13 @@ def test_paint_project_picker_syncs_before_refresh() -> None:
     )
     assert "hint.textContent" in fn, "_paintProjectPicker must seed the required/optional hint"
     assert "opts.fork" in fn, "_paintProjectPicker must skip for a fork"
-    sync_call = fn.find("paint(freshOnOpen)")
-    async_refresh = fn.find("refreshProjects().then")
-    assert async_refresh >= 0, "_paintProjectPicker must keep refreshProjects().then"
-    assert 0 <= sync_call < async_refresh, (
-        "_paintProjectPicker must paint synchronously (paint(freshOnOpen)) BEFORE the "
-        "async refreshProjects().then repaint"
+    assert "return Promise.resolve();" in fn, (
+        "_paintProjectPicker's fork/absent-bridge path must return a resolved "
+        "promise (the dashboard chains its Options-chip recompute on the return)"
     )
-    assert "paint(false)" in fn[async_refresh:], (
-        "_paintProjectPicker's async repaint must pass fresh=false (preserve a mid-window pick)"
+    assert "return _paintFromCache(window.TurnstoneProjects.refreshProjects, paint, opts)" in fn, (
+        "_paintProjectPicker's tail must route through the _paintFromCache "
+        "chokepoint (sync paint(freshOnOpen) then always-fresh:false repaint)"
     )
 
 
@@ -2537,6 +2540,17 @@ def test_paint_model_and_skill_wrappers_sync_before_refresh() -> None:
         "_paintFromCache's async repaint must pass fresh:false (never leak "
         "freshOnOpen, or it clobbers a mid-window pick)"
     )
+    # Promise contract: callers (the dashboard Options-chip recompute) chain on
+    # the async repaint landing; the no-refresh path must still hand back a
+    # resolved promise or the chain throws on a cold bridge.
+    assert "return Promise.resolve()" in helper, (
+        "_paintFromCache must return an already-resolved promise when there is "
+        "no refresh (dashboard callers chain the Options-chip recompute)"
+    )
+    assert "return refresh().then" in helper, (
+        "_paintFromCache must return the async-repaint promise (callers act "
+        "after the repaint lands)"
+    )
     for wrapper, bridge_refresh, populate in (
         (
             "function _paintModelSelects(",
@@ -2555,7 +2569,7 @@ def test_paint_model_and_skill_wrappers_sync_before_refresh() -> None:
         ),
     ):
         fn = _slice_top_level_fn(body, wrapper)
-        assert "_paintFromCache(" in fn, f"{wrapper} must route through _paintFromCache"
+        assert "return _paintFromCache(" in fn, f"{wrapper} must return the _paintFromCache promise"
         assert bridge_refresh in fn, f"{wrapper} must pass its own bridge refresh"
         assert populate in fn, f"{wrapper} must thread fresh through to its own populate helper"
 
@@ -2593,17 +2607,23 @@ def test_new_ws_modal_renders_all_selects_fresh_on_open() -> None:
 
 
 def test_dashboard_paints_model_and_skill_via_wrappers_preserving() -> None:
-    """Dashboard twin — model + skill paint via the SAME wrappers but freshOnOpen:false
-    (a persistent panel preserves a pick across a repaint), and the old fetch-once
-    ``options.length <= 1`` guard is gone."""
+    """Dashboard twin — all four pickers paint via the SAME wrappers but
+    freshOnOpen:false (a persistent panel preserves a pick across a repaint), the
+    old fetch-once ``options.length <= 1`` guard is gone, and EVERY paint chains
+    _refreshDashboardOptionsSummary on its async repaint: a repaint can drop a
+    server-removed pick (or revert persona to its kind default) without firing
+    'change', and the collapsed Options chip must always name what submit sends."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function _loadDashboardOptionsLists(")
-    assert "_paintModelSelects(modelSel, judgeSel, { freshOnOpen: false })" in fn, (
-        "the dashboard must paint model+judge via the wrapper, preserving (freshOnOpen:false)"
-    )
-    assert "_paintSkillSelect(skillSel, { freshOnOpen: false })" in fn, (
-        "the dashboard must paint skill via the wrapper, preserving"
-    )
+    for paint in (
+        "_paintModelSelects(modelSel, judgeSel, { freshOnOpen: false })",
+        "_paintSkillSelect(skillSel, { freshOnOpen: false })",
+        "_paintProjectPicker(projSel, projHint, { fork: false })",
+        "_paintPersonaSelect(personaSel, { freshOnOpen: false })",
+    ):
+        assert re.search(re.escape(paint) + r"\.then\(\s*_refreshDashboardOptionsSummary", fn), (
+            f"dashboard paint must chain the Options-chip recompute: {paint[:36]}"
+        )
     assert "options.length <= 1" not in fn, (
         "the dashboard model/skill fetch-once guard must be removed (refresh-on-open now)"
     )
@@ -2645,23 +2665,28 @@ def test_new_ws_modal_fork_inherits_model_and_judge() -> None:
 
 
 def test_console_launcher_paints_model_and_skill_from_cache_synchronously() -> None:
-    """Console launcher — the model + skill refresh wrappers paint synchronously
-    from the warm cache before the async refresh-and-repaint.  The model wrapper
-    threads callOpts so models_changed can force a trailing refresh."""
+    """Console launcher — the four _refreshAndPopulate* wrappers route through the
+    _paintHomeFromCache chokepoint: sync paint from the warm cache BEFORE the
+    async refresh(callOpts)-and-repaint (callOpts threads {force:true} for the
+    models_changed / onLoginSuccess invalidation callers).  The ordering
+    discipline is asserted once, on the helper; the wrappers are pairing-checked
+    (model/skill here, project/persona in their twin test)."""
     body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    helper = _slice_top_level_fn(body, "function _paintHomeFromCache(")
+    sync = helper.find("populate()")
+    async_ = helper.find("refresh(callOpts).then")
+    assert 0 <= sync < async_, (
+        "_paintHomeFromCache must sync-paint (populate()) BEFORE the async "
+        "refresh(callOpts).then repaint"
+    )
     model_fn = _slice_top_level_fn(body, "function _refreshAndPopulateModels(")
-    sync_model = model_fn.find("_populateHomeModelDropdowns()")
-    async_model = model_fn.find("refreshModels(callOpts).then")
-    assert sync_model >= 0, "the launcher must paint the model pickers from cache synchronously"
-    assert sync_model < async_model, (
-        "the synchronous launcher model paint must precede the async refresh repaint"
-    )
+    assert re.search(
+        r"_paintHomeFromCache\(\s*TM && TM\.refreshModels,\s*_populateHomeModelDropdowns", model_fn
+    ), "the launcher model wrapper must pair its bridge refresh + populate via the chokepoint"
     skill_fn = _slice_top_level_fn(body, "function _refreshAndPopulateSkills(")
-    sync_skill = skill_fn.find("_populateHomeSkillDropdown()")
-    async_skill = skill_fn.find("refreshSkills(callOpts).then")
-    assert 0 <= sync_skill < async_skill, (
-        "the synchronous launcher skill paint must precede the async refresh repaint"
-    )
+    assert re.search(
+        r"_paintHomeFromCache\(\s*TS && TS\.refreshSkills,\s*_populateHomeSkillDropdown", skill_fn
+    ), "the launcher skill wrapper must pair its bridge refresh + populate via the chokepoint"
 
 
 def test_console_relogin_rewarms_all_four_caches_with_force() -> None:
@@ -2723,13 +2748,22 @@ def test_models_label_centralized_on_bridge() -> None:
 
 
 def test_models_skills_module_tagged_in_both_apps() -> None:
-    """models.js + skills.js are ``<script type=module>``-tagged before app.js in
-    BOTH index.html so their window bridges install before the classic bundle
-    boots and reads window.TurnstoneModels / window.TurnstoneSkills."""
+    """All four data-layer modules (projects/personas/models/skills) are
+    ``<script type=module>``-tagged BEFORE /shared/shell.js in BOTH index.html.
+    shell.js is the LAST module tag and calls TS_APP.boot (the first dashboard /
+    launcher paint); module execution follows tag order, and classic app.js is
+    parse-time definitions only — so a data-layer tag reordered below shell.js
+    boots the app before that bridge installs: the sync paint no-ops AND the
+    refresh is skipped, a silent test-green FOUC regression without this guard."""
     for idx in (_INDEX_HTML, _CONSOLE_INDEX):
         html = idx.read_text(encoding="utf-8")
-        assert "/shared/models.js" in html, f"models.js must be module-tagged in {idx.name}"
-        assert "/shared/skills.js" in html, f"skills.js must be module-tagged in {idx.name}"
+        for mod in ("projects", "personas", "models", "skills"):
+            path = f"/shared/{mod}.js"
+            assert path in html, f"{mod}.js must be module-tagged in {idx.name}"
+            assert html.index(path) < html.index("/shared/shell.js"), (
+                f"{mod}.js must be tagged BEFORE shell.js in {idx.name} — its "
+                "bridge must install before TS_APP.boot paints the composers"
+            )
 
 
 def test_list_cache_core_is_failopen_coalesced_and_gated() -> None:

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2481,7 +2481,9 @@ def test_paint_project_picker_syncs_before_refresh() -> None:
     the two can't drift and silently re-introduce the FOUC) seeds the required/
     optional hint + paints the picker via _populateProjectSelect SYNCHRONOUSLY,
     then refreshes-and-repaints.  It skips a fork, and both paints route through
-    the same _populateProjectSelect (preserving the #867 strict-picker invariant)."""
+    the same _populateProjectSelect (preserving the #867 strict-picker invariant).
+    The sync paint passes freshOnOpen; the async repaint MUST pass fresh=false, or
+    it clobbers a project the user picked mid-refresh (require_project -> 400)."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function _paintProjectPicker(")
     assert "_populateProjectSelect(" in fn, (
@@ -2489,12 +2491,15 @@ def test_paint_project_picker_syncs_before_refresh() -> None:
     )
     assert "hint.textContent" in fn, "_paintProjectPicker must seed the required/optional hint"
     assert "opts.fork" in fn, "_paintProjectPicker must skip for a fork"
-    sync_call = fn.find("paint();")
+    sync_call = fn.find("paint(freshOnOpen)")
     async_refresh = fn.find("refreshProjects().then")
     assert async_refresh >= 0, "_paintProjectPicker must keep refreshProjects().then"
     assert 0 <= sync_call < async_refresh, (
-        "_paintProjectPicker must paint synchronously (paint()) BEFORE the async "
-        "refreshProjects().then repaint"
+        "_paintProjectPicker must paint synchronously (paint(freshOnOpen)) BEFORE the "
+        "async refreshProjects().then repaint"
+    )
+    assert "paint(false)" in fn[async_refresh:], (
+        "_paintProjectPicker's async repaint must pass fresh=false (preserve a mid-window pick)"
     )
 
 
@@ -2516,57 +2521,103 @@ _PROJECTS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static
 _PERSONAS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/personas.js"
 
 
-def test_new_ws_modal_paints_model_and_skill_from_cache_synchronously() -> None:
-    """The modal's model + skill pickers paint from the warm cache SYNCHRONOUSLY
-    on open, BEFORE the async refresh-and-repaint (no empty-dropdown flash)."""
+def test_paint_model_and_skill_wrappers_sync_before_refresh() -> None:
+    """The shared _paintModelSelects / _paintSkillSelect wrappers (used by BOTH the
+    modal and dashboard — collapsing the 4x paint-then-refresh dup) paint from the
+    warm cache SYNCHRONOUSLY, then refresh-and-repaint.  CRITICAL: the sync paint
+    passes fresh=freshOnOpen but the ASYNC repaint MUST pass fresh:false — a wrapper
+    leaking freshOnOpen into the async paint would clobber a mid-window pick (for the
+    project picker that reconciles to "" -> a require_project 400)."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    for wrapper, populate, refresh in (
+        ("function _paintModelSelects(", "_populateModelSelect(", "refreshModels().then"),
+        ("function _paintSkillSelect(", "_populateSkillSelect(", "refreshSkills().then"),
+    ):
+        fn = _slice_top_level_fn(body, wrapper)
+        sync = fn.find(populate)
+        async_ = fn.find(refresh)
+        assert 0 <= sync < async_, f"{wrapper} must paint synchronously before the async refresh"
+        assert "{ fresh: freshOnOpen }" in fn, f"{wrapper} sync paint must pass fresh=freshOnOpen"
+        assert "{ fresh: false }" in fn, (
+            f"{wrapper} async repaint must pass fresh:false (never leak freshOnOpen, "
+            "or it clobbers a mid-window pick)"
+        )
+
+
+def test_new_ws_modal_renders_all_selects_fresh_on_open() -> None:
+    """Finding [0] fix — every composer select in the reused new-ws <dialog> renders
+    its ACTUAL value fresh on open (no stale carryover from the last open): model +
+    skill via the wrappers with freshOnOpen:true, persona via {fresh:true}, project
+    via _paintProjectPicker freshOnOpen:true.  The model paint is fork-gated."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function showNewWsModal(")
-    sync_model = fn.find("_populateModelSelect(modelSelect")
-    async_model = fn.find("refreshModels().then")
-    assert sync_model >= 0, "the modal must paint the model picker from cache synchronously"
-    assert async_model >= 0, "the modal must keep refreshModels().then"
-    assert sync_model < async_model, (
-        "the synchronous model paint must precede the async refreshModels().then repaint"
+    assert "_paintModelSelects(modelSelect, judgeSelect, { freshOnOpen: true })" in fn, (
+        "the modal must paint model+judge fresh-on-open via the shared wrapper"
     )
-    sync_skill = fn.find("_populateSkillSelect(tplSelect)")
-    async_skill = fn.find("refreshSkills().then")
-    assert sync_skill >= 0, "the modal must paint the skill picker from cache synchronously"
-    assert async_skill >= 0, "the modal must keep refreshSkills().then"
-    assert sync_skill < async_skill, (
-        "the synchronous skill paint must precede the async refreshSkills().then repaint"
+    assert "_paintSkillSelect(tplSelect, { freshOnOpen: true })" in fn, (
+        "the modal must paint skill fresh-on-open"
     )
+    assert "_populatePersonaSelect(personaSelect, { fresh: true })" in fn, (
+        "the modal must paint persona fresh-on-open (kind default, no stale carryover)"
+    )
+    proj = fn[fn.find("_paintProjectPicker(projSelect") :]
+    assert "freshOnOpen: true" in proj[:120], (
+        "the modal must paint the project picker fresh-on-open"
+    )
+    # the model wrapper call is fork-gated (a fork inherits + hides model/judge)
+    guard = fn.find("if (!_forkFromWsId) {")
+    model_paint = fn.find("_paintModelSelects(modelSelect")
+    assert 0 <= guard < model_paint, "the modal model paint must be skipped for a fork"
 
 
-def test_dashboard_paints_model_and_skill_from_cache_synchronously() -> None:
-    """Dashboard twin — model + skill paint synchronously before the refresh, and
-    the old fetch-once ``options.length <= 1`` guard is GONE (upgraded to
-    refresh-on-open via the coalesced cache, matching project/persona)."""
+def test_dashboard_paints_model_and_skill_via_wrappers_preserving() -> None:
+    """Dashboard twin — model + skill paint via the SAME wrappers but freshOnOpen:false
+    (a persistent panel preserves a pick across a repaint), and the old fetch-once
+    ``options.length <= 1`` guard is gone."""
     body = _APP_JS.read_text(encoding="utf-8")
     fn = _slice_top_level_fn(body, "function _loadDashboardOptionsLists(")
-    sync_model = fn.find("_populateModelSelect(modelSel")
-    async_model = fn.find("refreshModels().then")
-    assert sync_model >= 0, "the dashboard must paint the model picker from cache synchronously"
-    assert 0 <= sync_model < async_model, (
-        "the synchronous dashboard model paint must precede the async refresh repaint"
+    assert "_paintModelSelects(modelSel, judgeSel, { freshOnOpen: false })" in fn, (
+        "the dashboard must paint model+judge via the wrapper, preserving (freshOnOpen:false)"
     )
-    sync_skill = fn.find("_populateSkillSelect(skillSel)")
-    async_skill = fn.find("refreshSkills().then")
-    assert sync_skill >= 0, "the dashboard must paint the skill picker from cache synchronously"
-    assert 0 <= sync_skill < async_skill, (
-        "the synchronous dashboard skill paint must precede the async refresh repaint"
+    assert "_paintSkillSelect(skillSel, { freshOnOpen: false })" in fn, (
+        "the dashboard must paint skill via the wrapper, preserving"
     )
     assert "options.length <= 1" not in fn, (
         "the dashboard model/skill fetch-once guard must be removed (refresh-on-open now)"
     )
 
 
+def test_new_ws_modal_fork_inherits_model_and_judge() -> None:
+    """Q2 — a fork INHERITS its source's model + judge: the modal hides both selects
+    for a fork (like skill/persona/project), and submitNewWs gates body.model AND
+    body.judge_model on !_forkFromWsId.  Asserts the model line SPECIFICALLY — its
+    guard `model && !_forkFromWsId` is a substring of the judge line, so a
+    model-unguarded regression would otherwise false-pass."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    modal = _slice_top_level_fn(body, "function showNewWsModal(")
+    assert "modelSelect.hidden = !!_forkFromWsId" in modal, (
+        "modal must hide the model select for a fork"
+    )
+    assert "judgeSelect.hidden = !!_forkFromWsId" in modal, (
+        "modal must hide the judge select for a fork"
+    )
+    submit = _slice_top_level_fn(body, "function submitNewWs(")
+    assert "if (model && !_forkFromWsId) body.model = model;" in submit, (
+        "submitNewWs must fork-gate body.model (distinct from the judge line)"
+    )
+    assert "if (judge_model && !_forkFromWsId) body.judge_model = judge_model;" in submit, (
+        "submitNewWs must fork-gate body.judge_model"
+    )
+
+
 def test_console_launcher_paints_model_and_skill_from_cache_synchronously() -> None:
     """Console launcher — the model + skill refresh wrappers paint synchronously
-    from the warm cache before the async refresh-and-repaint."""
+    from the warm cache before the async refresh-and-repaint.  The model wrapper
+    threads callOpts so models_changed can force a trailing refresh."""
     body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
     model_fn = _slice_top_level_fn(body, "function _refreshAndPopulateModels(")
     sync_model = model_fn.find("_populateHomeModelDropdowns()")
-    async_model = model_fn.find("refreshModels().then")
+    async_model = model_fn.find("refreshModels(callOpts).then")
     assert sync_model >= 0, "the launcher must paint the model pickers from cache synchronously"
     assert 0 <= sync_model < async_model, (
         "the synchronous launcher model paint must precede the async refresh repaint"
@@ -2574,7 +2625,6 @@ def test_console_launcher_paints_model_and_skill_from_cache_synchronously() -> N
     skill_fn = _slice_top_level_fn(body, "function _refreshAndPopulateSkills(")
     sync_skill = skill_fn.find("_populateHomeSkillDropdown()")
     async_skill = skill_fn.find("refreshSkills().then")
-    assert sync_skill >= 0, "the launcher must paint the skill picker from cache synchronously"
     assert 0 <= sync_skill < async_skill, (
         "the synchronous launcher skill paint must precede the async refresh repaint"
     )
@@ -2591,18 +2641,38 @@ def test_console_relogin_rewarms_model_and_skill() -> None:
     assert "_refreshAndPopulateModels()" in login, "onLoginSuccess must re-warm models"
 
 
-def test_models_changed_single_repaint_path() -> None:
-    """The console ``models_changed`` SSE handler repaints the launcher via the
-    refresh wrapper (which reads the warm cache), and the launcher does NOT ALSO
-    subscribe onModelsChange — one repaint path, no double rebuild (graph R7)."""
+def test_models_changed_forces_trailing_single_repaint_path() -> None:
+    """The console ``models_changed`` handler repaints via the refresh wrapper with
+    {force:true} — so a burst of model-config changes converges to the latest server
+    state (trailing refresh) — and the launcher does NOT ALSO subscribe onModelsChange
+    (one repaint path, no double rebuild)."""
     body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
     mc = body.index('data.type === "models_changed"')
-    handler = body[mc : mc + 600]
-    assert "_refreshAndPopulateModels()" in handler, (
-        "models_changed must repaint the launcher model dropdowns via the refresh wrapper"
+    handler = body[mc : mc + 700]
+    assert "_refreshAndPopulateModels({ force: true })" in handler, (
+        "models_changed must force a trailing refresh so it converges to the latest"
     )
     assert "onModelsChange" not in body, (
-        "the console must not ALSO subscribe onModelsChange (single repaint path — R7)"
+        "the console must not ALSO subscribe onModelsChange (single repaint path)"
+    )
+
+
+def test_models_label_centralized_on_bridge() -> None:
+    """Finding [7] — the "alias (model)" label lives ONCE in models.js: modelLabel is
+    exported AND registered on the window.TurnstoneModels bridge (the classic app.js
+    bundles reach it only via the bridge — an ES-only export throws at runtime), and
+    neither app keeps a local _resolveModelLabel copy."""
+    models_src = _MODELS_JS.read_text(encoding="utf-8")
+    assert "export function modelLabel(" in models_src, "models.js must export modelLabel"
+    assert "modelLabel: modelLabel" in models_src, (
+        "models.js must register modelLabel on the window.TurnstoneModels bridge "
+        "(classic bundles call it via the bridge)"
+    )
+    assert "_resolveModelLabel" not in _APP_JS.read_text(encoding="utf-8"), (
+        "the ui app must not keep a local _resolveModelLabel (use TurnstoneModels.modelLabel)"
+    )
+    assert "_resolveModelLabel" not in _CONSOLE_APP_JS.read_text(encoding="utf-8"), (
+        "the console app must not keep a local _resolveModelLabel"
     )
 
 
@@ -2616,21 +2686,44 @@ def test_models_skills_module_tagged_in_both_apps() -> None:
         assert "/shared/skills.js" in html, f"skills.js must be module-tagged in {idx.name}"
 
 
-def test_list_cache_core_is_failopen_and_coalesced() -> None:
-    """The extracted list_cache.js core coalesces concurrent refreshes, fails open
-    (keeps the prior cache + records the error on a non-OK/exception, never
-    rejects — only the SUCCESS branch calls _setCache), and fires subscribers only
-    on first load or a changed fingerprint."""
+def test_list_cache_core_is_failopen_coalesced_and_gated() -> None:
+    """The extracted list_cache.js core: non-force callers coalesce onto the in-flight
+    refresh; it fails open (keeps the prior cache + records the error, never rejects —
+    only the SUCCESS branch calls _setCache); the extra-reset is GATED on
+    resetExtraOnError across BOTH error branches (finding [1]); and a force caller
+    schedules a trailing refetch that converges to the latest (finding [2])."""
     src = _LIST_CACHE_JS.read_text(encoding="utf-8")
-    assert "if (_inflight) return _inflight" in src, "refresh must coalesce concurrent callers"
+    assert "return _inflight;" in src, "non-force callers must coalesce onto the in-flight refresh"
     assert "_lastError = r.status" in src and "_lastError = 0" in src, (
         "a non-OK status and a network/parse error must both be recorded (fail-open)"
     )
     assert src.count("_setCache(data[dataKey]") == 1, (
         "only the success branch may repopulate the cache (non-OK/catch keep the prior cache)"
     )
+    # finding [1]: the extra-reset must be gated on resetExtraOnError on BOTH the
+    # non-OK branch AND the network/parse .catch branch (a cosmetic extra must
+    # survive a network drop too, not just a non-OK status).
+    assert src.count("resetExtraOnError && extraDefaults") == 2, (
+        "resetExtraOnError must gate the extra-reset on BOTH error branches"
+    )
+    # finding [2]: a force caller gets a trailing refetch (converges to latest).
+    assert "callOpts.force" in src and "_pending" in src, (
+        "a force caller must schedule a trailing refetch so it converges to the latest state"
+    )
     assert "firstLoad || fp !== _fingerprint" in src, (
         "subscribers must fire on first load or a changed fingerprint only"
+    )
+
+
+def test_reset_extra_policy_per_cache() -> None:
+    """require_project (an advisory that GATES the picker) must fail open on error;
+    the models default-aliases (a COSMETIC annotation) must keep their last-known
+    value.  So projects opts INTO the reset, models opts OUT (finding [1])."""
+    assert "resetExtraOnError: true" in _PROJECTS_JS.read_text(encoding="utf-8"), (
+        "projects.js must reset the require_project advisory on error (fail-open)"
+    )
+    assert "resetExtraOnError: false" in _MODELS_JS.read_text(encoding="utf-8"), (
+        "models.js must keep last-known default aliases on error (cosmetic, not a gate)"
     )
 
 

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2412,12 +2412,10 @@ def test_new_ws_modal_paints_project_and_persona_from_cache_synchronously() -> N
     assert "_paintProjectPicker(projSelect" in fn, (
         "the modal must paint the project picker via the shared _paintProjectPicker helper"
     )
-    sync_persona = fn.find("_populatePersonaSelect(personaSelect")
-    async_persona = fn.find("refreshPersonas().then")
-    assert sync_persona >= 0, "the modal must paint the persona picker from cache synchronously"
-    assert async_persona >= 0, "the modal must keep refreshPersonas().then"
-    assert sync_persona < async_persona, (
-        "the synchronous persona paint must precede the async refreshPersonas().then repaint"
+    # Persona is painted via the shared _paintPersonaSelect wrapper (fork-gated);
+    # its sync-before-async ordering is pinned in the wrapper-internals test.
+    assert "_paintPersonaSelect(personaSelect" in fn, (
+        "the modal must paint the persona picker via the shared _paintPersonaSelect helper"
     )
 
 
@@ -2433,12 +2431,9 @@ def test_dashboard_paints_project_and_persona_from_cache_synchronously() -> None
     assert "_paintProjectPicker(projSel" in fn, (
         "the dashboard must paint the project picker via the shared _paintProjectPicker helper"
     )
-    sync_persona = fn.find("_populatePersonaSelect(personaSel")
-    async_persona = fn.find("refreshPersonas().then")
-    assert sync_persona >= 0, "the dashboard must paint the persona picker from cache synchronously"
-    assert async_persona >= 0, "the dashboard must keep refreshPersonas().then"
-    assert sync_persona < async_persona, (
-        "the synchronous dashboard persona paint must precede the async refresh repaint"
+    # Persona is painted via the shared _paintPersonaSelect wrapper (freshOnOpen:false).
+    assert "_paintPersonaSelect(personaSel, { freshOnOpen: false })" in fn, (
+        "the dashboard must paint the persona picker via _paintPersonaSelect (preserving)"
     )
     # require_project label-hint parity: the dashboard Project label gained a
     # .label-hint span, seeded synchronously from requireProject() like the modal.
@@ -2460,17 +2455,17 @@ def test_console_launcher_paints_project_and_persona_from_cache_synchronously() 
     # The bare _populateHomeProjectDropdown() call is the sync paint; the refresh's
     # .then argument has no parens, so this matches only the standalone sync call.
     sync_proj = proj_fn.find("_populateHomeProjectDropdown()")
-    async_proj = proj_fn.find("refreshProjects().then")
+    async_proj = proj_fn.find("refreshProjects(callOpts).then")
     assert sync_proj >= 0, "the launcher must paint the project picker from cache synchronously"
-    assert async_proj >= 0, "the launcher must keep refreshProjects().then"
+    assert async_proj >= 0, "the launcher must keep refreshProjects(callOpts).then"
     assert sync_proj < async_proj, (
         "the synchronous launcher project paint must precede the async refresh repaint"
     )
     persona_fn = _slice_top_level_fn(body, "function _refreshAndPopulatePersonas(")
     sync_persona = persona_fn.find("_populateHomePersonaDropdown()")
-    async_persona = persona_fn.find("refreshPersonas().then")
+    async_persona = persona_fn.find("refreshPersonas(callOpts).then")
     assert sync_persona >= 0, "the launcher must paint the persona picker from cache synchronously"
-    assert async_persona >= 0, "the launcher must keep refreshPersonas().then"
+    assert async_persona >= 0, "the launcher must keep refreshPersonas(callOpts).then"
     assert sync_persona < async_persona, (
         "the synchronous launcher persona paint must precede the async refresh repaint"
     )
@@ -2532,6 +2527,11 @@ def test_paint_model_and_skill_wrappers_sync_before_refresh() -> None:
     for wrapper, populate, refresh in (
         ("function _paintModelSelects(", "_populateModelSelect(", "refreshModels().then"),
         ("function _paintSkillSelect(", "_populateSkillSelect(", "refreshSkills().then"),
+        (
+            "function _paintPersonaSelect(",
+            "_populatePersonaSelect(",
+            "refreshPersonas().then",
+        ),
     ):
         fn = _slice_top_level_fn(body, wrapper)
         sync = fn.find(populate)
@@ -2557,8 +2557,8 @@ def test_new_ws_modal_renders_all_selects_fresh_on_open() -> None:
     assert "_paintSkillSelect(tplSelect, { freshOnOpen: true })" in fn, (
         "the modal must paint skill fresh-on-open"
     )
-    assert "_populatePersonaSelect(personaSelect, { fresh: true })" in fn, (
-        "the modal must paint persona fresh-on-open (kind default, no stale carryover)"
+    assert "_paintPersonaSelect(personaSelect, { freshOnOpen: true })" in fn, (
+        "the modal must paint persona fresh-on-open via the shared wrapper"
     )
     proj = fn[fn.find("_paintProjectPicker(projSelect") :]
     assert "freshOnOpen: true" in proj[:120], (
@@ -2601,6 +2601,17 @@ def test_new_ws_modal_fork_inherits_model_and_judge() -> None:
     assert "judgeSelect.hidden = !!_forkFromWsId" in modal, (
         "modal must hide the judge select for a fork"
     )
+    # [4] fix: the skill paint is fork-gated too (skill is hidden for a fork).
+    # Tie the gate to the skill paint SPECIFICALLY — a first-gate check would be
+    # satisfied by the model gate at line ~352 even if the skill paint were left
+    # unconditional, so require the nearest preceding gate to be right above it.
+    skill_paint = modal.find("_paintSkillSelect(tplSelect")
+    assert skill_paint >= 0, "the modal must paint the skill picker"
+    gate = modal.rfind("if (!_forkFromWsId) {", 0, skill_paint)
+    assert gate >= 0 and (skill_paint - gate) < 50, (
+        "the modal skill paint must be directly wrapped in `if (!_forkFromWsId)` "
+        "(skip the wasted fetch + hidden-select rebuild on a fork)"
+    )
     submit = _slice_top_level_fn(body, "function submitNewWs(")
     assert "if (model && !_forkFromWsId) body.model = model;" in submit, (
         "submitNewWs must fork-gate body.model (distinct from the judge line)"
@@ -2624,21 +2635,26 @@ def test_console_launcher_paints_model_and_skill_from_cache_synchronously() -> N
     )
     skill_fn = _slice_top_level_fn(body, "function _refreshAndPopulateSkills(")
     sync_skill = skill_fn.find("_populateHomeSkillDropdown()")
-    async_skill = skill_fn.find("refreshSkills().then")
+    async_skill = skill_fn.find("refreshSkills(callOpts).then")
     assert 0 <= sync_skill < async_skill, (
         "the synchronous launcher skill paint must precede the async refresh repaint"
     )
 
 
-def test_console_relogin_rewarms_model_and_skill() -> None:
-    """onLoginSuccess re-warms BOTH the skill and model caches after auth lands —
-    the boot-time pass runs pre-login (401), so without the model re-warm the
-    console model dropdown would stay at its placeholder until a reload."""
+def test_console_relogin_rewarms_all_four_caches_with_force() -> None:
+    """onLoginSuccess re-warms ALL FOUR composer caches after auth lands (the boot
+    pass runs pre-login -> 401 -> fail-open empty), EACH with {force:true} so a
+    still-in-flight failing pre-auth fetch yields a trailing authenticated refetch
+    (skills/personas have no *_changed event to recover otherwise). Fixes [0]+[2]."""
     body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
     start = body.index("window.onLoginSuccess = function ()")
+    # The four re-warm calls live before the // Active-coordinators marker; an
+    # assert falling outside this slice fails loudly rather than silently passing.
     login = body[start : body.index("// Active-coordinators", start)]
-    assert "_refreshAndPopulateSkills()" in login, "onLoginSuccess must re-warm skills"
-    assert "_refreshAndPopulateModels()" in login, "onLoginSuccess must re-warm models"
+    for name in ("Skills", "Models", "Projects", "Personas"):
+        assert f"_refreshAndPopulate{name}({{ force: true }})" in login, (
+            f"onLoginSuccess must force-re-warm {name.lower()} after login"
+        )
 
 
 def test_models_changed_forces_trailing_single_repaint_path() -> None:
@@ -2667,6 +2683,13 @@ def test_models_label_centralized_on_bridge() -> None:
     assert "modelLabel: modelLabel" in models_src, (
         "models.js must register modelLabel on the window.TurnstoneModels bridge "
         "(classic bundles call it via the bridge)"
+    )
+    # [7] fix: modelLabel resolves via the core's O(1) keyField index, not a scan.
+    assert 'keyField: "alias"' in models_src, (
+        "models.js must index by alias (keyField) so modelLabel is an O(1) getByKey"
+    )
+    assert "getByKey(alias)" in models_src, (
+        "modelLabel must resolve via the core's getByKey index (not a per-paint scan)"
     )
     assert "_resolveModelLabel" not in _APP_JS.read_text(encoding="utf-8"), (
         "the ui app must not keep a local _resolveModelLabel (use TurnstoneModels.modelLabel)"
@@ -2730,14 +2753,19 @@ def test_reset_extra_policy_per_cache() -> None:
 def test_models_cache_exposes_both_server_schemas() -> None:
     """models.js must carry ALL default-alias fields — the node server sends
     default_alias, the console sends coordinator_default_alias, both send
-    judge_default_alias — so each app reads its own, and fold them into the
-    fingerprint so a default-only change still fires onChange (R6)."""
+    judge_default_alias — so each app reads its own (via modelDefaults/captureExtra,
+    which drive the "Default — <alias>" placeholder).  The dead onChange
+    subscription (+ its fingerprint fold) was removed: models has no live-render
+    subscriber (the console repaints via its direct models_changed handler), so it
+    exposes no onModelsChange."""
     src = _MODELS_JS.read_text(encoding="utf-8")
     for field in ("default_alias", "judge_default_alias", "coordinator_default_alias"):
         assert field in src, f"models.js must carry {field} for the two server schemas"
     assert "window.TurnstoneModels" in src, "models.js must install the classic bridge"
     assert "makeListCache" in src, "models.js must build on the shared list_cache core"
-    assert "fpExtra" in src, "models.js must fold the default aliases into the fingerprint (R6)"
+    assert "onModelsChange" not in src, (
+        "models.js must not expose the dead onModelsChange subscription (no subscribers)"
+    )
 
 
 def test_skills_cache_returns_raw_rows() -> None:

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2473,6 +2473,11 @@ def test_console_launcher_paints_project_and_persona_from_cache_synchronously() 
     assert "defaultPersona(_launcherKind)" in pop, (
         "the persona populate must revert to the kind default when the pick is gone"
     )
+    proj_pop = _slice_top_level_fn(body, "function _populateHomeProjectDropdown(")
+    assert '_restorePick("project"' in proj_pop, (
+        "the project populate must validate a previous pick via _restorePick (a "
+        "since-deleted project falls back to the placeholder, not a blank select)"
+    )
 
 
 def test_paint_project_picker_syncs_before_refresh() -> None:

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2382,8 +2382,8 @@ def test_strict_picker_requires_explicit_pick() -> None:
 # empty dropdown for a network round-trip even when the data was already in
 # memory.  These guards pin the ordering — a synchronous populate must precede
 # the refresh().then — for all three composer surfaces (new-ws modal, dashboard
-# Options, console launcher).  Model/skill selectors are a separate later pass
-# and intentionally NOT covered here.
+# Options, console launcher).  The model/skill selectors (phase 2b) are covered
+# by the guards further down (search "models/skills composer FOUC").
 
 
 def _slice_top_level_fn(body: str, header: str) -> str:
@@ -2496,3 +2496,198 @@ def test_paint_project_picker_syncs_before_refresh() -> None:
         "_paintProjectPicker must paint synchronously (paint()) BEFORE the async "
         "refreshProjects().then repaint"
     )
+
+
+# --- models/skills composer FOUC (phase 2b) --------------------------------
+#
+# The model + skill pickers had NO client cache: every composer open re-fetched
+# /v1/api/models and /v1/api/skills inline, flashing an empty dropdown for the
+# round-trip.  Phase 2b adds shared caches (models.js / skills.js) on the
+# extracted list_cache.js core that the composers read synchronously, then
+# refresh-and-repaint — the same pattern the project/persona pickers use.  These
+# guards pin the sync-before-async ordering on all three surfaces, the cache
+# fail-open/coalesce contract, the two-server-schema exposure, and the
+# single-repaint-path wiring.
+
+_LIST_CACHE_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/list_cache.js"
+_MODELS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/models.js"
+_SKILLS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/skills.js"
+_PROJECTS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/projects.js"
+_PERSONAS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/personas.js"
+
+
+def test_new_ws_modal_paints_model_and_skill_from_cache_synchronously() -> None:
+    """The modal's model + skill pickers paint from the warm cache SYNCHRONOUSLY
+    on open, BEFORE the async refresh-and-repaint (no empty-dropdown flash)."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function showNewWsModal(")
+    sync_model = fn.find("_populateModelSelect(modelSelect")
+    async_model = fn.find("refreshModels().then")
+    assert sync_model >= 0, "the modal must paint the model picker from cache synchronously"
+    assert async_model >= 0, "the modal must keep refreshModels().then"
+    assert sync_model < async_model, (
+        "the synchronous model paint must precede the async refreshModels().then repaint"
+    )
+    sync_skill = fn.find("_populateSkillSelect(tplSelect)")
+    async_skill = fn.find("refreshSkills().then")
+    assert sync_skill >= 0, "the modal must paint the skill picker from cache synchronously"
+    assert async_skill >= 0, "the modal must keep refreshSkills().then"
+    assert sync_skill < async_skill, (
+        "the synchronous skill paint must precede the async refreshSkills().then repaint"
+    )
+
+
+def test_dashboard_paints_model_and_skill_from_cache_synchronously() -> None:
+    """Dashboard twin — model + skill paint synchronously before the refresh, and
+    the old fetch-once ``options.length <= 1`` guard is GONE (upgraded to
+    refresh-on-open via the coalesced cache, matching project/persona)."""
+    body = _APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function _loadDashboardOptionsLists(")
+    sync_model = fn.find("_populateModelSelect(modelSel")
+    async_model = fn.find("refreshModels().then")
+    assert sync_model >= 0, "the dashboard must paint the model picker from cache synchronously"
+    assert 0 <= sync_model < async_model, (
+        "the synchronous dashboard model paint must precede the async refresh repaint"
+    )
+    sync_skill = fn.find("_populateSkillSelect(skillSel)")
+    async_skill = fn.find("refreshSkills().then")
+    assert sync_skill >= 0, "the dashboard must paint the skill picker from cache synchronously"
+    assert 0 <= sync_skill < async_skill, (
+        "the synchronous dashboard skill paint must precede the async refresh repaint"
+    )
+    assert "options.length <= 1" not in fn, (
+        "the dashboard model/skill fetch-once guard must be removed (refresh-on-open now)"
+    )
+
+
+def test_console_launcher_paints_model_and_skill_from_cache_synchronously() -> None:
+    """Console launcher — the model + skill refresh wrappers paint synchronously
+    from the warm cache before the async refresh-and-repaint."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    model_fn = _slice_top_level_fn(body, "function _refreshAndPopulateModels(")
+    sync_model = model_fn.find("_populateHomeModelDropdowns()")
+    async_model = model_fn.find("refreshModels().then")
+    assert sync_model >= 0, "the launcher must paint the model pickers from cache synchronously"
+    assert 0 <= sync_model < async_model, (
+        "the synchronous launcher model paint must precede the async refresh repaint"
+    )
+    skill_fn = _slice_top_level_fn(body, "function _refreshAndPopulateSkills(")
+    sync_skill = skill_fn.find("_populateHomeSkillDropdown()")
+    async_skill = skill_fn.find("refreshSkills().then")
+    assert sync_skill >= 0, "the launcher must paint the skill picker from cache synchronously"
+    assert 0 <= sync_skill < async_skill, (
+        "the synchronous launcher skill paint must precede the async refresh repaint"
+    )
+
+
+def test_console_relogin_rewarms_model_and_skill() -> None:
+    """onLoginSuccess re-warms BOTH the skill and model caches after auth lands —
+    the boot-time pass runs pre-login (401), so without the model re-warm the
+    console model dropdown would stay at its placeholder until a reload."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    start = body.index("window.onLoginSuccess = function ()")
+    login = body[start : body.index("// Active-coordinators", start)]
+    assert "_refreshAndPopulateSkills()" in login, "onLoginSuccess must re-warm skills"
+    assert "_refreshAndPopulateModels()" in login, "onLoginSuccess must re-warm models"
+
+
+def test_models_changed_single_repaint_path() -> None:
+    """The console ``models_changed`` SSE handler repaints the launcher via the
+    refresh wrapper (which reads the warm cache), and the launcher does NOT ALSO
+    subscribe onModelsChange — one repaint path, no double rebuild (graph R7)."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    mc = body.index('data.type === "models_changed"')
+    handler = body[mc : mc + 600]
+    assert "_refreshAndPopulateModels()" in handler, (
+        "models_changed must repaint the launcher model dropdowns via the refresh wrapper"
+    )
+    assert "onModelsChange" not in body, (
+        "the console must not ALSO subscribe onModelsChange (single repaint path — R7)"
+    )
+
+
+def test_models_skills_module_tagged_in_both_apps() -> None:
+    """models.js + skills.js are ``<script type=module>``-tagged before app.js in
+    BOTH index.html so their window bridges install before the classic bundle
+    boots and reads window.TurnstoneModels / window.TurnstoneSkills."""
+    for idx in (_INDEX_HTML, _CONSOLE_INDEX):
+        html = idx.read_text(encoding="utf-8")
+        assert "/shared/models.js" in html, f"models.js must be module-tagged in {idx.name}"
+        assert "/shared/skills.js" in html, f"skills.js must be module-tagged in {idx.name}"
+
+
+def test_list_cache_core_is_failopen_and_coalesced() -> None:
+    """The extracted list_cache.js core coalesces concurrent refreshes, fails open
+    (keeps the prior cache + records the error on a non-OK/exception, never
+    rejects — only the SUCCESS branch calls _setCache), and fires subscribers only
+    on first load or a changed fingerprint."""
+    src = _LIST_CACHE_JS.read_text(encoding="utf-8")
+    assert "if (_inflight) return _inflight" in src, "refresh must coalesce concurrent callers"
+    assert "_lastError = r.status" in src and "_lastError = 0" in src, (
+        "a non-OK status and a network/parse error must both be recorded (fail-open)"
+    )
+    assert src.count("_setCache(data[dataKey]") == 1, (
+        "only the success branch may repopulate the cache (non-OK/catch keep the prior cache)"
+    )
+    assert "firstLoad || fp !== _fingerprint" in src, (
+        "subscribers must fire on first load or a changed fingerprint only"
+    )
+
+
+def test_models_cache_exposes_both_server_schemas() -> None:
+    """models.js must carry ALL default-alias fields — the node server sends
+    default_alias, the console sends coordinator_default_alias, both send
+    judge_default_alias — so each app reads its own, and fold them into the
+    fingerprint so a default-only change still fires onChange (R6)."""
+    src = _MODELS_JS.read_text(encoding="utf-8")
+    for field in ("default_alias", "judge_default_alias", "coordinator_default_alias"):
+        assert field in src, f"models.js must carry {field} for the two server schemas"
+    assert "window.TurnstoneModels" in src, "models.js must install the classic bridge"
+    assert "makeListCache" in src, "models.js must build on the shared list_cache core"
+    assert "fpExtra" in src, "models.js must fold the default aliases into the fingerprint (R6)"
+
+
+def test_skills_cache_returns_raw_rows() -> None:
+    """skills.js exposes raw rows (getSkills) — the ui pickers add a ' [MCP]' suffix
+    the console omits, so a single pre-formatted label in the cache would silently
+    change one app's labels."""
+    src = _SKILLS_JS.read_text(encoding="utf-8")
+    assert "window.TurnstoneSkills" in src, "skills.js must install the classic bridge"
+    assert "makeListCache" in src, "skills.js must build on the shared list_cache core"
+    assert "getSkills" in src, "skills.js must expose raw rows via getSkills"
+
+
+def test_projects_personas_keep_public_surface_on_factory() -> None:
+    """The projects.js / personas.js retrofit onto list_cache.js must preserve their
+    full public surface — rail.js and project_creator.js import these by name, and
+    the classic bundles read the window bridges."""
+    proj = _PROJECTS_JS.read_text(encoding="utf-8")
+    assert "makeListCache" in proj, "projects.js must build on the shared core"
+    for name in (
+        "refreshProjects",
+        "getProjects",
+        "projectsLoaded",
+        "projectsError",
+        "requireProject",
+        "projectName",
+        "projectChoices",
+        "onProjectsChange",
+        "createProject",
+    ):
+        assert f"function {name}(" in proj, f"projects.js must still export {name}"
+    assert "requireProject: false" in proj, (
+        "the require_project advisory must seed / fail-open to false"
+    )
+    persona = _PERSONAS_JS.read_text(encoding="utf-8")
+    assert "makeListCache" in persona, "personas.js must build on the shared core"
+    for name in (
+        "refreshPersonas",
+        "getPersonas",
+        "personasLoaded",
+        "personasError",
+        "personaLabel",
+        "defaultPersona",
+        "personaChoices",
+        "onPersonasChange",
+    ):
+        assert f"function {name}(" in persona, f"personas.js must still export {name}"

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2517,31 +2517,47 @@ _PERSONAS_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static
 
 
 def test_paint_model_and_skill_wrappers_sync_before_refresh() -> None:
-    """The shared _paintModelSelects / _paintSkillSelect wrappers (used by BOTH the
-    modal and dashboard — collapsing the 4x paint-then-refresh dup) paint from the
-    warm cache SYNCHRONOUSLY, then refresh-and-repaint.  CRITICAL: the sync paint
-    passes fresh=freshOnOpen but the ASYNC repaint MUST pass fresh:false — a wrapper
-    leaking freshOnOpen into the async paint would clobber a mid-window pick (for the
-    project picker that reconciles to "" -> a require_project 400)."""
+    """The _paintFromCache chokepoint (PR #869 review: the three wrapper twins
+    repeated the same wiring, so the discipline now lives ONCE) paints from the
+    warm cache SYNCHRONOUSLY, then refreshes-and-repaints.  CRITICAL: the sync
+    paint mirrors the caller's freshOnOpen but the ASYNC repaint MUST pass
+    fresh:false — leaking freshOnOpen into the async paint would clobber a
+    mid-window pick (for the project picker that reconciles to "" -> a
+    require_project 400).  Each wrapper must pair its OWN bridge refresh with
+    its OWN populate helper and thread `fresh` through untouched."""
     body = _APP_JS.read_text(encoding="utf-8")
-    for wrapper, populate, refresh in (
-        ("function _paintModelSelects(", "_populateModelSelect(", "refreshModels().then"),
-        ("function _paintSkillSelect(", "_populateSkillSelect(", "refreshSkills().then"),
+    helper = _slice_top_level_fn(body, "function _paintFromCache(")
+    sync = helper.find("repaint(!!(opts && opts.freshOnOpen))")
+    async_ = helper.find("refresh().then")
+    assert 0 <= sync < async_, (
+        "_paintFromCache must sync-paint (repaint mirroring freshOnOpen) BEFORE "
+        "the async refresh repaint"
+    )
+    assert "repaint(false)" in helper[async_:], (
+        "_paintFromCache's async repaint must pass fresh:false (never leak "
+        "freshOnOpen, or it clobbers a mid-window pick)"
+    )
+    for wrapper, bridge_refresh, populate in (
+        (
+            "function _paintModelSelects(",
+            "window.TurnstoneModels && window.TurnstoneModels.refreshModels",
+            "_populateModelSelect(modelSel, judgeSel, { fresh: fresh })",
+        ),
+        (
+            "function _paintSkillSelect(",
+            "window.TurnstoneSkills && window.TurnstoneSkills.refreshSkills",
+            "_populateSkillSelect(sel, { fresh: fresh })",
+        ),
         (
             "function _paintPersonaSelect(",
-            "_populatePersonaSelect(",
-            "refreshPersonas().then",
+            "window.TurnstonePersonas && window.TurnstonePersonas.refreshPersonas",
+            "_populatePersonaSelect(sel, { fresh: fresh })",
         ),
     ):
         fn = _slice_top_level_fn(body, wrapper)
-        sync = fn.find(populate)
-        async_ = fn.find(refresh)
-        assert 0 <= sync < async_, f"{wrapper} must paint synchronously before the async refresh"
-        assert "{ fresh: freshOnOpen }" in fn, f"{wrapper} sync paint must pass fresh=freshOnOpen"
-        assert "{ fresh: false }" in fn, (
-            f"{wrapper} async repaint must pass fresh:false (never leak freshOnOpen, "
-            "or it clobbers a mid-window pick)"
-        )
+        assert "_paintFromCache(" in fn, f"{wrapper} must route through _paintFromCache"
+        assert bridge_refresh in fn, f"{wrapper} must pass its own bridge refresh"
+        assert populate in fn, f"{wrapper} must thread fresh through to its own populate helper"
 
 
 def test_new_ws_modal_renders_all_selects_fresh_on_open() -> None:
@@ -2564,10 +2580,16 @@ def test_new_ws_modal_renders_all_selects_fresh_on_open() -> None:
     assert "freshOnOpen: true" in proj[:120], (
         "the modal must paint the project picker fresh-on-open"
     )
-    # the model wrapper call is fork-gated (a fork inherits + hides model/judge)
-    guard = fn.find("if (!_forkFromWsId) {")
-    model_paint = fn.find("_paintModelSelects(modelSelect")
-    assert 0 <= guard < model_paint, "the modal model paint must be skipped for a fork"
+    # Fork-gates: the model + persona paints must each be the FIRST statement
+    # inside their own `if (!_forkFromWsId)` block.  (A first-gate ordering
+    # check is vacuous here — the first gate in showNewWsModal IS the model
+    # gate, so it would pass even with the paint hoisted out below it.)
+    assert re.search(r"if \(!_forkFromWsId\) \{\s*_paintModelSelects\(modelSelect", fn), (
+        "the modal model paint must be skipped for a fork"
+    )
+    assert re.search(r"if \(!_forkFromWsId\) \{\s*_paintPersonaSelect\(personaSelect", fn), (
+        "the modal persona paint must be skipped for a fork"
+    )
 
 
 def test_dashboard_paints_model_and_skill_via_wrappers_preserving() -> None:
@@ -2603,12 +2625,13 @@ def test_new_ws_modal_fork_inherits_model_and_judge() -> None:
     )
     # [4] fix: the skill paint is fork-gated too (skill is hidden for a fork).
     # Tie the gate to the skill paint SPECIFICALLY — a first-gate check would be
-    # satisfied by the model gate at line ~352 even if the skill paint were left
-    # unconditional, so require the nearest preceding gate to be right above it.
+    # satisfied by the model gate even if the skill paint were left
+    # unconditional, so require the paint to be the FIRST statement inside its
+    # own gate block.  (A nearest-preceding-gate proximity window false-passes
+    # a gate block that CLOSES before the paint.)
     skill_paint = modal.find("_paintSkillSelect(tplSelect")
     assert skill_paint >= 0, "the modal must paint the skill picker"
-    gate = modal.rfind("if (!_forkFromWsId) {", 0, skill_paint)
-    assert gate >= 0 and (skill_paint - gate) < 50, (
+    assert re.search(r"if \(!_forkFromWsId\) \{\s*_paintSkillSelect\(tplSelect", modal), (
         "the modal skill paint must be directly wrapped in `if (!_forkFromWsId)` "
         "(skip the wasted fetch + hidden-select rebuild on a fork)"
     )
@@ -2630,7 +2653,7 @@ def test_console_launcher_paints_model_and_skill_from_cache_synchronously() -> N
     sync_model = model_fn.find("_populateHomeModelDropdowns()")
     async_model = model_fn.find("refreshModels(callOpts).then")
     assert sync_model >= 0, "the launcher must paint the model pickers from cache synchronously"
-    assert 0 <= sync_model < async_model, (
+    assert sync_model < async_model, (
         "the synchronous launcher model paint must precede the async refresh repaint"
     )
     skill_fn = _slice_top_level_fn(body, "function _refreshAndPopulateSkills(")
@@ -2717,6 +2740,11 @@ def test_list_cache_core_is_failopen_coalesced_and_gated() -> None:
     schedules a trailing refetch that converges to the latest (finding [2])."""
     src = _LIST_CACHE_JS.read_text(encoding="utf-8")
     assert "return _inflight;" in src, "non-force callers must coalesce onto the in-flight refresh"
+    assert src.count("_byKey = Object.create(null)") == 2, (
+        "both _byKey sites (declaration + _setCache rebuild) must be null-prototype "
+        "(a row keyed __proto__ must not swap the map's prototype; inherited members "
+        "must not resolve as rows)"
+    )
     assert "_lastError = r.status" in src and "_lastError = 0" in src, (
         "a non-OK status and a network/parse error must both be recorded (fail-open)"
     )

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1497,20 +1497,51 @@ function _ensureHomeComposerInit() {
   _refreshHomeComposerVisibility();
 }
 
+// One chokepoint for the launcher paint discipline shared by the four
+// _refreshAndPopulate* wrappers below: sync-paint NOW from the warm cache (no
+// empty flash for the refresh round-trip), then refresh-and-repaint (callOpts
+// threads {force:true} for invalidation callers — models_changed,
+// onLoginSuccess).  `refresh` absent = bridge missing (module still loading /
+// pre-auth): the wrapper no-ops and onLoginSuccess re-runs each once auth
+// lands.  If the module graph itself failed to load, the picker stays empty
+// until a reload — the ACCEPTED shared-cache tradeoff; see _paintFromCache in
+// ui/static/app.js for the full ruling (no per-picker retry, no inline-fetch
+// fallback).
+function _paintHomeFromCache(refresh, populate, callOpts) {
+  if (!refresh) return;
+  populate();
+  refresh(callOpts).then(function () {
+    populate();
+  });
+}
+
+// Restore a launcher-composer option pick after a choices rebuild IF it is
+// still a valid choice; returns whether it was restored (the persona caller
+// reverts to the kind default otherwise).  Console-composer setter idiom
+// ONLY — the ui twin (_populatePersonaSelect etc.) works on raw <select>
+// elements via sel.value/_optionExists and is deliberately NOT unified
+// across files.
+function _restorePick(fieldId, previous, choices) {
+  const still =
+    previous &&
+    choices.some(function (c) {
+      return c.value === previous;
+    });
+  if (still) _homeCoordComposer.setOptionValue(fieldId, previous);
+  return !!still;
+}
+
 // Refresh the shared personas cache (window.TurnstonePersonas — also feeds
 // the saved-list / rail labels) then repaint the launcher's Persona picker.
 // Safe when the bridge is absent (module still loading): the picker keeps
 // its "Default" placeholder, which the server resolves to the kind default.
 function _refreshAndPopulatePersonas(callOpts) {
   const TP = window.TurnstonePersonas;
-  if (!TP) return;
-  // Paint from the warm cache SYNCHRONOUSLY first so the Persona picker isn't
-  // empty for the refresh round-trip (the rail warms personas at startup), then
-  // refresh-and-repaint to catch a persona created elsewhere. _populateHome-
-  // PersonaDropdown preserves a mid-window pick and only applies the kind default
-  // when nothing valid is selected, so the second paint can't clobber a choice.
-  _populateHomePersonaDropdown();
-  TP.refreshPersonas(callOpts).then(_populateHomePersonaDropdown);
+  _paintHomeFromCache(
+    TP && TP.refreshPersonas,
+    _populateHomePersonaDropdown,
+    callOpts,
+  );
 }
 
 // Populate the launcher's Persona picker for the ACTIVE kind, preselecting
@@ -1524,14 +1555,7 @@ function _populateHomePersonaDropdown() {
   const previous = _homeCoordComposer.getOptionValue("persona");
   const choices = TP.personaChoices(_launcherKind);
   _homeCoordComposer.setOptionChoices("persona", choices);
-  const stillValid =
-    previous &&
-    choices.some(function (c) {
-      return c.value === previous;
-    });
-  if (stillValid) {
-    _homeCoordComposer.setOptionValue("persona", previous);
-  } else {
+  if (!_restorePick("persona", previous, choices)) {
     const dflt = TP.defaultPersona(_launcherKind);
     if (dflt) _homeCoordComposer.setOptionValue("persona", dflt.name);
   }
@@ -1543,14 +1567,11 @@ function _populateHomePersonaDropdown() {
 // picker simply keeps its "No project" placeholder.
 function _refreshAndPopulateProjects(callOpts) {
   const TP = window.TurnstoneProjects;
-  if (!TP) return;
-  // Sync paint from the warm cache first (the launcher keeps its "No project"
-  // placeholder when cold), then refresh-and-repaint to catch a project created
-  // elsewhere. _populateHomeProjectDropdown preserves a mid-window pick. The
-  // console launcher intentionally does NOT gate on requireProject() (§8) — the
-  // node create endpoint is the authoritative gate.
-  _populateHomeProjectDropdown();
-  TP.refreshProjects(callOpts).then(_populateHomeProjectDropdown);
+  _paintHomeFromCache(
+    TP && TP.refreshProjects,
+    _populateHomeProjectDropdown,
+    callOpts,
+  );
 }
 
 // Populate the launcher's Project picker from the shared cache, preserving the
@@ -1742,9 +1763,11 @@ function _mountHomeCoordComposer() {
 // this once auth lands).
 function _refreshAndPopulateSkills(callOpts) {
   const TS = window.TurnstoneSkills;
-  if (!TS) return;
-  _populateHomeSkillDropdown();
-  TS.refreshSkills(callOpts).then(_populateHomeSkillDropdown);
+  _paintHomeFromCache(
+    TS && TS.refreshSkills,
+    _populateHomeSkillDropdown,
+    callOpts,
+  );
 }
 
 // Populate the launcher's Skill picker from the shared cache, preserving the
@@ -1769,12 +1792,7 @@ function _populateHomeSkillDropdown() {
     };
   });
   _homeCoordComposer.setOptionChoices("skill", choices);
-  const stillValid =
-    previous &&
-    choices.some(function (c) {
-      return c.value === previous;
-    });
-  if (stillValid) _homeCoordComposer.setOptionValue("skill", previous);
+  _restorePick("skill", previous, choices);
 }
 
 // Refresh the shared models cache then repaint the launcher's Model + Judge
@@ -1786,9 +1804,11 @@ function _populateHomeSkillDropdown() {
 // (subscription) path that would double-repaint.
 function _refreshAndPopulateModels(callOpts) {
   const TM = window.TurnstoneModels;
-  if (!TM) return;
-  _populateHomeModelDropdowns();
-  TM.refreshModels(callOpts).then(_populateHomeModelDropdowns);
+  _paintHomeFromCache(
+    TM && TM.refreshModels,
+    _populateHomeModelDropdowns,
+    callOpts,
+  );
 }
 
 // Populate the launcher's Model + Judge Model pickers from the shared cache —
@@ -1829,22 +1849,8 @@ function _populateHomeModelDropdowns() {
     judgeDefault ? "Default — " + judgeDefault : "Default model",
   );
   // Preserve a mid-window pick on each select independently.
-  if (
-    prevModel &&
-    choices.some(function (c) {
-      return c.value === prevModel;
-    })
-  ) {
-    _homeCoordComposer.setOptionValue("model", prevModel);
-  }
-  if (
-    prevJudge &&
-    choices.some(function (c) {
-      return c.value === prevJudge;
-    })
-  ) {
-    _homeCoordComposer.setOptionValue("judge_model", prevJudge);
-  }
+  _restorePick("model", prevModel, choices);
+  _restorePick("judge_model", prevJudge, choices);
 }
 
 function _refreshHomeComposerVisibility() {

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -5,12 +5,16 @@ window.onLoginSuccess = function () {
   if (typeof _refreshHomeComposerVisibility === "function") {
     _refreshHomeComposerVisibility();
   }
-  // Re-populate the home-composer skill dropdown now that auth has
-  // landed.  The initial page-load pass runs before login completes,
-  // so /v1/api/skills 401s; without this re-run the dropdown stays
-  // empty.
-  if (typeof _populateHomeSkillDropdown === "function") {
-    _populateHomeSkillDropdown();
+  // Re-warm the home-composer skill AND model pickers now that auth has
+  // landed.  The initial page-load pass runs before login completes, so
+  // /v1/api/skills and /v1/api/models 401 (fail-open: the caches keep their
+  // empty state); without this re-run the dropdowns stay at their placeholders
+  // until a reload (models used to only recover on a chance models_changed).
+  if (typeof _refreshAndPopulateSkills === "function") {
+    _refreshAndPopulateSkills();
+  }
+  if (typeof _refreshAndPopulateModels === "function") {
+    _refreshAndPopulateModels();
   }
   // Active-coordinators list is SSE-driven via the console pseudo-node
   // (#9) — no poller to restart after login.  The home-view renderer
@@ -426,8 +430,8 @@ function handleClusterEvent(data) {
     // setting (model.default_alias, judge.model, coordinator.model_alias,
     // coordinator.reasoning_effort) changes.  Refresh anything that
     // renders model aliases so labels stay accurate without a reload.
-    if (typeof _populateHomeModelDropdowns === "function") {
-      _populateHomeModelDropdowns();
+    if (typeof _refreshAndPopulateModels === "function") {
+      _refreshAndPopulateModels();
     }
     if (typeof _sklcInvalidateModelsCache === "function") {
       _sklcInvalidateModelsCache();
@@ -1474,8 +1478,8 @@ function _ensureHomeComposerInit() {
   _homeComposerInit = true;
   _mountHomeCoordComposer();
   _wireLauncherToggle();
-  _populateHomeSkillDropdown();
-  _populateHomeModelDropdowns();
+  _refreshAndPopulateSkills();
+  _refreshAndPopulateModels();
   _refreshAndPopulateProjects();
   _refreshAndPopulatePersonas();
   _ensureHomeProjectCreator();
@@ -1720,24 +1724,40 @@ function _mountHomeCoordComposer() {
   });
 }
 
+// Refresh the shared skills cache then repaint the launcher's Skill picker.
+// Sync paint from the warm cache first (no empty flash for the round-trip),
+// then refresh-and-repaint to catch a skill created elsewhere.  Safe when the
+// bridge is absent (module still loading / 401 pre-auth — onLoginSuccess re-runs
+// this once auth lands).
+function _refreshAndPopulateSkills() {
+  const TS = window.TurnstoneSkills;
+  if (!TS) return;
+  _populateHomeSkillDropdown();
+  TS.refreshSkills().then(_populateHomeSkillDropdown);
+}
+
+// Populate the launcher's Skill picker from the shared cache, preserving the
+// current pick across the rebuild (the async repaint must not clobber a
+// mid-window choice).  The console label omits the " [MCP]" suffix the ui
+// pickers add — which is why the cache returns raw rows.
 function _populateHomeSkillDropdown() {
   if (!_homeCoordComposer) return;
-  authFetch("/v1/api/skills")
-    .then(function (r) {
-      return r.ok ? r.json() : { skills: [] };
-    })
-    .then(function (data) {
-      const choices = (data.skills || []).map(function (t) {
-        return {
-          value: t.name,
-          text: t.is_default ? t.name + " (default)" : t.name,
-        };
-      });
-      _homeCoordComposer.setOptionChoices("skill", choices);
-    })
-    .catch(function () {
-      /* defaults still work even without the dropdown populated */
+  const TS = window.TurnstoneSkills;
+  if (!TS) return;
+  const previous = _homeCoordComposer.getOptionValue("skill");
+  const choices = TS.getSkills().map(function (t) {
+    return {
+      value: t.name,
+      text: t.is_default ? t.name + " (default)" : t.name,
+    };
+  });
+  _homeCoordComposer.setOptionChoices("skill", choices);
+  const stillValid =
+    previous &&
+    choices.some(function (c) {
+      return c.value === previous;
     });
+  if (stillValid) _homeCoordComposer.setOptionValue("skill", previous);
 }
 
 // Format a resolved alias with its model suffix the same way as the
@@ -1755,52 +1775,75 @@ function _resolveModelLabel(alias, models) {
   return "";
 }
 
-// Populate Model + Judge Model dropdowns from /v1/api/models — same
-// list the interactive new-ws modal uses.  Empty/default option stays
-// at the top so submitting without a choice falls back to the
-// ConfigStore-configured coordinator.model_alias / judge.model.
+// Refresh the shared models cache then repaint the launcher's Model + Judge
+// Model pickers.  Sync paint from the warm cache first (no empty flash for the
+// round-trip), then refresh-and-repaint.  This is ALSO the single repaint path
+// for the `models_changed` SSE event: it refreshes the cache and repaints, so
+// there is no second (subscription) path that would double-repaint.
+function _refreshAndPopulateModels() {
+  const TM = window.TurnstoneModels;
+  if (!TM) return;
+  _populateHomeModelDropdowns();
+  TM.refreshModels().then(_populateHomeModelDropdowns);
+}
+
+// Populate the launcher's Model + Judge Model pickers from the shared cache —
+// same list the interactive new-ws modal uses.  One list feeds both selects;
+// each keeps its "Default …" placeholder (option 0) and its own preserved pick
+// (the async repaint must not clobber a mid-window choice).  The console reads
+// its OWN default-alias fields (coordinator_default_alias for the model,
+// judge_default_alias for the judge) — the node server sends different ones, so
+// the shared cache exposes all of them and each app picks its own.
 function _populateHomeModelDropdowns() {
   if (!_homeCoordComposer) return;
-  authFetch("/v1/api/models")
-    .then(function (r) {
-      return r.ok ? r.json() : { models: [] };
+  const TM = window.TurnstoneModels;
+  if (!TM) return;
+  const choices = TM.modelChoices();
+  const models = TM.getModels();
+  const defaults = TM.modelDefaults();
+  const prevModel = _homeCoordComposer.getOptionValue("model");
+  const prevJudge = _homeCoordComposer.getOptionValue("judge_model");
+  _homeCoordComposer.setOptionChoices("model", choices);
+  _homeCoordComposer.setOptionChoices("judge_model", choices);
+  // Both placeholders use the same "Default — alias (model)" template — the
+  // field-row labels (MODEL / JUDGE MODEL) already carry the role context, so an
+  // asymmetric "Default judge model" reads awkwardly alongside the plain
+  // "Default model" line above it.  Em-dash separator (rather than nested
+  // parens) keeps the alias's "(model)" suffix legible and matches the
+  // ``(default — alias (model))`` pattern used in the admin Roles tab.
+  const coordDefault = _resolveModelLabel(
+    defaults.coordinator_default_alias || "",
+    models,
+  );
+  const judgeDefault = _resolveModelLabel(
+    defaults.judge_default_alias || "",
+    models,
+  );
+  _homeCoordComposer.setOptionPlaceholder(
+    "model",
+    coordDefault ? "Default — " + coordDefault : "Default model",
+  );
+  _homeCoordComposer.setOptionPlaceholder(
+    "judge_model",
+    judgeDefault ? "Default — " + judgeDefault : "Default model",
+  );
+  // Preserve a mid-window pick on each select independently.
+  if (
+    prevModel &&
+    choices.some(function (c) {
+      return c.value === prevModel;
     })
-    .then(function (data) {
-      const choices = (data.models || []).map(function (m) {
-        const label =
-          m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
-        return { value: m.alias, text: label };
-      });
-      _homeCoordComposer.setOptionChoices("model", choices);
-      _homeCoordComposer.setOptionChoices("judge_model", choices);
-      // Both placeholders use the same "Default — alias (model)"
-      // template — the field-row labels (MODEL / JUDGE MODEL) already
-      // carry the role context, so an asymmetric "Default judge model"
-      // reads awkwardly alongside the plain "Default model" line above
-      // it.  Em-dash separator (rather than nested parens) keeps the
-      // alias's "(model)" suffix legible and matches the
-      // ``(default — alias (model))`` pattern used in the admin Roles
-      // tab.
-      const coordDefault = _resolveModelLabel(
-        data.coordinator_default_alias || "",
-        data.models || [],
-      );
-      const judgeDefault = _resolveModelLabel(
-        data.judge_default_alias || "",
-        data.models || [],
-      );
-      _homeCoordComposer.setOptionPlaceholder(
-        "model",
-        coordDefault ? "Default — " + coordDefault : "Default model",
-      );
-      _homeCoordComposer.setOptionPlaceholder(
-        "judge_model",
-        judgeDefault ? "Default — " + judgeDefault : "Default model",
-      );
+  ) {
+    _homeCoordComposer.setOptionValue("model", prevModel);
+  }
+  if (
+    prevJudge &&
+    choices.some(function (c) {
+      return c.value === prevJudge;
     })
-    .catch(function () {
-      /* defaults still work even without the dropdown populated */
-    });
+  ) {
+    _homeCoordComposer.setOptionValue("judge_model", prevJudge);
+  }
 }
 
 function _refreshHomeComposerVisibility() {

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -5,16 +5,25 @@ window.onLoginSuccess = function () {
   if (typeof _refreshHomeComposerVisibility === "function") {
     _refreshHomeComposerVisibility();
   }
-  // Re-warm the home-composer skill AND model pickers now that auth has
-  // landed.  The initial page-load pass runs before login completes, so
-  // /v1/api/skills and /v1/api/models 401 (fail-open: the caches keep their
-  // empty state); without this re-run the dropdowns stay at their placeholders
-  // until a reload (models used to only recover on a chance models_changed).
+  // Re-warm ALL FOUR home-composer caches now that auth has landed.  The initial
+  // page-load pass runs before login completes, so /v1/api/{skills,models,
+  // projects,personas} all 401 (fail-open: the caches keep their empty state);
+  // without this re-run the launcher dropdowns — and the rail's group-by-project +
+  // the saved-coordinator project/persona columns — stay empty until a reload.
+  // {force:true} so a still-in-flight failing pre-auth fetch yields a trailing
+  // AUTHENTICATED refetch rather than coalescing onto the 401 (skills/personas
+  // have no *_changed event to recover otherwise).
   if (typeof _refreshAndPopulateSkills === "function") {
-    _refreshAndPopulateSkills();
+    _refreshAndPopulateSkills({ force: true });
   }
   if (typeof _refreshAndPopulateModels === "function") {
-    _refreshAndPopulateModels();
+    _refreshAndPopulateModels({ force: true });
+  }
+  if (typeof _refreshAndPopulateProjects === "function") {
+    _refreshAndPopulateProjects({ force: true });
+  }
+  if (typeof _refreshAndPopulatePersonas === "function") {
+    _refreshAndPopulatePersonas({ force: true });
   }
   // Active-coordinators list is SSE-driven via the console pseudo-node
   // (#9) — no poller to restart after login.  The home-view renderer
@@ -1492,7 +1501,7 @@ function _ensureHomeComposerInit() {
 // the saved-list / rail labels) then repaint the launcher's Persona picker.
 // Safe when the bridge is absent (module still loading): the picker keeps
 // its "Default" placeholder, which the server resolves to the kind default.
-function _refreshAndPopulatePersonas() {
+function _refreshAndPopulatePersonas(callOpts) {
   const TP = window.TurnstonePersonas;
   if (!TP) return;
   // Paint from the warm cache SYNCHRONOUSLY first so the Persona picker isn't
@@ -1501,7 +1510,7 @@ function _refreshAndPopulatePersonas() {
   // PersonaDropdown preserves a mid-window pick and only applies the kind default
   // when nothing valid is selected, so the second paint can't clobber a choice.
   _populateHomePersonaDropdown();
-  TP.refreshPersonas().then(_populateHomePersonaDropdown);
+  TP.refreshPersonas(callOpts).then(_populateHomePersonaDropdown);
 }
 
 // Populate the launcher's Persona picker for the ACTIVE kind, preselecting
@@ -1532,7 +1541,7 @@ function _populateHomePersonaDropdown() {
 // rail's group-by-project) then repaint the launcher's Project picker.  Safe
 // when the bridge is absent (project.read denied / module still loading): the
 // picker simply keeps its "No project" placeholder.
-function _refreshAndPopulateProjects() {
+function _refreshAndPopulateProjects(callOpts) {
   const TP = window.TurnstoneProjects;
   if (!TP) return;
   // Sync paint from the warm cache first (the launcher keeps its "No project"
@@ -1541,7 +1550,7 @@ function _refreshAndPopulateProjects() {
   // console launcher intentionally does NOT gate on requireProject() (§8) — the
   // node create endpoint is the authoritative gate.
   _populateHomeProjectDropdown();
-  TP.refreshProjects().then(_populateHomeProjectDropdown);
+  TP.refreshProjects(callOpts).then(_populateHomeProjectDropdown);
 }
 
 // Populate the launcher's Project picker from the shared cache, preserving the
@@ -1731,11 +1740,11 @@ function _mountHomeCoordComposer() {
 // then refresh-and-repaint to catch a skill created elsewhere.  Safe when the
 // bridge is absent (module still loading / 401 pre-auth — onLoginSuccess re-runs
 // this once auth lands).
-function _refreshAndPopulateSkills() {
+function _refreshAndPopulateSkills(callOpts) {
   const TS = window.TurnstoneSkills;
   if (!TS) return;
   _populateHomeSkillDropdown();
-  TS.refreshSkills().then(_populateHomeSkillDropdown);
+  TS.refreshSkills(callOpts).then(_populateHomeSkillDropdown);
 }
 
 // Populate the launcher's Skill picker from the shared cache, preserving the
@@ -1746,6 +1755,11 @@ function _populateHomeSkillDropdown() {
   if (!_homeCoordComposer) return;
   const TS = window.TurnstoneSkills;
   if (!TS) return;
+  // Reads the shared skills cache, which is FAIL-OPEN by design: a transient
+  // non-OK refresh keeps the last-known rows rather than blanking to the
+  // placeholder (main blanked via `r.ok ? json : {skills:[]}`; this matches the
+  // projects/personas policy).  A since-removed skill is rejected server-side on
+  // launch — a narrow stale-selection window traded for not blanking on a blip.
   const previous = _homeCoordComposer.getOptionValue("skill");
   const choices = TS.getSkills().map(function (t) {
     return {

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1757,8 +1757,9 @@ function _populateHomeSkillDropdown() {
   if (!TS) return;
   // Reads the shared skills cache, which is FAIL-OPEN by design: a transient
   // non-OK refresh keeps the last-known rows rather than blanking to the
-  // placeholder (main blanked via `r.ok ? json : {skills:[]}`; this matches the
-  // projects/personas policy).  A since-removed skill is rejected server-side on
+  // placeholder (the pre-cache inline fetch blanked on any non-OK via
+  // `r.ok ? json : {skills:[]}`; this cache matches the projects/personas
+  // policy instead).  A since-removed skill is rejected server-side on
   // launch — a narrow stale-selection window traded for not blanking on a blip.
   const previous = _homeCoordComposer.getOptionValue("skill");
   const choices = TS.getSkills().map(function (t) {
@@ -1776,10 +1777,6 @@ function _populateHomeSkillDropdown() {
   if (stillValid) _homeCoordComposer.setOptionValue("skill", previous);
 }
 
-// Format a resolved alias with its model suffix the same way as the
-// dropdown rows ("alias (model)", or just "alias" when they coincide).
-// Returns "" when alias is empty or unknown so callers can fall back
-// to a neutral placeholder.
 // Refresh the shared models cache then repaint the launcher's Model + Judge
 // Model pickers.  Sync paint from the warm cache first (no empty flash for the
 // round-trip), then refresh-and-repaint.  This is ALSO the single repaint path

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -429,9 +429,11 @@ function handleClusterEvent(data) {
     // Server emits this when a model definition or a role-assignment
     // setting (model.default_alias, judge.model, coordinator.model_alias,
     // coordinator.reasoning_effort) changes.  Refresh anything that
-    // renders model aliases so labels stay accurate without a reload.
+    // renders model aliases so labels stay accurate without a reload.  Pass
+    // {force:true} so a burst of changes converges to the latest (the coalesced
+    // open/startup path stays plain — see _refreshAndPopulateModels).
     if (typeof _refreshAndPopulateModels === "function") {
-      _refreshAndPopulateModels();
+      _refreshAndPopulateModels({ force: true });
     }
     if (typeof _sklcInvalidateModelsCache === "function") {
       _sklcInvalidateModelsCache();
@@ -1764,27 +1766,18 @@ function _populateHomeSkillDropdown() {
 // dropdown rows ("alias (model)", or just "alias" when they coincide).
 // Returns "" when alias is empty or unknown so callers can fall back
 // to a neutral placeholder.
-function _resolveModelLabel(alias, models) {
-  if (!alias) return "";
-  for (let i = 0; i < (models || []).length; i++) {
-    const m = models[i];
-    if (m.alias === alias) {
-      return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
-    }
-  }
-  return "";
-}
-
 // Refresh the shared models cache then repaint the launcher's Model + Judge
 // Model pickers.  Sync paint from the warm cache first (no empty flash for the
 // round-trip), then refresh-and-repaint.  This is ALSO the single repaint path
-// for the `models_changed` SSE event: it refreshes the cache and repaints, so
-// there is no second (subscription) path that would double-repaint.
-function _refreshAndPopulateModels() {
+// for the `models_changed` SSE event, which passes {force:true} so the refresh
+// converges to the latest server state (and its .then repaints from THAT) even
+// when a burst of model-config changes lands mid-fetch — no second
+// (subscription) path that would double-repaint.
+function _refreshAndPopulateModels(callOpts) {
   const TM = window.TurnstoneModels;
   if (!TM) return;
   _populateHomeModelDropdowns();
-  TM.refreshModels().then(_populateHomeModelDropdowns);
+  TM.refreshModels(callOpts).then(_populateHomeModelDropdowns);
 }
 
 // Populate the launcher's Model + Judge Model pickers from the shared cache —
@@ -1799,8 +1792,11 @@ function _populateHomeModelDropdowns() {
   const TM = window.TurnstoneModels;
   if (!TM) return;
   const choices = TM.modelChoices();
-  const models = TM.getModels();
   const defaults = TM.modelDefaults();
+  // The launcher composer is a PERSISTENT panel (it never reopens like the new-ws
+  // modal), so preserving the prior pick across a repaint is INTENDED — not the
+  // modal's fresh-on-open reset.  A background models_changed must not clobber a
+  // mid-window model/judge choice.
   const prevModel = _homeCoordComposer.getOptionValue("model");
   const prevJudge = _homeCoordComposer.getOptionValue("judge_model");
   _homeCoordComposer.setOptionChoices("model", choices);
@@ -1811,14 +1807,8 @@ function _populateHomeModelDropdowns() {
   // "Default model" line above it.  Em-dash separator (rather than nested
   // parens) keeps the alias's "(model)" suffix legible and matches the
   // ``(default — alias (model))`` pattern used in the admin Roles tab.
-  const coordDefault = _resolveModelLabel(
-    defaults.coordinator_default_alias || "",
-    models,
-  );
-  const judgeDefault = _resolveModelLabel(
-    defaults.judge_default_alias || "",
-    models,
-  );
+  const coordDefault = TM.modelLabel(defaults.coordinator_default_alias || "");
+  const judgeDefault = TM.modelLabel(defaults.judge_default_alias || "");
   _homeCoordComposer.setOptionPlaceholder(
     "model",
     coordDefault ? "Default — " + coordDefault : "Default model",

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1592,8 +1592,12 @@ function _populateHomeProjectDropdown() {
   const choices = TP.projectChoices();
   choices.push({ value: _PROJECT_NEW, text: "+ New project…" });
   _homeCoordComposer.setOptionChoices("project", choices);
-  if (previous && previous !== _PROJECT_NEW)
-    _homeCoordComposer.setOptionValue("project", previous);
+  // Validate before restoring (via _restorePick, like the other pickers): a
+  // since-deleted project must fall back to the "No project" placeholder, not
+  // a blank selectedIndex=-1 select.  The "+ New project…" sentinel is never
+  // restored — it is a command, not a state (and it IS in `choices`, so the
+  // validity check alone would not exclude it).
+  if (previous !== _PROJECT_NEW) _restorePick("project", previous, choices);
 }
 
 // The inline "+ New project…" creator (project_creator.js), mounted once into

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -4029,6 +4029,8 @@
     <script type="module" src="/shared/kb.js"></script>
     <script type="module" src="/shared/projects.js"></script>
     <script type="module" src="/shared/personas.js"></script>
+    <script type="module" src="/shared/models.js"></script>
+    <script type="module" src="/shared/skills.js"></script>
     <script type="module" src="/shared/project_creator.js"></script>
     <script type="module" src="/shared/composer.js"></script>
     <!-- coordinator-pane deps (step 4): the controller builds its chrome + uses

--- a/turnstone/shared_static/list_cache.js
+++ b/turnstone/shared_static/list_cache.js
@@ -1,0 +1,179 @@
+/* list_cache.js — shared client-side list-cache core.
+ *
+ * The four creation-surface data layers (projects.js, personas.js,
+ * models.js, skills.js) all fetch a single list from a `/v1/api/*`
+ * endpoint into a warm client cache that the composers read
+ * SYNCHRONOUSLY to paint their pickers without a network round-trip,
+ * then refresh-and-repaint.  They shared ~70% of their body verbatim —
+ * the coalescing, the fail-open refresh, the change-detection fan-out,
+ * and the `window.Turnstone*` bridge — so that machinery lives here once
+ * and each module layers its own bespoke readers (kind-filtered choices,
+ * the require_project advisory, default-alias resolution, ...) on top.
+ *
+ * This is an INTERNAL helper module — it installs no window bridge and is
+ * imported (never `<script>`-tagged) by the four data layers.  All fetches
+ * ride the shared cookie-auth `authFetch`.
+ */
+
+import { authFetch } from "./auth.js";
+
+/**
+ * Build a coalesced, fail-open list cache over `opts.url`.
+ *
+ * @param {object} opts
+ * @param {string}  opts.url            endpoint to GET (e.g. "/v1/api/projects")
+ * @param {string}  opts.dataKey        response field holding the row array
+ *                                      (e.g. "projects" -> `data.projects`)
+ * @param {string}  opts.name           short label for console.warn on failure
+ * @param {string} [opts.keyField]      row field to index by for O(1) lookup
+ *                                      (`getByKey`); omit for no index map
+ * @param {(row:object)=>any} opts.fpRow  per-row fingerprint tuple — the fields
+ *                                      subscribers render, so a refresh that
+ *                                      returns identical data skips the fan-out
+ * @param {(extra:object)=>any} [opts.fpExtra]  extra top-level fields to fold
+ *                                      into the fingerprint (e.g. models' default
+ *                                      aliases, so a default-only change still
+ *                                      fires onChange).  Omit to fingerprint rows
+ *                                      only (a `captureExtra` value that changes
+ *                                      without a row change then does NOT fire).
+ * @param {(data:object)=>object} [opts.captureExtra]  pull extra top-level
+ *                                      response fields into cache state on a
+ *                                      successful refresh (returns the new
+ *                                      `extra` object, replacing the prior one)
+ * @param {object} [opts.extraDefaults] the fail-open `extra` value — installed
+ *                                      at init AND restored on every refresh
+ *                                      failure, so a stale-true advisory can't
+ *                                      survive a transient error
+ * @returns {{refresh:Function, get:Function, getByKey:Function,
+ *            loaded:Function, error:Function, extra:Function, onChange:Function}}
+ */
+export function makeListCache(opts) {
+  const url = opts.url;
+  const dataKey = opts.dataKey;
+  const name = opts.name;
+  const keyField = opts.keyField || null;
+  const fpRow = opts.fpRow;
+  const fpExtra = opts.fpExtra || null;
+  const captureExtra = opts.captureExtra || null;
+  const extraDefaults = opts.extraDefaults || null;
+
+  let _cache = []; // last-fetched rows (caller-visible)
+  let _byKey = {}; // keyField value -> row, for O(1) lookup (when keyField set)
+  let _loaded = false; // has the first refresh attempt completed (ok or failed)?
+  let _lastError = null; // last failure: HTTP status, 0 for network/parse, null when ok
+  let _inflight = null; // shared pending refresh so concurrent callers coalesce
+  let _fingerprint = null; // last fired signature, for change-detection
+  let _extra = extraDefaults ? Object.assign({}, extraDefaults) : {};
+  const _subs = []; // () => void, fired after each CHANGED refresh
+
+  function _fp() {
+    // Cheap signature of what subscribers render, so a refresh returning
+    // identical data skips the fan-out.  JSON.stringify is collision-proof
+    // (it escapes anything inside a string field) and needs no separator
+    // chars; an earlier per-module version joined on raw control bytes,
+    // which made git see the whole file as binary.
+    return JSON.stringify([
+      _cache.map(fpRow),
+      fpExtra ? fpExtra(_extra) : null,
+    ]);
+  }
+
+  function _setCache(rows) {
+    _cache = Array.isArray(rows) ? rows : [];
+    if (keyField) {
+      _byKey = {};
+      for (const r of _cache) if (r && r[keyField]) _byKey[r[keyField]] = r;
+    }
+    const firstLoad = !_loaded;
+    _loaded = true;
+    const fp = _fp();
+    // Fire only when the signature actually changed (or on first load) — a
+    // redundant refresh (picker re-open, a mutation that no-ops the visible
+    // set) shouldn't force every subscriber to rebuild.
+    if (firstLoad || fp !== _fingerprint) {
+      _fingerprint = fp;
+      _subs.forEach(function (cb) {
+        try {
+          cb(_cache);
+        } catch (_) {
+          /* a subscriber throwing must not abort the rest of the fan-out */
+        }
+      });
+    }
+  }
+
+  function refresh() {
+    // Coalesce concurrent callers (startup warm + a picker open can both fire
+    // this) onto one in-flight request — they share the promise and _setCache
+    // runs once.
+    if (_inflight) return _inflight;
+    _inflight = authFetch(url)
+      .then(function (r) {
+        if (r.ok) return r.json();
+        // A non-OK status (403 when a grant is missing, a 5xx, ...) is NOT "you
+        // have zero rows": keep the prior cache rather than blanking it, record
+        // the status so the failure is visible, and reset the advisory extra to
+        // its fail-open default (a stale-true value must not survive an error).
+        _lastError = r.status;
+        if (extraDefaults) _extra = Object.assign({}, extraDefaults);
+        console.warn(name + ": GET " + url + " -> " + r.status);
+        return null;
+      })
+      .then(function (data) {
+        if (data) {
+          _lastError = null;
+          if (captureExtra) _extra = captureExtra(data);
+          _setCache(data[dataKey] || []);
+        }
+        return _cache;
+      })
+      .catch(function (e) {
+        // Network drop or a non-JSON body — same policy as a non-OK status:
+        // preserve the last-known cache, never reject (callers chain a bare
+        // .then), surface the failure, fail-open the extra.
+        _lastError = 0;
+        if (extraDefaults) _extra = Object.assign({}, extraDefaults);
+        console.warn(name + ": refresh failed", e);
+        return _cache;
+      })
+      .finally(function () {
+        // One attempt has completed (ok or not) — lets a reader tell "still
+        // loading" from "loaded, genuinely empty" / "load failed".
+        _loaded = true;
+        _inflight = null;
+      });
+    return _inflight;
+  }
+
+  return {
+    refresh: refresh,
+    /** Cached rows (empty array until the first refresh resolves). */
+    get: function () {
+      return _cache;
+    },
+    /** Row indexed by keyField value, or null (unknown / no keyField). */
+    getByKey: function (k) {
+      return (k && _byKey[k]) || null;
+    },
+    /** Whether the first refresh has resolved — distinguishes "empty" from
+     *  "not loaded yet". */
+    loaded: function () {
+      return _loaded;
+    },
+    /** Last refresh failure status (HTTP status, 0 for network/parse), or null
+     *  when the last refresh succeeded. */
+    error: function () {
+      return _lastError;
+    },
+    /** The captured extra top-level fields (fail-open defaults until a
+     *  successful refresh; reset to those defaults on any failure). */
+    extra: function () {
+      return _extra;
+    },
+    /** Subscribe to post-refresh CHANGES.  Idempotent — the same callback is
+     *  registered at most once. */
+    onChange: function (cb) {
+      if (typeof cb === "function" && _subs.indexOf(cb) < 0) _subs.push(cb);
+    },
+  };
+}

--- a/turnstone/shared_static/list_cache.js
+++ b/turnstone/shared_static/list_cache.js
@@ -45,6 +45,8 @@ import { authFetch } from "./auth.js";
  *                                      false for a merely COSMETIC extra that
  *                                      should keep its last-known value through a
  *                                      transient failure rather than blank.
+ *                                      Moot unless extraDefaults is set — the
+ *                                      reset branch is gated on both.
  * `refresh(opts)` accepts `{force:true}` — an INVALIDATION (e.g. a *_changed SSE
  * event) that must converge to the latest server state: if a refresh is already
  * in flight it chains ONE trailing refetch after it and awaits that, instead of
@@ -66,7 +68,12 @@ export function makeListCache(opts) {
   const resetExtraOnError = opts.resetExtraOnError !== false;
 
   let _cache = []; // last-fetched rows (caller-visible)
-  let _byKey = {}; // keyField value -> row, for O(1) lookup (when keyField set)
+  // keyField value -> row, for O(1) lookup (when keyField set).  Null-prototype:
+  // a row keyed "__proto__" must not swap this map's prototype via the inherited
+  // setter, and an absent-key lookup ("toString", "constructor") must miss (->
+  // undefined -> getByKey's null) instead of resolving an inherited
+  // Object.prototype member as a "row".
+  let _byKey = Object.create(null);
   let _loaded = false; // has the first refresh attempt completed (ok or failed)?
   let _lastError = null; // last failure: HTTP status, 0 for network/parse, null when ok
   let _inflight = null; // shared pending refresh so concurrent callers coalesce
@@ -87,7 +94,7 @@ export function makeListCache(opts) {
   function _setCache(rows) {
     _cache = Array.isArray(rows) ? rows : [];
     if (keyField) {
-      _byKey = {};
+      _byKey = Object.create(null);
       for (const r of _cache) if (r && r[keyField]) _byKey[r[keyField]] = r;
     }
     const firstLoad = !_loaded;
@@ -122,7 +129,13 @@ export function makeListCache(opts) {
         // collapses to one trailing).  INVARIANT: refresh() never rejects (the
         // chain below always resolves via .catch), so this .then always runs; if
         // a reject path is ever added, clear _pending in a .catch or force
-        // callers wedge on a stuck promise.
+        // callers wedge on a stuck promise.  The _pending = null clear is
+        // deliberately BEFORE the recursive refresh() (NOT in a .finally after
+        // it): a force landing DURING the trailing refetch must find _pending
+        // null and chain a NEW trailing fetch, because its invalidation
+        // postdates this one's start.  Clearing after the trailing refresh
+        // resolves would coalesce that late force onto a fetch that predates
+        // its change — the exact race this path exists to close.
         _pending =
           _pending ||
           _inflight.then(function () {
@@ -197,7 +210,8 @@ export function makeListCache(opts) {
       return _lastError;
     },
     /** The captured extra top-level fields (fail-open defaults until a
-     *  successful refresh; reset to those defaults on any failure). */
+     *  successful refresh; reset to those defaults on failure ONLY when
+     *  resetExtraOnError — a cosmetic extra keeps its last-known value). */
     extra: function () {
       return _extra;
     },

--- a/turnstone/shared_static/list_cache.js
+++ b/turnstone/shared_static/list_cache.js
@@ -30,12 +30,6 @@ import { authFetch } from "./auth.js";
  * @param {(row:object)=>any} opts.fpRow  per-row fingerprint tuple — the fields
  *                                      subscribers render, so a refresh that
  *                                      returns identical data skips the fan-out
- * @param {(extra:object)=>any} [opts.fpExtra]  extra top-level fields to fold
- *                                      into the fingerprint (e.g. models' default
- *                                      aliases, so a default-only change still
- *                                      fires onChange).  Omit to fingerprint rows
- *                                      only (a `captureExtra` value that changes
- *                                      without a row change then does NOT fire).
  * @param {(data:object)=>object} [opts.captureExtra]  pull extra top-level
  *                                      response fields into cache state on a
  *                                      successful refresh (returns the new
@@ -64,7 +58,6 @@ export function makeListCache(opts) {
   const name = opts.name;
   const keyField = opts.keyField || null;
   const fpRow = opts.fpRow;
-  const fpExtra = opts.fpExtra || null;
   const captureExtra = opts.captureExtra || null;
   const extraDefaults = opts.extraDefaults || null;
   // Default true: an advisory that gates UI (projects' require_project) must fail
@@ -88,10 +81,7 @@ export function makeListCache(opts) {
     // (it escapes anything inside a string field) and needs no separator
     // chars; an earlier per-module version joined on raw control bytes,
     // which made git see the whole file as binary.
-    return JSON.stringify([
-      _cache.map(fpRow),
-      fpExtra ? fpExtra(_extra) : null,
-    ]);
+    return JSON.stringify(_cache.map(fpRow));
   }
 
   function _setCache(rows) {

--- a/turnstone/shared_static/list_cache.js
+++ b/turnstone/shared_static/list_cache.js
@@ -41,9 +41,20 @@ import { authFetch } from "./auth.js";
  *                                      successful refresh (returns the new
  *                                      `extra` object, replacing the prior one)
  * @param {object} [opts.extraDefaults] the fail-open `extra` value — installed
- *                                      at init AND restored on every refresh
- *                                      failure, so a stale-true advisory can't
- *                                      survive a transient error
+ *                                      at init AND (when resetExtraOnError)
+ *                                      restored on a refresh failure, so a
+ *                                      stale-true advisory can't survive a
+ *                                      transient error
+ * @param {boolean} [opts.resetExtraOnError=true]  whether a failed refresh resets
+ *                                      `extra` to extraDefaults.  True for an
+ *                                      ADVISORY that gates UI (must fail open);
+ *                                      false for a merely COSMETIC extra that
+ *                                      should keep its last-known value through a
+ *                                      transient failure rather than blank.
+ * `refresh(opts)` accepts `{force:true}` — an INVALIDATION (e.g. a *_changed SSE
+ * event) that must converge to the latest server state: if a refresh is already
+ * in flight it chains ONE trailing refetch after it and awaits that, instead of
+ * coalescing onto the in-flight response that may predate the change.
  * @returns {{refresh:Function, get:Function, getByKey:Function,
  *            loaded:Function, error:Function, extra:Function, onChange:Function}}
  */
@@ -56,12 +67,17 @@ export function makeListCache(opts) {
   const fpExtra = opts.fpExtra || null;
   const captureExtra = opts.captureExtra || null;
   const extraDefaults = opts.extraDefaults || null;
+  // Default true: an advisory that gates UI (projects' require_project) must fail
+  // open, so a stale-true value can't survive an error.  A cosmetic extra
+  // (models' resolved default aliases) passes false to keep the last-known value.
+  const resetExtraOnError = opts.resetExtraOnError !== false;
 
   let _cache = []; // last-fetched rows (caller-visible)
   let _byKey = {}; // keyField value -> row, for O(1) lookup (when keyField set)
   let _loaded = false; // has the first refresh attempt completed (ok or failed)?
   let _lastError = null; // last failure: HTTP status, 0 for network/parse, null when ok
   let _inflight = null; // shared pending refresh so concurrent callers coalesce
+  let _pending = null; // trailing refresh chained after _inflight for a force() call
   let _fingerprint = null; // last fired signature, for change-detection
   let _extra = extraDefaults ? Object.assign({}, extraDefaults) : {};
   const _subs = []; // () => void, fired after each CHANGED refresh
@@ -102,20 +118,43 @@ export function makeListCache(opts) {
     }
   }
 
-  function refresh() {
+  function refresh(callOpts) {
     // Coalesce concurrent callers (startup warm + a picker open can both fire
     // this) onto one in-flight request — they share the promise and _setCache
     // runs once.
-    if (_inflight) return _inflight;
+    if (_inflight) {
+      if (callOpts && callOpts.force) {
+        // A force caller is an INVALIDATION ("the data definitely changed" — a
+        // *_changed SSE event): it must converge to the latest server state, so
+        // chain ONE trailing refetch after the in-flight one and await THAT,
+        // rather than coalescing onto a response that may predate the change.
+        // Reused if several force calls land during the same fetch (a burst
+        // collapses to one trailing).  INVARIANT: refresh() never rejects (the
+        // chain below always resolves via .catch), so this .then always runs; if
+        // a reject path is ever added, clear _pending in a .catch or force
+        // callers wedge on a stuck promise.
+        _pending =
+          _pending ||
+          _inflight.then(function () {
+            _pending = null;
+            return refresh();
+          });
+        return _pending;
+      }
+      return _inflight;
+    }
     _inflight = authFetch(url)
       .then(function (r) {
         if (r.ok) return r.json();
         // A non-OK status (403 when a grant is missing, a 5xx, ...) is NOT "you
-        // have zero rows": keep the prior cache rather than blanking it, record
-        // the status so the failure is visible, and reset the advisory extra to
-        // its fail-open default (a stale-true value must not survive an error).
+        // have zero rows": keep the prior cache rather than blanking it and
+        // record the status.  Reset the extra to its fail-open default ONLY when
+        // resetExtraOnError (an advisory that gates UI must not survive stale); a
+        // cosmetic extra keeps its last-known value.
         _lastError = r.status;
-        if (extraDefaults) _extra = Object.assign({}, extraDefaults);
+        if (resetExtraOnError && extraDefaults) {
+          _extra = Object.assign({}, extraDefaults);
+        }
         console.warn(name + ": GET " + url + " -> " + r.status);
         return null;
       })
@@ -130,9 +169,11 @@ export function makeListCache(opts) {
       .catch(function (e) {
         // Network drop or a non-JSON body — same policy as a non-OK status:
         // preserve the last-known cache, never reject (callers chain a bare
-        // .then), surface the failure, fail-open the extra.
+        // .then), surface the failure, fail-open the extra (when configured).
         _lastError = 0;
-        if (extraDefaults) _extra = Object.assign({}, extraDefaults);
+        if (resetExtraOnError && extraDefaults) {
+          _extra = Object.assign({}, extraDefaults);
+        }
         console.warn(name + ": refresh failed", e);
         return _cache;
       })

--- a/turnstone/shared_static/models.js
+++ b/turnstone/shared_static/models.js
@@ -61,9 +61,10 @@ const _core = makeListCache({
  * Fetch /v1/api/models into the cache.  Resolves to the row list and NEVER
  * rejects — a failed/forbidden fetch keeps the prior cache (a picker never
  * blanks) AND keeps the last-known default aliases; a first-load failure still
- * shows all-"".  Recorded (see {@link modelsError}) rather than masqueraded as
- * "no models".  Pass `{force:true}` to force a fresh fetch that converges to the
- * latest server state even mid-flight (the `models_changed` SSE path uses this).
+ * shows all-"".  Failures are warned and fail open (see list_cache.js) rather
+ * than masqueraded as "no models".  Pass `{force:true}` to force a fresh fetch
+ * that converges to the latest server state even mid-flight (the
+ * `models_changed` SSE path uses this).
  */
 export function refreshModels(callOpts) {
   return _core.refresh(callOpts);
@@ -73,18 +74,6 @@ export function refreshModels(callOpts) {
  *  a caller can resolve a default alias to its "alias (model)" label. */
 export function getModels() {
   return _core.get();
-}
-
-/** Whether the first refresh has resolved — distinguishes "no models" from
- *  "not loaded yet". */
-export function modelsLoaded() {
-  return _core.loaded();
-}
-
-/** Last refresh failure status (HTTP status, 0 for network/parse), or null
- *  when the last refresh succeeded. */
-export function modelsError() {
-  return _core.error();
 }
 
 // The one place the "alias (model)" label (or just "alias" when they coincide)
@@ -127,14 +116,14 @@ export function modelDefaults() {
 // No onChange subscription is exposed (unlike projects.js / personas.js, whose
 // onChange is consumed by rail.js): the models cache has no live-render consumer
 // — the console repaints on `models_changed` via its own direct handler, the ui
-// composers repaint on open.  Omitted rather than exposed-and-unused.
+// composers repaint on open.  The loaded/error readers are omitted for the same
+// no-consumer reason; projects.js/personas.js keep theirs as pre-existing
+// public surface.  Omitted rather than exposed-and-unused.
 
 // Classic (non-module) app.js bundles reach the data layer through this bridge.
 window.TurnstoneModels = {
   refreshModels: refreshModels,
   getModels: getModels,
-  modelsLoaded: modelsLoaded,
-  modelsError: modelsError,
   modelChoices: modelChoices,
   modelLabel: modelLabel,
   modelDefaults: modelDefaults,

--- a/turnstone/shared_static/models.js
+++ b/turnstone/shared_static/models.js
@@ -1,0 +1,128 @@
+/* models.js — client-side model-list data layer.
+ *
+ * Backs the model + judge-model pickers on every creation surface (the
+ * standalone new-ws modal, the dashboard quick-create, and the console
+ * launcher composer).  Before this the pickers each re-fetched
+ * /v1/api/models inline on every open, flashing an empty dropdown for the
+ * round-trip; this warms a shared cache the composers read synchronously.
+ *
+ * TWO SERVER SCHEMAS, ONE CACHE.  /v1/api/models is served by BOTH the node
+ * server (ui app) and the console server, with DIFFERENT default-alias
+ * fields: the node sends `default_alias` (+ `judge_default_alias`), the
+ * console sends `coordinator_default_alias` (+ `judge_default_alias`).  So
+ * the cache exposes the raw default-alias fields via {@link modelDefaults}
+ * (each "" when the local server didn't send it) and each app reads its own
+ * — it must NOT normalize to a single field name.  The per-row alias/model
+ * shape is common, so {@link modelChoices} formats one app-agnostic label.
+ *
+ * House style mirrors projects.js: coalescing / fail-open refresh /
+ * change-detection / bridge come from the shared `makeListCache` core;
+ * installs a `window.TurnstoneModels` bridge for the classic app.js bundles.
+ *
+ * NOTE (parallel readers, intentionally NOT unified here): the console
+ * governance panel (_sklcModelsPromise), the per-node voice-role fetch, and
+ * the admin schedule picker are independent /v1/api/models readers with
+ * their own (or no) caching.  This cache is a fourth path scoped to the
+ * composer pickers; unifying the others is a separate follow-up.
+ */
+
+import { makeListCache } from "./list_cache.js";
+
+const _core = makeListCache({
+  url: "/v1/api/models",
+  dataKey: "models",
+  name: "models",
+  fpRow: function (m) {
+    return [m.alias, m.model];
+  },
+  // Fold the default-alias fields into the fingerprint so a role-alias change
+  // (server emits `models_changed` for it) still fires onChange even when the
+  // model rows themselves are unchanged.
+  fpExtra: function (e) {
+    return [
+      e.default_alias,
+      e.judge_default_alias,
+      e.coordinator_default_alias,
+    ];
+  },
+  captureExtra: function (data) {
+    return {
+      default_alias: data.default_alias || "",
+      judge_default_alias: data.judge_default_alias || "",
+      coordinator_default_alias: data.coordinator_default_alias || "",
+    };
+  },
+  extraDefaults: {
+    default_alias: "",
+    judge_default_alias: "",
+    coordinator_default_alias: "",
+  },
+});
+
+/**
+ * Fetch /v1/api/models into the cache.  Resolves to the row list and NEVER
+ * rejects — a failed/forbidden fetch keeps the prior cache (a picker never
+ * blanks) and resets the default aliases to "".  Recorded (see
+ * {@link modelsError}) and warned rather than masqueraded as "no models".
+ */
+export function refreshModels() {
+  return _core.refresh();
+}
+
+/** Cached model rows (empty until the first refresh resolves).  Raw rows so
+ *  a caller can resolve a default alias to its "alias (model)" label. */
+export function getModels() {
+  return _core.get();
+}
+
+/** Whether the first refresh has resolved — distinguishes "no models" from
+ *  "not loaded yet". */
+export function modelsLoaded() {
+  return _core.loaded();
+}
+
+/** Last refresh failure status (HTTP status, 0 for network/parse), or null
+ *  when the last refresh succeeded. */
+export function modelsError() {
+  return _core.error();
+}
+
+/** `{value, text}` choices for a model <select> — the label ("alias (model)",
+ *  or just "alias" when they coincide) is identical across all three creation
+ *  surfaces, so it is centralized here.  Callers seed their own static
+ *  "Default …" placeholder as option 0. */
+export function modelChoices() {
+  return _core.get().map(function (m) {
+    return {
+      value: m.alias,
+      text: m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")",
+    };
+  });
+}
+
+/** The resolved default aliases the local server reported:
+ *  `{default_alias, judge_default_alias, coordinator_default_alias}` (each ""
+ *  when not sent).  The ui dashboard reads default_alias, the console launcher
+ *  reads coordinator_default_alias; both read judge_default_alias.  Fails open
+ *  to all-"" on a refresh error. */
+export function modelDefaults() {
+  return _core.extra();
+}
+
+/** Subscribe to post-refresh changes.  Idempotent.  (No composer subscribes
+ *  today — the console repaints via its direct `models_changed` handler — but
+ *  the hook is exposed for parity with the other data layers.) */
+export function onModelsChange(cb) {
+  _core.onChange(cb);
+}
+
+// Classic (non-module) app.js bundles reach the data layer through this bridge.
+window.TurnstoneModels = {
+  refreshModels: refreshModels,
+  getModels: getModels,
+  modelsLoaded: modelsLoaded,
+  modelsError: modelsError,
+  modelChoices: modelChoices,
+  modelDefaults: modelDefaults,
+  onModelsChange: onModelsChange,
+};

--- a/turnstone/shared_static/models.js
+++ b/turnstone/shared_static/models.js
@@ -32,18 +32,11 @@ const _core = makeListCache({
   url: "/v1/api/models",
   dataKey: "models",
   name: "models",
+  // alias is the unique <select> key — index by it so modelLabel() is an O(1)
+  // getByKey rather than a per-paint scan.
+  keyField: "alias",
   fpRow: function (m) {
     return [m.alias, m.model];
-  },
-  // Fold the default-alias fields into the fingerprint so a role-alias change
-  // (server emits `models_changed` for it) still fires onChange even when the
-  // model rows themselves are unchanged.
-  fpExtra: function (e) {
-    return [
-      e.default_alias,
-      e.judge_default_alias,
-      e.coordinator_default_alias,
-    ];
   },
   captureExtra: function (data) {
     return {
@@ -113,15 +106,12 @@ export function modelChoices() {
 
 /** The "alias (model)" label for a model alias, or "" when the alias is empty or
  *  unknown — lets a composer annotate its "Default — <resolved>" placeholder
- *  without re-implementing the format.  The models cache has no key index, so
- *  this scans the (small) row list. */
+ *  without re-implementing the format.  Resolves via the keyField:"alias" index
+ *  (getByKey), O(1). */
 export function modelLabel(alias) {
   if (!alias) return "";
-  const rows = _core.get();
-  for (let i = 0; i < rows.length; i++) {
-    if (rows[i].alias === alias) return _fmtLabel(rows[i]);
-  }
-  return "";
+  const row = _core.getByKey(alias);
+  return row ? _fmtLabel(row) : "";
 }
 
 /** The resolved default aliases the local server reported:
@@ -134,12 +124,10 @@ export function modelDefaults() {
   return _core.extra();
 }
 
-/** Subscribe to post-refresh changes.  Idempotent.  (No composer subscribes
- *  today — the console repaints via its direct `models_changed` handler — but
- *  the hook is exposed for parity with the other data layers.) */
-export function onModelsChange(cb) {
-  _core.onChange(cb);
-}
+// No onChange subscription is exposed (unlike projects.js / personas.js, whose
+// onChange is consumed by rail.js): the models cache has no live-render consumer
+// — the console repaints on `models_changed` via its own direct handler, the ui
+// composers repaint on open.  Omitted rather than exposed-and-unused.
 
 // Classic (non-module) app.js bundles reach the data layer through this bridge.
 window.TurnstoneModels = {
@@ -150,5 +138,4 @@ window.TurnstoneModels = {
   modelChoices: modelChoices,
   modelLabel: modelLabel,
   modelDefaults: modelDefaults,
-  onModelsChange: onModelsChange,
 };

--- a/turnstone/shared_static/models.js
+++ b/turnstone/shared_static/models.js
@@ -57,16 +57,23 @@ const _core = makeListCache({
     judge_default_alias: "",
     coordinator_default_alias: "",
   },
+  // The default aliases are a COSMETIC placeholder annotation ("Default — gpt-5"),
+  // not a UI-gating advisory, so keep the last-known value through a transient
+  // refresh failure instead of blanking it back to an un-annotated "Default
+  // model".  A first-load failure still shows all-"" (the seed above).
+  resetExtraOnError: false,
 });
 
 /**
  * Fetch /v1/api/models into the cache.  Resolves to the row list and NEVER
  * rejects — a failed/forbidden fetch keeps the prior cache (a picker never
- * blanks) and resets the default aliases to "".  Recorded (see
- * {@link modelsError}) and warned rather than masqueraded as "no models".
+ * blanks) AND keeps the last-known default aliases; a first-load failure still
+ * shows all-"".  Recorded (see {@link modelsError}) rather than masqueraded as
+ * "no models".  Pass `{force:true}` to force a fresh fetch that converges to the
+ * latest server state even mid-flight (the `models_changed` SSE path uses this).
  */
-export function refreshModels() {
-  return _core.refresh();
+export function refreshModels(callOpts) {
+  return _core.refresh(callOpts);
 }
 
 /** Cached model rows (empty until the first refresh resolves).  Raw rows so
@@ -87,24 +94,42 @@ export function modelsError() {
   return _core.error();
 }
 
-/** `{value, text}` choices for a model <select> — the label ("alias (model)",
- *  or just "alias" when they coincide) is identical across all three creation
- *  surfaces, so it is centralized here.  Callers seed their own static
- *  "Default …" placeholder as option 0. */
+// The one place the "alias (model)" label (or just "alias" when they coincide)
+// is formatted — modelChoices, modelLabel, and every composer placeholder
+// annotation resolve through here so the option labels and the "Default — …"
+// placeholder can never disagree.
+function _fmtLabel(m) {
+  return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
+}
+
+/** `{value, text}` choices for a model <select> — the label is identical across
+ *  all three creation surfaces, so it is centralized here.  Callers seed their
+ *  own static "Default …" placeholder as option 0. */
 export function modelChoices() {
   return _core.get().map(function (m) {
-    return {
-      value: m.alias,
-      text: m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")",
-    };
+    return { value: m.alias, text: _fmtLabel(m) };
   });
+}
+
+/** The "alias (model)" label for a model alias, or "" when the alias is empty or
+ *  unknown — lets a composer annotate its "Default — <resolved>" placeholder
+ *  without re-implementing the format.  The models cache has no key index, so
+ *  this scans the (small) row list. */
+export function modelLabel(alias) {
+  if (!alias) return "";
+  const rows = _core.get();
+  for (let i = 0; i < rows.length; i++) {
+    if (rows[i].alias === alias) return _fmtLabel(rows[i]);
+  }
+  return "";
 }
 
 /** The resolved default aliases the local server reported:
  *  `{default_alias, judge_default_alias, coordinator_default_alias}` (each ""
  *  when not sent).  The ui dashboard reads default_alias, the console launcher
- *  reads coordinator_default_alias; both read judge_default_alias.  Fails open
- *  to all-"" on a refresh error. */
+ *  reads coordinator_default_alias; both read judge_default_alias.  Keeps the
+ *  last-known values on a refresh error (a cosmetic annotation, not a UI gate);
+ *  all-"" only before the first successful load. */
 export function modelDefaults() {
   return _core.extra();
 }
@@ -123,6 +148,7 @@ window.TurnstoneModels = {
   modelsLoaded: modelsLoaded,
   modelsError: modelsError,
   modelChoices: modelChoices,
+  modelLabel: modelLabel,
   modelDefaults: modelDefaults,
   onModelsChange: onModelsChange,
 };

--- a/turnstone/shared_static/personas.js
+++ b/turnstone/shared_static/personas.js
@@ -11,51 +11,26 @@
  * at creation is a user action, authoring lives behind the console admin
  * CRUD.
  *
- * House style mirrors projects.js: an ES module for module consumers that
- * ALSO installs a `window.TurnstonePersonas` bridge for the classic
- * (non-module) app.js bundles.  All fetches ride the shared cookie-auth
- * `authFetch`.
+ * House style mirrors projects.js: the coalescing, fail-open refresh,
+ * change-detection fan-out, and bridge machinery come from the shared
+ * `makeListCache` core (list_cache.js); this module adds the persona-specific
+ * readers (kind-filtered choices, the kind default, name→label resolution).
+ * An ES module for module consumers that ALSO installs a
+ * `window.TurnstonePersonas` bridge for the classic (non-module) app.js
+ * bundles.  All fetches ride the shared cookie-auth `authFetch`.
  */
 
-import { authFetch } from "./auth.js";
+import { makeListCache } from "./list_cache.js";
 
-let _cache = []; // last-fetched persona rows (enabled only)
-let _byName = {}; // name -> row, for O(1) label/default resolution
-let _loaded = false; // has the first refresh attempt completed (ok or failed)?
-let _lastError = null; // last failure: HTTP status, 0 for network/parse, null when ok
-let _inflight = null; // shared pending refresh so concurrent callers coalesce
-let _fingerprint = null; // last fired list signature, for change-detection
-const _subs = []; // () => void, fired after each CHANGED refresh
-
-function _fp(rows) {
-  // Cheap signature of the fields subscribers render, so a refresh
-  // returning identical data skips the fan-out (same policy as
-  // projects.js — JSON.stringify keeps the file text-safe for git).
-  return JSON.stringify(
-    rows.map(function (p) {
-      return [p.name, p.display_name, p.applies_to_kinds, p.is_default];
-    }),
-  );
-}
-
-function _setCache(rows) {
-  _cache = Array.isArray(rows) ? rows : [];
-  _byName = {};
-  for (const p of _cache) if (p && p.name) _byName[p.name] = p;
-  const firstLoad = !_loaded;
-  _loaded = true;
-  const fp = _fp(_cache);
-  if (firstLoad || fp !== _fingerprint) {
-    _fingerprint = fp;
-    _subs.forEach(function (cb) {
-      try {
-        cb(_cache);
-      } catch (_) {
-        /* a subscriber throwing must not abort the rest of the fan-out */
-      }
-    });
-  }
-}
+const _core = makeListCache({
+  url: "/v1/api/personas",
+  dataKey: "personas",
+  name: "personas",
+  keyField: "name",
+  fpRow: function (p) {
+    return [p.name, p.display_name, p.applies_to_kinds, p.is_default];
+  },
+});
 
 /**
  * Fetch /v1/api/personas into the cache.  Resolves to the row list and
@@ -65,48 +40,24 @@ function _setCache(rows) {
  * than silently masqueraded as "no personas".
  */
 export function refreshPersonas() {
-  if (_inflight) return _inflight;
-  _inflight = authFetch("/v1/api/personas")
-    .then(function (r) {
-      if (r.ok) return r.json();
-      _lastError = r.status;
-      console.warn("personas: GET /v1/api/personas -> " + r.status);
-      return null;
-    })
-    .then(function (data) {
-      if (data) {
-        _lastError = null;
-        _setCache(data.personas || []);
-      }
-      return _cache;
-    })
-    .catch(function (e) {
-      _lastError = 0;
-      console.warn("personas: refresh failed", e);
-      return _cache;
-    })
-    .finally(function () {
-      _loaded = true;
-      _inflight = null;
-    });
-  return _inflight;
+  return _core.refresh();
 }
 
 /** Cached persona rows (empty array until the first refresh resolves). */
 export function getPersonas() {
-  return _cache;
+  return _core.get();
 }
 
 /** Whether the first refresh has resolved — lets a reader distinguish
  *  "no personas" (pre-seed database) from "not loaded yet". */
 export function personasLoaded() {
-  return _loaded;
+  return _core.loaded();
 }
 
 /** Status of the last refresh failure — HTTP status, 0 for network/parse
  *  error, null when the last refresh succeeded. */
 export function personasError() {
-  return _lastError;
+  return _core.error();
 }
 
 /** Display label for a persona name, or the raw name when unknown (a
@@ -114,13 +65,13 @@ export function personasError() {
  *  it), or "" for an empty/pre-persona value. */
 export function personaLabel(name) {
   if (!name) return "";
-  const p = _byName[name];
+  const p = _core.getByKey(name);
   return (p && p.display_name) || name;
 }
 
 /** The default persona row for a workstream kind, or null (pre-seed DB). */
 export function defaultPersona(kind) {
-  for (const p of _cache) {
+  for (const p of _core.get()) {
     if (p.is_default && (p.applies_to_kinds || []).indexOf(kind) >= 0) return p;
   }
   return null;
@@ -130,7 +81,7 @@ export function defaultPersona(kind) {
  *  ("interactive" | "coordinator").  The kind's default persona sorts
  *  first so a zero-touch composer preselects today's behavior. */
 export function personaChoices(kind) {
-  const rows = _cache.filter(function (p) {
+  const rows = _core.get().filter(function (p) {
     return (p.applies_to_kinds || []).indexOf(kind) >= 0;
   });
   rows.sort(function (a, b) {
@@ -145,7 +96,7 @@ export function personaChoices(kind) {
 /** Subscribe to post-refresh changes (picker repopulate, label refresh).
  *  Idempotent — the same callback is registered at most once. */
 export function onPersonasChange(cb) {
-  if (typeof cb === "function" && _subs.indexOf(cb) < 0) _subs.push(cb);
+  _core.onChange(cb);
 }
 
 // Classic (non-module) app.js bundles reach the data layer through this

--- a/turnstone/shared_static/personas.js
+++ b/turnstone/shared_static/personas.js
@@ -39,8 +39,8 @@ const _core = makeListCache({
  * Failures are recorded (see {@link personasError}) and warned, rather
  * than silently masqueraded as "no personas".
  */
-export function refreshPersonas() {
-  return _core.refresh();
+export function refreshPersonas(callOpts) {
+  return _core.refresh(callOpts);
 }
 
 /** Cached persona rows (empty array until the first refresh resolves). */

--- a/turnstone/shared_static/projects.js
+++ b/turnstone/shared_static/projects.js
@@ -39,6 +39,11 @@ const _core = makeListCache({
     return { requireProject: !!data.require_project };
   },
   extraDefaults: { requireProject: false },
+  // require_project GATES the picker (strict mode hides the projectless option),
+  // so it must fail OPEN: a failed refresh resets it to false rather than letting
+  // a stale-true value hide options.  (Default, but explicit for the contrast
+  // with models.js, whose cosmetic extra opts out of the reset.)
+  resetExtraOnError: true,
 });
 
 /**

--- a/turnstone/shared_static/projects.js
+++ b/turnstone/shared_static/projects.js
@@ -23,10 +23,10 @@ import { makeListCache } from "./list_cache.js";
 // The require_project advisory rides the same /v1/api/projects response as an
 // extra top-level field.  It fails OPEN to false: a stale-true value would make
 // the composer hide options on a transient error, so `extraDefaults` resets it
-// on every refresh failure and it seeds false before the first refresh.  It is
-// deliberately NOT in the fingerprint (no fpExtra) — a require_project-only
-// toggle with an unchanged project list should not force a rail rebuild; the
-// composers re-read it synchronously on their next open.
+// on every refresh failure and it seeds false before the first refresh.  The
+// fingerprint is the project rows only, so a require_project-only toggle (with an
+// unchanged project list) does NOT force a rail rebuild; the composers re-read it
+// synchronously on their next open.
 const _core = makeListCache({
   url: "/v1/api/projects",
   dataKey: "projects",
@@ -53,8 +53,8 @@ const _core = makeListCache({
  * a half-open picker.  A failure is recorded (see {@link projectsError})
  * and warned, rather than silently masqueraded as an empty project list.
  */
-export function refreshProjects() {
-  return _core.refresh();
+export function refreshProjects(callOpts) {
+  return _core.refresh(callOpts);
 }
 
 /** Cached project rows (empty array until the first refresh resolves). */

--- a/turnstone/shared_static/projects.js
+++ b/turnstone/shared_static/projects.js
@@ -7,58 +7,39 @@
  * per-snapshot backend join and every creation surface agrees on the
  * same list.
  *
- * House style mirrors composer.js / hatch.js: an ES module for the
- * module consumers (rail.js, shell-side) that ALSO installs a
- * `window.TurnstoneProjects` bridge for the classic (non-module)
+ * House style mirrors personas.js / models.js / skills.js: the coalescing,
+ * fail-open refresh, change-detection fan-out, and bridge machinery come
+ * from the shared `makeListCache` core (list_cache.js); this module adds the
+ * projects-specific readers (the require_project advisory, id→name
+ * resolution, {value,text} choices) and the `createProject` POST helper.
+ * An ES module for module consumers (rail.js, project_creator.js) that ALSO
+ * installs a `window.TurnstoneProjects` bridge for the classic (non-module)
  * app.js bundles.  All fetches ride the shared cookie-auth `authFetch`.
  */
 
 import { authFetch } from "./auth.js";
+import { makeListCache } from "./list_cache.js";
 
-let _cache = []; // last-fetched project rows (active, caller-visible)
-let _byId = {}; // project_id -> row, for O(1) rail name resolution
-let _loaded = false; // has the first refresh attempt completed (ok or failed)?
-let _lastError = null; // last failure: HTTP status, 0 for network/parse, null when ok
-let _inflight = null; // shared pending refresh so concurrent callers coalesce
-let _fingerprint = null; // last fired map signature, for change-detection
-let _requireProject = false; // server.require_project advisory; fail-open false
-const _subs = []; // () => void, fired after each CHANGED refresh
-
-function _fp(rows) {
-  // Cheap signature of the fields subscribers render (id + name + visibility +
-  // state) so a refresh returning identical data skips the fan-out (and the
-  // rail's O(workstreams) rebuild).  JSON.stringify is collision-proof (it
-  // escapes anything inside a project name) and needs no separator chars; an
-  // earlier version joined on raw control bytes, which made git see this whole
-  // file as binary.
-  return JSON.stringify(
-    rows.map(function (p) {
-      return [p.project_id, p.name, p.visibility, p.state];
-    }),
-  );
-}
-
-function _setCache(rows) {
-  _cache = Array.isArray(rows) ? rows : [];
-  _byId = {};
-  for (const p of _cache) if (p && p.project_id) _byId[p.project_id] = p;
-  const firstLoad = !_loaded;
-  _loaded = true;
-  const fp = _fp(_cache);
-  // Fire only when the map actually changed (or on first load) — a redundant
-  // refresh (picker re-open, a mutation that no-ops the visible set) shouldn't
-  // force every subscriber to rebuild.
-  if (firstLoad || fp !== _fingerprint) {
-    _fingerprint = fp;
-    _subs.forEach(function (cb) {
-      try {
-        cb(_cache);
-      } catch (_) {
-        /* a subscriber throwing must not abort the rest of the fan-out */
-      }
-    });
-  }
-}
+// The require_project advisory rides the same /v1/api/projects response as an
+// extra top-level field.  It fails OPEN to false: a stale-true value would make
+// the composer hide options on a transient error, so `extraDefaults` resets it
+// on every refresh failure and it seeds false before the first refresh.  It is
+// deliberately NOT in the fingerprint (no fpExtra) — a require_project-only
+// toggle with an unchanged project list should not force a rail rebuild; the
+// composers re-read it synchronously on their next open.
+const _core = makeListCache({
+  url: "/v1/api/projects",
+  dataKey: "projects",
+  name: "projects",
+  keyField: "project_id",
+  fpRow: function (p) {
+    return [p.project_id, p.name, p.visibility, p.state];
+  },
+  captureExtra: function (data) {
+    return { requireProject: !!data.require_project };
+  },
+  extraDefaults: { requireProject: false },
+});
 
 /**
  * Fetch /v1/api/projects into the cache.  Resolves to the row list and
@@ -68,60 +49,19 @@ function _setCache(rows) {
  * and warned, rather than silently masqueraded as an empty project list.
  */
 export function refreshProjects() {
-  // Coalesce concurrent callers (on console load both mountRail and the launcher
-  // init fire this) onto one in-flight request — they share the same promise and
-  // _setCache runs once.
-  if (_inflight) return _inflight;
-  _inflight = authFetch("/v1/api/projects")
-    .then(function (r) {
-      if (r.ok) return r.json();
-      // A non-OK status (403 when the caller lacks the project.read grant, a
-      // 5xx, ...) is NOT "you have zero projects": keep the prior cache rather
-      // than blanking it, and record the status so the failure is visible
-      // instead of looking like an empty list.
-      _lastError = r.status;
-      // The require_project advisory fails OPEN: a stale-true value would make
-      // the composer hide options on a transient error, so reset it to false.
-      _requireProject = false;
-      console.warn("projects: GET /v1/api/projects -> " + r.status);
-      return null;
-    })
-    .then(function (data) {
-      if (data) {
-        _lastError = null;
-        _requireProject = !!data.require_project;
-        _setCache(data.projects || []);
-      }
-      return _cache;
-    })
-    .catch(function (e) {
-      // Network drop or a non-JSON body — same policy as a non-OK status:
-      // preserve the last-known cache, never reject (callers chain a bare
-      // .then), and surface the failure.
-      _lastError = 0;
-      _requireProject = false; // fail-open (see the non-OK branch above)
-      console.warn("projects: refresh failed", e);
-      return _cache;
-    })
-    .finally(function () {
-      // One attempt has completed (ok or not) — lets a reader tell "still
-      // loading" from "loaded, genuinely empty" / "load failed".
-      _loaded = true;
-      _inflight = null;
-    });
-  return _inflight;
+  return _core.refresh();
 }
 
 /** Cached project rows (empty array until the first refresh resolves). */
 export function getProjects() {
-  return _cache;
+  return _core.get();
 }
 
 /** Whether the first refresh has resolved — lets a reader distinguish
  *  "no projects" from "not loaded yet" (the rail falls back to the bare
  *  id only when loaded-but-unknown, i.e. a stale/again-removed project). */
 export function projectsLoaded() {
-  return _loaded;
+  return _core.loaded();
 }
 
 /** Status of the last refresh failure — the HTTP status (e.g. 403 when the
@@ -129,7 +69,7 @@ export function projectsLoaded() {
  *  when the last refresh succeeded.  Lets a reader tell "loaded, no projects"
  *  apart from "couldn't load projects" without re-fetching. */
 export function projectsError() {
-  return _lastError;
+  return _core.error();
 }
 
 /** Whether this deployment requires new chats to be filed under a project
@@ -141,13 +81,13 @@ export function projectsError() {
  *  change. Fails OPEN to false on any refresh failure too, so the composer never
  *  hides options on a stale-true value. */
 export function requireProject() {
-  return _requireProject;
+  return _core.extra().requireProject;
 }
 
 /** Display name for a project_id, or "" when unknown (not yet loaded, no
  *  access, or since-removed). */
 export function projectName(id) {
-  const p = id && _byId[id];
+  const p = _core.getByKey(id);
   return p ? p.name || "" : "";
 }
 
@@ -155,7 +95,7 @@ export function projectName(id) {
  *  seed their own "No project" placeholder (preserved by the composer's
  *  setOptionChoices) and any "+ New project…" sentinel. */
 export function projectChoices() {
-  return _cache.map(function (p) {
+  return _core.get().map(function (p) {
     return { value: p.project_id, text: p.name };
   });
 }
@@ -163,7 +103,7 @@ export function projectChoices() {
 /** Subscribe to post-refresh changes (rail re-render, picker repopulate).
  *  Idempotent — the same callback is registered at most once. */
 export function onProjectsChange(cb) {
-  if (typeof cb === "function" && _subs.indexOf(cb) < 0) _subs.push(cb);
+  _core.onChange(cb);
 }
 
 /** Create a project owned by the caller.  Resolves `{ok, status, data}`

--- a/turnstone/shared_static/skills.js
+++ b/turnstone/shared_static/skills.js
@@ -36,8 +36,8 @@ const _core = makeListCache({
 /**
  * Fetch /v1/api/skills into the cache.  Resolves to the row list and NEVER
  * rejects — a failed/forbidden fetch keeps the prior cache (a picker never
- * blanks).  Recorded (see {@link skillsError}) rather than masqueraded as "no
- * skills".  Pass `{force:true}` to force a fresh fetch that converges to the
+ * blanks).  Failures are warned and fail open (see list_cache.js) rather than
+ * masqueraded as "no skills".  Pass `{force:true}` to force a fresh fetch that converges to the
  * latest even mid-flight (onLoginSuccess uses this to recover a failed pre-auth
  * warm — skills has no *_changed event to recover otherwise).
  */
@@ -51,26 +51,14 @@ export function getSkills() {
   return _core.get();
 }
 
-/** Whether the first refresh has resolved — distinguishes "no skills" from
- *  "not loaded yet". */
-export function skillsLoaded() {
-  return _core.loaded();
-}
-
-/** Last refresh failure status (HTTP status, 0 for network/parse), or null
- *  when the last refresh succeeded. */
-export function skillsError() {
-  return _core.error();
-}
-
 // No onChange subscription is exposed (unlike projects.js / personas.js): the
 // skills cache has no live-render consumer — the composers repaint on open.
+// The loaded/error readers are omitted for the same no-consumer reason;
+// projects.js/personas.js keep theirs as pre-existing public surface.
 // Omitted rather than exposed-and-unused.
 
 // Classic (non-module) app.js bundles reach the data layer through this bridge.
 window.TurnstoneSkills = {
   refreshSkills: refreshSkills,
   getSkills: getSkills,
-  skillsLoaded: skillsLoaded,
-  skillsError: skillsError,
 };

--- a/turnstone/shared_static/skills.js
+++ b/turnstone/shared_static/skills.js
@@ -36,11 +36,13 @@ const _core = makeListCache({
 /**
  * Fetch /v1/api/skills into the cache.  Resolves to the row list and NEVER
  * rejects — a failed/forbidden fetch keeps the prior cache (a picker never
- * blanks).  Recorded (see {@link skillsError}) and warned rather than
- * masqueraded as "no skills".
+ * blanks).  Recorded (see {@link skillsError}) rather than masqueraded as "no
+ * skills".  Pass `{force:true}` to force a fresh fetch that converges to the
+ * latest even mid-flight (onLoginSuccess uses this to recover a failed pre-auth
+ * warm — skills has no *_changed event to recover otherwise).
  */
-export function refreshSkills() {
-  return _core.refresh();
+export function refreshSkills(callOpts) {
+  return _core.refresh(callOpts);
 }
 
 /** Cached skill rows (`{name, is_default, origin, ...}`; empty until the
@@ -61,10 +63,9 @@ export function skillsError() {
   return _core.error();
 }
 
-/** Subscribe to post-refresh changes.  Idempotent. */
-export function onSkillsChange(cb) {
-  _core.onChange(cb);
-}
+// No onChange subscription is exposed (unlike projects.js / personas.js): the
+// skills cache has no live-render consumer — the composers repaint on open.
+// Omitted rather than exposed-and-unused.
 
 // Classic (non-module) app.js bundles reach the data layer through this bridge.
 window.TurnstoneSkills = {
@@ -72,5 +73,4 @@ window.TurnstoneSkills = {
   getSkills: getSkills,
   skillsLoaded: skillsLoaded,
   skillsError: skillsError,
-  onSkillsChange: onSkillsChange,
 };

--- a/turnstone/shared_static/skills.js
+++ b/turnstone/shared_static/skills.js
@@ -1,0 +1,76 @@
+/* skills.js — client-side skill-list data layer.
+ *
+ * Backs the skill picker on the standalone new-ws modal and the dashboard
+ * quick-create (the console launcher has its own skill picker too).  Before
+ * this each open re-fetched /v1/api/skills inline, flashing an empty
+ * dropdown for the round-trip; this warms a shared cache the composers read
+ * synchronously.
+ *
+ * RAW ROWS, PER-APP LABEL.  The skill label diverges between apps — the ui
+ * pickers append a " [MCP]" suffix for MCP-origin skills, the console
+ * launcher does not — so this cache exposes the raw rows via
+ * {@link getSkills} (`{name, is_default, origin}`) and each populate helper
+ * formats its own label.  A single pre-formatted `text` here would silently
+ * change one app's labels.
+ *
+ * House style mirrors projects.js: coalescing / fail-open refresh /
+ * change-detection / bridge come from the shared `makeListCache` core;
+ * installs a `window.TurnstoneSkills` bridge for the classic app.js bundles.
+ *
+ * NOTE: unlike models there is no `skills_changed` SSE event, so the cache
+ * only re-warms on a picker-open refresh / onLoginSuccess — a skill created
+ * elsewhere appears on the next open (same as before this cache existed).
+ */
+
+import { makeListCache } from "./list_cache.js";
+
+const _core = makeListCache({
+  url: "/v1/api/skills",
+  dataKey: "skills",
+  name: "skills",
+  fpRow: function (s) {
+    return [s.name, s.is_default, s.origin];
+  },
+});
+
+/**
+ * Fetch /v1/api/skills into the cache.  Resolves to the row list and NEVER
+ * rejects — a failed/forbidden fetch keeps the prior cache (a picker never
+ * blanks).  Recorded (see {@link skillsError}) and warned rather than
+ * masqueraded as "no skills".
+ */
+export function refreshSkills() {
+  return _core.refresh();
+}
+
+/** Cached skill rows (`{name, is_default, origin, ...}`; empty until the
+ *  first refresh resolves).  Raw so each app formats its own label. */
+export function getSkills() {
+  return _core.get();
+}
+
+/** Whether the first refresh has resolved — distinguishes "no skills" from
+ *  "not loaded yet". */
+export function skillsLoaded() {
+  return _core.loaded();
+}
+
+/** Last refresh failure status (HTTP status, 0 for network/parse), or null
+ *  when the last refresh succeeded. */
+export function skillsError() {
+  return _core.error();
+}
+
+/** Subscribe to post-refresh changes.  Idempotent. */
+export function onSkillsChange(cb) {
+  _core.onChange(cb);
+}
+
+// Classic (non-module) app.js bundles reach the data layer through this bridge.
+window.TurnstoneSkills = {
+  refreshSkills: refreshSkills,
+  getSkills: getSkills,
+  skillsLoaded: skillsLoaded,
+  skillsError: skillsError,
+  onSkillsChange: onSkillsChange,
+};

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -527,8 +527,11 @@ function _optionExists(sel, val) {
 // skips entirely (a fork inherits its source's project server-side; the modal
 // hides the picker for forks).  Both paints reuse _populateProjectSelect, so the
 // #867 strict-picker invariant (never auto-select a real project) holds on each.
+// The sync-then-refresh tail routes through _paintFromCache (the fork skip and
+// the hint stay bespoke here); returns its async-repaint promise.
 function _paintProjectPicker(sel, hint, opts) {
-  if ((opts && opts.fork) || !sel || !window.TurnstoneProjects) return;
+  if ((opts && opts.fork) || !sel || !window.TurnstoneProjects)
+    return Promise.resolve();
   // paint(fresh): a fresh open renders the actual default (no prior selection);
   // the async repaint MUST pass fresh=false, or it clobbers a project the user
   // picked during the refresh round-trip — under require_project that reconciles
@@ -538,36 +541,41 @@ function _paintProjectPicker(sel, hint, opts) {
     if (hint) hint.textContent = strict ? "required" : "optional";
     _populateProjectSelect(sel, { requireProject: strict, fresh: fresh });
   };
-  const freshOnOpen = !!(opts && opts.freshOnOpen);
-  paint(freshOnOpen); // sync from the warm cache (no-op when cold; the async fills it)
-  window.TurnstoneProjects.refreshProjects().then(function () {
-    paint(false);
-  });
+  return _paintFromCache(window.TurnstoneProjects.refreshProjects, paint, opts);
 }
 
 // One chokepoint for the composer paint discipline, shared by the three
-// cache-backed wrappers below (mirrors _paintProjectPicker, which keeps its own
-// tail — fork/hint logic): sync-paint NOW from the warm cache, then
-// refresh-and-repaint.  The sync paint mirrors the caller's freshOnOpen (a
-// reused-dialog open renders the actual defaults); the async repaint is ALWAYS
-// fresh:false — it must preserve a pick made during the fetch window, never
-// re-blank.  `refresh` may be absent (bridge module still loading): the
-// populate helpers no-op without their bridge and the refresh is skipped —
-// never worse than the pre-cache behavior.
+// cache-backed wrappers below and _paintProjectPicker's tail: sync-paint NOW
+// from the warm cache, then refresh-and-repaint.  The sync paint mirrors the
+// caller's freshOnOpen (a reused-dialog open renders the actual defaults); the
+// async repaint is ALWAYS fresh:false — it must preserve a pick made during
+// the fetch window, never re-blank.  Returns the async-repaint promise
+// (already-resolved when there is nothing to refresh) so a caller can act
+// after the repaint lands — the dashboard chains its Options-chip recompute.
+//
+// `refresh` may be absent (bridge missing): the sync populate no-ops and the
+// refresh is skipped.  If the module graph itself failed to load (a failed
+// /shared/models.js, skills.js, personas.js, projects.js, or list_cache.js
+// fetch at page load), that picker stays empty until a reload — an ACCEPTED
+// tradeoff of the shared-cache architecture, the same class the projects/
+// personas pickers + rail have carried since #867/#868.  Do NOT add a
+// per-picker retry (a cache-busted dynamic re-import creates a second cache
+// instance with split-brain state) or an inline-fetch fallback (it resurrects
+// the dual-path this refactor deleted); surfacing a failed bridge, if ever
+// wanted, belongs in the app shell for all bridges at once.
 function _paintFromCache(refresh, repaint, opts) {
   repaint(!!(opts && opts.freshOnOpen));
-  if (refresh) {
-    refresh().then(function () {
-      repaint(false);
-    });
-  }
+  if (!refresh) return Promise.resolve();
+  return refresh().then(function () {
+    repaint(false);
+  });
 }
 
 // Paint the model + judge pickers from the warm cache then refresh-and-repaint,
 // collapsing the identical sync-then-refresh dance the modal and dashboard both
 // need.
 function _paintModelSelects(modelSel, judgeSel, opts) {
-  _paintFromCache(
+  return _paintFromCache(
     window.TurnstoneModels && window.TurnstoneModels.refreshModels,
     function (fresh) {
       _populateModelSelect(modelSel, judgeSel, { fresh: fresh });
@@ -578,7 +586,7 @@ function _paintModelSelects(modelSel, judgeSel, opts) {
 
 // Skill twin of _paintModelSelects.
 function _paintSkillSelect(sel, opts) {
-  _paintFromCache(
+  return _paintFromCache(
     window.TurnstoneSkills && window.TurnstoneSkills.refreshSkills,
     function (fresh) {
       _populateSkillSelect(sel, { fresh: fresh });
@@ -591,7 +599,7 @@ function _paintSkillSelect(sel, opts) {
 // default when nothing valid is selected, so the fresh:false repaint can't
 // clobber a mid-window pick.
 function _paintPersonaSelect(sel, opts) {
-  _paintFromCache(
+  return _paintFromCache(
     window.TurnstonePersonas && window.TurnstonePersonas.refreshPersonas,
     function (fresh) {
       _populatePersonaSelect(sel, { fresh: fresh });
@@ -1539,11 +1547,23 @@ function _loadDashboardOptionsLists() {
   // (not a reused dialog), so freshOnOpen:false — it preserves a pick across a
   // repaint.  Previously fetch-once (guarded on options.length); now
   // refresh-on-open via the coalesced caches, matching the project/persona pickers.
+  //
+  // EVERY paint chains a recompute of the collapsed Options chip on its async
+  // repaint: a repaint can drop a server-removed pick (the select falls back to
+  // its placeholder) or revert the persona to its kind default WITHOUT firing
+  // 'change' — the optionsPanel change listener covers user edits only — and
+  // the chip must always name what submit will send.  The project paint is
+  // chained for symmetry/future chip coverage; _refreshDashboardOptionsSummary
+  // reads persona/model/judge/skill only today.
   const modelSel = document.getElementById("dashboard-model");
   const judgeSel = document.getElementById("dashboard-judge-model");
-  _paintModelSelects(modelSel, judgeSel, { freshOnOpen: false });
+  _paintModelSelects(modelSel, judgeSel, { freshOnOpen: false }).then(
+    _refreshDashboardOptionsSummary,
+  );
   const skillSel = document.getElementById("dashboard-skill");
-  _paintSkillSelect(skillSel, { freshOnOpen: false });
+  _paintSkillSelect(skillSel, { freshOnOpen: false }).then(
+    _refreshDashboardOptionsSummary,
+  );
 
   // Project picker — paint from the warm cache then refresh-and-repaint (also
   // feeds the rail's group-by-project). Dashboard quick-create is ALWAYS a fresh
@@ -1551,13 +1571,17 @@ function _loadDashboardOptionsLists() {
   const projSel = document.getElementById("dashboard-project");
   const projLabel = document.querySelector('label[for="dashboard-project"]');
   const projHint = projLabel ? projLabel.querySelector(".label-hint") : null;
-  _paintProjectPicker(projSel, projHint, { fork: false });
+  _paintProjectPicker(projSel, projHint, { fork: false }).then(
+    _refreshDashboardOptionsSummary,
+  );
 
   // Persona picker — via the shared wrapper; the dashboard is a persistent panel
   // so freshOnOpen:false (preserve a pick across a repaint), kind default when
   // nothing valid is selected.
   const personaSel = document.getElementById("dashboard-persona");
-  _paintPersonaSelect(personaSel, { freshOnOpen: false });
+  _paintPersonaSelect(personaSel, { freshOnOpen: false }).then(
+    _refreshDashboardOptionsSummary,
+  );
 }
 
 // localStorage key for the dashboard composer's Options-panel disclosure

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -336,27 +336,26 @@ function showNewWsModal(forkFromWsId) {
   if (skillLabel) skillLabel.hidden = !!_forkFromWsId;
   if (skillSelect) skillSelect.hidden = !!_forkFromWsId;
 
-  // Model + judge pickers — paint from the warm models cache first, then
-  // refresh-and-repaint.  The modal keeps the plain static "Default …"
-  // placeholders (annotate:false); the dashboard annotates with the resolved
-  // default.  On a cold cache the sync paint is a no-op the refresh fills.
+  // Model + judge pickers — HIDDEN for a fork: a fork inherits its source's
+  // model + judge (like skill/persona/project), and submitNewWs gates both on
+  // !_forkFromWsId.  For a fresh create, paint from the warm cache with the
+  // resolved-default annotation ("Default — gpt-5"), FRESH on open (the reused
+  // dialog has no prior pick to carry over), then refresh-and-repaint.
+  const modelLabel = document.querySelector('label[for="new-ws-model"]');
+  const judgeLabel = document.querySelector('label[for="new-ws-judge-model"]');
   const modelSelect = document.getElementById("new-ws-model");
   const judgeSelect = document.getElementById("new-ws-judge-model");
-  _populateModelSelect(modelSelect, judgeSelect, { annotate: false });
-  if (window.TurnstoneModels) {
-    window.TurnstoneModels.refreshModels().then(function () {
-      _populateModelSelect(modelSelect, judgeSelect, { annotate: false });
-    });
+  if (modelLabel) modelLabel.hidden = !!_forkFromWsId;
+  if (judgeLabel) judgeLabel.hidden = !!_forkFromWsId;
+  if (modelSelect) modelSelect.hidden = !!_forkFromWsId;
+  if (judgeSelect) judgeSelect.hidden = !!_forkFromWsId;
+  if (!_forkFromWsId) {
+    _paintModelSelects(modelSelect, judgeSelect, { freshOnOpen: true });
   }
 
-  // Skill picker — same paint-from-cache-then-refresh.
+  // Skill picker — paint fresh-on-open from the warm cache, then refresh.
   const tplSelect = document.getElementById("new-ws-skill");
-  _populateSkillSelect(tplSelect);
-  if (window.TurnstoneSkills) {
-    window.TurnstoneSkills.refreshSkills().then(function () {
-      _populateSkillSelect(tplSelect);
-    });
-  }
+  _paintSkillSelect(tplSelect, { freshOnOpen: true });
 
   // Project picker — populated from the shared projects cache, refreshed on
   // open. Fresh creates SHOW it; forks HIDE it — a fork's project is its
@@ -378,7 +377,10 @@ function showNewWsModal(forkFromWsId) {
   // refresh-and-repaint — shared with the dashboard via _paintProjectPicker so
   // the two can't drift; skips for a fork (its picker is hidden above,
   // inheritance is server-enforced).
-  _paintProjectPicker(projSelect, projHint, { fork: !!_forkFromWsId });
+  _paintProjectPicker(projSelect, projHint, {
+    fork: !!_forkFromWsId,
+    freshOnOpen: true,
+  });
 
   // Persona picker — hidden when forking (a fork resumes the source's
   // stamped persona; the create handler skips resolution on resume_ws).
@@ -387,13 +389,13 @@ function showNewWsModal(forkFromWsId) {
   if (personaLabel) personaLabel.hidden = !!_forkFromWsId;
   if (personaSelect) personaSelect.hidden = !!_forkFromWsId;
   if (personaSelect && !_forkFromWsId && window.TurnstonePersonas) {
-    // Sync paint from the warm cache first, then refresh-and-repaint to catch a
-    // persona created elsewhere. _populatePersonaSelect preserves a mid-window
-    // pick and only applies the kind default when nothing valid is selected, so
-    // the second (async) paint can't clobber the user's choice.
-    _populatePersonaSelect(personaSelect);
+    // Fresh-on-open sync paint (renders the kind default; the reused dialog has
+    // no prior pick to carry over), then refresh-and-repaint. The async paint
+    // passes fresh:false so it preserves a mid-window pick and only re-applies
+    // the kind default when nothing valid is selected.
+    _populatePersonaSelect(personaSelect, { fresh: true });
     window.TurnstonePersonas.refreshPersonas().then(function () {
-      _populatePersonaSelect(personaSelect);
+      _populatePersonaSelect(personaSelect, { fresh: false });
     });
   }
 
@@ -471,9 +473,12 @@ function _ensureStandaloneProjectCreator(sel) {
 // — this dialog only creates interactive workstreams), preselecting the kind
 // default so a zero-touch create behaves exactly like today.  No-op when the
 // personas bridge is absent (module still loading / pre-seed database).
-function _populatePersonaSelect(sel) {
+function _populatePersonaSelect(sel, opts) {
   if (!sel || !window.TurnstonePersonas) return;
-  const previous = sel.value;
+  // A fresh modal open has no prior selection to preserve — render the kind
+  // default; a repaint (fresh=false) keeps a mid-window pick.
+  const fresh = !!(opts && opts.fresh);
+  const previous = fresh ? "" : sel.value;
   const placeholder = sel.options.length ? sel.options[0] : null;
   sel.replaceChildren();
   if (placeholder) sel.appendChild(placeholder);
@@ -518,37 +523,66 @@ function _optionExists(sel, val) {
 // #867 strict-picker invariant (never auto-select a real project) holds on each.
 function _paintProjectPicker(sel, hint, opts) {
   if ((opts && opts.fork) || !sel || !window.TurnstoneProjects) return;
-  const paint = function () {
+  // paint(fresh): a fresh open renders the actual default (no prior selection);
+  // the async repaint MUST pass fresh=false, or it clobbers a project the user
+  // picked during the refresh round-trip — under require_project that reconciles
+  // the select back to "" and submit then sends no project -> a 400.
+  const paint = function (fresh) {
     const strict = !!window.TurnstoneProjects.requireProject();
     if (hint) hint.textContent = strict ? "required" : "optional";
-    _populateProjectSelect(sel, { requireProject: strict });
+    _populateProjectSelect(sel, { requireProject: strict, fresh: fresh });
   };
-  paint(); // sync from the warm cache (no-op when cold; the async fills it)
-  window.TurnstoneProjects.refreshProjects().then(paint);
+  const freshOnOpen = !!(opts && opts.freshOnOpen);
+  paint(freshOnOpen); // sync from the warm cache (no-op when cold; the async fills it)
+  window.TurnstoneProjects.refreshProjects().then(function () {
+    paint(false);
+  });
 }
 
-// Fill the model + judge-model <select>s from the shared models cache.  One
-// list feeds BOTH selects with the same "alias (model)" labels; each keeps its
-// own static "Default …" placeholder (option 0) and its own preserved pick.
-// When opts.annotate is set (the dashboard) the placeholders show the
-// server-resolved default alias; the modal passes annotate:false and keeps the
-// plain static text.  No-op when the models bridge is absent (still loading) —
-// the async refresh then fills it, exactly as before this cache existed.
+// Paint the model + judge pickers from the warm cache then refresh-and-repaint,
+// collapsing the identical sync-then-refresh dance the modal and dashboard both
+// need (mirrors _paintProjectPicker).  freshOnOpen renders the actual defaults on
+// a reused-dialog open; the async repaint ALWAYS preserves (fresh:false) so a
+// mid-window pick survives.  The populate helper no-ops when the bridge/select is
+// absent (cold cache -> the async refresh fills it, never worse than before).
+function _paintModelSelects(modelSel, judgeSel, opts) {
+  const freshOnOpen = !!(opts && opts.freshOnOpen);
+  _populateModelSelect(modelSel, judgeSel, { fresh: freshOnOpen });
+  if (window.TurnstoneModels) {
+    window.TurnstoneModels.refreshModels().then(function () {
+      _populateModelSelect(modelSel, judgeSel, { fresh: false });
+    });
+  }
+}
+
+// Skill twin of _paintModelSelects.
+function _paintSkillSelect(sel, opts) {
+  const freshOnOpen = !!(opts && opts.freshOnOpen);
+  _populateSkillSelect(sel, { fresh: freshOnOpen });
+  if (window.TurnstoneSkills) {
+    window.TurnstoneSkills.refreshSkills().then(function () {
+      _populateSkillSelect(sel, { fresh: false });
+    });
+  }
+}
+
+// Fill the model + judge-model <select>s from the shared models cache.  One list
+// feeds BOTH selects with the same "alias (model)" labels; each placeholder is
+// annotated with the server-resolved default alias ("Default — gpt-5"), resolved
+// once via the cache's modelLabel.  A fresh open renders the default (no prior
+// selection); a repaint preserves each select's mid-window pick independently.
+// No-op when the models bridge is absent (still loading) — the async refresh then
+// fills it, exactly as before this cache existed.
 function _populateModelSelect(modelSel, judgeSel, opts) {
   if (!modelSel || !window.TurnstoneModels) return;
-  const annotate = !!(opts && opts.annotate);
+  const fresh = !!(opts && opts.fresh);
   const M = window.TurnstoneModels;
   const choices = M.modelChoices();
   const defaults = M.modelDefaults();
-  const models = M.getModels();
-  const prevModel = modelSel.value;
-  const prevJudge = judgeSel ? judgeSel.value : "";
-  const modelDefault = annotate
-    ? _resolveModelLabel(defaults.default_alias || "", models)
-    : "";
-  const judgeDefault = annotate
-    ? _resolveModelLabel(defaults.judge_default_alias || "", models)
-    : "";
+  const prevModel = fresh ? "" : modelSel.value;
+  const prevJudge = fresh || !judgeSel ? "" : judgeSel.value;
+  const modelDefault = M.modelLabel(defaults.default_alias || "");
+  const judgeDefault = M.modelLabel(defaults.judge_default_alias || "");
   modelSel.textContent = "";
   _appendOption(
     modelSel,
@@ -569,10 +603,11 @@ function _populateModelSelect(modelSel, judgeSel, opts) {
     _appendOption(modelSel, c.value, c.text, false);
     if (judgeSel) _appendOption(judgeSel, c.value, c.text, false);
   });
-  // Preserve a mid-window pick on EACH select independently so the async
-  // repaint can't clobber a fast user's choice.
-  if (prevModel && _optionExists(modelSel, prevModel))
+  // Preserve a mid-window pick on EACH select independently so the async repaint
+  // can't clobber a fast user's choice (a fresh open zeroed both above).
+  if (prevModel && _optionExists(modelSel, prevModel)) {
     modelSel.value = prevModel;
+  }
   if (judgeSel && prevJudge && _optionExists(judgeSel, prevJudge)) {
     judgeSel.value = prevJudge;
   }
@@ -583,9 +618,10 @@ function _populateModelSelect(modelSel, judgeSel, opts) {
 // ui label appends " [MCP]" for MCP-origin skills (the console launcher does
 // not — which is why the cache returns raw rows).  No-op when the bridge is
 // absent.
-function _populateSkillSelect(sel) {
+function _populateSkillSelect(sel, opts) {
   if (!sel || !window.TurnstoneSkills) return;
-  const previous = sel.value;
+  const fresh = !!(opts && opts.fresh);
+  const previous = fresh ? "" : sel.value;
   sel.textContent = "";
   _appendOption(sel, "", "Use defaults", false);
   window.TurnstoneSkills.getSkills().forEach(function (t) {
@@ -615,10 +651,15 @@ function _populateSkillSelect(sel) {
 function _populateProjectSelect(sel, opts) {
   if (!sel || !window.TurnstoneProjects) return;
   const mode = opts || sel._projMode || {};
-  sel._projMode = mode;
+  // Stamp ONLY the picker mode onto the element (the inline "+ New project…"
+  // creator's no-opts repaint reuses it); `fresh` is read from the LIVE opts
+  // per-call and deliberately NOT stamped, so a fresh:true modal open can't
+  // persist into a later preserve-repaint.
+  sel._projMode = { requireProject: !!mode.requireProject };
   const strict = !!mode.requireProject;
+  const fresh = !!(opts && opts.fresh);
   _ensureStandaloneProjectCreator(sel);
-  const previous = sel.value;
+  const previous = fresh ? "" : sel.value;
   const choices = window.TurnstoneProjects.projectChoices();
   sel.replaceChildren();
   if (!strict) {
@@ -687,8 +728,10 @@ function submitNewWs() {
   const initEl = document.getElementById("new-ws-initial-message");
   const initial_message = initEl ? initEl.value.trim() : "";
   if (name) body.name = name;
-  if (model) body.model = model;
-  if (judge_model) body.judge_model = judge_model;
+  // Forks inherit their source's model + judge (the selects are hidden for a
+  // fork), so never override them — matches the skill/persona/project fork guards.
+  if (model && !_forkFromWsId) body.model = model;
+  if (judge_model && !_forkFromWsId) body.judge_model = judge_model;
   if (skill && !_forkFromWsId) body.skill = skill;
   // Only a FRESH create sends a project_id; a fork's project is its source's,
   // enforced server-side (the picker is hidden for forks, and any explicit pid is
@@ -1450,46 +1493,18 @@ function _refreshDashboardSubmitLabel() {
   btn.textContent = hasText || hasFiles ? "Send" : "Create";
 }
 
-// Format a resolved alias with its model suffix the same way as the
-// dropdown rows ("alias (model)", or just "alias" when they coincide).
-// Returns "" when alias is empty or unknown so callers fall back to a
-// neutral placeholder.
-function _resolveModelLabel(alias, models) {
-  if (!alias) return "";
-  for (let i = 0; i < (models || []).length; i++) {
-    const m = models[i];
-    if (m.alias === alias) {
-      return m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
-    }
-  }
-  return "";
-}
-
 function _loadDashboardOptionsLists() {
-  // Models — paint from the warm cache (placeholders annotated with the
-  // server-resolved default alias) then refresh-and-repaint.  Previously
-  // fetch-once (guarded on options.length); now refresh-on-open via the
-  // coalesced models cache, matching the project/persona pickers.
+  // Models + skills — paint from the warm cache (model placeholders annotated
+  // with the server-resolved default) then refresh-and-repaint, via the shared
+  // wrappers (same paths the modal uses).  The dashboard composer is persistent
+  // (not a reused dialog), so freshOnOpen:false — it preserves a pick across a
+  // repaint.  Previously fetch-once (guarded on options.length); now
+  // refresh-on-open via the coalesced caches, matching the project/persona pickers.
   const modelSel = document.getElementById("dashboard-model");
   const judgeSel = document.getElementById("dashboard-judge-model");
-  if (modelSel) {
-    _populateModelSelect(modelSel, judgeSel, { annotate: true });
-    if (window.TurnstoneModels) {
-      window.TurnstoneModels.refreshModels().then(function () {
-        _populateModelSelect(modelSel, judgeSel, { annotate: true });
-      });
-    }
-  }
-  // Skills — same paint-from-cache-then-refresh.
+  _paintModelSelects(modelSel, judgeSel, { freshOnOpen: false });
   const skillSel = document.getElementById("dashboard-skill");
-  if (skillSel) {
-    _populateSkillSelect(skillSel);
-    if (window.TurnstoneSkills) {
-      window.TurnstoneSkills.refreshSkills().then(function () {
-        _populateSkillSelect(skillSel);
-      });
-    }
-  }
+  _paintSkillSelect(skillSel, { freshOnOpen: false });
 
   // Project picker — paint from the warm cache then refresh-and-repaint (also
   // feeds the rail's group-by-project). Dashboard quick-create is ALWAYS a fresh

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -336,67 +336,27 @@ function showNewWsModal(forkFromWsId) {
   if (skillLabel) skillLabel.hidden = !!_forkFromWsId;
   if (skillSelect) skillSelect.hidden = !!_forkFromWsId;
 
-  // Populate model dropdown
+  // Model + judge pickers — paint from the warm models cache first, then
+  // refresh-and-repaint.  The modal keeps the plain static "Default …"
+  // placeholders (annotate:false); the dashboard annotates with the resolved
+  // default.  On a cold cache the sync paint is a no-op the refresh fills.
   const modelSelect = document.getElementById("new-ws-model");
   const judgeSelect = document.getElementById("new-ws-judge-model");
-  const curModel = ""; // (focused-pane model prefill was PaneManager-only; dead in the L-shell)
-  modelSelect.textContent = "";
-  judgeSelect.textContent = "";
-  const defaultOpt = document.createElement("option");
-  defaultOpt.value = "";
-  defaultOpt.textContent = curModel
-    ? "Default (" + curModel + ")"
-    : "Default model";
-  modelSelect.appendChild(defaultOpt);
-  const defJudgeOpt = document.createElement("option");
-  defJudgeOpt.value = "";
-  defJudgeOpt.textContent = "Default (agent model)";
-  judgeSelect.appendChild(defJudgeOpt);
-  authFetch("/v1/api/models")
-    .then(function (r) {
-      return r.json();
-    })
-    .then(function (data) {
-      (data.models || []).forEach(function (m) {
-        const opt = document.createElement("option");
-        opt.value = m.alias;
-        opt.textContent =
-          m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
-        modelSelect.appendChild(opt);
-
-        const judgeOpt = document.createElement("option");
-        judgeOpt.value = m.alias;
-        judgeOpt.textContent = opt.textContent;
-        judgeSelect.appendChild(judgeOpt);
-      });
-    })
-    .catch(function () {
-      /* ignore — default model still works */
+  _populateModelSelect(modelSelect, judgeSelect, { annotate: false });
+  if (window.TurnstoneModels) {
+    window.TurnstoneModels.refreshModels().then(function () {
+      _populateModelSelect(modelSelect, judgeSelect, { annotate: false });
     });
+  }
 
+  // Skill picker — same paint-from-cache-then-refresh.
   const tplSelect = document.getElementById("new-ws-skill");
-  const tplDefaultOpt = document.createElement("option");
-  tplDefaultOpt.value = "";
-  tplDefaultOpt.textContent = "Use defaults";
-  tplSelect.replaceChildren(tplDefaultOpt);
-  authFetch("/v1/api/skills")
-    .then(function (r) {
-      return r.json();
-    })
-    .then(function (data) {
-      (data.skills || []).forEach(function (t) {
-        const opt = document.createElement("option");
-        opt.value = t.name;
-        let label = t.name;
-        if (t.is_default) label += " (default)";
-        if (t.origin === "mcp") label += " [MCP]";
-        opt.textContent = label;
-        tplSelect.appendChild(opt);
-      });
-    })
-    .catch(function () {
-      /* ignore */
+  _populateSkillSelect(tplSelect);
+  if (window.TurnstoneSkills) {
+    window.TurnstoneSkills.refreshSkills().then(function () {
+      _populateSkillSelect(tplSelect);
     });
+  }
 
   // Project picker — populated from the shared projects cache, refreshed on
   // open. Fresh creates SHOW it; forks HIDE it — a fork's project is its
@@ -565,6 +525,76 @@ function _paintProjectPicker(sel, hint, opts) {
   };
   paint(); // sync from the warm cache (no-op when cold; the async fills it)
   window.TurnstoneProjects.refreshProjects().then(paint);
+}
+
+// Fill the model + judge-model <select>s from the shared models cache.  One
+// list feeds BOTH selects with the same "alias (model)" labels; each keeps its
+// own static "Default …" placeholder (option 0) and its own preserved pick.
+// When opts.annotate is set (the dashboard) the placeholders show the
+// server-resolved default alias; the modal passes annotate:false and keeps the
+// plain static text.  No-op when the models bridge is absent (still loading) —
+// the async refresh then fills it, exactly as before this cache existed.
+function _populateModelSelect(modelSel, judgeSel, opts) {
+  if (!modelSel || !window.TurnstoneModels) return;
+  const annotate = !!(opts && opts.annotate);
+  const M = window.TurnstoneModels;
+  const choices = M.modelChoices();
+  const defaults = M.modelDefaults();
+  const models = M.getModels();
+  const prevModel = modelSel.value;
+  const prevJudge = judgeSel ? judgeSel.value : "";
+  const modelDefault = annotate
+    ? _resolveModelLabel(defaults.default_alias || "", models)
+    : "";
+  const judgeDefault = annotate
+    ? _resolveModelLabel(defaults.judge_default_alias || "", models)
+    : "";
+  modelSel.textContent = "";
+  _appendOption(
+    modelSel,
+    "",
+    modelDefault ? "Default — " + modelDefault : "Default model",
+    false,
+  );
+  if (judgeSel) {
+    judgeSel.textContent = "";
+    _appendOption(
+      judgeSel,
+      "",
+      judgeDefault ? "Default — " + judgeDefault : "Default (agent model)",
+      false,
+    );
+  }
+  choices.forEach(function (c) {
+    _appendOption(modelSel, c.value, c.text, false);
+    if (judgeSel) _appendOption(judgeSel, c.value, c.text, false);
+  });
+  // Preserve a mid-window pick on EACH select independently so the async
+  // repaint can't clobber a fast user's choice.
+  if (prevModel && _optionExists(modelSel, prevModel))
+    modelSel.value = prevModel;
+  if (judgeSel && prevJudge && _optionExists(judgeSel, prevJudge)) {
+    judgeSel.value = prevJudge;
+  }
+}
+
+// Fill a skill <select> from the shared skills cache, keeping the static
+// "Use defaults" placeholder (option 0) and preserving a mid-window pick.  The
+// ui label appends " [MCP]" for MCP-origin skills (the console launcher does
+// not — which is why the cache returns raw rows).  No-op when the bridge is
+// absent.
+function _populateSkillSelect(sel) {
+  if (!sel || !window.TurnstoneSkills) return;
+  const previous = sel.value;
+  sel.textContent = "";
+  _appendOption(sel, "", "Use defaults", false);
+  window.TurnstoneSkills.getSkills().forEach(function (t) {
+    let label = t.name;
+    if (t.is_default) label += " (default)";
+    if (t.origin === "mcp") label += " [MCP]";
+    _appendOption(sel, t.name, label, false);
+  });
+  if (previous && _optionExists(sel, previous)) sel.value = previous;
 }
 
 // Fill a project <select> from the shared projects cache.  The picker MODE is
@@ -1436,76 +1466,29 @@ function _resolveModelLabel(alias, models) {
 }
 
 function _loadDashboardOptionsLists() {
-  // Models
+  // Models — paint from the warm cache (placeholders annotated with the
+  // server-resolved default alias) then refresh-and-repaint.  Previously
+  // fetch-once (guarded on options.length); now refresh-on-open via the
+  // coalesced models cache, matching the project/persona pickers.
   const modelSel = document.getElementById("dashboard-model");
   const judgeSel = document.getElementById("dashboard-judge-model");
-  if (modelSel && modelSel.options.length <= 1) {
-    authFetch("/v1/api/models")
-      .then(function (r) {
-        return r.json();
-      })
-      .then(function (data) {
-        (data.models || []).forEach(function (m) {
-          const opt = document.createElement("option");
-          opt.value = m.alias;
-          opt.textContent =
-            m.alias === m.model ? m.alias : m.alias + " (" + m.model + ")";
-          modelSel.appendChild(opt);
-          if (judgeSel) {
-            const jOpt = document.createElement("option");
-            jOpt.value = m.alias;
-            jOpt.textContent = opt.textContent;
-            judgeSel.appendChild(jOpt);
-          }
-        });
-        // Surface the resolved defaults in the placeholder rows so the
-        // panel shows which model actually runs when left untouched —
-        // mirrors the coordinator launcher.  The judge tracks the
-        // per-workstream agent model unless judge.model is explicitly
-        // configured, so keep the "(agent model)" wording in that case
-        // rather than advertising a fixed alias the judge won't use.
-        const modelDefault = _resolveModelLabel(
-          data.default_alias || "",
-          data.models || [],
-        );
-        modelSel.options[0].textContent = modelDefault
-          ? "Default — " + modelDefault
-          : "Default model";
-        if (judgeSel) {
-          const judgeDefault = _resolveModelLabel(
-            data.judge_default_alias || "",
-            data.models || [],
-          );
-          judgeSel.options[0].textContent = judgeDefault
-            ? "Default — " + judgeDefault
-            : "Default (agent model)";
-        }
-      })
-      .catch(function () {
-        /* default model still works */
+  if (modelSel) {
+    _populateModelSelect(modelSel, judgeSel, { annotate: true });
+    if (window.TurnstoneModels) {
+      window.TurnstoneModels.refreshModels().then(function () {
+        _populateModelSelect(modelSel, judgeSel, { annotate: true });
       });
+    }
   }
-  // Skills
+  // Skills — same paint-from-cache-then-refresh.
   const skillSel = document.getElementById("dashboard-skill");
-  if (skillSel && skillSel.options.length <= 1) {
-    authFetch("/v1/api/skills")
-      .then(function (r) {
-        return r.json();
-      })
-      .then(function (data) {
-        (data.skills || []).forEach(function (t) {
-          const opt = document.createElement("option");
-          opt.value = t.name;
-          let label = t.name;
-          if (t.is_default) label += " (default)";
-          if (t.origin === "mcp") label += " [MCP]";
-          opt.textContent = label;
-          skillSel.appendChild(opt);
-        });
-      })
-      .catch(function () {
-        /* ignore */
+  if (skillSel) {
+    _populateSkillSelect(skillSel);
+    if (window.TurnstoneSkills) {
+      window.TurnstoneSkills.refreshSkills().then(function () {
+        _populateSkillSelect(skillSel);
       });
+    }
   }
 
   // Project picker — paint from the warm cache then refresh-and-repaint (also

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -545,46 +545,59 @@ function _paintProjectPicker(sel, hint, opts) {
   });
 }
 
-// Paint the model + judge pickers from the warm cache then refresh-and-repaint,
-// collapsing the identical sync-then-refresh dance the modal and dashboard both
-// need (mirrors _paintProjectPicker).  freshOnOpen renders the actual defaults on
-// a reused-dialog open; the async repaint ALWAYS preserves (fresh:false) so a
-// mid-window pick survives.  The populate helper no-ops when the bridge/select is
-// absent (cold cache -> the async refresh fills it, never worse than before).
-function _paintModelSelects(modelSel, judgeSel, opts) {
-  const freshOnOpen = !!(opts && opts.freshOnOpen);
-  _populateModelSelect(modelSel, judgeSel, { fresh: freshOnOpen });
-  if (window.TurnstoneModels) {
-    window.TurnstoneModels.refreshModels().then(function () {
-      _populateModelSelect(modelSel, judgeSel, { fresh: false });
+// One chokepoint for the composer paint discipline, shared by the three
+// cache-backed wrappers below (mirrors _paintProjectPicker, which keeps its own
+// tail — fork/hint logic): sync-paint NOW from the warm cache, then
+// refresh-and-repaint.  The sync paint mirrors the caller's freshOnOpen (a
+// reused-dialog open renders the actual defaults); the async repaint is ALWAYS
+// fresh:false — it must preserve a pick made during the fetch window, never
+// re-blank.  `refresh` may be absent (bridge module still loading): the
+// populate helpers no-op without their bridge and the refresh is skipped —
+// never worse than the pre-cache behavior.
+function _paintFromCache(refresh, repaint, opts) {
+  repaint(!!(opts && opts.freshOnOpen));
+  if (refresh) {
+    refresh().then(function () {
+      repaint(false);
     });
   }
+}
+
+// Paint the model + judge pickers from the warm cache then refresh-and-repaint,
+// collapsing the identical sync-then-refresh dance the modal and dashboard both
+// need.
+function _paintModelSelects(modelSel, judgeSel, opts) {
+  _paintFromCache(
+    window.TurnstoneModels && window.TurnstoneModels.refreshModels,
+    function (fresh) {
+      _populateModelSelect(modelSel, judgeSel, { fresh: fresh });
+    },
+    opts,
+  );
 }
 
 // Skill twin of _paintModelSelects.
 function _paintSkillSelect(sel, opts) {
-  const freshOnOpen = !!(opts && opts.freshOnOpen);
-  _populateSkillSelect(sel, { fresh: freshOnOpen });
-  if (window.TurnstoneSkills) {
-    window.TurnstoneSkills.refreshSkills().then(function () {
-      _populateSkillSelect(sel, { fresh: false });
-    });
-  }
+  _paintFromCache(
+    window.TurnstoneSkills && window.TurnstoneSkills.refreshSkills,
+    function (fresh) {
+      _populateSkillSelect(sel, { fresh: fresh });
+    },
+    opts,
+  );
 }
 
-// Persona twin of _paintModelSelects (fourth composer picker on the same shape,
-// so the modal + dashboard don't maintain the persona sync-then-refresh dance
-// two different ways).  _populatePersonaSelect keeps the kind default when
-// nothing valid is selected, so the async fresh:false repaint can't clobber a
-// mid-window pick.
+// Persona twin of _paintModelSelects.  _populatePersonaSelect keeps the kind
+// default when nothing valid is selected, so the fresh:false repaint can't
+// clobber a mid-window pick.
 function _paintPersonaSelect(sel, opts) {
-  const freshOnOpen = !!(opts && opts.freshOnOpen);
-  _populatePersonaSelect(sel, { fresh: freshOnOpen });
-  if (window.TurnstonePersonas) {
-    window.TurnstonePersonas.refreshPersonas().then(function () {
-      _populatePersonaSelect(sel, { fresh: false });
-    });
-  }
+  _paintFromCache(
+    window.TurnstonePersonas && window.TurnstonePersonas.refreshPersonas,
+    function (fresh) {
+      _populatePersonaSelect(sel, { fresh: fresh });
+    },
+    opts,
+  );
 }
 
 // Fill the model + judge-model <select>s from the shared models cache.  One list
@@ -604,7 +617,7 @@ function _populateModelSelect(modelSel, judgeSel, opts) {
   const prevJudge = fresh || !judgeSel ? "" : judgeSel.value;
   const modelDefault = M.modelLabel(defaults.default_alias || "");
   const judgeDefault = M.modelLabel(defaults.judge_default_alias || "");
-  modelSel.textContent = "";
+  modelSel.replaceChildren();
   _appendOption(
     modelSel,
     "",
@@ -612,7 +625,7 @@ function _populateModelSelect(modelSel, judgeSel, opts) {
     false,
   );
   if (judgeSel) {
-    judgeSel.textContent = "";
+    judgeSel.replaceChildren();
     _appendOption(
       judgeSel,
       "",
@@ -643,7 +656,7 @@ function _populateSkillSelect(sel, opts) {
   if (!sel || !window.TurnstoneSkills) return;
   const fresh = !!(opts && opts.fresh);
   const previous = fresh ? "" : sel.value;
-  sel.textContent = "";
+  sel.replaceChildren();
   _appendOption(sel, "", "Use defaults", false);
   window.TurnstoneSkills.getSkills().forEach(function (t) {
     let label = t.name;

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -105,6 +105,12 @@ setInterval(pollHealth, 30000);
 // ===========================================================================
 
 window.onLoginSuccess = function () {
+  // Deferred (follow-up): a cold in-place login leaves the dashboard composer
+  // caches (models/skills/projects/personas) warmed pre-auth as empty (401 ->
+  // fail-open) until the Dashboard pane is re-focused (loadDashboard ->
+  // _loadDashboardOptionsLists) or the page reloads. The CONSOLE force-re-warms
+  // all four in its onLoginSuccess; the ui relies on the re-focus repaint and is
+  // NOT force-warmed here (out of the composer-cache scope) — revisit if it bites.
   initWorkstreams();
 };
 
@@ -353,9 +359,13 @@ function showNewWsModal(forkFromWsId) {
     _paintModelSelects(modelSelect, judgeSelect, { freshOnOpen: true });
   }
 
-  // Skill picker — paint fresh-on-open from the warm cache, then refresh.
+  // Skill picker — hidden for a fork (inherited + submit-gated), so skip its
+  // paint too (no wasted /v1/api/skills fetch + hidden-select rebuild); a fresh
+  // create paints fresh-on-open from the warm cache, then refreshes.
   const tplSelect = document.getElementById("new-ws-skill");
-  _paintSkillSelect(tplSelect, { freshOnOpen: true });
+  if (!_forkFromWsId) {
+    _paintSkillSelect(tplSelect, { freshOnOpen: true });
+  }
 
   // Project picker — populated from the shared projects cache, refreshed on
   // open. Fresh creates SHOW it; forks HIDE it — a fork's project is its
@@ -388,15 +398,11 @@ function showNewWsModal(forkFromWsId) {
   const personaSelect = document.getElementById("new-ws-persona");
   if (personaLabel) personaLabel.hidden = !!_forkFromWsId;
   if (personaSelect) personaSelect.hidden = !!_forkFromWsId;
-  if (personaSelect && !_forkFromWsId && window.TurnstonePersonas) {
-    // Fresh-on-open sync paint (renders the kind default; the reused dialog has
-    // no prior pick to carry over), then refresh-and-repaint. The async paint
-    // passes fresh:false so it preserves a mid-window pick and only re-applies
-    // the kind default when nothing valid is selected.
-    _populatePersonaSelect(personaSelect, { fresh: true });
-    window.TurnstonePersonas.refreshPersonas().then(function () {
-      _populatePersonaSelect(personaSelect, { fresh: false });
-    });
+  // Fresh-on-open (the reused dialog has no prior pick); the async repaint
+  // preserves a mid-window pick and re-applies the kind default only when nothing
+  // valid is selected.  Shared with the dashboard via _paintPersonaSelect.
+  if (!_forkFromWsId) {
+    _paintPersonaSelect(personaSelect, { freshOnOpen: true });
   }
 
   document.getElementById("new-ws-name").value = "";
@@ -566,6 +572,21 @@ function _paintSkillSelect(sel, opts) {
   }
 }
 
+// Persona twin of _paintModelSelects (fourth composer picker on the same shape,
+// so the modal + dashboard don't maintain the persona sync-then-refresh dance
+// two different ways).  _populatePersonaSelect keeps the kind default when
+// nothing valid is selected, so the async fresh:false repaint can't clobber a
+// mid-window pick.
+function _paintPersonaSelect(sel, opts) {
+  const freshOnOpen = !!(opts && opts.freshOnOpen);
+  _populatePersonaSelect(sel, { fresh: freshOnOpen });
+  if (window.TurnstonePersonas) {
+    window.TurnstonePersonas.refreshPersonas().then(function () {
+      _populatePersonaSelect(sel, { fresh: false });
+    });
+  }
+}
+
 // Fill the model + judge-model <select>s from the shared models cache.  One list
 // feeds BOTH selects with the same "alias (model)" labels; each placeholder is
 // annotated with the server-resolved default alias ("Default — gpt-5"), resolved
@@ -728,8 +749,13 @@ function submitNewWs() {
   const initEl = document.getElementById("new-ws-initial-message");
   const initial_message = initEl ? initEl.value.trim() : "";
   if (name) body.name = name;
-  // Forks inherit their source's model + judge (the selects are hidden for a
-  // fork), so never override them — matches the skill/persona/project fork guards.
+  // Forks DELIBERATELY inherit their source's model + judge: the selects are
+  // hidden for a fork (showNewWsModal) and never sent here — matching the
+  // skill/persona/project fork guards. A fork resumes the source session
+  // (resume_ws), which already carries its model, so there is intentionally no
+  // fork model/judge override. Do NOT drop these !_forkFromWsId guards without
+  // also un-hiding the selects (a bare gate-removal ships a hidden-select's stale
+  // value).
   if (model && !_forkFromWsId) body.model = model;
   if (judge_model && !_forkFromWsId) body.judge_model = judge_model;
   if (skill && !_forkFromWsId) body.skill = skill;
@@ -1514,17 +1540,11 @@ function _loadDashboardOptionsLists() {
   const projHint = projLabel ? projLabel.querySelector(".label-hint") : null;
   _paintProjectPicker(projSel, projHint, { fork: false });
 
-  // Persona picker — same paint-from-cache-then-refresh policy; kind default
-  // preselected so a zero-touch launch behaves exactly like today.
+  // Persona picker — via the shared wrapper; the dashboard is a persistent panel
+  // so freshOnOpen:false (preserve a pick across a repaint), kind default when
+  // nothing valid is selected.
   const personaSel = document.getElementById("dashboard-persona");
-  if (personaSel && window.TurnstonePersonas) {
-    // Sync paint first, then refresh-and-repaint; the helper preserves a mid-
-    // window pick and only applies the kind default when nothing valid is chosen.
-    _populatePersonaSelect(personaSel);
-    window.TurnstonePersonas.refreshPersonas().then(function () {
-      _populatePersonaSelect(personaSel);
-    });
-  }
+  _paintPersonaSelect(personaSel, { freshOnOpen: false });
 }
 
 // localStorage key for the dashboard composer's Options-panel disclosure

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -660,6 +660,8 @@
     <script type="module" src="/shared/toast.js"></script>
     <script type="module" src="/shared/projects.js"></script>
     <script type="module" src="/shared/personas.js"></script>
+    <script type="module" src="/shared/models.js"></script>
+    <script type="module" src="/shared/skills.js"></script>
     <script type="module" src="/shared/project_creator.js"></script>
     <script type="module" src="/shared/composer.js"></script>
     <script type="module" src="/shared/composer_attachments.js"></script>


### PR DESCRIPTION
The model and skill composer pickers had no client cache: the new-ws modal, the
dashboard quick-create, and the console launcher each re-fetched /v1/api/models
and /v1/api/skills inline on every open, flashing an empty dropdown for the
round-trip even though the data was usually already in memory. Add shared caches
(models.js, skills.js) the composers read SYNCHRONOUSLY, then refresh-and-repaint
— the pattern the project/persona pickers already use.

The coalescing / fail-open refresh / change-detection / window-bridge machinery
was ~70% duplicated between projects.js and personas.js. Extract it once into
list_cache.js (makeListCache) and retrofit projects.js + personas.js onto it,
preserving their full public surface byte-for-byte (rail.js + project_creator.js
import them by name; the classic bundles read the window bridges). The
require_project advisory rides projects.js as fail-open `extra` state; personas
keep their kind-filtered choices and name->label map.

models.js carries BOTH server schemas (the node sends default_alias, the console
sends coordinator_default_alias; both send judge_default_alias) so each app reads
its own, and folds them into the fingerprint so a role-alias change still fires
onChange. skills.js returns raw rows (the ui pickers add a " [MCP]" suffix the
console omits). Selection is preserved across the sync->async repaint on every
select, including model + judge independently.

Also: the dashboard model/skill fetch-once guard is dropped (refresh-on-open now,
matching project/persona); the console re-warms models on login too (the boot
pass runs pre-auth, so the dropdown used to stay empty until a reload); and
models_changed repaints via the single refresh wrapper (no double path).