### PR TITLE
SSE recovery: lossless truncated replay, chunk batching, MessageEvent cursor capture + e2e harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       # -v lists each test id as it starts (pytest prints the nodeid at
       # logstart), so a hang names the culprit on the last line instead of
       # riding the job timeout with only a trail of "..." dots.
-      - run: pytest tests/ -m "not live" --cov=turnstone --cov-report=term-missing --cov-report=xml -v
+      - run: pytest tests/ -m "not live and not e2e_recovery" --cov=turnstone --cov-report=term-missing --cov-report=xml -v
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
@@ -90,7 +90,7 @@ jobs:
         with:
           node-version: "24"
       - run: pip install -e ".[test]"
-      - run: pytest tests/ -m "not live" --storage-backend=postgresql -v
+      - run: pytest tests/ -m "not live and not e2e_recovery" --storage-backend=postgresql -v
         env:
           TURNSTONE_TEST_PG_URL: postgresql+psycopg://postgres:postgres@localhost:5432/turnstone_test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ testpaths = ["tests"]
 markers = [
     "live: requires a running LLM backend",
     "allow_thread_leak: test intentionally leaves a background thread running (opts out of the leaked-thread guard)",
+    "e2e_recovery: opt-in end-to-end SSE recovery harness (real server + real SSE consumers, scripted provider); tens of seconds each, deselected from the fast default suite. Co-marked ``live`` so the CI ``-m 'not live'`` run skips them; select with ``-m e2e_recovery``.",
 ]
 filterwarnings = [
     # mcp v1 deprecates streamablehttp_client for an entry point whose call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ testpaths = ["tests"]
 markers = [
     "live: requires a running LLM backend",
     "allow_thread_leak: test intentionally leaves a background thread running (opts out of the leaked-thread guard)",
-    "e2e_recovery: opt-in end-to-end SSE recovery harness (real server + real SSE consumers, scripted provider); tens of seconds each, deselected from the fast default suite. Co-marked ``live`` so the CI ``-m 'not live'`` run skips them; select with ``-m e2e_recovery``.",
+    "e2e_recovery: opt-in end-to-end SSE recovery harness (real server + real SSE consumers, scripted provider — NOT live, no LLM backend needed); tens of seconds each. CI lanes run ``-m 'not live and not e2e_recovery'``; select with ``-m e2e_recovery``.",
 ]
 filterwarnings = [
     # mcp v1 deprecates streamablehttp_client for an entry point whose call

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -27,19 +27,21 @@ the page asserts the final DOM has the expected top-level tool rows, the
 task_agent card nests its sub-tool rows (NO child escaped to the top
 level), and the composer settles idle. Stamps ``RECOVERY-READY-STORM-<n>``.
 
-Scenario B (hide -> restart -> show): the page runs a turn, the runner
-hides the tab (interactive.js closes the stream), restarts the node on the
-SAME port (fresh empty ring, storage-seeded counter), then shows the tab;
-the pane reconnects to the restarted node, the committed transcript stays
-intact, and the composer settles idle. Stamps ``RECOVERY-READY-RESTART``.
-
-The specific ``replay_truncated`` envelope is NOT asserted at the browser
-level here: it needs a browser cursor below the restarted node's seeded
-counter, and Chrome's ``EventSource`` tracks that cursor internally only on
-its native auto-reconnect (not on the close-on-hide reconnect, which opens
-a fresh stream). The truncated -> lost_count -> /history-cursor rebuild is
-proven deterministically at the server-contract level in Tier 1's
-``test_restart_truncated_honesty`` / ``test_failed_resync_retries_via_truncation_record``.
+Scenario B (hide mid-turn -> restart -> show): the runner hides the tab
+the moment the first streamed line paints (freezing the pane's cursor at
+a mid-turn event id — the MessageEvent ``lastEventId`` capture is what
+makes that cursor real; the pre-2026-07 object-form read left it null and
+this whole path unassertable), lets the turn and a follow-up text commit
+while hidden, restarts the node on the SAME port (fresh empty ring,
+storage-seeded counter), then shows the tab.  The show-edge reconnect
+presents the stale cursor, MUST draw ``replay_truncated`` (asserted:
+trunc>=1), the truncated resync rebuilds from /history, and the turns
+committed during the hide window MUST be present afterwards (asserted:
+``healed`` — the 'turn disappeared' field symptom).  Stamps
+``RECOVERY-READY-RESTART-rows<n>-trunc<n>``.  The exact ``lost_count``
+arithmetic and the failed-resync retry stay at the server-contract level
+in Tier 1's ``test_restart_truncated_honesty`` /
+``test_failed_resync_retries_via_truncation_record``.
 
 A NOTE ON THE BROWSER OVERFLOW (server-side poison): a real listener-queue
 poison needs the browser to STOP reading the socket so TCP backpressure
@@ -81,6 +83,13 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+# Healed-gap sentinel for scenario B: injected as the scripted turn-2 text
+# AND threaded to the page via ``?healed=`` (read into ``healedSentinel``),
+# so the injected text and the DOM check share one definition.  Must never
+# collide with rendered command/output text — the bash command row paints
+# its shell source verbatim, which contains the keyword ``done``.
+HEALED_SENTINEL = "HEALED-e5b1"
+
 # ---------------------------------------------------------------------------
 # The recovery page — served same-origin by the node at /recovery.
 # ---------------------------------------------------------------------------
@@ -117,6 +126,9 @@ PAGE_HTML = r"""<!doctype html>
       const wsId = q.get("ws_id");
       const scenario = q.get("scenario") || "storm";
       const expectRows = parseInt(q.get("rows") || "4", 10);
+      // Healed-gap sentinel, threaded from the runner (HEALED_SENTINEL)
+      // so the injected turn text and this check cannot drift apart.
+      const healedSentinel = q.get("healed") || "";
 
       // REAL pane against THIS origin (base=""): real authFetch (cookie) and
       // real EventSource. The default host provides all SSE seams.
@@ -212,24 +224,41 @@ PAGE_HTML = r"""<!doctype html>
           return origHandle(ev);
         };
         window.__verifyRestart = function () {
-          // Browser-level restart RECOVERY: after the node restarts on the
-          // same port, the pane reconnects (status bar not stuck
-          // disconnected), the committed transcript is intact, and the
-          // composer settles idle. (The specific ``replay_truncated``
-          // envelope requires a browser cursor below the restarted node's
-          // seeded counter; Chrome's EventSource tracks that cursor
-          // internally only on its native auto-reconnect, so it is proven
-          // deterministically at the server-contract level in Tier 1's
-          // test_restart_truncated_honesty. ``__truncatedSeen`` is recorded
-          // here for the runs where it does fire.)
+          // Browser-level restart RECOVERY, full contract: the runner hid
+          // the tab MID-turn (cursor frozen below the commits that land
+          // while hidden), so the show-edge reconnect must present the
+          // stale cursor and draw ``replay_truncated`` (REQUIRED since the
+          // MessageEvent lastEventId capture fix — the pre-fix object-form
+          // read left manual reconnects cursorless and this envelope
+          // unreachable, which is why trunc used to report 0), the
+          // truncated resync must rebuild from /history, and the turns
+          // committed DURING the hide window must be present afterwards
+          // (``healed`` — the 'turn disappeared' field symptom).  Composer
+          // idle, status bar not stuck disconnected.
           const c = domCounts();
           const idle = !pane.busy;
           const disc = document.querySelector(".ws-sb-disconnected") !== null;
-          document.title =
-            c.topLevel >= 1 && idle && !disc
-              ? "RECOVERY-READY-RESTART-rows" + c.topLevel + "-trunc" + window.__truncatedSeen
-              : "RECOVERY-FAILED-RESTART-rows" + c.topLevel +
-                "-busy" + (pane.busy ? 1 : 0) + "-disc" + (disc ? 1 : 0);
+          // Sentinel must be collision-proof against everything else the
+          // transcript renders: the paced bash COMMAND row paints its
+          // shell text verbatim (buildConvCmd), which contains the
+          // keyword ``done`` — a plain-word sentinel is vacuously
+          // present whether or not the hidden-window turn survived.
+          // The value rides the ?healed= param (single source:
+          // HEALED_SENTINEL in the runner).
+          const healed =
+            healedSentinel !== "" &&
+            (pane.messagesEl.textContent || "").includes(healedSentinel);
+          const ok =
+            c.topLevel >= 1 &&
+            idle &&
+            !disc &&
+            healed &&
+            window.__truncatedSeen >= 1;
+          document.title = ok
+            ? "RECOVERY-READY-RESTART-rows" + c.topLevel + "-trunc" + window.__truncatedSeen
+            : "RECOVERY-FAILED-RESTART-rows" + c.topLevel +
+              "-busy" + (pane.busy ? 1 : 0) + "-disc" + (disc ? 1 : 0) +
+              "-healed" + (healed ? 1 : 0) + "-trunc" + window.__truncatedSeen;
         };
       }
     </script>
@@ -514,31 +543,54 @@ def run_restart(chrome: str) -> str:
 
     port = _free_port()
     node = _boot_node(port=port)
-    # A PACED turn so the tab can hide MID-turn (browser cursor below the
-    # committed counter) -> the post-restart reconnect draws truncated.
+    # A PACED turn so the tab can hide MID-turn: the browser cursor
+    # freezes at a mid-stream event id, the rest of turn 1 plus the
+    # turn-2 text commit while hidden, and the restarted node's seeded
+    # counter therefore sits ABOVE the frozen cursor -> the show-edge
+    # reconnect draws ``replay_truncated`` and must heal the gap.
     paced = parallel_bash_script({"r0": "for i in $(seq 1 40); do echo r-$i; sleep 0.05; done"})
-    ws_id = node.create_workstream(paced, final_text_script("done"), name="browser-restart")
+    # The turn-2 text is the healed-gap sentinel — it must be a token
+    # that cannot appear in any rendered command/output (the bash
+    # command row contains the shell keyword ``done``, so the obvious
+    # word is vacuously present; see __verifyRestart).  Single source:
+    # the same constant is injected as the scripted turn text AND
+    # threaded to the page via ?healed=, so the two sides cannot drift.
+    ws_id = node.create_workstream(
+        paced, final_text_script(HEALED_SENTINEL), name="browser-restart"
+    )
     profile = Path(_scratch()) / "chrome-restart"
     proc, cdp_port = _launch_chrome(chrome, profile)
     cdp: CDP | None = None
     try:
         cdp = CDP(_page_ws_url(cdp_port))
-        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=restart"
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=restart&healed={HEALED_SENTINEL}"
         _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
-        node.wait_turn(ws_id, timeout=30)  # the turn renders into the DOM
-        time.sleep(0.5)
-        # Hide the tab -> interactive.js closes the stream (close-on-hide).
+        # Hide as soon as the FIRST streamed line has painted (proof the
+        # pane holds a live mid-turn cursor) — NOT after wait_turn, which
+        # would leave the cursor at/above the committed counter and the
+        # reconnect on the lossless replay_ok path (trunc0).
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            painted = cdp.evaluate("document.querySelector('.tool-output-stream') !== null")
+            if painted:
+                break
+            time.sleep(0.2)
+        else:
+            raise AssertionError("restart scenario: first streamed line never painted")
         cdp.evaluate("window.__hide && window.__hide()")
+        # The turn (and the follow-up text) commits while the tab is hidden.
+        node.wait_turn(ws_id, timeout=30)
         # Restart the node on the SAME port (fresh empty ring, seeded counter).
         node.stop()
         node = _boot_node(port=port)
         node.open_workstream(ws_id)
-        # Show the tab -> the pane reconnects to the restarted node and recovers.
-        # The reconnect + any resync carries jitter, so settle before the verdict.
+        # Show the tab -> stale-cursor reconnect -> truncated -> jittered
+        # resync (0-10s) -> /history rebuild.  Settle past the worst-case
+        # jitter before the verdict.
         cdp.evaluate("window.__show && window.__show()")
-        time.sleep(9.0)
+        time.sleep(12.0)
         cdp.evaluate("window.__verifyRestart && window.__verifyRestart()")
-        return _poll_title(cdp, 15)
+        return _poll_title(cdp, 20)
     finally:
         if cdp is not None:
             cdp.close()

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Browser-level SSE recovery livepass — boots the REAL interactive.js
+``InteractivePane`` against a REAL Turnstone node and drives the two
+headline recovery scenarios through headless Chrome over CDP, stamping
+``document.title`` verdicts (``RECOVERY-READY-*`` / ``RECOVERY-FAILED-*``)
+the livepass convention.
+
+Unlike ``scripts/livepass.py`` (which stubs ``window.authFetch`` with
+canned fixtures), this page uses the REAL auth + REAL EventSource against a
+REAL node: the page is served same-origin by the node itself (so cookie
+auth and EventSource just work), the node runs a scripted-provider
+workstream so a REST ``/send`` drives a real bash storm, and the pane's
+own state machine (interactive.js) does the recovery.
+
+Usage::
+
+    python3 scripts/recovery_e2e.py                 # run both scenarios
+    python3 scripts/recovery_e2e.py --scenario storm
+    python3 scripts/recovery_e2e.py --scenario restart
+    python3 scripts/recovery_e2e.py --keep-open 8971  # serve the storm page
+                                                      # for manual inspection
+
+Scenario A (storm): the page connects, POSTs ``/send`` on stream-open (so
+the listener is registered first), the node runs a 4-parallel-bash
+``seq 1 500`` storm plus a task_agent whose sub-tools are chatty bashes;
+the page asserts the final DOM has the expected top-level tool rows, the
+task_agent card nests its sub-tool rows (NO child escaped to the top
+level), and the composer settles idle. Stamps ``RECOVERY-READY-STORM-<n>``.
+
+Scenario B (hide -> restart -> show): the page runs a turn, the runner
+hides the tab (interactive.js closes the stream), restarts the node on the
+SAME port (fresh empty ring, storage-seeded counter), then shows the tab;
+the pane reconnects to the restarted node, the committed transcript stays
+intact, and the composer settles idle. Stamps ``RECOVERY-READY-RESTART``.
+
+The specific ``replay_truncated`` envelope is NOT asserted at the browser
+level here: it needs a browser cursor below the restarted node's seeded
+counter, and Chrome's ``EventSource`` tracks that cursor internally only on
+its native auto-reconnect (not on the close-on-hide reconnect, which opens
+a fresh stream). The truncated -> lost_count -> /history-cursor rebuild is
+proven deterministically at the server-contract level in Tier 1's
+``test_restart_truncated_honesty`` / ``test_failed_resync_retries_via_truncation_record``.
+
+A NOTE ON THE BROWSER OVERFLOW (server-side poison): a real listener-queue
+poison needs the browser to STOP reading the socket so TCP backpressure
+reaches the server. A backgrounded/CPU-throttled tab does NOT do this --
+Chrome's network stack keeps draining the socket regardless of JS
+throttling, and interactive.js deliberately CLOSES the stream on tab-hide
+rather than starving it. So the server-side overflow -> stream_overflow ->
+reconnect path is NOT reliably forcible from a real browser (which is why
+that field bug was subtle); it is proven at the server-contract level in
+``tests/test_sse_recovery_e2e.py::test_slow_consumer_overflow_then_lossless_reconnect``.
+Scenario A here proves the OTHER half at the browser level: fix-3's
+de-amplified storm renders correctly with no escaped sub-agent children.
+
+MANUAL RUNBOOK (if Chrome/CDP is unavailable): run this with
+``--keep-open PORT`` to boot the node + serve the storm page, open the
+printed URL in a browser (the script prints the auth cookie to set), and
+watch ``document.title``. For the restart scenario, boot with a fixed
+port, load the restart page, background the tab, restart the node
+(``RecoveryServer`` on the same port), foreground the tab, and watch the
+title settle to ``RECOVERY-READY-RESTART``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import json
+import os
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# ---------------------------------------------------------------------------
+# The recovery page — served same-origin by the node at /recovery.
+# ---------------------------------------------------------------------------
+
+PAGE_HTML = r"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>recovery livepass</title>
+    <link rel="stylesheet" href="/shared/base.css" />
+    <link rel="stylesheet" href="/shared/ui-base.css" />
+    <link rel="stylesheet" href="/shared/chat.css" />
+    <link rel="stylesheet" href="/shared/conversation.css" />
+    <link rel="stylesheet" href="/shared/cards.css" />
+    <link rel="stylesheet" href="/shared/interactive.css" />
+    <style>
+      body { margin: 0; background: var(--bg); color: var(--ink); }
+      #mount { height: 100vh; display: flex; }
+      #mount > * { flex: 1; min-height: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="header"><div id="status-bar"></div></div>
+    <div id="mount"></div>
+    <script>
+      // Minimal globals interactive.js reads on the standalone path.
+      window.showToast = function (m) { console.log("toast:", m); };
+      window.showLogin = function () {};
+    </script>
+    <script type="module">
+      import { InteractivePane } from "/shared/interactive.js";
+
+      const q = new URLSearchParams(location.search);
+      const wsId = q.get("ws_id");
+      const scenario = q.get("scenario") || "storm";
+      const expectRows = parseInt(q.get("rows") || "4", 10);
+
+      // REAL pane against THIS origin (base=""): real authFetch (cookie) and
+      // real EventSource. The default host provides all SSE seams.
+      const pane = new InteractivePane(wsId, { base: "" });
+      document.getElementById("mount").appendChild(pane.el);
+      pane.wsId = wsId;
+      window.__pane = pane;
+
+      window.__hide = function () {
+        Object.defineProperty(document, "hidden", { configurable: true, value: true });
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+        document.dispatchEvent(new Event("visibilitychange"));
+      };
+      window.__show = function () {
+        Object.defineProperty(document, "hidden", { configurable: true, value: false });
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+        document.dispatchEvent(new Event("visibilitychange"));
+      };
+
+      // Count top-level tool rows and escaped sub-agent children.
+      function domCounts() {
+        const topRows = pane.messagesEl.querySelectorAll(
+          ".conv-batch > .conv-row[data-call-id]"
+        );
+        let topLevel = 0;
+        let escapedChildren = 0;
+        topRows.forEach((r) => {
+          const cid = r.dataset.callId || "";
+          if (cid.includes("::")) escapedChildren += 1;  // a child at the top level
+          else topLevel += 1;
+        });
+        const agentCard = pane.messagesEl.querySelector(".conv-agent");
+        const nested = pane.messagesEl.querySelectorAll(
+          ".conv-agent .conv-row[data-call-id]"
+        ).length;
+        return { topLevel, escapedChildren, agentCard: !!agentCard, nested };
+      }
+
+      let sent = false;
+      function sendOnce(msg) {
+        if (sent) return;
+        sent = true;
+        // The pane's SSE is open (host.onStreamOpen fired), so the listener is
+        // registered before this /send -- no missed events.
+        window
+          .authFetch("/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message: msg }),
+          })
+          .catch((e) => { document.title = "RECOVERY-FAILED-send-" + e; });
+      }
+
+      // Drive /send once the stream is live (wrap the default host hook).
+      const origOpen = pane._host.onStreamOpen.bind(pane._host);
+      pane._host.onStreamOpen = function (p) {
+        origOpen(p);
+        window.__streamOpen = (window.__streamOpen || 0) + 1;
+        if (scenario === "storm") sendOnce("run the storm");
+        else if (scenario === "restart" && window.__streamOpen === 1) sendOnce("run a turn");
+      };
+
+      // First paint the REAL way: /history then connect SSE.
+      pane._loadHistoryThenConnect(wsId);
+
+      if (scenario === "storm") {
+        const deadline = Date.now() + 40000;
+        const poll = () => {
+          const c = domCounts();
+          const idle = !pane.busy;
+          if (c.topLevel >= expectRows && c.agentCard && c.nested >= 2 && idle) {
+            document.title = c.escapedChildren
+              ? "RECOVERY-FAILED-escaped-" + c.escapedChildren
+              : "RECOVERY-READY-STORM-" + c.topLevel + "-nested-" + c.nested;
+            return;
+          }
+          if (Date.now() > deadline) {
+            document.title =
+              "RECOVERY-FAILED-STORM-top" + c.topLevel + "-agent" + (c.agentCard ? 1 : 0) +
+              "-nested" + c.nested + "-escaped" + c.escapedChildren + "-busy" + (pane.busy ? 1 : 0);
+            return;
+          }
+          setTimeout(poll, 200);
+        };
+        setTimeout(poll, 400);
+      } else if (scenario === "restart") {
+        // The runner drives hide -> (restart node) -> show via window.__hide/
+        // __show. We watch for the truncated-triggered rebuild + idle settle.
+        window.__truncatedSeen = 0;
+        const origHandle = pane.handleEvent.bind(pane);
+        pane.handleEvent = function (ev) {
+          if (ev && ev.type === "replay_truncated") window.__truncatedSeen += 1;
+          return origHandle(ev);
+        };
+        window.__verifyRestart = function () {
+          // Browser-level restart RECOVERY: after the node restarts on the
+          // same port, the pane reconnects (status bar not stuck
+          // disconnected), the committed transcript is intact, and the
+          // composer settles idle. (The specific ``replay_truncated``
+          // envelope requires a browser cursor below the restarted node's
+          // seeded counter; Chrome's EventSource tracks that cursor
+          // internally only on its native auto-reconnect, so it is proven
+          // deterministically at the server-contract level in Tier 1's
+          // test_restart_truncated_honesty. ``__truncatedSeen`` is recorded
+          // here for the runs where it does fire.)
+          const c = domCounts();
+          const idle = !pane.busy;
+          const disc = document.querySelector(".ws-sb-disconnected") !== null;
+          document.title =
+            c.topLevel >= 1 && idle && !disc
+              ? "RECOVERY-READY-RESTART-rows" + c.topLevel + "-trunc" + window.__truncatedSeen
+              : "RECOVERY-FAILED-RESTART-rows" + c.topLevel +
+                "-busy" + (pane.busy ? 1 : 0) + "-disc" + (disc ? 1 : 0);
+        };
+      }
+    </script>
+  </body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Minimal dependency-free CDP client (WebSocket over a raw socket).
+# ---------------------------------------------------------------------------
+
+
+class CDP:
+    """Just enough Chrome DevTools Protocol: navigate, evaluate, set cookie."""
+
+    def __init__(self, ws_url: str) -> None:
+        from urllib.parse import urlsplit
+
+        u = urlsplit(ws_url)
+        self._sock = socket.create_connection((u.hostname, u.port or 80), timeout=10)
+        key = base64.b64encode(os.urandom(16)).decode()
+        path = u.path + (f"?{u.query}" if u.query else "")
+        handshake = (
+            f"GET {path} HTTP/1.1\r\nHost: {u.hostname}:{u.port}\r\n"
+            f"Upgrade: websocket\r\nConnection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+        )
+        self._sock.sendall(handshake.encode())
+        resp = b""
+        while b"\r\n\r\n" not in resp:
+            resp += self._sock.recv(4096)
+        if b" 101 " not in resp.split(b"\r\n", 1)[0]:
+            raise RuntimeError(f"CDP websocket handshake failed: {resp[:80]!r}")
+        self._id = 0
+        self._rbuf = b""
+
+    def _send(self, payload: bytes) -> None:
+        header = bytearray([0x81])  # FIN + text opcode
+        mask = os.urandom(4)
+        n = len(payload)
+        if n < 126:
+            header.append(0x80 | n)
+        elif n < 65536:
+            header.append(0x80 | 126)
+            header += struct.pack(">H", n)
+        else:
+            header.append(0x80 | 127)
+            header += struct.pack(">Q", n)
+        header += mask
+        self._sock.sendall(bytes(header) + bytes(b ^ mask[i % 4] for i, b in enumerate(payload)))
+
+    def _recv_exact(self, n: int) -> bytes:
+        while len(self._rbuf) < n:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                raise ConnectionError("CDP socket closed")
+            self._rbuf += chunk
+        out, self._rbuf = self._rbuf[:n], self._rbuf[n:]
+        return out
+
+    def _recv_message(self) -> str:
+        data = b""
+        while True:
+            b0, b1 = self._recv_exact(2)
+            fin = b0 & 0x80
+            length = b1 & 0x7F
+            if length == 126:
+                length = struct.unpack(">H", self._recv_exact(2))[0]
+            elif length == 127:
+                length = struct.unpack(">Q", self._recv_exact(8))[0]
+            data += self._recv_exact(length)
+            if fin:
+                return data.decode("utf-8", "replace")
+
+    def cmd(self, method: str, params: dict[str, Any] | None = None, timeout: float = 15) -> Any:
+        self._id += 1
+        mid = self._id
+        self._send(json.dumps({"id": mid, "method": method, "params": params or {}}).encode())
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._sock.settimeout(max(0.1, deadline - time.monotonic()))
+            obj = json.loads(self._recv_message())
+            if obj.get("id") == mid:
+                if "error" in obj:
+                    raise RuntimeError(f"{method}: {obj['error']}")
+                return obj.get("result", {})
+        raise TimeoutError(method)
+
+    def evaluate(self, expression: str) -> Any:
+        r = self.cmd(
+            "Runtime.evaluate",
+            {"expression": expression, "returnByValue": True, "awaitPromise": True},
+        )
+        return r.get("result", {}).get("value")
+
+    def title(self) -> str:
+        return str(self.evaluate("document.title") or "")
+
+    def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self._sock.close()
+
+
+# ---------------------------------------------------------------------------
+# Chrome launch + node boot
+# ---------------------------------------------------------------------------
+
+
+def _find_chrome() -> str | None:
+    for name in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+        p = shutil.which(name)
+        if p:
+            return p
+    return None
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _launch_chrome(chrome: str, profile: Path) -> tuple[subprocess.Popen[bytes], int]:
+    cdp_port = _free_port()
+    proc = subprocess.Popen(
+        [
+            chrome,
+            "--headless=new",
+            "--disable-gpu",
+            "--no-sandbox",
+            "--no-first-run",
+            "--disable-extensions",
+            "--disable-background-timer-throttling",
+            f"--remote-debugging-port={cdp_port}",
+            f"--user-data-dir={profile}",
+            "about:blank",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc, cdp_port
+
+
+def _page_ws_url(cdp_port: int, timeout: float = 15) -> str:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{cdp_port}/json", timeout=2) as r:
+                targets = json.loads(r.read())
+            for t in targets:
+                if t.get("type") == "page" and t.get("webSocketDebuggerUrl"):
+                    return str(t["webSocketDebuggerUrl"])
+        except Exception:
+            pass
+        time.sleep(0.2)
+    raise TimeoutError("no CDP page target")
+
+
+def _page_route() -> Any:
+    from starlette.responses import HTMLResponse
+    from starlette.routing import Route
+
+    async def recovery_page(_request: Any) -> HTMLResponse:
+        return HTMLResponse(PAGE_HTML)
+
+    return Route("/recovery", recovery_page)
+
+
+def _boot_node(port: int = 0) -> Any:
+    from tests._sse_recovery_server import RecoveryServer
+    from turnstone.core.storage import init_storage, reset_storage
+
+    # The page route must bypass auth on first load (the cookie is set by the
+    # runner via CDP BEFORE navigation), so make it public by prefixing under
+    # a public path is unavailable here; instead the runner sets the cookie so
+    # /recovery passes the middleware. init storage per boot (shared singleton).
+    reset_storage()
+    init_storage("sqlite", path=os.path.join(_scratch(), "recovery_e2e.db"), run_migrations=True)
+    return RecoveryServer(extra_routes=[_page_route()], port=port)
+
+
+def _scratch() -> str:
+    d = os.environ.get("RECOVERY_E2E_TMP") or "/tmp/recovery_e2e"
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _set_cookie_and_navigate(cdp: CDP, base_url: str, token: str, page_url: str) -> None:
+    cdp.cmd("Page.enable")
+    cdp.cmd("Runtime.enable")
+    cdp.cmd("Network.enable")
+    cdp.cmd(
+        "Network.setCookie",
+        {
+            "name": "turnstone_auth_server",
+            "value": token,
+            "url": base_url,
+            "path": "/",
+        },
+    )
+    cdp.cmd("Page.navigate", {"url": page_url})
+
+
+def _poll_title(cdp: CDP, timeout: float) -> str:
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = cdp.title()
+        if last.startswith("RECOVERY-"):
+            return last
+        time.sleep(0.3)
+    return last or "RECOVERY-FAILED-timeout"
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+def _storm_scripts() -> tuple[Any, ...]:
+    """A parallel bash storm PLUS a task_agent whose sub-tools are chatty
+    bashes (so the browser proves both fix-3 batching AND sub-agent nesting
+    with no escaped children)."""
+    from tests._sse_recovery_server import final_text_script, parallel_bash_script
+
+    storm = parallel_bash_script({f"call_{i}": "seq 1 500" for i in range(4)})
+    task = dict(
+        tool_calls=[
+            {
+                "id": "task1",
+                "name": "task_agent",
+                "arguments": json.dumps({"prompt": "sub tools"}),
+            }
+        ],
+        finish_reason="tool_calls",
+    )
+    sub = dict(
+        tool_calls=[
+            {"id": "s_a", "name": "bash", "arguments": json.dumps({"command": ": a; seq 1 200"})},
+            {"id": "s_b", "name": "bash", "arguments": json.dumps({"command": ": b; seq 1 200"})},
+        ],
+        finish_reason="tool_calls",
+    )
+    # Turn 1: the 4-bash storm; turn 2: a task_agent with 2 chatty sub-bashes.
+    return (
+        storm,
+        final_text_script("storm done"),
+        task,
+        sub,
+        final_text_script("sub done"),
+        final_text_script("all done"),
+    )
+
+
+def run_storm(chrome: str) -> str:
+    node = _boot_node()
+    ws_id = node.create_workstream(*_storm_scripts(), name="browser-storm")
+    profile = Path(_scratch()) / "chrome-storm"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        # The page POSTs the STORM turn on stream-open; the runner sends the
+        # task_agent follow-up once the first turn settles so both land.
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=storm&rows=4"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # After the storm turn, trigger the task_agent turn via REST so the
+        # page renders the nested sub-agent card.
+        _wait_state(node, ws_id, "idle", 40)
+        node.send(ws_id, "spawn the sub agent")
+        return _poll_title(cdp, 45)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def run_restart(chrome: str) -> str:
+    from tests._sse_recovery_server import final_text_script, parallel_bash_script
+
+    port = _free_port()
+    node = _boot_node(port=port)
+    # A PACED turn so the tab can hide MID-turn (browser cursor below the
+    # committed counter) -> the post-restart reconnect draws truncated.
+    paced = parallel_bash_script({"r0": "for i in $(seq 1 40); do echo r-$i; sleep 0.05; done"})
+    ws_id = node.create_workstream(paced, final_text_script("done"), name="browser-restart")
+    profile = Path(_scratch()) / "chrome-restart"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=restart"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        node.wait_turn(ws_id, timeout=30)  # the turn renders into the DOM
+        time.sleep(0.5)
+        # Hide the tab -> interactive.js closes the stream (close-on-hide).
+        cdp.evaluate("window.__hide && window.__hide()")
+        # Restart the node on the SAME port (fresh empty ring, seeded counter).
+        node.stop()
+        node = _boot_node(port=port)
+        node.open_workstream(ws_id)
+        # Show the tab -> the pane reconnects to the restarted node and recovers.
+        # The reconnect + any resync carries jitter, so settle before the verdict.
+        cdp.evaluate("window.__show && window.__show()")
+        time.sleep(9.0)
+        cdp.evaluate("window.__verifyRestart && window.__verifyRestart()")
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def _wait_state(node: Any, ws_id: str, state: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if node.ws_state(ws_id) == state:
+            return
+        time.sleep(0.1)
+
+
+def _kill(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(8)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def keep_open(port: int) -> None:
+    """Boot the node + storm ws and serve the page for manual inspection."""
+    node = _boot_node(port=port)
+    ws_id = node.create_workstream(*_storm_scripts(), name="manual-storm")
+    print(f"node: {node.base_url}")
+    print(f"cookie: turnstone_auth_server={node.token}")
+    print(f"page:  {node.base_url}/recovery?ws_id={ws_id}&scenario=storm&rows=4")
+    print("set the cookie for this origin, then open the page. Ctrl+C to stop.")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        node.stop()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--scenario", choices=["storm", "restart", "both"], default="both")
+    ap.add_argument("--keep-open", type=int, metavar="PORT", help="serve the storm page, no CDP")
+    args = ap.parse_args()
+
+    if args.keep_open:
+        keep_open(args.keep_open)
+        return
+
+    chrome = _find_chrome()
+    if chrome is None:
+        print("recovery_e2e: no chrome/chromium on PATH — see the module docstring runbook")
+        raise SystemExit(2)
+
+    failures = 0
+    if args.scenario in ("storm", "both"):
+        verdict = run_storm(chrome)
+        print(f"scenario A (storm):   {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("restart", "both"):
+        verdict = run_restart(chrome)
+        print(f"scenario B (restart): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_sse_recovery_helpers.py
+++ b/tests/_sse_recovery_helpers.py
@@ -1,0 +1,604 @@
+"""Browser-fidelity SSE recovery harness helpers.
+
+The load-bearing assembly for ``tests/test_sse_recovery_e2e.py``: a
+``BrowserlikeSSEClient`` that speaks the exact wire contract the real
+``turnstone/shared_static/interactive.js`` pane speaks, and the
+assertion helpers the scenarios share. The server boot machinery lives
+in ``_sse_recovery_server.py``.
+
+Why a raw-socket SSE reader (and not ``httpx.stream``): the slow-consumer
+overflow scenario needs the consumer to STALL — stop reading the socket
+so the server's SSE generator blocks on ``await send`` and stops draining
+the per-UI listener queue, which then poisons at its cap. A faithful
+stall needs (a) precise control over when bytes are read and (b) a small
+``SO_RCVBUF`` so the in-flight backlog before poison stays bounded to
+~100 KB instead of the client kernel's multi-MB autotuned default (which
+would need tens of thousands of events to overflow). A raw socket gives
+both; httpx (used here only for the plain ``/history`` request/response)
+gives neither. This is ALSO closer to the browser: EventSource has a
+bounded receive buffer, not an unbounded one.
+
+Client contract mirrored from interactive.js (line references are to
+that file on the ``fix/sse-truncated-resync`` branch):
+
+- ``_last_event_id`` advances ONLY from SSE ``id:`` fields, and only
+  ring-buffer events carry one — synthetic replay frames (connected /
+  status / state_change / in_progress_snapshot / replay_truncated /
+  stream_overflow) do not, exactly like ``EventSource.lastEventId``
+  (interactive.js onmessage ~1378).
+- reconnect presents ``connectCursor = _truncatedFromCursor ??
+  _lastEventId`` as ``?last_event_id=`` (manual path) or a
+  ``Last-Event-ID`` header (native EventSource auto-reconnect path)
+  (interactive.js connectSSE ~1328).
+- on a ``replay_truncated`` envelope the client records the
+  truncation-time cursor keep-oldest (``_truncatedFromCursor =
+  _lastEventId`` only when null) and runs ``_loadHistoryThenConnect``
+  (disconnect → /history → adopt cursor → reconnect); a FAILED
+  /history leaves the record armed so the reconnect re-presents the
+  truncation-time cursor and re-draws the envelope (interactive.js
+  handleEvent replay_truncated ~2303, _loadHistoryThenConnect ~1604,
+  _refetchHistory seedCursor ~1706).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Small client receive buffer so a stalled consumer's in-flight backlog
+# before the server-side poison stays bounded (~100 KB) instead of the
+# multi-MB autotuned default. Paired with the server's small SO_SNDBUF
+# (see _sse_recovery_server.build_recovery_server).
+_CLIENT_RCVBUF = 2048
+
+
+@dataclass
+class SSEFrame:
+    """One decoded SSE frame, tagged with the connection it arrived on.
+
+    ``event_id`` is the ``id:`` field verbatim (a stringified integer,
+    or ``None`` for id-less synthetic frames — the same string domain as
+    ``EventSource.lastEventId``). ``etype`` is the ``type`` field of the
+    JSON ``data:`` payload (the application event type), distinct from
+    any SSE ``event:`` field, which the server never uses.
+    """
+
+    conn_index: int
+    event_id: str | None
+    etype: str | None
+    payload: dict[str, Any] | None
+    raw: str
+
+    @property
+    def event_id_int(self) -> int | None:
+        if self.event_id is None:
+            return None
+        try:
+            return int(self.event_id)
+        except ValueError:
+            return None
+
+
+class BrowserlikeSSEClient:
+    """A single interactive pane's SSE + /history state machine.
+
+    Not thread-safe against concurrent public calls; drive it from one
+    test thread. Internally a per-connection reader thread decodes the
+    stream; ``stall()`` / ``resume()`` gate that thread's socket reads so
+    a test can build server-side backpressure without closing the
+    connection (the slow-consumer → listener-queue-poison path).
+    """
+
+    def __init__(self, base_url: str, ws_id: str, token: str) -> None:
+        parts = urlsplit(base_url)
+        self._host = parts.hostname or "127.0.0.1"
+        self._port = parts.port or 80
+        self._ws_id = ws_id
+        self._token = token
+        self._auth = {"Authorization": f"Bearer {token}"}
+        self._http = httpx.Client(
+            base_url=f"http://{self._host}:{self._port}", timeout=httpx.Timeout(15.0)
+        )
+
+        # EventSource-equivalent cursor state.
+        self._last_event_id: str | None = None
+        self._truncated_from_cursor: str | None = None
+
+        # Transcript. ``_all_frames`` is the cross-connection accumulation
+        # (what "the client eventually saw"); ``_conn_frames`` keeps each
+        # connection's slice for per-connection assertions (contiguity).
+        self._all_frames: list[SSEFrame] = []
+        self._conn_frames: list[list[SSEFrame]] = []
+        self._frames_lock = threading.Lock()
+
+        # Reader plumbing.
+        self._sock: socket.socket | None = None
+        self._reader: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._read_gate = threading.Event()
+        self._read_gate.set()  # reading permitted by default
+        self._status: int | None = None
+        self._headers_done = threading.Event()
+
+    # -- connection lifecycle ------------------------------------------------
+
+    def _events_path(self, cursor: str | None) -> str:
+        path = f"/v1/api/workstreams/{self._ws_id}/events"
+        if cursor is not None:
+            path += f"?last_event_id={cursor}"
+        return path
+
+    def connect(self, *, native: bool = False, rcvbuf: int | None = None) -> None:
+        """Open the SSE stream, presenting the client's current cursor.
+
+        ``native=True`` models the browser's EventSource auto-reconnect:
+        the cursor rides a ``Last-Event-ID`` HEADER and never appears in
+        the URL. ``native=False`` models the manual ``new EventSource(url
+        + '?last_event_id=')`` path interactive.js uses when it must
+        override the live cursor (the ``connectCursor`` chokepoint).
+
+        ``rcvbuf`` shrinks this connection's ``SO_RCVBUF`` — pass
+        ``_CLIENT_RCVBUF`` on a connection the test will ``stall()`` so the
+        in-flight backlog before the server-side poison stays bounded.
+        Leave it ``None`` (OS default) on recovery reconnects so the ring
+        replay is not throttled to a crawl.
+        """
+        if self._reader is not None:
+            raise RuntimeError("already connected; disconnect() first")
+        connect_cursor = (
+            self._truncated_from_cursor
+            if self._truncated_from_cursor is not None
+            else self._last_event_id
+        )
+        header_lines = [
+            f"Host: {self._host}:{self._port}",
+            f"Authorization: Bearer {self._token}",
+            "Accept: text/event-stream",
+            "Cache-Control: no-cache",
+        ]
+        if native:
+            path = self._events_path(None)
+            if connect_cursor is not None:
+                header_lines.append(f"Last-Event-ID: {connect_cursor}")
+        else:
+            path = self._events_path(connect_cursor)
+        request = f"GET {path} HTTP/1.1\r\n" + "\r\n".join(header_lines) + "\r\n\r\n"
+
+        sock = socket.create_connection((self._host, self._port), timeout=10)
+        if rcvbuf is not None:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, rcvbuf)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sock.settimeout(None)
+        sock.sendall(request.encode())
+        self._sock = sock
+
+        self._stop.clear()
+        self._read_gate.set()
+        self._status = None
+        self._headers_done.clear()
+        conn_index = len(self._conn_frames)
+        frames: list[SSEFrame] = []
+        self._conn_frames.append(frames)
+        self._reader = threading.Thread(
+            target=self._read_loop,
+            args=(sock, conn_index, frames),
+            name=f"sse-reader-{self._ws_id[:6]}-{conn_index}",
+            daemon=True,
+        )
+        self._reader.start()
+
+        # Surface a non-200 handshake to the caller (409 half-built UI,
+        # 404 unknown ws, 401 auth) rather than silently reading nothing.
+        if not self._headers_done.wait(timeout=10):
+            self.disconnect()
+            raise AssertionError("events connect: no HTTP response headers")
+        if self._status != 200:
+            status = self._status
+            self.disconnect()
+            raise AssertionError(f"events connect returned HTTP {status}")
+
+    def disconnect(self) -> None:
+        """Close the stream and join the reader (leak-guard clean)."""
+        self._stop.set()
+        self._read_gate.set()  # release a stalled reader so it sees _stop
+        sock = self._sock
+        if sock is not None:
+            with contextlib.suppress(OSError):
+                sock.shutdown(socket.SHUT_RDWR)  # interrupt a blocked recv
+        reader = self._reader
+        if reader is not None:
+            reader.join(timeout=15)
+            if reader.is_alive():
+                raise AssertionError("SSE reader thread failed to stop")
+        if sock is not None:
+            with contextlib.suppress(OSError):
+                sock.close()
+        self._sock = None
+        self._reader = None
+
+    def close(self) -> None:
+        """Full teardown: disconnect any live stream + close the HTTP client."""
+        if self._reader is not None:
+            self.disconnect()
+        self._http.close()
+
+    # -- the stall gate (backpressure driver) --------------------------------
+
+    def stall(self) -> None:
+        """Stop reading the socket. The kernel + uvicorn send buffers fill,
+        blocking the server's SSE generator on its ``await send``, so it
+        stops draining the per-UI listener queue — which poisons at its cap.
+        """
+        self._read_gate.clear()
+
+    def resume(self) -> None:
+        """Resume reading. A poisoned-and-closed stream delivers its
+        ``stream_overflow`` farewell frame once the backlog drains."""
+        self._read_gate.set()
+
+    # -- reader --------------------------------------------------------------
+
+    def _read_loop(self, sock: socket.socket, conn_index: int, frames: list[SSEFrame]) -> None:
+        raw = b""  # undecoded bytes (headers, then chunked framing)
+        sse = b""  # decoded SSE byte stream
+        headers_parsed = False
+        chunked = False
+        while not self._stop.is_set():
+            # Backpressure gate: while stalled we do NOT read the socket, so
+            # its receive buffer fills and TCP flow control stalls the server.
+            if not self._read_gate.wait(timeout=0.1):
+                continue
+            if self._stop.is_set():
+                break
+            try:
+                chunk = sock.recv(65536)
+            except OSError:
+                break
+            if not chunk:
+                break  # server closed
+            raw += chunk
+            if not headers_parsed:
+                if b"\r\n\r\n" not in raw:
+                    continue
+                header_blob, raw = raw.split(b"\r\n\r\n", 1)
+                self._parse_headers(header_blob)
+                chunked = b"transfer-encoding: chunked" in header_blob.lower()
+                headers_parsed = True
+                self._headers_done.set()
+            if chunked:
+                decoded, raw = _dechunk(raw)
+                sse += decoded
+            else:
+                sse += raw
+                raw = b""
+            sse = sse.replace(b"\r\n", b"\n")
+            while b"\n\n" in sse:
+                block, sse = sse.split(b"\n\n", 1)
+                self._handle_block(block.decode("utf-8", "replace"), conn_index, frames)
+
+    def _parse_headers(self, header_blob: bytes) -> None:
+        first_line = header_blob.split(b"\r\n", 1)[0].decode("latin-1")
+        # "HTTP/1.1 200 OK"
+        parts = first_line.split(" ", 2)
+        if len(parts) >= 2 and parts[1].isdigit():
+            self._status = int(parts[1])
+
+    def _handle_block(self, block_text: str, conn_index: int, frames: list[SSEFrame]) -> None:
+        event_id: str | None = None
+        data_parts: list[str] = []
+        retry: str | None = None
+        for line in block_text.split("\n"):
+            if not line or line.startswith(":"):
+                continue  # blank or comment (ping)
+            field_name, _, value = line.partition(":")
+            if value.startswith(" "):
+                value = value[1:]  # SSE strips a single leading space
+            if field_name == "id":
+                event_id = value
+            elif field_name == "data":
+                data_parts.append(value)
+            elif field_name == "retry":
+                retry = value
+        # EventSource semantics: an event carrying an ``id:`` sets the
+        # last-event-id buffer; an event without one leaves it unchanged.
+        if event_id is not None:
+            self._last_event_id = event_id
+        if not data_parts:
+            if retry is not None:
+                self._record(SSEFrame(conn_index, None, "retry", None, block_text), frames)
+            return
+        data_str = "\n".join(data_parts)
+        payload: dict[str, Any] | None
+        try:
+            parsed = json.loads(data_str)
+            payload = parsed if isinstance(parsed, dict) else None
+        except ValueError:
+            payload = None
+        etype = payload.get("type") if payload is not None else None
+        frame = SSEFrame(conn_index, event_id, etype, payload, data_str)
+        self._record(frame, frames)
+        # Mirror the pane: the FIRST replay_truncated for an unrepaired gap
+        # records the truncation-time cursor (keep-oldest). Its consumer is
+        # the reconnect chokepoint (see ``connect``).
+        if etype == "replay_truncated" and self._truncated_from_cursor is None:
+            self._truncated_from_cursor = self._last_event_id
+
+    def _record(self, frame: SSEFrame, frames: list[SSEFrame]) -> None:
+        with self._frames_lock:
+            frames.append(frame)
+            self._all_frames.append(frame)
+
+    # -- /history + cursor flow ----------------------------------------------
+
+    def fetch_history(self) -> dict[str, Any]:
+        """GET /history and return the parsed JSON ({ws_id, messages, cursor})."""
+        r = self._http.get(f"/v1/api/workstreams/{self._ws_id}/history", headers=self._auth)
+        r.raise_for_status()
+        result: dict[str, Any] = r.json()
+        return result
+
+    def seed_from_history(self) -> dict[str, Any]:
+        """The seedCursor step: fetch /history, adopt a non-null resume
+        cursor into ``_last_event_id``, and clear the truncation record on
+        a successful render (replayHistory clears ``_truncatedFromCursor``).
+        """
+        data = self.fetch_history()
+        cursor = data.get("cursor")
+        if cursor is not None:
+            self._last_event_id = str(cursor)
+        self._truncated_from_cursor = None  # successful full render repairs the gap
+        return data
+
+    def load_history_then_connect(
+        self, *, fail_history: bool = False, native: bool = False
+    ) -> dict[str, Any] | None:
+        """Reproduce interactive.js ``_loadHistoryThenConnect``.
+
+        Disconnect first, drop the live cursor (``_last_event_id = None``)
+        but KEEP ``_truncated_from_cursor`` armed, then fetch /history and
+        reconnect. On success adopt the returned cursor and clear the
+        truncation record; on a FAILED /history (``fail_history`` — the
+        harness IS the client here, so a client-side simulated failure is
+        faithful) leave the record armed so the reconnect re-presents the
+        truncation-time cursor and re-draws ``replay_truncated``.
+
+        Returns the /history JSON, or ``None`` when the fetch failed.
+        """
+        if self._reader is not None:
+            self.disconnect()
+        self._last_event_id = None
+        data: dict[str, Any] | None
+        if fail_history:
+            data = None
+        else:
+            data = self.fetch_history()
+            cursor = data.get("cursor")
+            if cursor is not None:
+                self._last_event_id = str(cursor)
+            self._truncated_from_cursor = None
+        self.connect(native=native)
+        return data
+
+    # -- accessors + waits ---------------------------------------------------
+
+    @property
+    def last_event_id(self) -> str | None:
+        return self._last_event_id
+
+    @property
+    def truncated_from_cursor(self) -> str | None:
+        return self._truncated_from_cursor
+
+    def all_frames(self) -> list[SSEFrame]:
+        with self._frames_lock:
+            return list(self._all_frames)
+
+    def conn_frames(self, conn_index: int) -> list[SSEFrame]:
+        with self._frames_lock:
+            return list(self._conn_frames[conn_index])
+
+    def latest_conn_frames(self) -> list[SSEFrame]:
+        with self._frames_lock:
+            return list(self._conn_frames[-1]) if self._conn_frames else []
+
+    def num_connections(self) -> int:
+        with self._frames_lock:
+            return len(self._conn_frames)
+
+    def frames_of_type(self, etype: str) -> list[SSEFrame]:
+        return [f for f in self.all_frames() if f.etype == etype]
+
+    def has_type(self, etype: str) -> bool:
+        return any(f.etype == etype for f in self.all_frames())
+
+    def tool_output_by_call(self) -> dict[str, str]:
+        """Concatenate every ``tool_output_chunk`` payload per call_id, in
+        arrival order — the reconstructed live stream for each call."""
+        out: dict[str, str] = {}
+        for f in self.all_frames():
+            if f.etype == "tool_output_chunk" and f.payload is not None:
+                cid = str(f.payload.get("call_id", ""))
+                out[cid] = out.get(cid, "") + str(f.payload.get("chunk", ""))
+        return out
+
+    def tool_results_by_call(self) -> dict[str, str]:
+        """The last ``tool_result`` output seen per call_id."""
+        out: dict[str, str] = {}
+        for f in self.all_frames():
+            if f.etype == "tool_result" and f.payload is not None:
+                out[str(f.payload.get("call_id", ""))] = str(f.payload.get("output", ""))
+        return out
+
+    def wait_for_type(self, etype: str, *, timeout: float = 45.0) -> SSEFrame:
+        """Block until a frame of ``etype`` has arrived on ANY connection."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for f in self.all_frames():
+                if f.etype == etype:
+                    return f
+            time.sleep(0.05)
+        raise AssertionError(f"timed out waiting for a {etype!r} frame")
+
+    def wait_for(
+        self, predicate: Callable[[BrowserlikeSSEClient], bool], *, timeout: float = 45.0
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate(self):
+                return
+            time.sleep(0.05)
+        raise AssertionError("timed out waiting for predicate")
+
+    def wait_for_call_result(self, call_id: str, *, timeout: float = 45.0) -> None:
+        self.wait_for(lambda c: call_id in c.tool_results_by_call(), timeout=timeout)
+
+
+def _dechunk(buf: bytes) -> tuple[bytes, bytes]:
+    """Incrementally decode HTTP/1.1 chunked transfer-encoding.
+
+    Consumes as many COMPLETE chunks from ``buf`` as possible and returns
+    ``(decoded_bytes, remainder)`` where ``remainder`` is the trailing
+    partial chunk to carry into the next read. A zero-length chunk (stream
+    end) simply stops consumption; the reader's ``recv`` EOF handles close.
+    """
+    decoded = b""
+    while True:
+        if b"\r\n" not in buf:
+            break  # incomplete size line
+        size_line, rest = buf.split(b"\r\n", 1)
+        try:
+            n = int(size_line.strip() or b"z", 16)
+        except ValueError:
+            break  # malformed / partial — wait for more bytes
+        if n == 0:
+            break  # last chunk marker
+        if len(rest) < n + 2:  # need n data bytes + trailing CRLF
+            break
+        decoded += rest[:n]
+        buf = rest[n + 2 :]
+    return decoded, buf
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers (shared by the scenarios).
+# ---------------------------------------------------------------------------
+
+
+def assert_contiguous_ids(frames: list[SSEFrame]) -> None:
+    """Every id-bearing frame in a connection forms a gap-free, dup-free,
+    strictly increasing run.
+
+    Holds for a connection that took no ``_seq``-filtered fresh path — a
+    fresh connect made before any event (snap_seq == 0) and every
+    ``replay_ok`` reconnect (snap_seq == 0). The server stamps a fresh
+    monotonic id per enqueue with no in-ring coalescing, so a
+    non-filtered consumer sees consecutive ids.
+    """
+    ids = [f.event_id_int for f in frames if f.event_id_int is not None]
+    assert ids, "connection carried no id-bearing frames"
+    assert len(set(ids)) == len(ids), f"duplicate SSE ids: {ids}"
+    assert ids == sorted(ids), f"SSE ids not monotonic: {ids}"
+    for prev, cur in zip(ids, ids[1:], strict=False):
+        assert cur == prev + 1, f"gap in SSE ids between {prev} and {cur}: {ids}"
+
+
+def assert_ids_monotonic_no_dupes(frames: list[SSEFrame]) -> None:
+    """Weaker invariant that holds on EVERY connection (including
+    ``_seq``-filtered fresh/truncated paths, where gaps are legal): ids
+    are strictly increasing with no duplicates."""
+    ids = [f.event_id_int for f in frames if f.event_id_int is not None]
+    assert len(set(ids)) == len(ids), f"duplicate SSE ids: {ids}"
+    assert ids == sorted(ids), f"SSE ids not monotonic: {ids}"
+
+
+def assert_chunk_result_ordering(frames: list[SSEFrame]) -> None:
+    """Every ``tool_output_chunk`` for a call precedes that call's own
+    ``tool_result`` on the wire (the load-bearing ordering — the client
+    removes the streaming <pre> when it renders the result)."""
+    result_index: dict[str, int] = {}
+    for i, f in enumerate(frames):
+        if f.etype == "tool_result" and f.payload is not None:
+            result_index[str(f.payload.get("call_id", ""))] = i
+    for i, f in enumerate(frames):
+        if f.etype == "tool_output_chunk" and f.payload is not None:
+            cid = str(f.payload.get("call_id", ""))
+            assert cid in result_index, f"chunk for call {cid} has no tool_result"
+            assert i < result_index[cid], (
+                f"chunk for call {cid} arrived AFTER its tool_result "
+                f"(chunk idx {i} >= result idx {result_index[cid]})"
+            )
+
+
+def assert_children_stamped(frames: list[SSEFrame], parent_call_id: str) -> None:
+    """Every sub-agent child tool event carries ``parent_call_id`` (stamped
+    at the flush chokepoint). Sub-tool call_ids are minted
+    ``{parent}::r{run}s{step}::{provider_id}`` — the ``::`` segment is the
+    identifying mark — and NONE may escape unstamped to the top level."""
+    unstamped: list[tuple[str | None, str, Any]] = []
+    stamped = 0
+    for f in frames:
+        if f.payload is None:
+            continue
+        items = f.payload.get("items")
+        entries = items if isinstance(items, list) else [f.payload]
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            cid = str(entry.get("call_id", ""))
+            if "::" not in cid:
+                continue
+            if entry.get("parent_call_id") == parent_call_id:
+                stamped += 1
+            else:
+                unstamped.append((f.etype, cid, entry.get("parent_call_id")))
+    assert stamped > 0, f"no child events found for parent {parent_call_id}"
+    assert not unstamped, f"child events escaped unstamped (parent {parent_call_id}): {unstamped}"
+
+
+def history_tool_outputs(history_json: dict[str, Any]) -> dict[str, str]:
+    """Extract {call_id: output} from a /history projection, however the
+    projection surfaces results (a folded ``output`` on a tool_call, or a
+    trailing ``role: tool`` row keyed by ``tool_call_id``)."""
+    out: dict[str, str] = {}
+    for msg in history_json.get("messages", []):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "tool":
+            cid = msg.get("tool_call_id") or msg.get("call_id")
+            if cid is not None:
+                out[str(cid)] = str(msg.get("content", ""))
+        for tc in msg.get("tool_calls") or ():
+            if not isinstance(tc, dict):
+                continue
+            cid = tc.get("id") or tc.get("call_id")
+            if cid is not None and tc.get("output") is not None:
+                out[str(cid)] = str(tc.get("output", ""))
+    return out
+
+
+def assert_converged(client: BrowserlikeSSEClient, history_json: dict[str, Any]) -> None:
+    """Turn-level equivalence: every tool result the client assembled live
+    is present, with the same output, in a fresh /history projection.
+
+    Compares by call_id so a reconnect that re-delivered a result can't
+    hide a divergence, and asserts the /history side isn't empty (a
+    silently-lost turn would leave the projection short)."""
+    live = client.tool_results_by_call()
+    hist = history_tool_outputs(history_json)
+    assert hist, "fresh /history projected no tool results — a turn was lost"
+    for call_id, output in live.items():
+        assert call_id in hist, f"call {call_id} seen live but absent from /history: {sorted(hist)}"
+        assert hist[call_id] == output, (
+            f"call {call_id} output diverged: live={output!r} history={hist[call_id]!r}"
+        )

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -1,0 +1,413 @@
+"""Boot the REAL interactive Turnstone server for the SSE recovery e2e
+harness: real ``SessionManager`` + real ``ChatSession`` engine driven
+through a scripted chat-completions client at the SDK boundary, executing
+REAL bash tools, exposed over a real uvicorn socket.
+
+The recipe (verified end-to-end) has four load-bearing pieces:
+
+1. **Provider injection seam.** ``create_app`` takes a PRE-BUILT
+   ``SessionManager``, so the harness owns the ``session_factory``: it
+   passes ``client=fake_client`` and OMITS the registry, so
+   ``ChatSession`` falls back to ``create_provider("openai-compatible")``
+   == ``OpenAIChatCompletionsProvider`` — exactly what
+   ``tests._session_helpers.scripted_chat_client`` targets. No production
+   monkeypatch of the engine.
+
+2. **Auto-title suppression.** The first user message spawns a background
+   ``_generate_title`` LLM call that would consume the first scripted
+   response (the tool call) and desync a positional script. Setting
+   ``session._title_generated = True`` before the first send disables it.
+
+3. **Completion barrier.** ``/send`` returns immediately after spawning
+   ``ws.worker_thread``; joining that thread is the true "turn complete,
+   every SSE event enqueued" barrier (``stream_end`` is per-LLM-call, not
+   per-turn, so it is NOT a completion marker).
+
+4. **Thread hygiene.** ``create_app``'s lifespan unconditionally starts
+   two daemon fan-out threads (``_global_fanout_thread`` blocking on
+   ``global_queue.get()``, ``_aggregate_emitter_thread`` on a 10s loop)
+   with no shutdown sentinel — they would trip conftest's leaked-thread
+   guard. They serve the cluster/global lane, which the per-ws ``/events``
+   path under test never touches, so the harness swaps them for no-ops
+   before boot (restored on ``stop``). The result is a fully clean
+   teardown — no ``allow_thread_leak`` needed — with the real per-ws SSE
+   engine fully intact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import queue as _q
+import socket
+import threading
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import uvicorn
+
+import turnstone.server as tsrv
+from tests._session_helpers import scripted_chat_client
+from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
+from turnstone.core.auth import JWT_AUD_SERVER, create_jwt
+from turnstone.core.session import ChatSession
+from turnstone.core.session_manager import SessionManager
+from turnstone.core.session_ui_base import SessionUIBase
+from turnstone.core.storage import get_storage
+from turnstone.core.workstream import WorkstreamKind
+from turnstone.prompts import ClientType
+from turnstone.server import WebUI, create_app
+
+if TYPE_CHECKING:
+    from turnstone.core.workstream import Workstream
+
+_JWT_SECRET = "sse-recovery-e2e-jwt-secret-minimum-32-chars!"
+# Small server send buffer so a stalled consumer's in-flight backlog before
+# the listener-queue poison stays bounded (paired with the client's small
+# SO_RCVBUF in _sse_recovery_helpers). Harmless for prompt readers.
+_DEFAULT_SNDBUF = 8192
+
+
+def _noop_thread(*_args: object, **_kwargs: object) -> None:
+    """Stand-in for the cluster-lane daemon threads (see module docstring)."""
+
+
+# The REAL daemon-thread factories, captured once at import so restore always
+# targets them regardless of how many servers neuter/restore in a run (the
+# restart scenarios build a second server before the run ends).
+_REAL_FANOUT = tsrv._global_fanout_thread
+_REAL_AGGREGATE = tsrv._aggregate_emitter_thread
+
+
+def _fake_client(scripts: tuple[Any, ...]) -> Any:
+    """An SDK-shaped fake whose ``chat.completions.create`` follows a
+    positional script (each a :func:`fake_chat_stream` kwargs dict)."""
+    create_fn = scripted_chat_client(*scripts)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create_fn)))
+    client.calls = create_fn.calls
+    return client
+
+
+class RecoveryServer:
+    """A booted interactive node the recovery scenarios drive."""
+
+    def __init__(
+        self,
+        *,
+        sndbuf: int = _DEFAULT_SNDBUF,
+        listener_cap: int | None = None,
+        extra_routes: list[Any] | None = None,
+        port: int = 0,
+    ) -> None:
+        self._global_queue: _q.Queue[dict[str, Any]] = _q.Queue(maxsize=100000)
+        self._global_listeners: list[_q.Queue[dict[str, Any]]] = []
+        self._global_listeners_lock = threading.Lock()
+        # Per-ws scripted client, resolved at factory-call time.
+        self._pending_client: Any = _fake_client((dict(content="ok", finish_reason="stop"),))
+        self._clients: dict[str, Any] = {}
+
+        WebUI._global_queue = self._global_queue
+
+        def session_factory(
+            ui: Any,
+            model_alias: str | None = None,
+            ws_id: str | None = None,
+            *,
+            skill: Any = None,
+            client_type: str = "",
+            kind: WorkstreamKind = WorkstreamKind.INTERACTIVE,
+            parent_ws_id: str | None = None,
+            project_id: str = "",
+            **_extra: Any,
+        ) -> ChatSession:
+            client = self._pending_client
+            if ws_id is not None:
+                self._clients[ws_id] = client
+            return ChatSession(
+                client=client,
+                model="test-model",
+                ui=ui,
+                instructions=None,
+                temperature=None,
+                max_tokens=1024,
+                tool_timeout=30,
+                ws_id=ws_id,
+                user_id="recovery-user",
+                client_type=ClientType.WEB,
+                kind=kind,
+                # Don't truncate large tool outputs: the harness tests
+                # recovery, not the tool-result truncation budget, and a
+                # truncated /history would diverge from the full live event
+                # and defeat the convergence assertions.
+                tool_truncation=10_000_000,
+            )
+
+        self._adapter = InteractiveAdapter(
+            global_queue=self._global_queue,
+            ui_factory=lambda ws: WebUI(
+                ws_id=ws.id, user_id=ws.user_id, kind=ws.kind, parent_ws_id=ws.parent_ws_id
+            ),
+            session_factory=session_factory,
+        )
+        self._manager = SessionManager(
+            self._adapter, storage=get_storage(), max_active=32, node_id="recovery-node"
+        )
+        self._adapter.attach(self._manager)
+        WebUI._workstream_mgr = self._manager
+
+        # Neuter the cluster-lane daemons for a clean teardown (see docstring).
+        tsrv._global_fanout_thread = _noop_thread
+        tsrv._aggregate_emitter_thread = _noop_thread
+
+        # Optional small listener-queue cap. The cap is a default arg on the
+        # registration methods with no config/env override, so lower it by
+        # patching their ``__defaults__`` (restored on stop). fix-3's
+        # de-amplification makes a real 500-cap overflow need a pathological
+        # storm; a small cap exercises the identical _ListenerOverflow ->
+        # stream_overflow -> reconnect-replay path within a bounded storm.
+        self._orig_defaults: list[tuple[Any, tuple[Any, ...] | None]] = []
+        if listener_cap is not None:
+            for meth in (
+                SessionUIBase._register_listener,
+                SessionUIBase.register_listener_with_in_progress_snapshot,
+                SessionUIBase.register_listener_with_replay,
+            ):
+                self._orig_defaults.append((meth, meth.__defaults__))
+                meth.__defaults__ = (listener_cap,)
+
+        self._app = create_app(
+            workstreams=self._manager,
+            global_queue=self._global_queue,
+            global_listeners=self._global_listeners,
+            global_listeners_lock=self._global_listeners_lock,
+            skip_permissions=True,
+            jwt_secret=_JWT_SECRET,
+            node_id="recovery-node",
+            # /history + tenant checks read app.state.auth_storage.
+            auth_storage=get_storage(),
+        )
+        # Same-origin extras (Tier 2 serves its recovery page here so the real
+        # Pane's cookie auth + EventSource work without cross-origin plumbing).
+        if extra_routes:
+            self._app.router.routes.extend(extra_routes)
+
+        # Pre-bind a listening socket with a small SO_SNDBUF (accepted conns
+        # inherit it), then hand it to uvicorn.
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, sndbuf)
+        self._sock.bind(("127.0.0.1", port))  # port=0 -> ephemeral; fixed -> restart reuse
+        self._port = int(self._sock.getsockname()[1])
+        self._sock.listen(128)
+
+        self._server = uvicorn.Server(uvicorn.Config(self._app, log_level="warning", lifespan="on"))
+        self._thread = threading.Thread(
+            target=self._serve, name=f"uvicorn-recovery-{self._port}", daemon=True
+        )
+        self._thread.start()
+        if not _tcp_ready(self._port, 10.0):
+            self.stop()
+            raise AssertionError("recovery server did not accept TCP")
+
+        self._token = create_jwt(
+            user_id="recovery-user",
+            scopes=frozenset({"read", "write", "approve", "service"}),
+            source="recovery",
+            secret=_JWT_SECRET,
+            audience=JWT_AUD_SERVER,
+        )
+        self._http = httpx.Client(base_url=self.base_url, timeout=httpx.Timeout(30.0))
+
+    def _serve(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(self._server.serve(sockets=[self._sock]))
+        finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                with contextlib.suppress(Exception):
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.close()
+
+    # -- properties ----------------------------------------------------------
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    @property
+    def manager(self) -> SessionManager:
+        return self._manager
+
+    # -- workstream lifecycle ------------------------------------------------
+
+    def create_workstream(self, *scripts: Any, name: str = "recovery-ws") -> str:
+        """Create a ws whose scripted LLM follows ``scripts`` (positional
+        :func:`fake_chat_stream` kwargs). Auto-approves tools and suppresses
+        the auto-title call so the positional script stays in sync."""
+        self._pending_client = _fake_client(scripts)
+        ws = self._manager.create(user_id="recovery-user", name=name)
+        self._prime_ws(ws)
+        return ws.id
+
+    def open_workstream(self, ws_id: str, *scripts: Any) -> None:
+        """Rehydrate a persisted ws on THIS node (the restart path). Fresh
+        UI → empty ring + storage-seeded ``_event_id``."""
+        if scripts:
+            self._pending_client = _fake_client(scripts)
+        ws = self._manager.open(ws_id)
+        if ws is None:
+            raise AssertionError(f"open_workstream: ws {ws_id} not resurrectable")
+        self._prime_ws(ws)
+
+    def _prime_ws(self, ws: Workstream) -> None:
+        if isinstance(ws.ui, SessionUIBase):
+            ws.ui.auto_approve = True  # blanket tool auto-approval
+        if ws.session is not None:
+            ws.session._title_generated = True  # suppress the auto-title LLM call
+
+    def send(self, ws_id: str, message: str = "go") -> None:
+        """POST /send — spawns the worker thread and returns immediately."""
+        r = self._http.post(
+            f"/v1/api/workstreams/{ws_id}/send",
+            headers={"Authorization": f"Bearer {self._token}"},
+            json={"message": message},
+        )
+        r.raise_for_status()
+
+    def wait_turn(self, ws_id: str, *, timeout: float = 45.0) -> None:
+        """Block until the turn's worker thread finishes (the true
+        turn-complete barrier) and the ws is idle."""
+        deadline = time.monotonic() + timeout
+        worker: threading.Thread | None = None
+        while time.monotonic() < deadline:
+            ws = self._manager.get(ws_id)
+            worker = ws.worker_thread if ws is not None else None
+            if worker is not None:
+                break
+            time.sleep(0.02)
+        if worker is not None:
+            worker.join(timeout=max(0.5, deadline - time.monotonic()))
+            if worker.is_alive():
+                raise AssertionError(f"turn worker for {ws_id} did not finish in {timeout}s")
+
+    def get_ws(self, ws_id: str) -> Workstream | None:
+        return self._manager.get(ws_id)
+
+    def ws_state(self, ws_id: str) -> str:
+        ws = self._manager.get(ws_id)
+        return ws.state.value if ws is not None else ""
+
+    def ring_span(self, ws_id: str) -> tuple[int | None, int]:
+        """(earliest retained ring event_id or None, latest counter) — lets a
+        scenario wait for the ring to evict a specific cursor."""
+        ws = self._manager.get(ws_id)
+        ui = ws.ui if ws is not None else None
+        if not isinstance(ui, SessionUIBase):
+            return None, 0
+        buf = ui._event_buffer
+        earliest = buf[0][0] if buf else None
+        return earliest, ui._event_id
+
+    def listener_poisoned(self, ws_id: str) -> bool:
+        """True once any live SSE listener on the ws has poisoned (overflow)."""
+        ws = self._manager.get(ws_id)
+        ui = ws.ui if ws is not None else None
+        if not isinstance(ui, SessionUIBase):
+            return False
+        return any(getattr(q, "poisoned", False) for q in list(ui._listeners))
+
+    def max_event_id(self, ws_id: str) -> int | None:
+        """The storage high-water ``MAX(conversations.event_id)`` — what a
+        restarted node's fresh UI seeds ``_event_id`` from."""
+        result: int | None = get_storage().get_max_event_id(ws_id)
+        return result
+
+    def fetch_history(self, ws_id: str) -> dict[str, Any]:
+        r = self._http.get(
+            f"/v1/api/workstreams/{ws_id}/history",
+            headers={"Authorization": f"Bearer {self._token}"},
+        )
+        r.raise_for_status()
+        result: dict[str, Any] = r.json()
+        return result
+
+    # -- teardown ------------------------------------------------------------
+
+    def stop(self) -> None:
+        with contextlib.suppress(Exception):
+            for ws in list(self._manager.list_all()):
+                with contextlib.suppress(Exception):
+                    self._manager.close(ws.id)
+        self._server.should_exit = True
+        self._thread.join(timeout=20)
+        with contextlib.suppress(Exception):
+            self._http.close()
+        with contextlib.suppress(OSError):
+            self._sock.close()
+        # Restore the cluster-lane daemon factories + any patched cap defaults.
+        tsrv._global_fanout_thread = _REAL_FANOUT
+        tsrv._aggregate_emitter_thread = _REAL_AGGREGATE
+        for meth, defaults in self._orig_defaults:
+            meth.__defaults__ = defaults
+
+
+def _tcp_ready(port: int, timeout: float) -> bool:
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.3):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def bash_toolcall_script(
+    call_id: str, command: str, *, finish_reason: str = "tool_calls"
+) -> dict[str, Any]:
+    """A scripted assistant turn issuing ONE bash tool call."""
+    return dict(
+        tool_calls=[{"id": call_id, "name": "bash", "arguments": json.dumps({"command": command})}],
+        finish_reason=finish_reason,
+    )
+
+
+def parallel_bash_script(commands: dict[str, str]) -> dict[str, Any]:
+    """A scripted assistant turn issuing SEVERAL bash tool calls at once
+    (the parallel-pool storm), ``{call_id: command}``.
+
+    Each command is prefixed with a no-op ``: <call_id>;`` so the tool
+    ARGUMENTS are distinct per call while the OUTPUT is unchanged (``:``
+    ignores its args and prints nothing). Identical-argument parallel
+    calls otherwise trip the session's repeat-tool-call guard, which
+    appends a warning to the PERSISTED result only (not the live event) —
+    an orthogonal divergence that would mask the recovery behavior the
+    convergence assertions test.
+    """
+    return dict(
+        tool_calls=[
+            {
+                "id": cid,
+                "name": "bash",
+                "arguments": json.dumps({"command": f": {cid}; {cmd}"}),
+            }
+            for cid, cmd in commands.items()
+        ],
+        finish_reason="tool_calls",
+    )
+
+
+def final_text_script(content: str = "done") -> dict[str, Any]:
+    """The scripted assistant turn that ends the agent loop (no tools)."""
+    return dict(content=content, finish_reason="stop")

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1024,7 +1024,11 @@ def _slice_balanced_body(body: str, anchor: int) -> str | None:
     depth = 0
     in_str: str | None = None
     start = i
-    while i < n and i - start < 8000:
+    # 12000: connectSSE reached ~7950 chars during the 2026-07 SSE
+    # recovery campaign (cursor-override + capture-rationale comments);
+    # the window exists to bound a runaway scan, not to cap legitimate
+    # method growth — keep it comfortably above the largest real body.
+    while i < n and i - start < 12000:
         ch = body[i]
         if in_str:
             if ch == "\\" and i + 1 < n:
@@ -1996,12 +2000,79 @@ def test_coord_detects_server_restart_by_backwards_event_id() -> None:
     m = re.search(r"evtSource\.onmessage = function \(event\) \{(.*?)\n    \};", body, re.S)
     assert m is not None, "onmessage handler not found"
     handler = m.group(1)
-    assert "Number(evtSource.lastEventId) < Number(lastEventId)" in handler
+    assert "Number(event.lastEventId) < Number(lastEventId)" in handler
     assert "!gapRefreshedAtOpen" in handler
     assert "refreshSidebarAfterGap();" in handler
-    check = handler.index("Number(evtSource.lastEventId) < Number(lastEventId)")
-    overwrite = handler.index("lastEventId = evtSource.lastEventId;")
+    check = handler.index("Number(event.lastEventId) < Number(lastEventId)")
+    overwrite = handler.index("lastEventId = event.lastEventId;")
     assert check < overwrite
+
+
+def test_sse_cursor_captured_from_message_event_never_the_source_object() -> None:
+    """``lastEventId`` lives on the MessageEvent — EventSource exposes no
+    such property (WHATWG: url/withCredentials/readyState only), so an
+    object-form read like ``evtSource.lastEventId`` is undefined in every
+    real browser.  All three clients shipped exactly that dead
+    conditional: the cursor never tracked live traffic, every MANUAL
+    reconnect (close-on-hide show edge, degraded retry, recover beat)
+    connected fresh, and turns committed during the gap silently never
+    painted — the 2026-07 'turn disappeared' field mechanism.  Only a
+    real-browser harness could catch it (source-pattern tests pinned the
+    broken form as happily as the fixed one), so this tripwire at least
+    pins the corrected form and forbids the dead one by name.
+
+    Guard shape is pinned too — the explicit ``!= null && !== ""`` form.
+    On a DOMString this is behaviorally identical to truthiness (the
+    valid id "0" is a truthy STRING; only "" and null/undefined are
+    falsy here), so the pin is for cross-site symmetry with the NUMERIC
+    cursor gates (``_lastEventId != null`` / ``data.cursor != null``),
+    where truthiness genuinely drops a valid 0 — one visual idiom for
+    every cursor guard keeps a future editor from "simplifying" the
+    numeric ones to match a terser string form.
+
+    The GLOBAL stream (app.js) is the deliberate exception: its manual
+    reconnects are pinned CURSORLESS — the global ring's counter reboots
+    at 0 on restart (KNOWN GAP #881), so a stale cursor draws
+    ``replay_ok``-empty with no node_snapshot and the roster ghosts;
+    cursorless always draws the fresh snapshot.  Revisit when #881
+    lands.
+
+    Comments are stripped before the scan (module-level, string-aware
+    stripper) so documentation may name the anti-pattern verbatim — the
+    tripwire forbids the dead CODE, not its description."""
+    dead_form = re.compile(r"(?:this\.)?\w*[Ee]vtSource\.lastEventId")
+    for path, capture in (
+        (
+            _INTERACTIVE_JS,
+            r'if \(e\.lastEventId != null && e\.lastEventId !== ""\) \{\s*'
+            r"this\._lastEventId = e\.lastEventId;",
+        ),
+        (
+            _COORD_JS,
+            r'if \(event\.lastEventId != null && event\.lastEventId !== ""\) \{',
+        ),
+    ):
+        body = path.read_text(encoding="utf-8")
+        code = _strip_js_comments(body)
+        hits = [m.group(0) for m in dead_form.finditer(code)]
+        assert not hits, (
+            f"{path.name}: cursor read off the EventSource OBJECT {hits} — "
+            "that property does not exist; capture from the MessageEvent."
+        )
+        assert re.search(capture, code), (
+            f"{path.name}: MessageEvent cursor capture (with the "
+            '``!= null && !== ""`` guard) not found'
+        )
+    app_code = _strip_js_comments(_APP_JS.read_text(encoding="utf-8"))
+    assert not dead_form.search(app_code), (
+        "app.js: dead EventSource-object cursor read must not return"
+    )
+    assert "lastEventId" not in app_code and "last_event_id" not in app_code, (
+        "app.js global stream must stay CURSORLESS on manual reconnects "
+        "until #881's boot-epoch staleness signal lands — a stale cursor "
+        "on the reborn global ring draws replay_ok-empty with no "
+        "node_snapshot (ghost roster)."
+    )
 
 
 def test_interactive_history_is_rest_first_not_sse() -> None:

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -199,10 +199,11 @@ def test_refetch_history_seeds_resume_cursor_only_on_initial_connect() -> None:
 
     Two load-bearing guards are pinned here:
 
-    1. The seed is gated on ``seedCursor`` so ONLY the initial-connect
-       caller (``_loadHistoryThenConnect``, which reconnects) seeds it;
-       the clear_ui / replay_truncated re-render callers (no reconnect)
-       must NOT rewind ``_lastEventId`` off the live stream position.
+    1. The seed is gated on ``seedCursor`` so ONLY callers that
+       reconnect (``_loadHistoryThenConnect`` — first paint, ws switch,
+       and both truncated-resync branches) seed it; the clear_ui
+       re-render caller runs on a LIVE stream with no reconnect and
+       must NOT rewind ``_lastEventId`` off the live position.
     2. ``connectSSE`` gates the ``?last_event_id=`` param on
        ``!= null`` (not truthiness) so a valid cursor of 0 — a brand-new
        ws's first-turn boundary — isn't silently dropped to the fresh
@@ -225,22 +226,34 @@ def test_refetch_history_seeds_resume_cursor_only_on_initial_connect() -> None:
         "rewind the live stream and a 0 cursor still fast-forwards."
     )
     assert "seedCursor = false" in fn, (
-        "seedCursor must default false so the clear_ui / replay_truncated "
-        "re-render callers (which pass only 2 args) never seed the cursor."
+        "seedCursor must default false so the clear_ui re-render caller "
+        "(which passes only 2 args and stays on the live stream) never "
+        "seeds the cursor."
     )
     # (1b) the initial-connect path opts in with seedCursor=true.
     assert "_refetchHistory(wsId, token, true)" in body, (
         "_loadHistoryThenConnect must call _refetchHistory(..., true) so "
         "the reconnecting initial-connect path is the only seeder."
     )
-    # (2) connectSSE gates the last_event_id param on != null, not truthiness.
+    # (2) connectSSE gates the last_event_id param on != null, not
+    # truthiness, and a recorded truncation gap overrides the live cursor
+    # (the connect-chokepoint half of the gap-repair guarantee).
     assert re.search(
-        r"if\s*\(\s*this\._lastEventId\s*!=\s*null\s*\)\s*\{\s*"
+        r"const connectCursor =\s*this\._truncatedFromCursor != null\s*"
+        r"\?\s*this\._truncatedFromCursor\s*:\s*this\._lastEventId;",
+        body,
+    ), (
+        "connectSSE must present the truncation-time cursor while a gap "
+        "is on record — the advanced live cursor would draw replay_ok "
+        "and silently forget the gap."
+    )
+    assert re.search(
+        r"if\s*\(\s*connectCursor\s*!=\s*null\s*\)\s*\{\s*"
         r"evtUrl\s*\+=\s*\"\?last_event_id=\"",
         body,
     ), (
         "connectSSE must gate the ?last_event_id= param on "
-        "this._lastEventId != null (not truthiness) — else a cursor of 0 "
+        "connectCursor != null (not truthiness) — else a cursor of 0 "
         "(brand-new ws first turn) is dropped to the fresh snapshot path."
     )
 

--- a/tests/test_bash_tool_background_hang.py
+++ b/tests/test_bash_tool_background_hang.py
@@ -128,6 +128,72 @@ def test_stdout_streams_to_ui_from_drain_thread():
     assert any("streamed-line" in c for c in chunks)
 
 
+def test_leaked_drain_stops_emitting_chunks_after_return(tmp_path):
+    """A double-``setsid`` grandchild escapes the session-group kill and
+    holds the stdout pipe open past the drain join (``bash.drain_leaked``)
+    — the leaked drain thread must STOP forwarding chunks to the UI once
+    ``_exec_bash`` returns (the ``emit_done`` gate).  Without the gate,
+    its lines land in later turns' panes: the UI batches per call_id,
+    some providers reuse call_ids across turns, and the client grafts
+    stray chunks under the completed row.
+
+    The grandchild's writer loop is time-bounded (~8s) so even a failed
+    cleanup cannot outlive the test session, and the finally kills it so
+    the drain thread hits EOF before the leaked-thread guard sweeps.
+    """
+    pidfile = str(tmp_path / "leak.pid")
+    chunks: list[str] = []
+
+    class RecordingUI(NullUI):
+        def on_tool_output_chunk(self, call_id, chunk):
+            chunks.append(chunk)
+
+    session = make_session(tool_timeout=30, ui=RecordingUI())
+    # setsid detaches the grandchild from the session group (killpg
+    # misses it); it inherits our stdout pipe and keeps writing.
+    command = (
+        f"setsid bash -c 'echo $$ > {pidfile}; "
+        "for i in $(seq 1 80); do echo leak-$i; sleep 0.1; done' & echo fg-done"
+    )
+    leak_pid = None
+    try:
+        finished, result = _run_in_thread(
+            lambda: session._exec_bash({"call_id": "c1", "command": command}),
+            timeout=20,
+        )
+        assert finished, "_exec_bash hung on the escaped grandchild"
+        assert result is not None
+        _call_id, output = result
+        assert "fg-done" in output
+        # The call has RETURNED (gate set).  The grandchild is still
+        # writing; give its lines time to traverse the leaked drain.
+        seen_at_return = len(chunks)
+        time.sleep(1.0)
+        # ``<= +1``: the gate documents a one-line residual race (a line
+        # already past the is_set() check when the event sets).  A broken
+        # gate keeps forwarding ~10 lines/sec and still fails loudly.
+        assert len(chunks) <= seen_at_return + 1, (
+            "leaked drain thread kept forwarding chunks to the UI after "
+            "the tool returned — the emit_done gate is not holding"
+        )
+    finally:
+        deadline = time.monotonic() + 5
+        while leak_pid is None and time.monotonic() < deadline:
+            try:
+                with open(pidfile) as f:
+                    leak_pid = int(f.read().strip())
+            except (FileNotFoundError, ValueError):
+                time.sleep(0.05)
+        if leak_pid is not None:
+            _kill_pid(leak_pid)
+            # Let the drain thread hit EOF before the leaked-thread
+            # guard sweeps the test's thread table.
+            deadline = time.monotonic() + 5
+            while _pid_alive(leak_pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            time.sleep(0.2)
+
+
 def test_cancel_midbash_reports_unknown():
     """An external ``cancel()`` during a running bash unblocks the process-bounded
     wait and reports UNKNOWN (unknown-never-none), not a clean result."""

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -275,17 +275,20 @@ def test_stream_pipeline_is_wedge_proof() -> None:
 
 
 def test_rebuild_quiesces_live_events_and_releases_agent_tracking() -> None:
-    """clear_ui / replay_truncated re-render race (perf audit P0): live SSE
-    events painted between the history snapshot and ``replaceChildren()``
-    were wiped with no redelivery, and streaming refs kept pointing at
-    detached nodes.  Pinned: the quiesce queue sits on the handleEvent hot
-    path, both re-render triggers arm it, ``replayHistory`` resets the
-    streaming refs and clears the agent-card/orphan maps (the detached-DOM
-    retention leak), and the mid-stream guard covers the reasoning bubble."""
+    """clear_ui re-render race (perf audit P0): live SSE events painted
+    between the history snapshot and ``replaceChildren()`` were wiped with
+    no redelivery, and streaming refs kept pointing at detached nodes.
+    Pinned: the quiesce queue sits on the handleEvent hot path, the
+    live-stream re-render trigger (clear_ui) arms it, ``replayHistory``
+    resets the streaming refs and clears the agent-card/orphan maps (the
+    detached-DOM retention leak), and the mid-stream guard covers the
+    reasoning bubble.  (replay_truncated no longer arms the quiesce — it
+    tears the stream down and runs the full fresh-connect flow instead;
+    see test_truncated_resync_is_full_fresh_connect.)"""
     body = _INTERACTIVE.read_text(encoding="utf-8")
     assert "this._replayQueue.events.push(evt);" in body
-    assert body.count("this._beginReplayQuiesce(") >= 2, (
-        "both clear_ui and replay_truncated must arm the quiesce"
+    assert body.count("this._beginReplayQuiesce(") >= 1, (
+        "clear_ui must arm the quiesce (it re-renders on a LIVE stream)"
     )
     assert "!this.currentAssistantEl && !this.currentReasoningEl" in body
     replay = body.index("replayHistory(messages) {")
@@ -309,7 +312,7 @@ def test_rebuild_quiesces_live_events_and_releases_agent_tracking() -> None:
     assert "this._clearAgentTracking();" not in disc_seg
     assert "this._replayQueue = null;" not in disc_seg
     load = body.index("_loadHistoryThenConnect(wsId) {")
-    load_seg = body[load : load + 2200]
+    load_seg = body[load : body.index("async _refetchHistory(", load)]
     assert "this._clearAgentTracking();" in load_seg
     assert "this._replayQueue = null;" in load_seg
     # A mid-stream replay_truncated DEFERS the re-sync (flag consumed on the
@@ -320,7 +323,7 @@ def test_rebuild_quiesces_live_events_and_releases_agent_tracking() -> None:
     # replayHistory, and stale refs there streamed the retried generation's
     # first segment into a detached bubble.
     fail = body.index("Failure path never reaches replayHistory")
-    assert "this._resetStreamingRefs();" in body[fail : fail + 400], (
+    assert "this._resetStreamingRefs();" in body[fail : fail + 700], (
         "the refetch failure branch must reset streaming refs"
     )
 
@@ -451,13 +454,176 @@ def test_stream_overflow_case_counts_and_rate_limits() -> None:
     body = _INTERACTIVE.read_text(encoding="utf-8")
     assert 'case "stream_overflow":' in body
     assert "this._noteStreamOverflow();" in body
-    assert "_streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 }" in body
+    # The health object carries all four field-forensics counters; the
+    # truncated-resync counter distinguishes the replay-window class from
+    # the dropped-events class (overflows).
+    health = re.search(r"_streamHealth = \{(.*?)\};", body, re.S)
+    assert health is not None, "_streamHealth initializer not found"
+    for field in ("overflows: 0", "renderThrows: 0", "malformedFrames: 0", "truncatedGaps: 0"):
+        assert field in health.group(1), f"_streamHealth must init {field!r}"
     # Both wedge-class catch sites increment the render-throw counter,
     # and the malformed-frame drop counts too — the C-OVERDETERMINED
     # instrumentation that tells drops apart from wedges in the field.
     assert body.count("this._streamHealth.renderThrows += 1;") == 2
     assert "this._streamHealth.malformedFrames += 1;" in body
     assert "this._streamHealth.overflows += 1;" in body
+
+
+def test_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None:
+    """replay_truncated = the stream admitted losing events past recovery.
+    The pane must treat the connection as DEAD: run the full fresh-connect
+    flow (``_loadHistoryThenConnect`` — disconnect first, REST /history,
+    adopt the resume cursor, reconnect) rather than an in-place refetch.
+    The in-place shape discarded the /history cursor while /history TRIMS
+    the trailing in-flight turn whenever it returns one — a mid-run
+    truncation wiped the executing turn (task cards included) with no
+    redelivery, and sub-agent children then escaped to top-level rows
+    after the orphan grace (the 2026-07 field reports).
+
+    Pinned: (1) the immediate branch routes through
+    ``_noteTruncatedResync()`` and SKIPS the resync when the limiter just
+    tripped — the cooldown disconnected the stream, and the flow's
+    ``.finally`` reconnect would defeat it; on no-trip it SCHEDULES the
+    fresh connect behind the herd-spreading jitter rather than starting
+    it inline (a node restart makes every stale-cursor tab resync inside
+    the EventSource retry window, and the per-tab limiter cannot see a
+    cross-tab herd); (2) the mid-stream guard still DEFERS (detachable
+    bubble); (3) the idle-edge consumption runs the same fresh-connect
+    flow, unjittered (staggered by turn-settle timing); (4) the limiter
+    feeds the SAME churn window as overflow closes and enters degraded
+    catch-up on trip; (5) neither truncated branch arms the quiesce or
+    calls the in-place ``_refetchHistory`` — the old shape must not come
+    back; (6) every ``truncatedGaps`` bump routes through the one
+    increment+log step (``_recordTruncatedGap``), whose class-of-event
+    wording never asserts a resync a trip may skip; (7) the scheduler
+    nulls its handle before loading and ``disconnectSSE`` cancels a
+    pending one, so a torn-down stream's resync can't fire against the
+    pane's next workstream; (8) the gap-repair guarantee is
+    interleaving-proof via the connect chokepoint; (9) a same-ws load
+    supersession must not strand a queued edit-and-resend."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    trunc = re.search(r'case "replay_truncated":(.*?)break;', body, re.S)
+    assert trunc is not None, "replay_truncated case not found"
+    t = trunc.group(1)
+    # (1) immediate branch: limiter check gates the JITTERED fresh connect.
+    assert "if (!this._noteTruncatedResync())" in t
+    assert "this._scheduleTruncatedResync();" in t
+    # (2) mid-stream defer unchanged.
+    assert "!this.currentAssistantEl && !this.currentReasoningEl" in t
+    assert "this._pendingTruncatedResync = true;" in t
+    # (5) the old in-place shape must not come back.
+    assert "_beginReplayQuiesce" not in t
+    assert "_refetchHistory" not in t
+    # (3) idle-edge consumption: consume the latch, record, fresh-connect.
+    idle = re.search(
+        r"if \(this\._pendingTruncatedResync\) \{(.*?)\n          \}",
+        body,
+        re.S,
+    )
+    assert idle is not None, "idle-edge truncated consumption not found"
+    i = idle.group(1)
+    assert "this._pendingTruncatedResync = false;" in i
+    assert "this._recordTruncatedGap();" in i
+    assert "this._loadHistoryThenConnect(this.wsId);" in i
+    assert "_refetchHistory" not in i
+    # (4) the limiter method: records the gap, then delegates churn
+    # accounting to the ONE shared trip step (also used by
+    # _noteStreamOverflow) so the trip parameters cannot silently diverge
+    # between the overflow and truncated classes.
+    note = re.search(r"_noteTruncatedResync\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert note is not None, "_noteTruncatedResync method not found"
+    n = note.group(1)
+    assert "this._recordTruncatedGap();" in n
+    assert "return this._recordChurnAndMaybeTrip();" in n
+    churn = re.search(r"_recordChurnAndMaybeTrip\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert churn is not None, "_recordChurnAndMaybeTrip method not found"
+    c = churn.group(1)
+    assert "this._overflowTimes.push(now);" in c
+    assert "overflowWindowTripped(" in c
+    assert "this._enterDegradedCatchup();" in c
+    assert "return true;" in c
+    assert "return false;" in c
+    over = re.search(r"_noteStreamOverflow\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert over is not None, "_noteStreamOverflow method not found"
+    assert "this._recordChurnAndMaybeTrip();" in over.group(1), (
+        "overflow closes must feed the same shared churn step"
+    )
+    # (6) the one increment+log step: every bump carries the running count,
+    # class-of-event wording (no action a trip may skip); the counter is
+    # named for what it counts — gap detections, not resyncs performed.
+    rec = re.search(r"_recordTruncatedGap\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert rec is not None, "_recordTruncatedGap method not found"
+    r = rec.group(1)
+    assert "this._streamHealth.truncatedGaps += 1;" in r
+    assert "console.warn(" in r
+    assert "resyncing history from REST" not in r, (
+        "the shared log line must not assert a resync the trip branch skips"
+    )
+    assert body.count("this._streamHealth.truncatedGaps += 1;") == 1, (
+        "all truncatedGaps bumps must route through _recordTruncatedGap "
+        "so the running-count console invariant holds"
+    )
+    # (7) jittered scheduler: dedup guard, null-before-load, cancel on
+    # disconnect.
+    sched = re.search(r"_scheduleTruncatedResync\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert sched is not None, "_scheduleTruncatedResync method not found"
+    s = sched.group(1)
+    assert "if (this._resyncTimer != null) return;" in s
+    assert "Math.random() * TRUNCATED_RESYNC_JITTER_MS" in s
+    null_then_load = s.index("this._resyncTimer = null;")
+    load = s.index("this._loadHistoryThenConnect(this.wsId);")
+    assert null_then_load < load, (
+        "the firing path must null the handle BEFORE loading, or "
+        "disconnectSSE (called inside the load) would cancel the work it "
+        "is part of"
+    )
+    dis = re.search(r"disconnectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert dis is not None, "disconnectSSE not found"
+    assert "clearTimeout(this._resyncTimer)" in dis.group(1)
+    # (8) interleaving-proof gap repair: the truncation-time cursor is a
+    # single record — captured keep-oldest at the envelope, cleared by
+    # any full committed-history render (replayHistory) or a ws switch —
+    # and the CONNECT CHOKEPOINT consumes it: while set, every manual
+    # (re)connect presents it instead of the since-advanced live cursor,
+    # so the server re-answers replay_truncated and the resync re-arms
+    # no matter which teardown (hide/show, degraded cooldown, recover
+    # beat, failed /history fetch) cancelled the pending jittered timer.
+    # A cancellable timer alone silently lost the repair when a
+    # hide/show cycle landed inside the jitter window.
+    assert re.search(
+        r"if \(this\._truncatedFromCursor == null\) \{\s*"
+        r"this\._truncatedFromCursor = this\._lastEventId;",
+        t,
+    ), "the truncated case must record the truncation-time cursor keep-oldest"
+    load = body.index("_loadHistoryThenConnect(wsId) {")
+    load_seg = body[load : body.index("async _refetchHistory(", load)]
+    assert "if (this.wsId !== wsId) this._truncatedFromCursor = null;" in load_seg, (
+        "a ws switch must drop the old ws's truncation record"
+    )
+    replay_fn = body.index("replayHistory(messages) {")
+    assert "this._truncatedFromCursor = null;" in body[replay_fn : replay_fn + 900], (
+        "a successful full-history render must clear the truncation record"
+    )
+    conn = body.index("connectSSE(wsId) {")
+    conn_seg = body[conn : body.index("this.evtSource = new EventSource", conn)]
+    assert "this._truncatedFromCursor != null" in conn_seg, (
+        "connectSSE must consult the truncation record"
+    )
+    assert "encodeURIComponent(connectCursor)" in conn_seg
+    # (9) same-ws supersession must not strand the queued edit-and-resend
+    # (the jittered resync bumps _historyLoadToken through
+    # _loadHistoryThenConnect while a clear_ui edit flow is in flight);
+    # only a ws SWITCH discards the resend, and then it recovers the
+    # composer instead of leaving the latch armed for the next ws.
+    clear = re.search(r'case "clear_ui": \{(.*?)break;', body, re.S)
+    assert clear is not None, "clear_ui case not found"
+    cl = clear.group(1)
+    assert "const editWs = this.wsId;" in cl
+    assert "if (token !== this._historyLoadToken && this.wsId !== editWs)" in cl, (
+        "only a cross-ws supersession may discard the edit-and-resend"
+    )
+    assert "this._pendingEditSend = null;" in cl
+    assert "this.setBusy(false);" in cl
 
 
 def test_degraded_catchup_stops_live_stream_and_retries() -> None:

--- a/tests/test_sse_chunk_batching.py
+++ b/tests/test_sse_chunk_batching.py
@@ -1,0 +1,283 @@
+"""Per-call_id emit-time batching of ``tool_output_chunk`` (SSE fix 3).
+
+Line-chatty tools under the 4-wide pool were the second event-storm
+source (one SSE event per stdout LINE, per concurrent tool) — and each
+line's ``_enqueue`` also force-flushed the pending token batch, so chunk
+traffic defeated token batching too (the amplifier).
+:meth:`SessionUIBase.on_tool_output_chunk` now buffers per call_id and
+flushes ONE concatenated event per window/size, bypassing ``_enqueue``.
+
+The conditions pinned here map to the dataflow rulings:
+
+- **Per-call keying.** Up to four concurrent tools stream at once; a
+  batch must never interleave text across call_ids.
+- **Terminal ordering (load-bearing).** The client REMOVES the
+  streaming ``<pre>`` when it renders ``tool_result``, so a call's
+  trailing chunks must precede its result on the wire —
+  ``on_tool_result`` flushes+closes the call's stream first.
+- **Closed-call discard (leaked-drain ruling).** A chunk arriving after
+  the call's terminal is a drain thread past its join timeout; it is
+  discarded, never mispainted below the already-rendered result.
+- **Teardown backstops.** ``stream_end`` / the idle-error snapshot /
+  turn commit / ``on_error`` flush all pending chunk batches (chunks
+  bypass ``_enqueue``, so its chokepoint flush cannot be their
+  backstop); ``on_turn_start`` DISCARDS stale residue and resets the
+  closed-call ledger (call_ids never span turns).
+- **Ring/reconnect contract unchanged.** A batch is one ordinary ring
+  entry (fresh ``_event_id``), carries no ``_seq`` (chunks never feed
+  the snapshot floor), and concatenation preserves the byte stream
+  (chunks are whole lines).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import queue
+from typing import Any
+
+import pytest
+
+from turnstone.core.session_ui_base import SessionUIBase
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_sse_token_batching.py)
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteUI(SessionUIBase):
+    """Minimal concrete subclass for direct UI tests."""
+
+
+def _make_ui(ws_id: str = "ws-chunk") -> _ConcreteUI:
+    return _ConcreteUI(ws_id=ws_id, user_id="u1")
+
+
+def _drain(lq: queue.Queue[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    while True:
+        try:
+            out.append(lq.get_nowait())
+        except queue.Empty:
+            return out
+
+
+@pytest.fixture
+def wide_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the shared batch window effectively infinite so tests control
+    flush points explicitly (terminal / backstops / size cap)."""
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 60.0)
+
+
+# ---------------------------------------------------------------------------
+# Coalescing shape
+# ---------------------------------------------------------------------------
+
+
+def test_fast_chunks_coalesce_and_result_is_the_terminal_flush(wide_window: None) -> None:
+    """First line flushes immediately (time-to-first-output protection);
+    the rest coalesce until the call's ``tool_result``, which delivers
+    the batch BEFORE the result event (the client removes the streaming
+    <pre> at the result render — trailing chunks must precede it)."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    for i in range(5):
+        ui.on_tool_output_chunk("call-1", f"l{i}\n")
+    ui.on_tool_result("call-1", "bash", "full output")
+    events = _drain(lq)
+    types = [ev["type"] for ev in events]
+    assert types == ["tool_output_chunk", "tool_output_chunk", "tool_result"]
+    assert events[0]["chunk"] == "l0\n"
+    assert events[1]["chunk"] == "l1\nl2\nl3\nl4\n", (
+        "concatenation must preserve the exact byte stream (whole lines)"
+    )
+    assert events[1]["call_id"] == "call-1"
+    # One fresh ring id per batch; chunks carry NO _seq (they never feed
+    # the snapshot floor, so the live-drain dedup must not drop them).
+    for ev in events:
+        assert isinstance(ev["_event_id"], int)
+        assert "_seq" not in ev
+
+
+def test_concurrent_calls_batch_independently(wide_window: None) -> None:
+    """Interleaved lines from two concurrent tools must never share a
+    batch — per-call keying is the whole point of the dict."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("call-a", "a0\n")  # immediate (TTFO)
+    ui.on_tool_output_chunk("call-b", "b0\n")  # immediate (TTFO)
+    ui.on_tool_output_chunk("call-a", "a1\n")  # pends on a
+    ui.on_tool_output_chunk("call-b", "b1\n")  # pends on b
+    ui.on_tool_output_chunk("call-a", "a2\n")  # pends on a
+    ui.on_tool_result("call-a", "bash", "out-a")
+    ui.on_tool_result("call-b", "bash", "out-b")
+    events = _drain(lq)
+    a_chunks = [
+        ev["chunk"]
+        for ev in events
+        if ev["type"] == "tool_output_chunk" and ev["call_id"] == "call-a"
+    ]
+    b_chunks = [
+        ev["chunk"]
+        for ev in events
+        if ev["type"] == "tool_output_chunk" and ev["call_id"] == "call-b"
+    ]
+    assert a_chunks == ["a0\n", "a1\na2\n"]
+    assert b_chunks == ["b0\n", "b1\n"]
+    # Each call's trailing batch precedes its own result.
+    order = [(ev["type"], ev.get("call_id")) for ev in events]
+    assert order.index(("tool_output_chunk", "call-a")) < order.index(("tool_result", "call-a"))
+    assert order.index(("tool_output_chunk", "call-b")) < order.index(("tool_result", "call-b"))
+
+
+def test_size_cap_flushes_mid_stream(wide_window: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The size cap bounds worst-case batch size (client repaint cost)
+    independent of rate — same check-before-append overshoot semantics
+    as the token batcher."""
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_MAX_CHARS", 8)
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("c", "0123\n")  # immediate first flush
+    ui.on_tool_output_chunk("c", "45\n")  # pends (3 chars < 8)
+    ui.on_tool_output_chunk("c", "6789a\n")  # 3+6=9 >= 8 -> flush
+    events = _drain(lq)
+    assert [ev["chunk"] for ev in events] == ["0123\n", "45\n6789a\n"]
+
+
+# ---------------------------------------------------------------------------
+# Terminal close + leaked-drain discard
+# ---------------------------------------------------------------------------
+
+
+def test_result_finishes_the_stream_and_drops_the_entry(wide_window: None) -> None:
+    """``tool_result`` is the terminal flush: trailing chunks precede it
+    on the wire and the per-call entry (window clock included) is
+    dropped.  A chunk arriving AFTER the terminal — only reachable
+    through the producer gate's one-line race, since ``_exec_bash``'s
+    ``emit_done`` stops the leaked drain thread at the source — simply
+    re-buffers and emits, identical to pre-batching behaviour for the
+    same line.  (The UI deliberately keeps NO closed-call ledger: keyed
+    on call_id it would either discard a reusing provider's NEW stream
+    or silently re-open under per-turn resets / LRU churn — both found
+    in review.)"""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("call-1", "live\n")
+    ui.on_tool_result("call-1", "bash", "out")
+    assert "call-1" not in ui._pending_chunks, "terminal must drop the entry"
+    ui.on_tool_output_chunk("call-1", "raced\n")  # gate-race survivor
+    events = _drain(lq)
+    chunks = [ev["chunk"] for ev in events if ev["type"] == "tool_output_chunk"]
+    # The racy line emits immediately (fresh entry, first-line-immediate)
+    # rather than stranding — pre-batching-equivalent, not silent loss.
+    assert chunks == ["live\n", "raced\n"]
+    types = [ev["type"] for ev in events]
+    assert types.index("tool_result") > types.index("tool_output_chunk"), (
+        "trailing chunks must precede the call's own result on the wire"
+    )
+
+
+def test_turn_start_discards_stale_chunk_residue(wide_window: None) -> None:
+    """``on_turn_start`` is the stale-crash residue path: pending chunk
+    text from a dead ``send()`` is DISCARDED (mirror of the token
+    discard — never enqueued, never ring-buffered, so discarding is
+    consistent everywhere).  A provider REUSING a finished call's id in
+    a later turn streams normally: the UI keeps no per-call_id closed
+    state across the terminal (the leaked-drain gate lives in the
+    producer's execution closure, which id reuse can't confuse)."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("call-1", "first\n")  # immediate
+    ui.on_tool_output_chunk("call-1", "stale\n")  # pends
+    ui.on_tool_result("call-2", "bash", "out")  # finishes call-2
+    ui.on_turn_start()
+    ui.on_tool_output_chunk("call-2", "fresh\n")  # id reuse -> streams normally
+    events = _drain(lq)
+    chunks = [(ev["call_id"], ev["chunk"]) for ev in events if ev["type"] == "tool_output_chunk"]
+    assert ("call-1", "stale\n") not in chunks, "stale residue must be discarded, never emitted"
+    assert ("call-2", "fresh\n") in chunks, "a reused call_id must stream normally next turn"
+
+
+# ---------------------------------------------------------------------------
+# Teardown backstops
+# ---------------------------------------------------------------------------
+
+
+def test_stream_end_flushes_pending_chunks_first(wide_window: None) -> None:
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("c", "one\n")  # immediate
+    ui.on_tool_output_chunk("c", "tail\n")  # pends
+    ui.on_stream_end()
+    events = _drain(lq)
+    types = [ev["type"] for ev in events]
+    assert types == ["tool_output_chunk", "tool_output_chunk", "stream_end"]
+    assert events[1]["chunk"] == "tail\n"
+
+
+def test_idle_snapshot_chokepoint_flushes_pending_chunks(wide_window: None) -> None:
+    """``snapshot_and_consume_state_payload`` is the cancel/error
+    chokepoint — a batch stranded in the accumulator would vanish from
+    connected panes on paths that skip ``stream_end``."""
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("c", "one\n")
+    ui.on_tool_output_chunk("c", "tail\n")  # pends
+    ui.snapshot_and_consume_state_payload("idle")
+    events = _drain(lq)
+    chunks = [ev["chunk"] for ev in events if ev["type"] == "tool_output_chunk"]
+    assert chunks == ["one\n", "tail\n"]
+
+
+def test_turn_committed_and_error_flush_pending_chunks(wide_window: None) -> None:
+    ui = _make_ui()
+    lq = ui._register_listener()
+    ui.on_tool_output_chunk("c1", "x\n")
+    ui.on_tool_output_chunk("c1", "y\n")  # pends
+    ui.on_turn_committed()
+    ui.on_tool_output_chunk("c2", "p\n")
+    ui.on_tool_output_chunk("c2", "q\n")  # pends
+    ui.on_error("boom")
+    events = _drain(lq)
+    chunks = [ev["chunk"] for ev in events if ev["type"] == "tool_output_chunk"]
+    assert chunks == ["x\n", "y\n", "p\n", "q\n"]
+    # The error teardown delivers the pending batch before the error event.
+    types = [ev["type"] for ev in events]
+    assert types.index("error") > types.index("tool_output_chunk")
+
+
+# ---------------------------------------------------------------------------
+# Producer-surface pin (dataflow ruling: order-within-key assumes ONE
+# producer thread per call_id)
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_producer_surface_is_single_site() -> None:
+    """Exactly one production call site feeds the per-call batcher
+    (``_exec_bash``'s stdout drain, one thread per call_id) plus the
+    CLI's Protocol-level no-op delegation (which never reaches
+    ``SessionUIBase``).  Order within a batcher key assumes the
+    single-producer topology — a future streaming tool that adds a
+    producer must revisit :meth:`_buffer_chunk_locked`'s ordering note
+    (and this pin).
+
+    Deliberately a raw line grep (comments excluded): a
+    ``.on_tool_output_chunk(`` occurrence inside a docstring or string
+    literal would also trip it — over-triggering is acceptable for an
+    architectural tripwire whose failure message says exactly what to
+    re-examine."""
+    pkg = pathlib.Path(__file__).resolve().parents[1] / "turnstone"
+    calls: dict[str, int] = {}
+    for path in pkg.rglob("*.py"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if "def on_tool_output_chunk" in stripped:
+                continue
+            if ".on_tool_output_chunk(" in stripped:
+                rel = str(path.relative_to(pkg.parent))
+                calls[rel] = calls.get(rel, 0) + 1
+    assert calls == {
+        "turnstone/core/session.py": 1,  # _exec_bash stdout drain (the producer)
+        "turnstone/cli.py": 1,  # WorkstreamTerminalUI super() delegation (no-op sink)
+    }, f"chunk producer surface changed: {calls}"

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -145,13 +145,72 @@ def test_replay_truncated_when_last_event_id_predates_buffer() -> None:
 def test_replay_empty_buffer_returns_replay_ok_empty() -> None:
     """Cold-start ws with zero events ever: replay_ok / empty list.
     A spurious ``replay_truncated`` envelope on a freshly-opened
-    workstream would be confusing and incorrect."""
+    workstream would be confusing and incorrect.  (This is the
+    regression guard for the derived-staleness rule's ``snap_seq > 0``
+    gate — an empty ring is only truncated when the counter proves
+    events once existed.)"""
     ui = _make_ui()
     lq, replay, status, lost, earliest, _ = ui.register_listener_with_replay(0)
     assert status == "replay_ok"
     assert replay == []
     assert lost == 0
     assert earliest == 0
+
+
+def test_replay_empty_buffer_with_seeded_counter_reports_truncated() -> None:
+    """Rehydrate case: the UI instance was rebuilt over an existing
+    conversation (``_seed_event_id_from_storage`` reseeds ``_event_id``
+    from ``MAX(conversations.event_id)``) but the ring died with the old
+    process.  A client whose cursor sits below the counter provably lost
+    events no ring can replay — report ``truncated`` so the client runs
+    its /history resync, instead of the pre-fix silent ``replay_ok``
+    (stuck-busy panes and committed turns missing until a manual
+    reload)."""
+    ui = _make_ui()
+    ui._event_id = 500  # what _seed_event_id_from_storage does on rehydrate
+    lq, replay, status, lost, earliest, snap = ui.register_listener_with_replay(400)
+    assert status == "truncated"
+    assert replay == []
+    assert lost == 100  # exact (not a lower bound) on the empty-ring path
+    assert earliest == 501  # next id that will exist; nothing below is retained
+    assert snap["seq"] == 500
+
+
+def test_replay_empty_buffer_cursor_at_counter_is_lossless_replay_ok() -> None:
+    """Strict ``<`` is load-bearing: a client that saw everything before
+    the rebuild (cursor == seeded counter) lost nothing — ``replay_ok``
+    with an empty slice, no spurious resync churn on every
+    reconnect-after-rehydrate."""
+    ui = _make_ui()
+    ui._event_id = 500
+    lq, replay, status, lost, earliest, _ = ui.register_listener_with_replay(500)
+    assert status == "replay_ok"
+    assert replay == []
+    assert lost == 0
+
+
+def test_replay_empty_buffer_negative_cursor_cold_start_stays_replay_ok() -> None:
+    """A malformed negative cursor (``?last_event_id=-1`` parses as an
+    int) on a brand-new ws must not manufacture a truncated envelope —
+    the ``snap_seq > 0`` guard keeps cold start on ``replay_ok``."""
+    ui = _make_ui()
+    lq, replay, status, lost, earliest, _ = ui.register_listener_with_replay(-1)
+    assert status == "replay_ok"
+    assert replay == []
+
+
+def test_can_replay_from_stays_false_on_empty_ring_despite_seeded_counter() -> None:
+    """Deliberate asymmetry with the register path (ruled 2026-07-20 —
+    see the ``can_replay_from`` docstring; do not "fix"): on an empty
+    ring with a stale cursor, ``register_listener_with_replay`` reports
+    ``truncated`` (the recovery MESSAGE) while ``can_replay_from`` stays
+    ``False`` (the recovery ROUTE — ``/history`` keeps the in-flight
+    turn and withholds the cursor, because a cursor pointing into an
+    empty ring would immediately re-truncate on connect and loop the
+    client through resync)."""
+    ui = _make_ui()
+    ui._event_id = 500
+    assert ui.can_replay_from(400) is False
 
 
 def test_replay_registers_listener_atomically_with_buffer_snapshot() -> None:

--- a/tests/test_sse_recovery_e2e.py
+++ b/tests/test_sse_recovery_e2e.py
@@ -1,0 +1,514 @@
+"""End-to-end SSE recovery harness (opt-in) for the three fixes on
+``fix/sse-truncated-resync``:
+
+1. **tool_output_chunk batching (de-amplifier).** A parallel storm of
+   line-chatty bash tools no longer emits one SSE event per stdout line.
+2. **Honest truncated replay.** An empty ring after eviction / node
+   restart reports ``replay_truncated`` with a real ``lost_count`` instead
+   of a silent ``replay_ok``; the client adopts the ``/history`` resume
+   cursor to rebuild the in-flight turn.
+3. **Sub-agent attribution.** Every child tool event a task_agent's
+   sub-tools produce is stamped ``parent_call_id`` at the batch flush.
+
+Each scenario drives a REAL interactive server (real ``SessionManager`` +
+real ``ChatSession`` engine executing REAL bash) through a scripted
+provider at the SDK boundary, with a ``BrowserlikeSSEClient`` that speaks
+the exact interactive.js wire contract, and asserts convergence.
+
+Marked ``e2e_recovery`` (select with ``-m e2e_recovery``) AND ``live`` so
+the fast default suite (``-m "not live"``) skips them: the marker
+mechanism the repo already deselects by. Each scenario runs in tens of
+seconds; the tier-1 suite stays under ~5 minutes.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests._sse_recovery_helpers import (
+    BrowserlikeSSEClient,
+    assert_children_stamped,
+    assert_chunk_result_ordering,
+    assert_contiguous_ids,
+    assert_converged,
+    history_tool_outputs,
+)
+from tests._sse_recovery_server import (
+    RecoveryServer,
+    bash_toolcall_script,
+    final_text_script,
+    parallel_bash_script,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+pytestmark = [pytest.mark.e2e_recovery, pytest.mark.live]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def recovery_db(tmp_path: object) -> Iterator[str]:
+    """A throwaway migrated sqlite DB (singleton registry) for one test."""
+    from turnstone.core.storage import init_storage, reset_storage
+
+    db_path = str(tmp_path / "recovery.db")  # type: ignore[operator]
+    reset_storage()
+    init_storage("sqlite", path=db_path, run_migrations=True)
+    yield db_path
+    reset_storage()
+
+
+@pytest.fixture
+def make_server(recovery_db: str) -> Iterator[Callable[..., RecoveryServer]]:
+    """Factory that builds RecoveryServers and stops them all at teardown
+    (LIFO), so a restart scenario can build a second node on the same DB."""
+    servers: list[RecoveryServer] = []
+
+    def _make(**kwargs: object) -> RecoveryServer:
+        srv = RecoveryServer(**kwargs)  # type: ignore[arg-type]
+        servers.append(srv)
+        return srv
+
+    yield _make
+    for srv in reversed(servers):
+        srv.stop()
+
+
+SEQ_OUTPUT = "".join(f"{n}\n" for n in range(1, 501))  # `seq 1 500` chunk stream
+# A PACED storm: streams slowly so an early disconnect captures a cursor
+# genuinely below the turn's committed-message counter (the restart-loss case).
+PACED_STORM = "for i in $(seq 1 40); do echo r-$i; sleep 0.05; done"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — storm without loss (fix-3 efficacy)
+# ---------------------------------------------------------------------------
+
+
+def test_storm_batches_without_loss(make_server: Callable[..., RecoveryServer]) -> None:
+    """One turn issues 4 parallel ``seq 1 500`` bash calls. Assert the
+    per-call chunk events are batched FAR below 500, each call's chunks
+    strictly precede its own result, the concatenated chunks reconstruct
+    the exact seq output, and a normally-draining consumer never overflows."""
+    srv = make_server()
+    call_ids = [f"call_{i}" for i in range(4)]
+    ws_id = srv.create_workstream(
+        parallel_bash_script(dict.fromkeys(call_ids, "seq 1 500")),
+        final_text_script("ran the storm"),
+        name="storm",
+    )
+    client = BrowserlikeSSEClient(srv.base_url, ws_id, srv.token)
+    try:
+        client.connect()  # before send — the listener must be registered
+        srv.send(ws_id, "run the storm")
+        srv.wait_turn(ws_id, timeout=45)
+        for cid in call_ids:
+            client.wait_for_call_result(cid, timeout=20)
+        time.sleep(0.4)  # settle trailing frames
+
+        # De-amplification: each call's chunk-event count is far below 500.
+        per_call: dict[str, int] = {}
+        for f in client.frames_of_type("tool_output_chunk"):
+            assert f.payload is not None
+            cid = str(f.payload["call_id"])
+            per_call[cid] = per_call.get(cid, 0) + 1
+        assert set(per_call) == set(call_ids), per_call
+        for cid, count in per_call.items():
+            assert count <= 60, f"{cid} emitted {count} chunk events (batching failed)"
+
+        # Lossless reconstruction per call + chunks precede results.
+        recon = client.tool_output_by_call()
+        for cid in call_ids:
+            assert recon[cid] == SEQ_OUTPUT, f"{cid} chunk stream diverged from seq 1..500"
+        assert_chunk_result_ordering(client.all_frames())
+
+        # A fresh connect made before any event has snap_seq==0, so the whole
+        # id-bearing stream is a gap-free contiguous run.
+        assert_contiguous_ids(client.conn_frames(0))
+
+        # A normally-draining consumer never overflows, and every committed
+        # tool result matches a fresh /history projection.
+        assert not client.has_type("stream_overflow")
+        assert_converged(client, srv.fetch_history(ws_id))
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — slow-consumer overflow -> poison -> lossless reconnect
+# ---------------------------------------------------------------------------
+
+
+def test_slow_consumer_overflow_then_lossless_reconnect(
+    make_server: Callable[..., RecoveryServer],
+) -> None:
+    """A stalled consumer poisons the listener queue; the server closes the
+    stream with an id-less ``stream_overflow`` frame; a native reconnect
+    with the pre-gap cursor replays the gap from the ring with contiguous
+    ids; the final transcript converges with a fresh /history projection."""
+    # fix-3 de-amplifies so hard that a real 500-cap overflow needs a
+    # pathological storm; a small cap + small buffers exercise the identical
+    # _ListenerOverflow -> stream_overflow -> reconnect-replay path.
+    srv = make_server(sndbuf=8192, listener_cap=64)
+    call_ids = [f"c{i}" for i in range(4)]
+    # ~4 KB-per-line paced output so the stall builds a poisoning backlog.
+    paced = "for i in $(seq 1 100); do printf '%04000d\\n' $i; sleep 0.03; done"
+    ws_id = srv.create_workstream(
+        parallel_bash_script(dict.fromkeys(call_ids, paced)),
+        final_text_script("done"),
+        name="overflow",
+    )
+    client = BrowserlikeSSEClient(srv.base_url, ws_id, srv.token)
+    try:
+        client.connect(rcvbuf=2048)  # small buffer -> the stall poisons quickly
+        srv.send(ws_id, "overflow storm")
+        client.wait_for(lambda c: len(c.frames_of_type("tool_output_chunk")) >= 2, timeout=20)
+        pre_gap = client.last_event_id
+        assert pre_gap is not None
+
+        client.stall()
+        _wait(lambda: srv.listener_poisoned(ws_id), timeout=20, what="listener poison")
+        # The turn finishes while the consumer is stalled: the worker keeps
+        # enqueuing (dropped by the poisoned queue) but the ring keeps all.
+        srv.wait_turn(ws_id, timeout=45)
+        client.resume()
+
+        overflow = client.wait_for_type("stream_overflow", timeout=15)
+        assert overflow.event_id is None, "stream_overflow must be id-less (cursor stays below gap)"
+
+        # Native EventSource reconnect: the pre-gap cursor rides a
+        # Last-Event-ID header; the ring replays everything past it.
+        client.disconnect()
+        client.connect(native=True)
+        for cid in call_ids:
+            client.wait_for_call_result(cid, timeout=30)
+
+        # The reconnect replayed the gap on the replay_ok path (snap_seq==0):
+        # a gap-free, dup-free contiguous run.
+        assert_contiguous_ids(client.conn_frames(1))
+        assert_converged(client, srv.fetch_history(ws_id))
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — truncated mid-run -> cursor-adoption rebuild (fix-2 client)
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_midrun_cursor_adoption_rebuild(
+    make_server: Callable[..., RecoveryServer],
+    tmp_path: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A consumer disconnects early in turn 1 (cursor C). Turn 1 commits
+    (boundary B1 > C). Turn 2 — the in-flight orphan storm — evicts C from a
+    small ring while keeping B1. Reconnect is truncated; /history's orphan
+    trim returns a non-null cursor (B1 still replayable); the cursor
+    reconnect's replay_ok delta rebuilds the in-flight turn; convergence
+    holds with no duplicate ids per connection."""
+    # A small ring so turn 1's tail evicts the disconnected consumer's cursor.
+    # Read at UI construction, so patch BEFORE the workstream is created.
+    monkeypatch.setattr("turnstone.core.session_ui_base._EVENT_BUFFER_MAX", 15)
+    release = str(tmp_path / "release_turn2")  # type: ignore[operator]
+
+    srv = make_server()
+    t1 = "for i in $(seq 1 30); do echo t1-$i; sleep 0.04; done"
+    # Turn 2 is FILE-GATED: it stays in-flight until the test releases it,
+    # removing every timing race around "reconnect while the turn is live".
+    gated = f"echo t2-start; while [ ! -f {release} ]; do sleep 0.05; done; seq 1 20; echo t2-done"
+    t2_ids = [f"c{i}" for i in range(3)]
+    ws_id = srv.create_workstream(
+        bash_toolcall_script("t1call", t1),
+        final_text_script("t1 done"),
+        parallel_bash_script(dict.fromkeys(t2_ids, gated)),
+        final_text_script("t2 done"),
+        name="truncate",
+    )
+    client = BrowserlikeSSEClient(srv.base_url, ws_id, srv.token)
+    try:
+        client.connect()
+        srv.send(ws_id, "turn 1")
+        client.wait_for(lambda c: len(c.frames_of_type("tool_output_chunk")) >= 2, timeout=20)
+        cursor_c = int(client.last_event_id or "-1")
+        client.disconnect()
+        srv.wait_turn(ws_id, timeout=30)  # turn 1 commits
+        b1 = srv.max_event_id(ws_id)
+        assert b1 is not None and b1 > cursor_c
+
+        srv.send(ws_id, "turn 2 storm")  # the in-flight orphan
+
+        def orphan_inflight_and_c_evicted() -> bool:
+            earliest, latest = srv.ring_span(ws_id)
+            return (
+                srv.ws_state(ws_id) == "running"
+                and earliest is not None
+                and earliest > cursor_c
+                and latest > b1 + 2
+            )
+
+        _wait(orphan_inflight_and_c_evicted, timeout=20, what="turn 2 in-flight + C evicted")
+
+        # Reconnect stale -> replay_truncated with a real lost_count.
+        client.connect()
+        truncated = client.wait_for_type("replay_truncated", timeout=15)
+        assert truncated.payload is not None
+        assert truncated.payload["lost_count"] > 0
+
+        # /history's orphan trim returns a non-null (replayable) cursor while
+        # the turn is in flight.
+        hist = client.fetch_history()
+        assert hist["cursor"] is not None, "in-flight orphan should trim to a resume cursor"
+
+        # The fix's flow: disconnect -> /history -> adopt cursor -> reconnect.
+        client.load_history_then_connect()
+        # The cursor-adoption reconnect takes replay_ok (no second truncation)
+        # and its delta rebuilds the in-flight turn's tool events.
+        client.wait_for(
+            lambda c: any(
+                f.conn_index == c.num_connections() - 1
+                and f.etype in ("tool_pending", "tool_info", "tool_output_chunk")
+                for f in c.all_frames()
+            ),
+            timeout=15,
+        )
+        adopt_conn = client.latest_conn_frames()
+        assert not any(f.etype == "replay_truncated" for f in adopt_conn)
+
+        # Release the orphan; it runs to completion and the transcript converges.
+        open(release, "w").close()  # noqa: SIM115 — a one-shot release flag
+        srv.wait_turn(ws_id, timeout=40)
+        for cid in t2_ids:
+            client.wait_for_call_result(cid, timeout=25)
+        time.sleep(0.4)
+        assert_converged(client, srv.fetch_history(ws_id))
+
+        # No duplicate ids WITHIN any single connection (cross-connection
+        # overlap on reconnect is legal; intra-connection dups are not).
+        for i in range(client.num_connections()):
+            ids = [f.event_id_int for f in client.conn_frames(i) if f.event_id_int is not None]
+            assert len(ids) == len(set(ids)), f"duplicate ids on connection {i}: {ids}"
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — rehydrate / restart honesty (fix-2 server)
+# ---------------------------------------------------------------------------
+
+
+def test_restart_truncated_honesty(make_server: Callable[..., RecoveryServer]) -> None:
+    """A client whose cursor predates the turn's committed messages
+    disconnects; the turn completes (storage counter = seeded); the node
+    restarts (fresh UI, empty ring, storage-seeded counter). Reconnecting
+    with the stale cursor draws ``replay_truncated`` (NOT a silent
+    ``replay_ok``) with the exact lost_count; /history returns cursor=null
+    (empty ring); a fresh connect converges. The no-loss variant —
+    cursor == seeded — draws ``replay_ok`` (empty)."""
+    srv1 = make_server()
+    call_ids = ["r0", "r1"]
+    ws_id = srv1.create_workstream(
+        parallel_bash_script(dict.fromkeys(call_ids, PACED_STORM)),
+        final_text_script("done"),
+        name="restart",
+    )
+    watcher = BrowserlikeSSEClient(srv1.base_url, ws_id, srv1.token)
+    try:
+        watcher.connect()
+        srv1.send(ws_id, "go")
+        # Disconnect MID-turn: the cursor predates the committed messages.
+        watcher.wait_for(lambda c: len(c.frames_of_type("tool_output_chunk")) >= 2, timeout=20)
+        stale_cursor = int(watcher.last_event_id or "-1")
+        watcher.disconnect()
+    finally:
+        watcher.close()
+    srv1.wait_turn(ws_id, timeout=45)  # turn completes; committed counter set
+    seeded = srv1.max_event_id(ws_id)
+    assert seeded is not None and stale_cursor < seeded
+    srv1.stop()  # node crash — the ring dies with the process, the DB survives
+
+    # Restart on the same DB.
+    srv2 = make_server()
+    srv2.open_workstream(ws_id)  # rehydrate: fresh UI, empty ring, seeded counter
+    assert srv2.max_event_id(ws_id) == seeded
+
+    # LOSS: reconnect with the stale cursor -> truncated with exact lost_count.
+    loss = BrowserlikeSSEClient(srv2.base_url, ws_id, srv2.token)
+    try:
+        loss._last_event_id = str(stale_cursor)
+        loss.connect()
+        tf = loss.wait_for_type("replay_truncated", timeout=15)
+        assert tf.payload is not None
+        assert tf.payload["lost_count"] == seeded - stale_cursor
+        # /history on an empty ring withholds the cursor (can_replay_from
+        # asymmetry) — the client rebuilds from the REST snapshot instead.
+        hist = loss.fetch_history()
+        assert hist["cursor"] is None
+        # The committed conversation is intact — a fresh /history projection
+        # carries every tool result (no permanently lost turn).
+        recovered = history_tool_outputs(hist)
+        assert set(call_ids).issubset(set(recovered))
+    finally:
+        loss.close()
+
+    # NO-LOSS: cursor == seeded counter -> replay_ok (empty), never truncated.
+    noloss = BrowserlikeSSEClient(srv2.base_url, ws_id, srv2.token)
+    try:
+        noloss._last_event_id = str(seeded)
+        noloss.connect()
+        time.sleep(1.0)
+        assert not noloss.has_type("replay_truncated"), (
+            "cursor == seeded is no loss — must be replay_ok, not truncated"
+        )
+    finally:
+        noloss.close()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — failed-resync retry via the truncation record
+# ---------------------------------------------------------------------------
+
+
+def test_failed_resync_retries_via_truncation_record(
+    make_server: Callable[..., RecoveryServer],
+) -> None:
+    """Restart truncation as in scenario 4, but the client's FIRST /history
+    resync fails: the reconnect re-presents the truncation-time cursor and
+    draws ``replay_truncated`` AGAIN (the retry stays armed). A subsequent
+    successful /history then converges."""
+    srv1 = make_server()
+    call_ids = ["r0", "r1"]
+    ws_id = srv1.create_workstream(
+        parallel_bash_script(dict.fromkeys(call_ids, PACED_STORM)),
+        final_text_script("done"),
+        name="failed-resync",
+    )
+    watcher = BrowserlikeSSEClient(srv1.base_url, ws_id, srv1.token)
+    try:
+        watcher.connect()
+        srv1.send(ws_id, "go")
+        watcher.wait_for(lambda c: len(c.frames_of_type("tool_output_chunk")) >= 2, timeout=20)
+        stale_cursor = int(watcher.last_event_id or "-1")
+        watcher.disconnect()
+    finally:
+        watcher.close()
+    srv1.wait_turn(ws_id, timeout=45)
+    seeded = srv1.max_event_id(ws_id)
+    assert seeded is not None and stale_cursor < seeded
+    srv1.stop()
+
+    srv2 = make_server()
+    srv2.open_workstream(ws_id)
+
+    client = BrowserlikeSSEClient(srv2.base_url, ws_id, srv2.token)
+    try:
+        client._last_event_id = str(stale_cursor)
+        client.connect()
+        client.wait_for_type("replay_truncated", timeout=15)
+        # The truncation-time cursor is recorded (keep-oldest).
+        assert client.truncated_from_cursor == str(stale_cursor)
+
+        # FIRST resync FAILS: /history is not fetched, so the record stays
+        # armed and the reconnect re-presents the truncation-time cursor ->
+        # the server re-answers replay_truncated on the NEW connection.
+        client.load_history_then_connect(fail_history=True)
+        client.wait_for(
+            lambda c: any(f.etype == "replay_truncated" for f in c.latest_conn_frames()),
+            timeout=15,
+        )
+        assert client.truncated_from_cursor == str(stale_cursor), "record must stay armed"
+
+        # SUCCESSFUL resync: /history clears the record and the committed
+        # conversation is recovered intact.
+        data = client.load_history_then_connect()
+        assert data is not None
+        assert client.truncated_from_cursor is None
+        recovered = history_tool_outputs(data)
+        assert set(call_ids).issubset(set(recovered))
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — sub-agent storm attribution (fix-3 parent stamping)
+# ---------------------------------------------------------------------------
+
+
+def test_subagent_storm_attribution(make_server: Callable[..., RecoveryServer]) -> None:
+    """A task_agent whose sub-tools are chatty bashes. Every chunk / tool
+    event for a child call carries ``parent_call_id`` (stamped at the batch
+    flush by its still-registered call_id); none escape unstamped to the top
+    level; the child chunk streams reconstruct losslessly."""
+    import json
+
+    srv = make_server()
+    task_call = dict(
+        tool_calls=[
+            {
+                "id": "task1",
+                "name": "task_agent",
+                "arguments": json.dumps({"prompt": "run the sub-tools"}),
+            }
+        ],
+        finish_reason="tool_calls",
+    )
+    sub_bash = dict(
+        tool_calls=[
+            {"id": "sub_a", "name": "bash", "arguments": json.dumps({"command": ": a; seq 1 300"})},
+            {"id": "sub_b", "name": "bash", "arguments": json.dumps({"command": ": b; seq 1 300"})},
+        ],
+        finish_reason="tool_calls",
+    )
+    ws_id = srv.create_workstream(
+        task_call,  # parent issues the task_agent
+        sub_bash,  # sub-agent issues chatty bashes
+        final_text_script("sub done"),  # sub-agent finishes
+        final_text_script("parent done"),  # parent finishes
+        name="subagent",
+    )
+    client = BrowserlikeSSEClient(srv.base_url, ws_id, srv.token)
+    try:
+        client.connect()
+        srv.send(ws_id, "spawn a sub agent")
+        srv.wait_turn(ws_id, timeout=60)
+        client.wait_for_call_result("task1", timeout=25)
+        time.sleep(0.6)
+
+        # Every child tool event carries parent_call_id="task1"; none escape.
+        assert_children_stamped(client.all_frames(), "task1")
+
+        # The two sub-tools' minted call_ids appear and reconstruct losslessly.
+        child_output = {
+            cid: text for cid, text in client.tool_output_by_call().items() if "::" in cid
+        }
+        assert len(child_output) == 2, sorted(child_output)
+        seq_300 = "".join(f"{n}\n" for n in range(1, 301))
+        for cid, text in child_output.items():
+            assert text == seq_300, f"child {cid} chunk stream diverged from seq 1..300"
+
+        # The parent's synthesis result is present.
+        assert "task1" in client.tool_results_by_call()
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Shared wait helper
+# ---------------------------------------------------------------------------
+
+
+def _wait(predicate: Callable[[], bool], *, timeout: float, what: str) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.03)
+    raise AssertionError(f"timed out waiting for {what}")

--- a/tests/test_sse_recovery_e2e.py
+++ b/tests/test_sse_recovery_e2e.py
@@ -46,7 +46,10 @@ from tests._sse_recovery_server import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
-pytestmark = [pytest.mark.e2e_recovery, pytest.mark.live]
+# NOT ``live`` — these run a scripted provider, no LLM backend.  The CI
+# lanes deselect via ``-m "not live and not e2e_recovery"``; select with
+# ``-m e2e_recovery``.
+pytestmark = pytest.mark.e2e_recovery
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sse_token_batching.py
+++ b/tests/test_sse_token_batching.py
@@ -22,6 +22,14 @@ was a verified corruption mode in the design review:
   batch would paint into a NEW assistant bubble (the split/duplicate
   look).  The flush lives at the top of ``_enqueue`` itself so every
   emit path — base-class, subclass, and route-level — is covered.
+  ``tool_output_chunk`` is deliberately NOT such an emit anymore: it
+  buffers in its own per-call batcher (see
+  ``test_sse_chunk_batching.py``) and bypasses ``_enqueue``, so chunk
+  traffic no longer force-flushes token batches (the per-line
+  amplifier).  Chunk-vs-content interleaving is cosmetic — independent
+  DOM subtrees — so losing that ordering is safe; the load-bearing
+  chunk ordering (against its own ``tool_result``) is enforced in
+  ``on_tool_result``.
 
 Negative-test discipline: the double-render tests fail if the flush's
 inflight-append + enqueue are split across ``_ws_lock`` sections, and
@@ -227,22 +235,33 @@ def test_direct_enqueue_flushes_pending_batch_first(wide_window: None) -> None:
     assert events[1]["text"] == "bb"
 
 
-def test_tool_and_status_emits_flush_pending_batch(wide_window: None) -> None:
-    """Representative non-token ``on_*`` emitters (tool output chunk,
-    status) deliver a pending batch before their own event."""
+def test_status_emit_flushes_but_chunks_do_not(wide_window: None) -> None:
+    """The ``_enqueue`` chokepoint flush covers real non-token emitters
+    (``status`` here) — but ``tool_output_chunk`` no longer counts as
+    one: it buffers in the per-call chunk batcher and bypasses
+    ``_enqueue`` entirely, so a chunk arriving mid-token-accumulation
+    must NOT flush the pending content batch (that per-line force-flush
+    was the amplifier that defeated token batching under line-chatty
+    tools).  Chunk-vs-content wire order is cosmetic (independent DOM
+    subtrees); the chunk's own load-bearing ordering is pinned in
+    ``test_sse_chunk_batching.py``."""
     ui = _make_ui()
     lq = ui._register_listener()
     ui.on_content_token("aa")
     ui.on_content_token("bb")  # pending
-    ui.on_tool_output_chunk("call-1", "chunk")
-    ui.on_content_token("cc")  # immediate?  No — window is wide and the
-    # flush just ran, so this pends; the status emit must deliver it.
+    ui.on_tool_output_chunk("call-1", "chunk")  # first chunk: emits its
+    # own (immediate, TTFO) batch, does NOT flush the pending "bb"
+    ui.on_content_token("cc")  # joins the still-pending batch
     ui.on_status({"prompt_tokens": 1, "completion_tokens": 2}, 1000, "med")
     events = _drain(lq)
     types = [ev["type"] for ev in events]
-    assert types == ["content", "content", "tool_output_chunk", "content", "status"]
-    assert events[1]["text"] == "bb"
-    assert events[3]["text"] == "cc"
+    assert types == ["content", "tool_output_chunk", "content", "status"]
+    assert events[0]["text"] == "aa"
+    assert events[1]["chunk"] == "chunk"
+    assert events[2]["text"] == "bbcc", (
+        "the pending token batch must survive chunk traffic and flush "
+        "at the next REAL non-token emit (status)"
+    )
 
 
 def test_reasoning_batches_and_kind_switch_flushes(wide_window: None) -> None:

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -3289,7 +3289,17 @@ function createCoordinatorPane(root, wsId, opts) {
         // nowhere.  Mid-stream the resync is DEFERRED, not dropped — skipping
         // outright left the ring-evicted gap unrepaired for the rest of the
         // session (no clean reconnect may come for hours); the idle edge
-        // consumes the flag.  Mirrors interactive.js's _pendingTruncatedResync.
+        // consumes the flag.
+        //
+        // KNOWN GAP (#882): this refetch discards the /history ``cursor``
+        // and stays on the live stream, so a MID-RUN truncation loses the
+        // trailing in-flight turn (/history trims it whenever it returns a
+        // cursor, expecting the caller to replay from that cursor).
+        // interactive.js now treats truncated as a dead stream (disconnect
+        // → refetch with cursor adoption → reconnect); mirroring that here
+        // is #882.  The rehydrate-triggered truncation (empty reborn ring)
+        // recovers correctly today — a rehydrated ws has no in-flight
+        // orphan to trim.
         if (!currentAssistantEl && !currentReasoningEl) {
           refetchHistory();
         } else {

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -2648,7 +2648,15 @@ function createCoordinatorPane(root, wsId, opts) {
       // Capture lastEventId BEFORE JSON.parse so a malformed event
       // doesn't desync the manual-reconnect fallback from native
       // auto-reconnect.
-      if (evtSource && evtSource.lastEventId) {
+      // ``lastEventId`` lives on the MESSAGE EVENT — EventSource exposes
+      // no such property, so the pre-2026-07 read off the source OBJECT
+      // was a dead conditional: the cursor never tracked live traffic
+      // and the counter-reset detector below never fired in a real
+      // browser.  ``!== ""``: no-id frames carry "" per spec.  (A
+      // DOMString — the valid id "0" is truthy, so truthiness would
+      // behave identically; the explicit form matches interactive.js's
+      // canonical capture.)
+      if (event.lastEventId != null && event.lastEventId !== "") {
         // A live event id BELOW our saved cursor means the server's per-ws
         // event counter reset — a coordinator process restart with a fresh,
         // empty ring.  The replay path can't flag that (a cursor at/above the
@@ -2661,12 +2669,12 @@ function createCoordinatorPane(root, wsId, opts) {
         if (
           lastEventId != null &&
           !gapRefreshedAtOpen &&
-          Number(evtSource.lastEventId) < Number(lastEventId)
+          Number(event.lastEventId) < Number(lastEventId)
         ) {
           refreshSidebarAfterGap();
           gapRefreshedAtOpen = true;
         }
-        lastEventId = evtSource.lastEventId;
+        lastEventId = event.lastEventId;
       }
       let data = null;
       try {

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -14843,9 +14843,13 @@ class ChatSession:
         timeout = item.get("timeout") or self.tool_timeout
         try:
             # Pre-bind so the ``finally`` can't raise ``UnboundLocalError``
-            # and mask the real error if the spawn below fails.
+            # and mask the real error if the spawn below fails.  The chunk
+            # gate pre-binds with them — its .set() runs in the same
+            # finally, and setting it when no drain ever started is a
+            # harmless no-op.
             proc: subprocess.Popen[str] | None = None
             script_path: str | None = None
+            emit_done = threading.Event()
             try:
                 from turnstone.core.env import scrubbed_env
 
@@ -14874,8 +14878,30 @@ class ChatSession:
                 # ``drain_pipe_lines`` (the drain half of the recipe both
                 # bash variants share); only the sinks differ — stdout also
                 # streams to the UI.
+                #
+                # ``emit_done`` gates the UI half only: once set (after the
+                # join window, before ANY report path), the drain callback
+                # stops forwarding lines to the UI but keeps collecting
+                # ``stdout_parts`` so the pipe always drains and the child
+                # never blocks on a full pipe.  Without the gate, a drain
+                # thread that outlives its join (``bash.drain_leaked``
+                # below — a double-``setsid`` grandchild holding stdout
+                # open) keeps emitting into LATER turns: the UI batches
+                # chunks per call_id, some local providers REUSE call_ids
+                # across turns, and the client grafts stray chunks under
+                # the completed row.  The execution closure is the one
+                # identity that id reuse can't confuse, so the leak is
+                # closed here at the source rather than with a UI-side
+                # closed-call ledger (which per-turn resets or LRU churn
+                # would silently re-open).  Residual race: a line already
+                # past the check when the event sets — at most one line,
+                # equivalent to the pre-batching behaviour.  (The event is
+                # pre-bound next to ``proc`` above so the finally's .set()
+                # can't UnboundLocalError on a failed spawn.)
                 def _on_stdout(line: str) -> None:
                     stdout_parts.append(line)
+                    if emit_done.is_set():
+                        return
                     try:
                         self.ui.on_tool_output_chunk(call_id, line)
                     except Exception:
@@ -14942,6 +14968,17 @@ class ChatSession:
                 if stdout_thread.is_alive() or stderr_thread.is_alive():
                     log.warning("bash.drain_leaked", call_id=call_id, pid=proc.pid)
             finally:
+                # The gate sets in the FINALLY, not after the joins in the
+                # try body: every report path (normal / cancel / timeout /
+                # exception) runs after this block, and an exception thrown
+                # anywhere between thread start and the joins — a failed
+                # stderr_thread.start() under thread exhaustion, say —
+                # would otherwise reach the outer handlers' tool_result
+                # with the gate unset, killpg unreached, and a live drain
+                # still forwarding chunks past its own result (the exact
+                # cross-turn grafting the gate exists to prevent).  On the
+                # normal path this is the same post-join position.
+                emit_done.set()
                 if proc is not None:
                     with self._procs_lock:
                         self._active_procs.discard(proc)

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2145,6 +2145,20 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
                     # cover the gap and treats the snapshot below as
                     # the recovery floor.
                     if replay_status == "truncated":
+                        # Node-side visibility for every replay-window
+                        # miss (evicted ring AND the empty-ring
+                        # rehydrate case) — pairs with the client's
+                        # ``_streamHealth.truncatedGaps`` counter so
+                        # a field report of missing turns can be
+                        # matched to server evidence.  ``lost_count``
+                        # is a lower bound on the evicted path, exact
+                        # on the empty-ring path.
+                        log.info(
+                            "ws.events.replay_truncated ws=%s lost>=%d earliest=%d",
+                            ws_id[:8],
+                            lost_count,
+                            earliest_available_id,
+                        )
                         yield {
                             "data": json.dumps(
                                 {

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -1141,18 +1141,36 @@ class SessionUIBase:
             ``last_event_id`` (the client has already seen everything
             up to and including ``last_event_id``).
 
-        Empty buffer: returned ``status="replay_ok"`` with empty
-        ``replay_events`` regardless of ``last_event_id``.  This is
-        the cold-start case (the ws just bootstrapped with no events
-        ever) and the all-quiet case (a long-idle ws past which all
-        events fall out of the buffer cap, but in practice the buffer
-        starts evicting only after the cap is hit — which means the
-        counter is at the cap and the client's last_event_id is below
-        earliest, so they get ``truncated`` instead).  We can't
-        distinguish the two without a separate ``highest_evicted_id``
-        tracker; treating empty as ``replay_ok`` is the safe choice
-        for the genuine cold-start case (no false ``replay_truncated``
-        envelopes on freshly-opened workstreams).
+        Empty buffer: the ring is created once and only ever appended
+        (one call site, :meth:`_enqueue_direct`; a ``deque(maxlen=…)``
+        past its cap evicts but never empties), so an empty ring means
+        exactly one of two things and the ``_event_id`` counter
+        distinguishes them:
+
+          - ``_event_id == 0`` — genuine cold start (brand-new ws,
+            nothing ever emitted) → ``"replay_ok"`` with an empty
+            slice.  No false ``replay_truncated`` on freshly-opened
+            workstreams; the ``> 0`` guard also rejects a malformed
+            negative cursor (``?last_event_id=-1`` parses as an int).
+          - ``_event_id > 0`` — this UI instance was rebuilt over an
+            existing conversation (:meth:`_seed_event_id_from_storage`
+            reseeds the counter from ``MAX(conversations.event_id)``
+            on rehydrate / node restart) and the ring died with the
+            old process.  A client whose ``last_event_id`` is BELOW
+            the counter provably missed events that no ring can
+            replay → ``"truncated"``, so the client runs its
+            /history resync instead of silently continuing with a
+            hole (the pre-fix behaviour: stuck-busy panes and
+            committed turns missing until a manual reload).
+            ``last_event_id == _event_id`` (strict ``<`` is
+            load-bearing) means the client saw everything before the
+            rebuild — no loss, ``"replay_ok"``.
+
+        On the empty-ring truncated path ``lost_count`` is the exact
+        counter gap and ``earliest_available_id`` is ``_event_id + 1``
+        (the next id that will exist; nothing below it is retained).
+        No production client reads either field — they are envelope
+        forensics — but tests assert them.
         """
         client_queue: queue.Queue[dict[str, Any]] = _ListenerQueue(maxsize=maxsize)
         # Lock order matches writer: ``_ws_lock`` outer, ``_listeners_lock``
@@ -1176,6 +1194,14 @@ class SessionUIBase:
             "seq": snap_seq,
         }
         if not buffered:
+            # Derived staleness — see the docstring's empty-buffer
+            # section.  ``snap_seq`` (the counter captured under the
+            # registration locks) rather than a re-read of
+            # ``self._event_id`` keeps the check atomic with the
+            # listener registration.
+            if snap_seq > 0 and last_event_id < snap_seq:
+                lost_count = snap_seq - last_event_id
+                return client_queue, [], "truncated", lost_count, snap_seq + 1, snapshot
             return client_queue, [], "replay_ok", 0, 0, snapshot
         earliest_id = buffered[0][0]
         if last_event_id < earliest_id - 1:
@@ -1205,6 +1231,21 @@ class SessionUIBase:
           - ``cursor < earliest_id - 1`` → False (would be ``truncated``);
           - no event id strictly greater than ``cursor`` → False (the
             delta would be empty — nothing in-flight to replay).
+
+        DELIBERATE asymmetry with ``register_listener_with_replay``'s
+        empty-ring branch (ruled 2026-07-20, do not "fix"): on an empty
+        ring with a stale cursor the register path reports
+        ``"truncated"`` (honesty — the client must resync from REST),
+        while this predicate stays False (an empty ring genuinely
+        cannot fast-forward, so ``/history`` must keep the in-flight
+        turn and withhold the cursor).  Mirroring the truncated rule
+        here would hand out cursors that point into a ring with
+        nothing in it — every such connect would immediately
+        re-truncate, looping the client through resync until new
+        events happen to cover the gap.  Both branches answer the same
+        underlying question ("can the ring cover it?" — no) at
+        different decision points: one picks the recovery MESSAGE, the
+        other picks the recovery ROUTE.
         """
         with self._listeners_lock:
             if not self._event_buffer:

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -57,6 +57,11 @@ _DEFAULT_LISTENER_QUEUE_MAX = 500
 # ``_enqueue`` and gets one fresh ``_event_id``, so it never violates
 # the no-in-ring-coalescing rule (see ``_resolve_event_buffer_max``):
 # no consumer's ``last_event_id`` can fall inside a batch.
+# ``tool_output_chunk`` shares this cadence (same two constants) via
+# the per-call_id batcher (``_PendingChunkBatch`` below) — line-chatty
+# tools under the 4-wide pool were the OTHER storm source, one event
+# per stdout line, and each line's ``_enqueue`` also force-flushed the
+# pending token batch (the amplifier).
 #
 # The window is measured from the LAST flush, checked on token
 # arrival (no timer thread): the first fragment after ≥window of
@@ -69,6 +74,28 @@ _DEFAULT_LISTENER_QUEUE_MAX = 500
 # tests can pin cadence-sensitive behaviour deterministically.
 _TOKEN_BATCH_WINDOW_SECS = 0.025
 _TOKEN_BATCH_MAX_CHARS = 4096
+
+
+class _PendingChunkBatch:
+    """One tool call's pending ``tool_output_chunk`` accumulator.
+
+    ``tool_output_chunk`` shares the token batcher's cadence (window +
+    size cap, same constants) but is keyed PER call_id — up to four
+    concurrent tools stream lines at once and their batches must not
+    interleave text.  ``last_flush`` lives on the entry (not a UI-level
+    scalar like ``_last_token_flush``) so each call's stream keeps its
+    own window clock; it starts at 0.0 so a call's FIRST line flushes
+    immediately (time-to-first-output protection, mirroring tokens).
+    The entry survives window flushes (the clock must persist) and is
+    removed at the call's terminal flush or turn teardown.
+    """
+
+    __slots__ = ("fragments", "last_flush", "size")
+
+    def __init__(self) -> None:
+        self.fragments: list[str] = []
+        self.size: int = 0
+        self.last_flush: float = 0.0
 
 
 class _ListenerOverflow(queue.Full):
@@ -642,6 +669,16 @@ class SessionUIBase:
         # ``time.monotonic()`` of the last real flush; 0.0 makes the
         # first fragment of a fresh UI flush immediately.
         self._last_token_flush: float = 0.0
+        # Per-call_id chunk batches (tool_output_chunk coalescing — the
+        # same emit-time batching as tokens, keyed per call because up
+        # to 4 concurrent tools stream lines at once).  Guarded by
+        # ``_ws_lock``; each KEY is single-writer (one bash drain
+        # thread per call_id — order within a key assumes that, see
+        # :meth:`_buffer_chunk_locked`), the DICT is multi-writer.
+        # Entries persist across window flushes (they carry the
+        # per-call cadence clock) and are removed at the call's
+        # terminal flush (:meth:`on_tool_result`) or turn teardown.
+        self._pending_chunks: dict[str, _PendingChunkBatch] = {}
         # Last broadcast (activity, activity_state) tuple — used by
         # :meth:`_broadcast_activity` overrides to dedup back-to-back
         # identical activity ticks. Tool-heavy turns can fire many
@@ -720,9 +757,16 @@ class SessionUIBase:
         acquires it (non-reentrant).  Token events never come through
         here: :meth:`on_content_token` / :meth:`on_reasoning_token`
         buffer under ``_ws_lock`` and their flush emits via
-        :meth:`_enqueue_direct`.  Every current call site enqueues
-        outside ``_ws_lock``; a violation deadlocks immediately (and
-        loudly) in any test that exercises the path.
+        :meth:`_enqueue_direct`.  ``tool_output_chunk`` likewise
+        bypasses this path via the per-call chunk batcher
+        (:meth:`on_tool_output_chunk`) — which is also why chunk
+        emission no longer force-flushes the token batch (chunk-vs-
+        content interleaving is cosmetic: independent DOM subtrees;
+        the load-bearing chunk ordering is against its OWN call's
+        ``tool_result``, enforced in :meth:`on_tool_result`).  Every
+        current call site enqueues outside ``_ws_lock``; a violation
+        deadlocks immediately (and loudly) in any test that exercises
+        the path.
 
         Returns the monotonic ``_event_id`` assigned to this event so a
         caller that also persists the same turn (e.g.
@@ -901,6 +945,118 @@ class SessionUIBase:
         would paint a dead ``send()``'s tail into the NEW turn's bubble.
         """
         self._reset_pending_locked()
+
+    def _buffer_chunk_locked(self, call_id: str, chunk: str) -> None:
+        """Accumulate one tool-output line; flush on window/size.
+
+        Caller holds ``_ws_lock``.  Chunks share the token batcher's
+        cadence constants but batch PER call_id (concurrent tools must
+        not interleave text) — see :class:`_PendingChunkBatch` for the
+        per-entry clock semantics.  Order within a key assumes ONE
+        producer thread per call_id, true by construction today (a
+        single ``bash-drain-out-{call_id}`` thread streams stdout;
+        stderr is not streamed) and pinned by
+        ``test_chunk_producer_surface_is_single_site``.
+
+        Tail latency, ruled ACCEPTED (do not add a flush timer): a tool
+        that prints a burst then runs silently holds the trailing
+        sub-window batch until its next line, its own ``tool_result``,
+        or turn teardown — the same arrival-driven stall the token
+        batcher documents (its backstop is the ``_enqueue`` chokepoint;
+        chunks' backstop is the call's terminal).  Bounded at one
+        sub-window batch, the burst's first line already painted
+        (first-line-immediate), and the result delivers the complete
+        output regardless; a timer thread would break the batchers'
+        deliberately timer-less design for that sliver.
+
+        Late chunks from a LEAKED drain thread (past its join timeout,
+        ``bash.drain_leaked``) are gated at the PRODUCER — the
+        ``emit_done`` event in ``_exec_bash``'s stdout closure — not
+        here: the execution closure is the one identity that call_id
+        reuse across turns can't confuse, whereas a UI-side
+        closed-call ledger keyed on call_id would either discard a
+        reusing provider's NEW stream or re-open under per-turn resets
+        / LRU churn (both found in review).  A chunk that slips the
+        gate's one-line race re-buffers here and emits — identical to
+        the pre-batching behaviour for the same line.
+        """
+        batch = self._pending_chunks.get(call_id)
+        if batch is None:
+            batch = _PendingChunkBatch()
+            self._pending_chunks[call_id] = batch
+        batch.fragments.append(chunk)
+        batch.size += len(chunk)
+        if (
+            time.monotonic() - batch.last_flush >= _TOKEN_BATCH_WINDOW_SECS
+            or batch.size >= _TOKEN_BATCH_MAX_CHARS
+        ):
+            self._flush_chunk_batch_locked(call_id)
+
+    def _flush_chunk_batch_locked(self, call_id: str) -> None:
+        """Emit ``call_id``'s pending chunks as ONE event.  Caller holds
+        ``_ws_lock``.
+
+        The entry stays in the dict (its ``last_flush`` clock re-arms
+        the window for the ongoing stream); removal happens only at the
+        call's terminal (:meth:`_finish_chunk_call_locked`) or turn
+        teardown.  Emits via :meth:`_enqueue_direct` — the same
+        lock-order (``_ws_lock`` outer → ``_listeners_lock`` inner) as
+        the token flush; ``_stamp_agent_parent`` runs at the chokepoint,
+        so a sub-agent's batch stamps by its (still-registered) call_id
+        at flush time.  Deliberately does NOT flush the token batch:
+        chunk-vs-content interleaving is cosmetic (independent DOM
+        subtrees) — wiring chunks into the token flush is the per-line
+        amplifier this batching removes.
+        """
+        batch = self._pending_chunks.get(call_id)
+        if batch is None or not batch.fragments:
+            return
+        text = "".join(batch.fragments)
+        batch.fragments = []
+        batch.size = 0
+        batch.last_flush = time.monotonic()
+        self._enqueue_direct({"type": "tool_output_chunk", "call_id": call_id, "chunk": text})
+
+    def _flush_all_chunk_batches_locked(self) -> None:
+        """Flush every call's pending chunks and drop the entries.
+
+        Caller holds ``_ws_lock``.  The turn-teardown backstop
+        (``stream_end`` / idle-error snapshot / turn commit / error) —
+        after it, no stream continues, so the per-call clocks are dead
+        weight and the entries go with the flush.  A tool that died
+        with NEITHER a self-reported nor a synthesized ``tool_result``
+        (unproven-reachable) self-heals here: its <pre> was never
+        removed (no result rendered), so the late batch paints in
+        place.
+        """
+        for call_id in list(self._pending_chunks):
+            self._flush_chunk_batch_locked(call_id)
+        self._pending_chunks.clear()
+
+    def _discard_pending_chunks_locked(self) -> None:
+        """Drop all pending chunk text without emitting.  Caller holds
+        ``_ws_lock``.
+
+        Only for the stale-crash path (:meth:`on_turn_start`) — the
+        mirror of :meth:`_discard_pending_tokens_locked`, same
+        rationale: never enqueued, never ring-buffered, so discarding
+        is consistent everywhere.
+        """
+        self._pending_chunks.clear()
+
+    def _finish_chunk_call_locked(self, call_id: str) -> None:
+        """Terminal flush for one call: emit its pending chunks and drop
+        the entry (its window clock included).  Caller holds ``_ws_lock``.
+
+        Runs BEFORE the call's ``tool_result`` enqueues (the
+        load-bearing ordering: the client removes the streaming <pre>
+        when it renders the result, so trailing chunks must be on the
+        wire first).  Late leaked-drain chunks after this point are
+        gated at the producer (see :meth:`_buffer_chunk_locked`), so no
+        closed-call bookkeeping lives here.
+        """
+        self._flush_chunk_batch_locked(call_id)
+        self._pending_chunks.pop(call_id, None)
 
     def _stamp_agent_parent(self, data: dict[str, Any]) -> dict[str, Any]:
         """Stamp ``parent_call_id`` on a sub-agent's child event.
@@ -2995,6 +3151,7 @@ class SessionUIBase:
         """
         with self._ws_lock:
             self._discard_pending_tokens_locked()
+            self._discard_pending_chunks_locked()
             self._reset_inflight_buffers_locked()
 
     def on_turn_committed(self) -> None:
@@ -3021,6 +3178,7 @@ class SessionUIBase:
         """
         with self._ws_lock:
             self._flush_token_batch_locked()
+            self._flush_all_chunk_batches_locked()
             self._reset_inflight_buffers_locked()
 
     def on_thinking_start(self) -> None:
@@ -3091,6 +3249,10 @@ class SessionUIBase:
 
     def on_stream_end(self) -> None:
         with self._ws_lock:
+            # Turn-teardown backstop for the chunk batcher (the token
+            # batch flushes via _enqueue's chokepoint below; chunks
+            # bypass _enqueue, so their backstop lives here).
+            self._flush_all_chunk_batches_locked()
             self._ws_current_activity = ""
             self._ws_activity_state = ""
         self._broadcast_activity()
@@ -3117,6 +3279,12 @@ class SessionUIBase:
         projection's ``preview`` field so live and replay render identically.
         """
         with self._ws_lock:
+            # Terminal flush of this call's chunk stream BEFORE the
+            # result event goes out — the client removes the streaming
+            # <pre> when it renders the result, so trailing chunks must
+            # precede it on the wire.  (Late leaked-drain chunks are
+            # gated at the producer; see _buffer_chunk_locked.)
+            self._finish_chunk_call_locked(call_id)
             self._ws_tool_calls[name] = self._ws_tool_calls.get(name, 0) + 1
             self._ws_turn_tool_calls += 1
             self._ws_current_activity = ""
@@ -3135,7 +3303,21 @@ class SessionUIBase:
         self._enqueue(event)
 
     def on_tool_output_chunk(self, call_id: str, chunk: str) -> None:
-        self._enqueue({"type": "tool_output_chunk", "call_id": call_id, "chunk": chunk})
+        """Buffer one tool-output line into the per-call chunk batcher.
+
+        The per-LINE ``_enqueue`` this replaces was the event-storm
+        source under parallel task agents (4 concurrent line-chatty
+        tools ⇒ hundreds-thousands of events/sec past the token
+        batcher, overflowing listener queues), and — because every
+        non-token ``_enqueue`` force-flushes the pending token batch —
+        each line also defeated token batching (the amplifier).
+        Buffered chunks bypass ``_enqueue`` entirely; the batch emits
+        via ``_enqueue_direct`` on window/size, the call's
+        ``tool_result`` (:meth:`on_tool_result`) is the per-call
+        ordering backstop, and turn teardown flushes stragglers.
+        """
+        with self._ws_lock:
+            self._buffer_chunk_locked(call_id, chunk)
 
     def on_status(self, usage: dict[str, Any], context_window: int, effort: str) -> None:
         """Record per-ws token / context counters + enqueue + persist usage.
@@ -3284,6 +3466,10 @@ class SessionUIBase:
         self._enqueue({"type": "info", "message": message})
 
     def on_error(self, message: str) -> None:
+        with self._ws_lock:
+            # Error teardown backstop for the chunk batcher (token
+            # batch flushes via _enqueue below; chunks bypass it).
+            self._flush_all_chunk_batches_locked()
         self._enqueue({"type": "error", "message": message})
 
     def on_system_turn(
@@ -3546,8 +3732,10 @@ class SessionUIBase:
             # below), and the terminal-state payload must carry the
             # full turn text — a batch stranded in the accumulator
             # would otherwise vanish from the dashboard payload AND
-            # from connected panes.
+            # from connected panes.  Pending chunk batches flush here
+            # for the same reason (cancel/error paths skip stream_end).
             self._flush_token_batch_locked()
+            self._flush_all_chunk_batches_locked()
             tokens = self._ws_prompt_tokens + self._ws_completion_tokens
             ctx = self._ws_context_ratio
             activity = self._ws_current_activity

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1075,6 +1075,17 @@ async def global_events_sse(request: Request) -> Response:
         else:
             buffered = list(event_buffer)
             if not buffered:
+                # KNOWN GAP (#881): an empty ring after a node restart
+                # reports ``replay_ok`` even when the client's cursor is
+                # stale, silently skipping the events lost with the old
+                # process.  The per-ws stream fixes this by deriving
+                # staleness from its storage-seeded ``_event_id`` counter
+                # (see ``register_listener_with_replay``); the global
+                # counter (``global_event_id_holder``) resets to 0 at
+                # boot, so the same rule cannot apply — a boot-epoch
+                # staleness signal is the fix direction tracked in #881.
+                # Tolerable meanwhile: consumers are idempotent roster
+                # state refreshed periodically, not append-only history.
                 replay_status = "replay_ok"
             else:
                 earliest_available_id = buffered[0][0]

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -62,6 +62,7 @@ import {
   DEGRADED_COOLDOWN_BASE_MS,
   DEGRADED_COOLDOWN_MAX_MS,
   DEGRADED_COOLDOWN_RESET_MS,
+  TRUNCATED_RESYNC_JITTER_MS,
   overflowWindowTripped,
   degradedCooldownStep,
 } from "./sse_overflow.js";
@@ -261,8 +262,10 @@ class Pane {
     this.projectName = "";
     this._lastStatusEvt = null;
     this._historyLoadToken = 0;
-    // Event backlog while a clear_ui / replay_truncated rebuild is in
-    // flight — see _beginReplayQuiesce.  {token, events[]} or null.
+    // Event backlog while a clear_ui rebuild is in flight — see
+    // _beginReplayQuiesce.  {token, events[]} or null.  (The truncated
+    // resync no longer quiesces: it tears the stream down first, so no
+    // live events exist during its rebuild.)
     this._replayQueue = null;
     // Hot-path caches — all invalidated by _clearAgentTracking/replayHistory.
     // _nearBottom mirrors the scroller position via a passive scroll listener
@@ -289,17 +292,45 @@ class Pane {
     // Set when replay_truncated arrives mid-stream (refetching then would
     // detach the live bubble); consumed on the next idle edge.
     this._pendingTruncatedResync = false;
+    // The cursor position a replay_truncated envelope was received AT —
+    // i.e. "a gap of lost events exists BELOW this cursor".  Keep-oldest:
+    // set only when null (repeated envelopes for the same unrepaired gap
+    // must not advance it), cleared by any successful full-history render
+    // (replayHistory — resync success or a clear_ui rebuild both repair
+    // the gap) or a ws switch.  Its one consumer is the connectSSE
+    // chokepoint: while set, every manual (re)connect presents THIS
+    // cursor (not the since-advanced live _lastEventId), so the server
+    // re-answers replay_truncated and the resync re-arms no matter which
+    // teardown cancelled the pending jittered timer — the gap-repair
+    // guarantee survives any interleaving of hide/show, degraded
+    // cooldowns, recover beats, and failed /history fetches.
+    this._truncatedFromCursor = null;
     // Field instrumentation for the two distinct "output stops while the
     // backend is healthy" causes: server-signalled overflow closes
     // (dropped-events class) vs client dispatch/render throws (wedge
     // class).  The console lines at each increment carry the running
     // count, so a field report shows which class fired without a
-    // debugger attached.
-    this._streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 };
-    // Rolling timestamps of stream_overflow closes — input to the
-    // degraded catch-up limiter (see overflowWindowTripped above).
+    // debugger attached.  ``truncatedGaps`` counts replay-window misses
+    // (truncated envelopes acted on), NOT resyncs performed — a
+    // degraded-catchup trip records the gap but skips its resync.
+    this._streamHealth = {
+      overflows: 0,
+      renderThrows: 0,
+      malformedFrames: 0,
+      truncatedGaps: 0,
+    };
+    // Rolling timestamps of heavyweight-recovery churn — stream_overflow
+    // closes AND truncated resyncs (both via _recordChurnAndMaybeTrip) —
+    // input to the degraded catch-up limiter (overflowWindowTripped).
     this._overflowTimes = [];
     this._degradedTimer = null;
+    // Pending jittered truncated-resync (see _scheduleTruncatedResync).
+    // Cancelled by disconnectSSE alongside _degradedTimer, so any path that
+    // tears the transport down (ws switch via _loadHistoryThenConnect,
+    // close-on-hide, degraded entry, destroy) also discards a resync
+    // scheduled for the OLD stream — the next connect's own truncated
+    // envelope reschedules if the gap still exists.
+    this._resyncTimer = null;
     this._degradedCooldownMs = DEGRADED_COOLDOWN_BASE_MS;
     // Timestamp of the last degraded-catchup trip; drives the cooldown
     // ladder's escalate-vs-reset decision independently of _overflowTimes.
@@ -370,6 +401,17 @@ class Pane {
     if (this._degradedTimer) {
       clearTimeout(this._degradedTimer);
       this._degradedTimer = null;
+    }
+    // Same ownership rule for a pending jittered truncated-resync: a
+    // torn-down stream's scheduled resync must not fire against whatever
+    // the pane connects to next (its .finally reconnect would land on the
+    // NEW ws).  The timer's own firing path nulls the field before calling
+    // _loadHistoryThenConnect, so — like _degradedTimer above — this never
+    // cancels the work it is part of.  If the gap still exists after the
+    // teardown, the next connect's truncated envelope reschedules it.
+    if (this._resyncTimer) {
+      clearTimeout(this._resyncTimer);
+      this._resyncTimer = null;
     }
     if (this.evtSource) {
       this.evtSource.close();
@@ -668,10 +710,11 @@ class Pane {
 
   _syncApprovalState() {
     // Prune orphaned cycles whose block elements are no longer in the DOM.
-    // A clear_ui / replay_truncated / re-render that wipes the conversation
-    // subtree (messagesEl.replaceChildren()) also clears approvalCycles via
-    // _resetStreamingRefs.  But if an approve_request event is processed
-    // between the wipe and the refetch, its cycle card is in a detached
+    // A rebuild that wipes the conversation subtree (clear_ui re-render,
+    // truncated resync — messagesEl.replaceChildren()) also clears
+    // approvalCycles via _resetStreamingRefs.  But if an approve_request
+    // event is processed between the wipe and the refetch, its cycle card
+    // is in a detached
     // subtree and the matching approval_resolved may never arrive — leaving
     // pendingApproval=true and the send button disabled forever.
     for (const [cid, entry] of this.approvalCycles) {
@@ -1259,14 +1302,35 @@ class Pane {
       "/v1/api/workstreams/" +
       encodeURIComponent(wsId) +
       "/events";
+    // A recorded truncation gap OVERRIDES the live cursor: while
+    // _truncatedFromCursor is set (gap detected, no full render yet),
+    // every manual (re)connect presents the truncation-time cursor, so
+    // the server re-answers replay_truncated and the resync re-arms —
+    // whatever teardown cancelled the pending jittered resync in the
+    // meantime (close-on-hide, degraded entry, ws reassignment beat).
+    // This connect chokepoint is what makes the gap-repair guarantee
+    // interleaving-proof; a cancellable timer alone silently lost the
+    // repair when a hide/show cycle landed inside the jitter window
+    // after the live cursor had advanced past the truncation point.
+    // Safe against double-render: ring eviction is forward-only, so a
+    // once-truncated cursor can never re-enter replay range — this
+    // connect always draws the envelope, never a bulk replay.  (Native
+    // EventSource auto-reconnects bypass this — the browser's header
+    // carries the advanced id — but they never run disconnectSSE, so
+    // the pending resync timer survives them.)
+    //
     // ``!= null`` (not truthiness): a resume cursor of 0 is valid — the
     // ring buffer's first emitted event is id 1, so register_listener_with_replay(0)
     // replays the whole in-flight turn. A brand-new ws seeds _event_id at 0,
     // so its first user row (and thus a first-turn /history cursor) can be 0;
     // a truthiness gate would silently drop it and fall back to the lossy
     // fresh snapshot. Mirrors the ``data.cursor != null`` guard in _refetchHistory.
-    if (this._lastEventId != null) {
-      evtUrl += "?last_event_id=" + encodeURIComponent(this._lastEventId);
+    const connectCursor =
+      this._truncatedFromCursor != null
+        ? this._truncatedFromCursor
+        : this._lastEventId;
+    if (connectCursor != null) {
+      evtUrl += "?last_event_id=" + encodeURIComponent(connectCursor);
     }
     // Close-on-hide / replay-on-show: installed once per pane, removed
     // by the factory's destroy().  A hidden tab's throttled drain is the
@@ -1401,19 +1465,17 @@ class Pane {
     this._hiddenDisconnect = false;
   }
 
-  _noteStreamOverflow() {
-    this._streamHealth.overflows += 1;
+  _recordChurnAndMaybeTrip() {
+    // The ONE rolling-window churn accounting step for the degraded
+    // ladder — stream_overflow closes (_noteStreamOverflow) AND
+    // truncated resyncs (_noteTruncatedResync) land here, so the trip
+    // parameters and the degraded-entry call have a single
+    // implementation that cannot silently diverge.  The cooldown-ladder
+    // reset lives in _enterDegradedCatchup (keyed off _lastDegradedAt),
+    // NOT here — this method only counts and trips.  Returns true when
+    // this entry ENTERED degraded catch-up.
     const now = Date.now();
     this._overflowTimes.push(now);
-    console.warn(
-      "interactive: server closed the stream after a send-queue overflow " +
-        "(total " +
-        this._streamHealth.overflows +
-        "); reconnect will replay the gap",
-    );
-    // Trip when OVERFLOW_TRIP_COUNT closes land inside the rolling window.
-    // The cooldown-ladder reset lives in _enterDegradedCatchup (keyed off
-    // _lastDegradedAt), NOT here — this method only counts and trips.
     if (
       overflowWindowTripped(
         this._overflowTimes,
@@ -1423,7 +1485,78 @@ class Pane {
       )
     ) {
       this._enterDegradedCatchup();
+      return true;
     }
+    return false;
+  }
+
+  _noteStreamOverflow() {
+    this._streamHealth.overflows += 1;
+    console.warn(
+      "interactive: server closed the stream after a send-queue overflow " +
+        "(total " +
+        this._streamHealth.overflows +
+        "); reconnect will replay the gap",
+    );
+    this._recordChurnAndMaybeTrip();
+  }
+
+  _recordTruncatedGap() {
+    // The one increment+log step for the replay-window class — EVERY
+    // truncatedGaps bump goes through here so the console invariant
+    // documented at the _streamHealth initializer holds (each increment
+    // carries the running count).  Class-of-event wording only: the
+    // recovery that follows differs by caller (jittered fresh-connect,
+    // idle-edge fresh-connect, or a degraded-catchup skip), so the line
+    // must not assert an action a trip may skip.  Churn accounting is
+    // deliberately NOT here — the idle-edge caller records the gap
+    // without feeding the degraded ladder.
+    this._streamHealth.truncatedGaps += 1;
+    console.warn(
+      "interactive: replay window could not cover the reconnect gap " +
+        "(total " +
+        this._streamHealth.truncatedGaps +
+        ")",
+    );
+  }
+
+  _noteTruncatedResync() {
+    // Count a truncated-triggered full resync into the SAME rolling
+    // churn window as overflow closes (_overflowTimes): both are "this
+    // consumer needed heavyweight recovery", and the degraded ladder is
+    // the bound for either loop.  Separate _streamHealth counter (via
+    // _recordTruncatedGap) so a field report distinguishes the
+    // dropped-events class (overflows) from the replay-window class
+    // (truncatedGaps).
+    //
+    // Returns true when this trip ENTERED degraded catch-up — the
+    // caller must then SKIP starting its resync: the cooldown ladder
+    // just disconnected the stream, and a _loadHistoryThenConnect
+    // started now would reconnect from its .finally and defeat the
+    // cooldown it triggered.  The wake-up reconnect re-arrives here via
+    // a fresh replay_truncated (its cursor is still stale), so the
+    // resync is deferred, not lost.
+    this._recordTruncatedGap();
+    return this._recordChurnAndMaybeTrip();
+  }
+
+  _scheduleTruncatedResync() {
+    // Start the truncated-triggered fresh connect after a random
+    // 0..TRUNCATED_RESYNC_JITTER_MS spread.  The truncated envelope is
+    // herd-shaped — a node restart makes every stale-cursor tab
+    // reconnect inside the EventSource retry jitter and each answers
+    // with a /history fetch — and the per-tab churn limiter cannot see
+    // a cross-tab herd (one resync per tab never trips it), so the
+    // spread is applied here, before the fetch.  During the wait the
+    // pane keeps painting live events from the still-open stream; the
+    // gap predates the resync either way, so the only cost is a
+    // delayed backfill.  disconnectSSE owns cancellation (ws switch,
+    // hide, degraded entry, destroy — see the field comment).
+    if (this._resyncTimer != null) return; // one pending resync at a time
+    this._resyncTimer = setTimeout(() => {
+      this._resyncTimer = null;
+      if (this.wsId) this._loadHistoryThenConnect(this.wsId);
+    }, Math.random() * TRUNCATED_RESYNC_JITTER_MS);
   }
 
   _enterDegradedCatchup() {
@@ -1488,7 +1621,11 @@ class Pane {
     // must preserve these): a stale quiesce queue would wedge the new load's
     // events behind a flush that never comes, stale agent tracking points at
     // the DOM this load is about to replace, and a pending truncated-resync
-    // is superseded by the full refetch below.
+    // is superseded by the full refetch below.  The truncation-gap cursor
+    // is dropped ONLY on a ws switch (it names a gap in the OLD ws); a
+    // same-ws reload keeps it armed until a successful full render
+    // (replayHistory clears it) so a failed fetch can retry below.
+    if (this.wsId !== wsId) this._truncatedFromCursor = null;
     this._replayQueue = null;
     this._clearAgentTracking();
     this._pendingTruncatedResync = false;
@@ -1497,12 +1634,25 @@ class Pane {
     // the pane has switched to another ws. Newest load wins; older ones drop.
     const token = (this._historyLoadToken || 0) + 1;
     this._historyLoadToken = token;
-    // ``seedCursor=true``: this is the initial-connect path (the
-    // ``.finally`` reconnects), so a resume cursor from /history should
-    // seed _lastEventId for that connect. The clear_ui / replay_truncated
-    // re-render callers pass it false — they run on an already-live stream
-    // and must NOT rewind _lastEventId off the live position.
+    // ``seedCursor=true``: every caller of THIS path reconnects (the
+    // ``.finally``), so a resume cursor from /history should seed
+    // _lastEventId for that connect.  Callers: first paint, ws switch,
+    // and — since the 2026-07 dead-stream ruling — both replay_truncated
+    // resync branches (a truncated stream is torn down and fully
+    // re-established, so cursor adoption is safe AND required: /history
+    // trims the in-flight turn whenever it returns a cursor).  Only the
+    // clear_ui re-render still calls _refetchHistory directly with
+    // seedCursor=false — it runs on an already-live stream and must NOT
+    // rewind _lastEventId off the live position.
     this._refetchHistory(wsId, token, true).finally(() => {
+      // Failed-fetch retry rides the connect chokepoint, not this
+      // callback: a fetch failure leaves _truncatedFromCursor set (only
+      // replayHistory's full render clears it), so the reconnect below
+      // presents the truncation-time cursor, draws replay_truncated
+      // again, and the resync retries — bounded by the churn limiter +
+      // degraded ladder.  The old transcript survives a failed fetch
+      // (the failure branch never reaches replayHistory's wipe), so the
+      // retry window shows stale-but-real content, not an empty pane.
       if (token === this._historyLoadToken) this.connectSSE(wsId);
     });
   }
@@ -1514,12 +1664,13 @@ class Pane {
     // → empty pane); the render is deliberately OUTSIDE the catch so a
     // render bug surfaces loudly instead of being masked as an empty pane.
     //
-    // ``seedCursor`` is true ONLY on the initial-connect path
-    // (_loadHistoryThenConnect, which reconnects via .finally). The
-    // re-render callers leave it false so a fast-forward cursor never
-    // rewinds the live stream's _lastEventId backward (which would
-    // double-render on a later transient reconnect, or — on a re-render
-    // that trims an orphan with no reconnect — strand the omitted turn).
+    // ``seedCursor`` is true ONLY via _loadHistoryThenConnect (which
+    // reconnects via .finally — first paint, ws switch, truncated
+    // resync). The live-stream re-render caller (clear_ui) leaves it
+    // false so a fast-forward cursor never rewinds the live stream's
+    // _lastEventId backward (which would double-render on a later
+    // transient reconnect, or — on a re-render that trims an orphan
+    // with no reconnect — strand the omitted turn).
     const id = wsId || this.wsId;
     let data = null;
     try {
@@ -1568,7 +1719,10 @@ class Pane {
     } else {
       // Failure path never reaches replayHistory — reset the streaming refs
       // here too, or the flushed backlog and resumed live events would paint
-      // into the subtree clear_ui already wiped.
+      // into the subtree clear_ui already wiped.  It also leaves
+      // _truncatedFromCursor SET (only replayHistory clears it), which is
+      // what arms the connect chokepoint's retry for a failed truncated
+      // resync.
       this._resetStreamingRefs();
       this.showEmptyState();
       this._endReplayQuiesce(token);
@@ -1576,10 +1730,12 @@ class Pane {
   }
 
   _beginReplayQuiesce(token) {
-    // Arm the handleEvent queue for a full re-render (clear_ui /
-    // replay_truncated).  Token-owned: a newer load's quiesce replaces this
-    // one wholesale — events queued before the newer snapshot was fetched
-    // are covered by that snapshot, so dropping them is lossless.
+    // Arm the handleEvent queue for a full re-render on a LIVE stream
+    // (clear_ui — the sole remaining quiescing caller; the truncated
+    // resync disconnects first instead).  Token-owned: a newer load's
+    // quiesce replaces this one wholesale — events queued before the
+    // newer snapshot was fetched are covered by that snapshot, so
+    // dropping them is lossless.
     this._replayQueue = { token: token, events: [] };
   }
 
@@ -1655,7 +1811,7 @@ class Pane {
     // Guard: drop events that belong to a different workstream.
     // This prevents cross-contamination during tab switches and reconnects.
     if (evt.ws_id && evt.ws_id !== this.wsId) return;
-    // While a clear_ui / replay_truncated rebuild is in flight, live events
+    // While a clear_ui rebuild is in flight, live events
     // must not paint into a DOM the imminent replaceChildren() will wipe —
     // anything painted in the [snapshot-fetch → rebuild] window is lost with
     // no redelivery (the re-render callers never rewind _lastEventId).  Queue
@@ -1814,12 +1970,21 @@ class Pane {
           // Deferred replay_truncated re-sync: the truncation arrived while
           // a segment was streaming (refetching then would have detached the
           // live bubble), so repair the lost-event gap now that the turn is
-          // settled and /history is complete.
+          // settled and /history is complete.  Same dead-stream flow as the
+          // immediate branch (full fresh connect, cursor adoption) — but NOT
+          // counted into the degraded-churn window, and NOT herd-jittered:
+          // this branch fires once per latch, and the latch only re-arms via
+          // a NEW truncated envelope followed by a full turn-settle —
+          // inherently rate-limited AND per-pane staggered by turn timing,
+          // unlike the immediate branch's reconnect loop (which the limiter
+          // bounds and _scheduleTruncatedResync spreads).  Usually /history
+          // returns no cursor here (no orphan at idle) and the reconnect is
+          // a plain fresh connect; a queued send racing the fetch just means
+          // a seeded reconnect instead — both converge.
           if (this._pendingTruncatedResync) {
             this._pendingTruncatedResync = false;
-            const rsToken = this._historyLoadToken;
-            this._beginReplayQuiesce(rsToken);
-            this._refetchHistory(this.wsId, rsToken);
+            this._recordTruncatedGap();
+            this._loadHistoryThenConnect(this.wsId);
           }
           // Only steal focus if this is the active pane and no approval pending.
           if (this._host.isFocused(this) && !this.pendingApproval) {
@@ -2042,15 +2207,28 @@ class Pane {
         // re-render from REST and dispatch any queued edit-and-resend
         // once the (possibly truncated) history lands. The resend keys
         // off this signal rather than an inline history SSE event. Capture
-        // the load token so a ws switch mid-flight discards both the
-        // re-render and the resend (no cross-ws send).
+        // the load token AND the ws identity: a ws SWITCH mid-flight
+        // discards both the re-render and the resend (no cross-ws send),
+        // but a SAME-ws supersession — the jittered truncated resync
+        // bumps _historyLoadToken through _loadHistoryThenConnect — must
+        // still fire the resend: the superseding load renders the same
+        // post-rewind history, and silently dropping the queued edit
+        // stranded the composer busy with a message that never sent.
         const token = this._historyLoadToken;
+        const editWs = this.wsId;
         this._beginReplayQuiesce(token);
         this.messagesEl.replaceChildren();
         this._resetStreamingRefs();
         this._refetchHistory(this.wsId, token)
           .then(() => {
-            if (token !== this._historyLoadToken) return;
+            if (token !== this._historyLoadToken && this.wsId !== editWs) {
+              // Cross-ws supersession: release the latch + busy so the
+              // composer recovers; the edit belongs to a pane state that
+              // no longer exists.
+              this._pendingEditSend = null;
+              this.setBusy(false);
+              return;
+            }
             if (!this._pendingEditSend) return;
             const editText = this._pendingEditSend;
             this._pendingEditSend = null;
@@ -2091,22 +2269,50 @@ class Pane {
       }
 
       case "replay_truncated":
-        // Reconnect buffer evicted past our last-seen event id — the
-        // live recovery replay no longer carries history, so re-sync
-        // from REST. Skip while a turn is mid-stream: the recovery
-        // floor's in_progress_snapshot already paints it, and an async
-        // refetch's replaceChildren() would detach the live bubble so
-        // content deltas render nowhere. Re-syncs on the next clean
-        // (re)connect.  The guard covers BOTH streaming targets — a
-        // reasoning-only segment (currentReasoningEl without a content
-        // bubble yet) is just as detachable as a content one.  Mid-stream
-        // the resync is DEFERRED, not dropped: skipping outright left the
-        // lost-event gap unrepaired for the rest of the session (no clean
-        // reconnect may come for hours); the idle edge consumes the flag.
+        // The stream just admitted losing events past recovery — treat
+        // the connection as DEAD and run the full fresh-connect flow
+        // (_loadHistoryThenConnect: disconnect first, REST /history,
+        // rebuild, adopt the returned resume cursor, reconnect).  The
+        // cursor adoption is the point (ruled 2026-07-20, do not revert
+        // to an in-place refetch): /history TRIMS the trailing in-flight
+        // turn whenever it hands back a cursor (_resume_cursor_and_trim),
+        // on the assumption the caller replays from that cursor.  The old
+        // in-place refetch here discarded the cursor, so a mid-run
+        // truncation wiped the executing turn's rows (task cards
+        // included) with no redelivery — sub-agent children then escaped
+        // to top-level rows after the orphan grace.  Disconnect-first
+        // also removes the old flush-vs-reconnect ambiguity: no live
+        // events arrive during the rebuild, so nothing double-renders.
+        //
+        // Skip while a turn is mid-stream: an async refetch's
+        // replaceChildren() would detach the live bubble so content
+        // deltas render nowhere.  The guard covers BOTH streaming
+        // targets — a reasoning-only segment (currentReasoningEl
+        // without a content bubble yet) is just as detachable as a
+        // content one.  Mid-stream the resync is DEFERRED, not
+        // dropped; the idle edge consumes the flag.
+        //
+        // Record WHERE the gap sits before either branch: the envelope
+        // arrived at the connect cursor, but by the time the resync's
+        // /history fetch runs (after the jitter, or at the idle edge)
+        // the live stream has advanced _lastEventId well past it — the
+        // failed-fetch retry needs this truncation-time value, not the
+        // advanced one (see _truncatedFromCursor's field comment).
+        // Keep-oldest: a retry reconnect re-delivers an envelope for the
+        // SAME unrepaired gap and must not advance the record.
+        if (this._truncatedFromCursor == null) {
+          this._truncatedFromCursor = this._lastEventId;
+        }
         if (!this.currentAssistantEl && !this.currentReasoningEl) {
-          const rtToken = this._historyLoadToken;
-          this._beginReplayQuiesce(rtToken);
-          this._refetchHistory(this.wsId, rtToken);
+          // Limiter check BEFORE scheduling the resync — a trip has just
+          // disconnected the stream for a cooldown, and a resync started
+          // now would reconnect from its .finally and defeat the cooldown
+          // (see _noteTruncatedResync).  No trip → the fresh connect
+          // starts after a herd-spreading jitter
+          // (_scheduleTruncatedResync).
+          if (!this._noteTruncatedResync()) {
+            this._scheduleTruncatedResync();
+          }
         } else {
           this._pendingTruncatedResync = true;
         }
@@ -2766,6 +2972,12 @@ class Pane {
 
   replayHistory(messages) {
     this.messagesEl.replaceChildren();
+    // A full committed-history render repairs any recorded truncation
+    // gap — whether this render came from the truncated resync itself or
+    // from an unrelated clear_ui rebuild.  Clear the retry cursor so a
+    // LATER failed reload doesn't rewind onto a gap that no longer
+    // exists.
+    this._truncatedFromCursor = null;
     // The rebuild just orphaned any in-flight streaming targets — reset them,
     // and release the agent-card/orphan maps whose entries now point at
     // replaced subtrees (detached-DOM retention).

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -1366,17 +1366,23 @@ class Pane {
     };
 
     this.evtSource.onmessage = (e) => {
-      // Capture lastEventId BEFORE JSON.parse so a (rare) malformed
-      // event doesn't desync the manual-reconnect fallback from
-      // native auto-reconnect (which advances lastEventId regardless
-      // of whether we successfully process the data).  Server's
-      // stamping contract: ``id:`` only on events sourced from the
-      // per-ws ring buffer — synthetic replay events (history /
-      // state_change / in_progress_snapshot) don't advance the
-      // counter, so reconnect resumes from the last BUFFERED id (or
-      // none on a truly-fresh connect that never received one).
-      if (this.evtSource && this.evtSource.lastEventId) {
-        this._lastEventId = this.evtSource.lastEventId;
+      // Capture lastEventId from the MESSAGE EVENT, before JSON.parse,
+      // so a malformed frame can't desync the manual-reconnect cursor
+      // from native auto-reconnect.  Spec shape — do NOT revert to
+      // reading the property off the EventSource OBJECT: per WHATWG the
+      // id lives on MessageEvent only, so the pre-2026-07 object-form
+      // read was a dead conditional and every manual reconnect (show
+      // edge, degraded retry, recover beat) went cursorless, silently
+      // dropping turns committed during the gap.  Guard: ``!= null &&
+      // !== ""`` — no-id frames carry "" per spec.  (lastEventId is a
+      // DOMString, so the valid id "0" — the error-surface snap_seq —
+      // is TRUTHY and plain truthiness would also accept it; the
+      // explicit form is for parity with the NUMERIC cursor gates
+      // below, where bare truthiness genuinely drops 0.)  Stamping
+      // contract: ``id:`` rides only ring-buffered events; synthetic
+      // replay frames never advance it.
+      if (e.lastEventId != null && e.lastEventId !== "") {
+        this._lastEventId = e.lastEventId;
       }
       // Guarded parse + dispatch.  onmessage is the pane's whole event
       // pipeline: an exception escaping it doesn't close the EventSource, so

--- a/turnstone/shared_static/sse_overflow.js
+++ b/turnstone/shared_static/sse_overflow.js
@@ -30,6 +30,20 @@ export const DEGRADED_COOLDOWN_MAX_MS = 120000;
 // top-of-ladder trips exceed the window and oscillate the cooldown back to
 // base — the escalation must survive its own backoff.
 export const DEGRADED_COOLDOWN_RESET_MS = 300000;
+// Random 0..this spread before a truncated-triggered /history resync starts.
+// The truncated envelope is herd-shaped: a node restart makes EVERY open tab
+// with a stale cursor reconnect inside the EventSource retry jitter
+// (2.5-4.5 s) and — since empty-ring reconnects now report truncated instead
+// of a silent replay_ok — each one answers with a full /history fetch.  The
+// per-tab churn limiter can't see the cross-tab herd (one resync per tab
+// never trips it), so the spread happens client-side, before the fetch.
+// During the wait the pane keeps painting live events (the gap predates the
+// resync either way), so the only cost is a delayed backfill.  If restart
+// herds ever measure hot despite the spread, the deeper complement is
+// server-side /history coalescing/rate-limiting (#884) — a node-side
+// change, not a bigger jitter: the spread lowers the peak but not the
+// total per-restart fetch count.
+export const TRUNCATED_RESYNC_JITTER_MS = 10000;
 
 // Rolling-window trip check.  Prunes `times` in place (entries older than
 // windowMs against nowMs) and reports whether count-or-more remain.  A

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -16,13 +16,6 @@ let workstreams = {};
 let currentWsId = null;
 let globalEvtSource = null;
 let globalRetryDelay = 1000;
-// Saved high-water mark for the manual-reconnect path (the
-// EventSource constructor can't set custom headers, so the
-// browser-native ``Last-Event-ID`` header is unavailable on
-// reconnect — we thread it via ``?last_event_id=N`` instead).  Updated
-// from ``globalEvtSource.lastEventId`` on every onmessage; native
-// auto-reconnect uses the header directly on the same source object.
-let globalLastEventId = null;
 let dashboardVisible = false;
 let _historyNavigation = false;
 let _lastHealth = null;
@@ -1759,28 +1752,29 @@ function connectGlobalSSE() {
     globalEvtSource.close();
     globalEvtSource = null;
   }
-  // Manual-reconnect path threads ``?last_event_id=N`` because the
-  // EventSource constructor can't set headers; native auto-reconnect
-  // on the same source uses the header directly.
-  let globalUrl = "/v1/api/events/global";
-  if (globalLastEventId) {
-    globalUrl += "?last_event_id=" + encodeURIComponent(globalLastEventId);
-  }
-  globalEvtSource = new EventSource(globalUrl);
+  // Manual reconnects on the GLOBAL stream are DELIBERATELY cursorless
+  // (no ``?last_event_id=`` — do not add a MessageEvent lastEventId
+  // capture here like the per-ws streams'): the global ring cannot
+  // report truncation for a stale cursor after a node restart (its
+  // counter reboots at 0 — KNOWN GAP #881), so presenting one draws
+  // ``replay_ok``-empty with NO node_snapshot and the roster ghosts
+  // exactly when a full rebuild is most needed.  Cursorless manual
+  // reconnects always draw the fresh node_snapshot — lossless for
+  // roster STATE (unlike per-ws append-only history, where the
+  // storage-seeded counter makes a stale cursor report ``truncated``
+  // and the cursor is therefore safe to track).  Native auto-reconnect
+  // keeps its browser-internal header either way.  Revisit when #881's
+  // boot-epoch staleness signal lands.
+  globalEvtSource = new EventSource("/v1/api/events/global");
   globalEvtSource.onopen = function () {
     globalRetryDelay = 1000;
   };
   globalEvtSource.onmessage = function (e) {
-    // Capture lastEventId BEFORE JSON.parse (see Pane.connectSSE
-    // onmessage for full rationale).
-    if (globalEvtSource && globalEvtSource.lastEventId) {
-      globalLastEventId = globalEvtSource.lastEventId;
-    }
-    // Guarded parse: the cursor above has already advanced past this frame,
-    // so a parse failure is a permanently-lost roster mutation — resync the
-    // roster from REST instead of silently drifting (a dropped ws_created
-    // renders as a conversation that never appears; a dropped ws_closed as
-    // a ghost row forever).
+    // Guarded parse: native auto-reconnect's header cursor has already
+    // advanced past this frame, so a parse failure is a permanently-lost
+    // roster mutation — resync the roster from REST instead of silently
+    // drifting (a dropped ws_created renders as a conversation that
+    // never appears; a dropped ws_closed as a ghost row forever).
     let data = null;
     try {
       data = JSON.parse(e.data);


### PR DESCRIPTION
Fixes the family of field reports termed "jank": turns that disappear and never come back, panes stuck busy after a tab was backgrounded, tool calls escaping a task_agent card into the main thread, and reconnect churn under parallel task agents.

## Root causes (five, interlocking)

1. **Truncated resync discarded the replay cursor.** `/history` trims the trailing in-flight turn whenever it returns a resume cursor, expecting the caller to replay from it; the client's `replay_truncated` handler refetched in place and threw the cursor away — a mid-run truncation wiped the executing turn (task cards included) with no redelivery, and the orphan grace then escaped still-streaming children to top-level rows.
2. **Empty-ring reconnects lied.** A workstream rehydrated after eviction/restart reported `replay_ok` for a provably stale cursor, so the gap was never signalled and never healed.
3. **`tool_output_chunk` emitted per stdout line** and each line force-flushed the pending token batch — the event storm that overflowed listener queues under 4-wide parallel agents and fed ring eviction.
4. **Fresh connects after hide windows never repainted committed turns** (consequence of 1+2+5 interacting with the fresh-connect contract).
5. **The reconnect cursor was never tracked in real browsers.** All three clients read `lastEventId` off the `EventSource` object; per WHATWG the property lives on the `MessageEvent`, so the captures were dead conditionals and every manual reconnect (close-on-hide show edge, degraded retry, recover beat) was cursorless. Native auto-reconnects masked it — transient blips healed, deliberate closes lost.

## Commits

- `fix(sse): make truncated replay recovery lossless and honest` — client treats a truncated stream as dead (disconnect → `/history` → adopt cursor → reconnect), with an interleaving-proof truncation record consumed at the connect chokepoint; server reports `truncated` on empty-ring reconnects when the storage-seeded counter proves loss (strict `<` keeps the caught-up case lossless; `can_replay_from` asymmetry ruled and documented); truncated resyncs share the degraded-catch-up churn window with a herd-spreading jitter; `_streamHealth.truncatedGaps` + `ws.events.replay_truncated` observability.
- `feat(sse): coalesce tool_output_chunk emission per call_id` — per-call batching on the token cadence, terminal flush before each call's own `tool_result` (the load-bearing ordering), teardown backstops, and a producer-side `emit_done` gate that stops leaked drain threads at the source. Chunks no longer force-flush token batches.
- `test(sse): end-to-end recovery harness` — six server-contract scenarios against a real server with a scripted provider (opt-in `e2e_recovery` marker), plus a browser-level livepass driving the real `InteractivePane` over real EventSource via a dependency-free CDP runner.
- `fix(sse): capture the reconnect cursor from the MessageEvent, not the EventSource` — the three-line fix that makes the rest reachable in the field, a tripwire test that forbids the dead form, and the global stream pinned deliberately cursorless until #881 (a stale cursor on the reborn global ring would draw `replay_ok`-empty with no `node_snapshot`).

## Verification

- Full non-live suite green at every commit (9674 at HEAD); ruff/format/mypy clean.
- Multi-round adversarial review to convergence per the house methodology on each production commit (the harness commit took a single-pass review); every declined finding's ruling is written into the code at the site.
- Harness on the final tree: Tier 1 6/6; browser scenario A `RECOVERY-READY-STORM-5-nested-2` (storm renders correctly, no escaped children); browser scenario B `RECOVERY-READY-RESTART-rows1-trunc1` (hide mid-turn → node restart → show: the browser observes `replay_truncated`, resyncs, and the turn that committed while hidden is present — the field symptom, healed, provable only since the cursor fix).

## Related issues (deferred, tracked)

#881 (global-stream boot-epoch staleness signal) · #882 (coordinator pane mid-run truncated parity) · #884 (`/history` coalescing lever if restart herds measure hot) · #885 (lifespan daemon shutdown sentinel) · #886 (listener-queue-cap env override).

CI: both lanes now run `-m "not live and not e2e_recovery"` and the e2e tests carry only their honest marker (final commit). Run them on demand with `pytest -m e2e_recovery`.
