### PR TITLE
fix(coord): port the truncated-recovery design from interactive (#882)

### DIFF
--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -14,9 +14,11 @@ own state machine (interactive.js) does the recovery.
 
 Usage::
 
-    python3 scripts/recovery_e2e.py                 # run both scenarios
+    python3 scripts/recovery_e2e.py                 # run all three scenarios
     python3 scripts/recovery_e2e.py --scenario storm
     python3 scripts/recovery_e2e.py --scenario restart
+    python3 scripts/recovery_e2e.py --scenario coord-restart
+    python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
     python3 scripts/recovery_e2e.py --keep-open 8971  # serve the storm page
                                                       # for manual inspection
 
@@ -62,6 +64,43 @@ watch ``document.title``. For the restart scenario, boot with a fixed
 port, load the restart page, background the tab, restart the node
 (``RecoveryServer`` on the same port), foreground the tab, and watch the
 title settle to ``RECOVERY-READY-RESTART``.
+
+Scenario C (coord-restart): the REAL coordinator pane
+(console/static/coordinator/coordinator.js — the #882 parity port of the
+same truncated-recovery machinery) driven through the SAME hide -> restart
+-> show sequence as Scenario B.  The coordinator only runs under the
+console app in production, and the console's coordinator subsystems build
+inside its server lifespan against a config-resolved model registry — no
+``create_app(prebuilt SessionManager)`` seam for this harness's scripted
+provider.  So the scenario mounts the pane against the interactive
+recovery node instead: the node serves the console's coordinator static
+tree at ``/coord-static`` (a distinct prefix — the node's own ``/static``
+mount would swallow the console path) and a pane-only page at
+``/coord-recovery``; the pane's module imports are all absolute
+``/shared/*`` and resolve against the node.  Fidelity caveats, all inert
+for the recovery machinery under test: the workstream is
+interactive-kind (no coordinator status events — the status bar keeps its
+placeholder), and ``/children`` + ``/tasks`` 404 here (the pane's loaders
+catch and render empty by design).  What IS real: the full chrome
+(buildCoordChrome), cookie auth, EventSource + MessageEvent cursor
+capture, the connect chokepoint, the dead-stream resync
+(loadHistoryThenReconnect), the churn limiter, and the jitter.  Asserted:
+the show-edge reconnect draws ``replay_truncated`` (trunc>=1, counted at
+the transport by a page-side EventSource wrapper — the coordinator's
+handleEvent, cursor, and even its SSE indicator are closure-private or
+deliberately absent from the chrome), the resync rebuilds from /history
+with the hidden-window turns present (``healed``), tool rows intact, the
+stream re-opened post-show, the status bar not stuck dim, and idle
+asserted server-side by the runner.  Stamps
+``RECOVERY-READY-COORD-rows<n>-trunc<n>``.
+
+MANUAL COORDINATOR RUNBOOK (real console topology, no CDP): boot a dev
+console + one node (docker-compose dev cluster), open a coordinator with
+running children, hide the tab mid-turn, restart the CONSOLE process (the
+coordinator ring lives there), show the tab, and verify: the pane draws
+one truncated full rebuild (no blank pane), the mid-run turn's tool rows
+re-appear inside their batch (no standalone top-level orphan bubbles),
+and turns committed while hidden are present.
 """
 
 from __future__ import annotations
@@ -266,6 +305,168 @@ PAGE_HTML = r"""<!doctype html>
 </html>
 """
 
+# ---------------------------------------------------------------------------
+# The coordinator recovery page — served same-origin by the node at
+# /coord-recovery.  A near-clone of the production standalone page
+# (console/static/coordinator/index.html): the same /shared script
+# substrate (classic theme.js first, then the deferred module set), the
+# same createCoordinatorPane(document.body, wsId, {standalone:true}) +
+# connect() bootstrap — with the coordinator files imported from
+# /coord-static (see the module docstring) and Google-fonts dropped
+# (hermetic run).  Scenario instrumentation reads only public chrome ids.
+# ---------------------------------------------------------------------------
+
+COORD_PAGE_HTML = r"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>coord recovery livepass</title>
+    <link rel="stylesheet" href="/shared/base.css" />
+    <link rel="stylesheet" href="/shared/ui-base.css" />
+    <link rel="stylesheet" href="/shared/chat.css" />
+    <link rel="stylesheet" href="/shared/conversation.css" />
+    <link rel="stylesheet" href="/shared/mcp_error.css" />
+    <link rel="stylesheet" href="/coord-static/coordinator.css" />
+    <link rel="stylesheet" href="/coord-static/coord-chrome.css" />
+    <style>
+      body { height: 100vh; margin: 0; }
+    </style>
+  </head>
+  <body>
+    <script>
+      // Transport-level instrumentation: the coordinator's handleEvent and
+      // cursor are closure-private (unlike interactive's class methods), and
+      // its chrome deliberately builds NO header/SSE indicator — so every
+      // scenario signal is read off the wire by wrapping EventSource BEFORE
+      // any module loads (classic script = runs before the deferred module
+      // set, so the pane's connectSSE always constructs the wrapper):
+      //   __truncatedSeen — replay_truncated frames (the envelope);
+      //   __esOpens      — stream opens (drives the send; a listener is
+      //                    registered before /send so no events are missed);
+      //   __idFrames     — id-bearing frames, i.e. exactly the frames that
+      //                    advance the pane's reconnect cursor (same
+      //                    ``!= null && !== ""`` guard as the pane) — the
+      //                    hide fires only after this proves a live mid-turn
+      //                    cursor.
+      window.__truncatedSeen = 0;
+      window.__esOpens = 0;
+      window.__idFrames = 0;
+      (function () {
+        const RealES = window.EventSource;
+        function CountingES(url, opts) {
+          const es = new RealES(url, opts);
+          es.addEventListener("open", function () {
+            window.__esOpens += 1;
+          });
+          es.addEventListener("message", function (e) {
+            if (e.lastEventId != null && e.lastEventId !== "") {
+              window.__idFrames += 1;
+            }
+            try {
+              const d = JSON.parse(e.data);
+              if (d && d.type === "replay_truncated") window.__truncatedSeen += 1;
+            } catch (_) {}
+          });
+          return es;
+        }
+        CountingES.prototype = RealES.prototype;
+        CountingES.CONNECTING = RealES.CONNECTING;
+        CountingES.OPEN = RealES.OPEN;
+        CountingES.CLOSED = RealES.CLOSED;
+        window.EventSource = CountingES;
+      })();
+    </script>
+    <script src="/shared/theme.js"></script>
+    <script type="module" src="/shared/utils.js"></script>
+    <script type="module" src="/shared/toast.js"></script>
+    <script type="module" src="/shared/auth.js"></script>
+    <script type="module" src="/shared/kb.js"></script>
+    <script type="module" src="/shared/composer.js"></script>
+    <script type="module" src="/shared/composer_attachments.js"></script>
+    <script type="module" src="/shared/composer_queue.js"></script>
+    <script type="module" src="/shared/status_bar.js"></script>
+    <script type="module" src="/shared/renderer.js"></script>
+    <script type="module">
+      import { createCoordinatorPane } from "/coord-static/coordinator.js";
+
+      const q = new URLSearchParams(location.search);
+      const wsId = q.get("ws_id");
+      const healedSentinel = q.get("healed") || "";
+
+      const pane = createCoordinatorPane(document.body, wsId, {
+        standalone: true,
+      });
+      window.__pane = pane;
+      if (pane) pane.connect();
+
+      window.__hide = function () {
+        Object.defineProperty(document, "hidden", { configurable: true, value: true });
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+        document.dispatchEvent(new Event("visibilitychange"));
+      };
+      window.__show = function () {
+        Object.defineProperty(document, "hidden", { configurable: true, value: false });
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+        document.dispatchEvent(new Event("visibilitychange"));
+      };
+
+      // Drive /send once the stream has OPENED at the transport (__esOpens —
+      // the pane's listener is registered by then, so no events are missed).
+      // The chrome has no SSE pill to poll: the header was deliberately
+      // dropped (see buildCoordChrome's comment).
+      let sent = false;
+      function sendOnce(msg) {
+        if (sent) return;
+        sent = true;
+        window
+          .authFetch("/v1/api/workstreams/" + encodeURIComponent(wsId) + "/send", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message: msg }),
+          })
+          .catch((e) => { document.title = "RECOVERY-FAILED-COORD-send-" + e; });
+      }
+      const sendPoll = setInterval(() => {
+        if (window.__esOpens >= 1) {
+          clearInterval(sendPoll);
+          sendOnce("run a turn");
+        }
+      }, 100);
+
+      window.__verifyCoordRestart = function () {
+        // Same contract as Scenario B, read off the coordinator's public
+        // chrome + the transport wrapper (idle is asserted SERVER-side by
+        // the runner — the chrome has no state text element): the show-edge
+        // reconnect must present the frozen mid-turn cursor and draw
+        // replay_truncated (trunc>=1), the dead-stream resync must rebuild
+        // from /history with the hidden-window turns present (healed), the
+        // stream must have re-opened after the show (__esOpens >= 2), the
+        // status bar must not be stuck dim (.ws-sb-disconnected removed by
+        // the post-recovery onopen), and the tool rows must be intact.
+        const messages = document.getElementById("coord-messages");
+        const rows = messages
+          ? messages.querySelectorAll(".conv-row[data-call-id]").length
+          : 0;
+        const reopened = window.__esOpens >= 2;
+        const disc =
+          document.querySelector("#coord-status-bar.ws-sb-disconnected") !== null;
+        const healed =
+          healedSentinel !== "" &&
+          ((messages && messages.textContent) || "").includes(healedSentinel);
+        const ok =
+          rows >= 1 && reopened && !disc && healed && window.__truncatedSeen >= 1;
+        document.title = ok
+          ? "RECOVERY-READY-COORD-rows" + rows + "-trunc" + window.__truncatedSeen
+          : "RECOVERY-FAILED-COORD-rows" + rows +
+            "-reopened" + (reopened ? 1 : 0) +
+            "-disc" + (disc ? 1 : 0) + "-healed" + (healed ? 1 : 0) +
+            "-trunc" + window.__truncatedSeen;
+      };
+    </script>
+  </body>
+</html>
+"""
+
 
 # ---------------------------------------------------------------------------
 # Minimal dependency-free CDP client (WebSocket over a raw socket).
@@ -428,6 +629,30 @@ def _page_route() -> Any:
     return Route("/recovery", recovery_page)
 
 
+def _coord_routes() -> list[Any]:
+    """The coordinator scenario's same-origin extras: the pane page, and the
+    console's coordinator static tree under the ``/coord-static`` prefix —
+    a DISTINCT prefix because the node's own ``/static`` mount (ui/static)
+    matches first and would 404 the console path from inside its own tree.
+    coordinator.js's module imports are all absolute ``/shared/*``, which
+    the node already serves."""
+    from starlette.responses import HTMLResponse
+    from starlette.routing import Mount, Route
+    from starlette.staticfiles import StaticFiles
+
+    import turnstone
+
+    coord_dir = Path(turnstone.__file__).resolve().parent / "console" / "static" / "coordinator"
+
+    async def coord_recovery_page(_request: Any) -> HTMLResponse:
+        return HTMLResponse(COORD_PAGE_HTML)
+
+    return [
+        Route("/coord-recovery", coord_recovery_page),
+        Mount("/coord-static", app=StaticFiles(directory=str(coord_dir)), name="coord-static"),
+    ]
+
+
 def _boot_node(port: int = 0) -> Any:
     from tests._sse_recovery_server import RecoveryServer
     from turnstone.core.storage import init_storage, reset_storage
@@ -438,7 +663,7 @@ def _boot_node(port: int = 0) -> Any:
     # /recovery passes the middleware. init storage per boot (shared singleton).
     reset_storage()
     init_storage("sqlite", path=os.path.join(_scratch(), "recovery_e2e.db"), run_migrations=True)
-    return RecoveryServer(extra_routes=[_page_route()], port=port)
+    return RecoveryServer(extra_routes=[_page_route(), *_coord_routes()], port=port)
 
 
 def _scratch() -> str:
@@ -598,6 +823,73 @@ def run_restart(chrome: str) -> str:
         node.stop()
 
 
+def run_coord_restart(chrome: str) -> str:
+    from tests._sse_recovery_server import final_text_script, parallel_bash_script
+
+    port = _free_port()
+    node = _boot_node(port=port)
+    # Same shape as Scenario B: a PACED turn so the tab can hide MID-turn.
+    # The coordinator renders no streamed tool output (no tool_output_chunk
+    # case), but the chunk frames still advance the pane's cursor in
+    # onmessage BEFORE dispatch — so the hide freezes a genuinely mid-turn
+    # cursor even though the paint signal differs (see below).  The closing
+    # assistant text after the bash is the healed-gap sentinel, committed
+    # while hidden.
+    paced = parallel_bash_script({"c0": "for i in $(seq 1 40); do echo c-$i; sleep 0.05; done"})
+    ws_id = node.create_workstream(
+        paced, final_text_script(HEALED_SENTINEL), name="browser-coord-restart"
+    )
+    profile = Path(_scratch()) / "chrome-coord-restart"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&healed={HEALED_SENTINEL}"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # Hide once the BROWSER has captured a live mid-turn cursor: the
+        # coordinator chrome has no status/SSE text elements (the header was
+        # deliberately dropped) and paints no streamed output line, so the
+        # signal is transport-level — id-bearing frames received by the page
+        # (__idFrames; exactly the frames that advance the pane's reconnect
+        # cursor).  The turn must also still be RUNNING server-side, or the
+        # frozen cursor could sit at/above the committed counter and the
+        # reconnect would take the lossless replay_ok path (trunc0).  The
+        # paced bash runs >=2s, so this lands mid-turn.
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            frames = cdp.evaluate("window.__idFrames || 0")
+            if isinstance(frames, int) and frames >= 2 and node.ws_state(ws_id) == "running":
+                break
+            time.sleep(0.2)
+        else:
+            raise AssertionError(
+                "coord-restart scenario: no mid-turn cursor captured "
+                "(id frames never reached the page while running)"
+            )
+        time.sleep(0.5)
+        cdp.evaluate("window.__hide && window.__hide()")
+        # The turn (and the sentinel closing text) commits while hidden.
+        node.wait_turn(ws_id, timeout=30)
+        # Restart the node on the SAME port (fresh empty ring, seeded counter).
+        node.stop()
+        node = _boot_node(port=port)
+        node.open_workstream(ws_id)
+        # Show the tab -> stale-cursor reconnect -> truncated -> jittered
+        # resync (0-10s) -> /history rebuild.  Settle past the worst-case
+        # jitter, assert idle SERVER-side (the chrome has no state text to
+        # read), then take the in-page verdict.
+        cdp.evaluate("window.__show && window.__show()")
+        time.sleep(12.0)
+        _wait_state(node, ws_id, "idle", 15)
+        cdp.evaluate("window.__verifyCoordRestart && window.__verifyCoordRestart()")
+        return _poll_title(cdp, 20)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 def _wait_state(node: Any, ws_id: str, state: str, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -632,7 +924,12 @@ def keep_open(port: int) -> None:
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--scenario", choices=["storm", "restart", "both"], default="both")
+    ap.add_argument(
+        "--scenario",
+        choices=["storm", "restart", "coord-restart", "both", "all"],
+        default="all",
+        help="'both' = A+B (legacy alias); 'all' adds the coordinator scenario",
+    )
     ap.add_argument("--keep-open", type=int, metavar="PORT", help="serve the storm page, no CDP")
     args = ap.parse_args()
 
@@ -646,13 +943,17 @@ def main() -> None:
         raise SystemExit(2)
 
     failures = 0
-    if args.scenario in ("storm", "both"):
+    if args.scenario in ("storm", "both", "all"):
         verdict = run_storm(chrome)
         print(f"scenario A (storm):   {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
-    if args.scenario in ("restart", "both"):
+    if args.scenario in ("restart", "both", "all"):
         verdict = run_restart(chrome)
         print(f"scenario B (restart): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-restart", "all"):
+        verdict = run_coord_restart(chrome)
+        print(f"scenario C (coord):   {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     raise SystemExit(1 if failures else 0)
 

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -1771,9 +1771,13 @@ def test_coord_stream_overflow_case_counts_and_rate_limits() -> None:
     body = _COORD_JS.read_text(encoding="utf-8")
     assert 'case "stream_overflow":' in body
     assert "noteStreamOverflow();" in body
-    # The three-way health counter distinguishes dropped events (overflow /
-    # malformed frame) from render wedges (dispatch / render throw).
-    assert "streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 }" in body
+    # The health object carries all four field-forensics counters; the
+    # truncated-resync counter distinguishes the replay-window class from
+    # the dropped-events class (overflows).
+    health = re.search(r"const streamHealth = \{(.*?)\};", body, re.S)
+    assert health is not None, "streamHealth initializer not found"
+    for field in ("overflows: 0", "renderThrows: 0", "malformedFrames: 0", "truncatedGaps: 0"):
+        assert field in health.group(1), f"streamHealth must init {field!r}"
     assert "streamHealth.overflows += 1;" in body
     assert "streamHealth.malformedFrames += 1;" in body
     # Exactly two render-throw increment sites: the noteRenderThrow helper
@@ -1789,11 +1793,13 @@ def test_coord_stream_overflow_case_counts_and_rate_limits() -> None:
     assert 'noteRenderThrow("streamingRender", e);' in body
     assert 'noteRenderThrow("in_progress_snapshot render", e);' in body
     assert 'noteRenderThrow("streamingRenderFinalize", e);' in body
+    # Overflow closes route through the ONE shared churn step (also fed by
+    # truncated resyncs — see the truncated fresh-connect test), keeping the
+    # class-specific instrumentation in noteStreamOverflow itself.
     note = re.search(r"function noteStreamOverflow\(\)\s*\{(.*?)\n  \}", body, re.S)
     assert note is not None, "noteStreamOverflow not found"
-    assert "overflowWindowTripped(" in note.group(1)
-    assert "enterDegradedCatchup()" in note.group(1)
-    # The trip handler only counts + trips; the cooldown reset lives in
+    assert "recordChurnAndMaybeTrip();" in note.group(1)
+    # The counting step only counts + trips; the cooldown reset lives in
     # enterDegradedCatchup (keyed off lastDegradedAt) — the finding [0] shape.
     assert "degradedCooldownMs" not in note.group(1), (
         "noteStreamOverflow must not touch the cooldown — that reset defeated the ladder escalation"
@@ -1929,16 +1935,25 @@ def test_coord_post_gap_sidebar_refresh_is_replay_aware() -> None:
     under close-on-hide must not rebuild the sidebar.  The refresh fires
     exactly when the replay cannot vouch for the gap: no resume cursor or an
     over-threshold gap at onopen, or the server's replay_truncated envelope
-    (ring evicted), deduped per open via gapRefreshedAtOpen."""
+    (ring evicted), deduped per open via gapRefreshedAtOpen.  While a
+    truncation gap is on record the onopen arm stands down entirely
+    (truncatedFromCursor == null gate): the gap machinery owns sidebar
+    recovery — gap-start envelope refresh + heal-time refresh — and the
+    failed-resync retry loop (which nulls lastEventId and never re-seeds it
+    on failure) must not re-fire this refresh once per reconnect."""
     body = _COORD_JS.read_text(encoding="utf-8")
     conn = re.search(r"function connectSSE\(\)\s*\{(.*?)\n  \}", body, re.S)
     assert conn is not None
     method = conn.group(1)
     gate = re.search(
-        r"wasReconnecting &&\s*\(lastEventId == null \|\| gapMs > GAP_REFRESH_THRESHOLD_MS\)",
+        r"wasReconnecting &&\s*truncatedFromCursor == null &&\s*"
+        r"\(lastEventId == null \|\| gapMs > GAP_REFRESH_THRESHOLD_MS\)",
         method,
     )
-    assert gate is not None, "onopen must gate the sidebar refresh on replay coverage"
+    assert gate is not None, (
+        "onopen must gate the sidebar refresh on replay coverage AND on no "
+        "truncation gap being on record (the gap machinery owns recovery)"
+    )
     assert "refreshSidebarAfterGap();" in method
     assert "gapRefreshedAtOpen = true;" in method
     # The ring-evicted signal triggers the same refresh (deduped per open).
@@ -1962,31 +1977,227 @@ def test_coord_post_gap_sidebar_refresh_is_replay_aware() -> None:
 
 def test_coord_defers_truncated_resync_and_consumes_at_idle() -> None:
     """replay_truncated seen mid-stream must be DEFERRED, not dropped (matches
-    interactive's _pendingTruncatedResync): refetching immediately would detach
-    the live bubble (content OR a reasoning-only one), but skipping outright
-    leaves the ring-evicted turns lost for the session.  The guard covers both
-    streaming targets and latches otherwise; the next state_change=idle consumes
-    the flag — which also repairs a turn stranded by close-on-hide (stream_end
-    evicted while hidden), resetting the streaming refs first since
-    refetchHistory does not null them."""
+    interactive's _pendingTruncatedResync): tearing down + refetching
+    immediately would detach the live bubble (content OR a reasoning-only
+    one), but skipping outright leaves the ring-evicted turns lost for the
+    session.  The guard covers both streaming targets and latches otherwise;
+    the next state_change=idle consumes the flag through the SAME dead-stream
+    flow as the immediate branch (loadHistoryThenReconnect, which owns the
+    streaming-ref reset) — recording the gap but NOT feeding the degraded
+    churn window (turn-settle timing already rate-limits this branch), and
+    NOT jittered (once per latch, staggered per pane by turn timing)."""
     body = _COORD_JS.read_text(encoding="utf-8")
     trunc = re.search(r'case "replay_truncated":(.*?)break;', body, re.S)
     assert trunc is not None, "replay_truncated case not found"
     t = trunc.group(1)
     assert "if (!currentAssistantEl && !currentReasoningEl)" in t
-    assert "refetchHistory();" in t
     assert "pendingTruncatedResync = true;" in t
     st = re.search(r'case "state_change":(.*?)\n      case ', body, re.S)
     assert st is not None, "state_change case not found"
     s = st.group(1)
-    assert "if (pendingTruncatedResync)" in s
-    assert "pendingTruncatedResync = false;" in s
-    assert "currentAssistantEl = null;" in s
-    assert "refetchHistory();" in s
-    # Consume the latch, THEN reset the dangling refs and refetch.
-    consume = s.index("pendingTruncatedResync = false;")
-    refetch = s.index("refetchHistory();")
-    assert consume < refetch
+    idle = re.search(r"if \(pendingTruncatedResync\) \{(.*?)\n          \}", s, re.S)
+    assert idle is not None, "idle-edge truncated consumption not found"
+    i = idle.group(1)
+    assert "pendingTruncatedResync = false;" in i
+    assert "recordTruncatedGap();" in i
+    assert "loadHistoryThenReconnect();" in i
+    # Consume the latch, THEN record the gap and run the fresh-connect flow.
+    consume = i.index("pendingTruncatedResync = false;")
+    load = i.index("loadHistoryThenReconnect();")
+    assert consume < load
+    # No churn feed and no jitter at the idle edge — noteTruncatedResync /
+    # scheduleTruncatedResync belong to the immediate branch only.
+    assert "noteTruncatedResync" not in i
+    assert "scheduleTruncatedResync" not in i
+    # And no in-place seedless refetch on either consumption path.
+    assert "refetchHistory();" not in i
+    assert "refetchHistory();" not in t
+
+
+def test_coord_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None:
+    """replay_truncated = the stream admitted losing events past recovery.
+    The coordinator pane must treat the connection as DEAD and mirror
+    interactive.js's converged recovery design (the #882 parity port).
+
+    Pinned: (1) the truncation-time cursor is recorded KEEP-OLDEST at the
+    envelope, BEFORE the mid-stream branch, and the connect chokepoint
+    presents it over the advanced live cursor while set — the
+    interleaving-proof half of the gap-repair guarantee (a cancellable
+    timer alone silently loses the repair when a hide/show cycle lands
+    inside the jitter window); (2) the record is cleared ONLY by a
+    successful full render (refetchHistory, below the ``!hist`` guard) —
+    never by the teardown chokepoint or suspendStream; (3) the immediate
+    branch routes through ``noteTruncatedResync()`` and SKIPS the resync
+    when the limiter just tripped (the cooldown disconnected the stream;
+    a ``.finally`` reconnect would defeat it), else SCHEDULES the fresh
+    connect behind the herd-spreading jitter; (4) churn accounting is ONE
+    shared step (``recordChurnAndMaybeTrip``) fed by BOTH overflow closes
+    and truncated resyncs, so the trip parameters cannot silently diverge;
+    (5) the jitter scheduler dedups to one pending resync and its fire
+    path nulls the handle BEFORE loading (the teardown inside the load
+    would cancel the work it is part of), while ``closeStreamTransport``
+    owns cancellation of a merely-pending timer; (6) the dead-stream flow
+    tears down FIRST, resets the streaming refs (refetchHistory does not
+    null them, and the envelope's own in_progress_snapshot may have
+    re-created a bubble inside the jitter window), seeds via
+    ``refetchHistory(true)``, and reconnects in ``.finally`` gated on the
+    pane still owning its stream lifecycle (``visHandler`` — the destroy /
+    close-session sentinel); (7) every ``truncatedGaps`` bump routes
+    through the one increment+log step; (8) the old in-place seedless
+    refetch must not come back; (9) repair-intent supersession is ONE
+    site — refetchHistory's success path clears the gap record, the
+    deferred latch, AND any pending resync timer together (a failed fetch
+    returns above the block and clears none, keeping the resync armed as
+    repair owner; a latch or timer surviving a heal fired a phantom
+    resync whose failed-fetch leg reconnected cursorless with nothing
+    armed) — and clear_ui carries no path-local cancel of its own;
+    (10) the envelope's sidebar refresh is deduped per GAP
+    (isNewTruncationGap) on top of the per-open flag — a failed-resync
+    retry loop must not re-stampede /children + /tasks once per reconnect
+    — with the retry-window staleness covered instead by ONE heal-time
+    refresh on the successful render inside loadHistoryThenReconnect."""
+    body = _COORD_JS.read_text(encoding="utf-8")
+    trunc = re.search(r'case "replay_truncated":(.*?)break;', body, re.S)
+    assert trunc is not None, "replay_truncated case not found"
+    t = trunc.group(1)
+    # (1) keep-oldest record at the envelope, before the refs branch (the
+    # null-check rides the isNewTruncationGap capture, which also feeds the
+    # per-gap sidebar dedup below).
+    assert "if (isNewTruncationGap) {" in t
+    assert "truncatedFromCursor = lastEventId;" in t
+    record = t.index("truncatedFromCursor = lastEventId;")
+    branch = t.index("if (!currentAssistantEl && !currentReasoningEl)")
+    assert record < branch, "the gap must be recorded before the mid-stream branch"
+    # (10) sidebar refresh deduped per GAP as well as per open: a retry
+    # reconnect re-draws the envelope for the SAME unrepaired gap and must
+    # NOT re-stampede /children + /tasks (only /history rides the jitter).
+    assert "const isNewTruncationGap = truncatedFromCursor == null;" in t
+    assert t.index("const isNewTruncationGap") < record, (
+        "the new-gap capture must precede the keep-oldest record"
+    )
+    assert "if (isNewTruncationGap && !gapRefreshedAtOpen) refreshSidebarAfterGap();" in t
+    # (1) connect chokepoint: the recorded cursor overrides the live one,
+    # gated ``!= null`` (0/"0" are valid ids).
+    assert re.search(
+        r"const connectCursor =\s*truncatedFromCursor != null\s*"
+        r"\?\s*truncatedFromCursor\s*:\s*lastEventId;",
+        body,
+    ), (
+        "connectSSE must present the truncation-time cursor while a gap is "
+        "on record — the advanced live cursor would draw replay_ok and "
+        "silently forget the gap."
+    )
+    assert re.search(
+        r"if\s*\(\s*connectCursor\s*!=\s*null\s*\)\s*\{\s*"
+        r"url\s*\+=\s*\"\?last_event_id=\"",
+        body,
+    ), "connectSSE must gate ?last_event_id= on connectCursor != null"
+    # (2) cleared only by a successful full render — below the !hist guard,
+    # riding the wipe — and never by the teardown paths.
+    start = body.index("async function refetchHistory(seedCursor = false)")
+    fn = body[start : start + 4500]
+    guard = fn.index("if (!hist) return;")
+    clear = fn.index("truncatedFromCursor = null;")
+    assert guard < clear, "the record must only clear once a payload rendered"
+    teardown = re.search(r"function closeStreamTransport\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert teardown is not None, "closeStreamTransport not found"
+    assert "truncatedFromCursor" not in teardown.group(1), (
+        "teardown must not clear the gap record — it is the durable repair state"
+    )
+    sus = re.search(r"function suspendStream\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert sus is not None
+    assert "truncatedFromCursor" not in sus.group(1)
+    # (3) limiter check gates the JITTERED fresh connect in the immediate
+    # branch.
+    assert "if (!noteTruncatedResync())" in t
+    assert "scheduleTruncatedResync();" in t
+    # (8) the old in-place seedless refetch must not come back in the case.
+    assert "refetchHistory();" not in t
+    # (4) ONE shared churn step, fed by both classes; ladder reset stays in
+    # enterDegradedCatchup.
+    churn = re.search(r"function recordChurnAndMaybeTrip\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert churn is not None, "recordChurnAndMaybeTrip not found"
+    c = churn.group(1)
+    assert "overflowTimes.push(now);" in c
+    assert "overflowWindowTripped(" in c
+    assert "enterDegradedCatchup();" in c
+    assert "return true;" in c
+    assert "return false;" in c
+    assert "degradedCooldownMs" not in c
+    over = re.search(r"function noteStreamOverflow\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert over is not None
+    assert "recordChurnAndMaybeTrip();" in over.group(1), (
+        "overflow closes must feed the same shared churn step"
+    )
+    note = re.search(r"function noteTruncatedResync\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert note is not None, "noteTruncatedResync not found"
+    n = note.group(1)
+    assert "recordTruncatedGap();" in n
+    assert "return recordChurnAndMaybeTrip();" in n
+    # (5) jittered scheduler: dedup guard, jitter const, null-before-load,
+    # cancellation owned by the teardown chokepoint.
+    sched = re.search(r"function scheduleTruncatedResync\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert sched is not None, "scheduleTruncatedResync not found"
+    s = sched.group(1)
+    assert "if (truncatedResyncTimer != null) return;" in s
+    assert "Math.random() * TRUNCATED_RESYNC_JITTER_MS" in s
+    null_then_load = s.index("truncatedResyncTimer = null;")
+    load = s.index("loadHistoryThenReconnect();")
+    assert null_then_load < load, (
+        "the firing path must null the handle BEFORE loading, or the "
+        "teardown inside loadHistoryThenReconnect would cancel the work it "
+        "is part of"
+    )
+    assert "clearTimeout(truncatedResyncTimer)" in teardown.group(1)
+    # (6) the dead-stream flow: teardown first, refs reset, seeded refetch,
+    # guarded .finally reconnect, deferred latch superseded.
+    flow = re.search(r"function loadHistoryThenReconnect\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert flow is not None, "loadHistoryThenReconnect not found"
+    f = flow.group(1)
+    assert f.index("suspendStream();") < f.index("refetchHistory(true)")
+    assert "currentAssistantEl = null;" in f
+    assert "currentReasoningEl = null;" in f
+    assert "pendingTruncatedResync = false;" in f
+    # Reborn-ring convergence: the load must DROP the live cursor before the
+    # fetch — without this, a post-restart heal on an idle ws (no /history
+    # cursor) re-presents the frozen pre-restart cursor against the reseeded
+    # empty ring, draws replay_truncated forever, and parks the pane in
+    # degraded cooldown cycles.  Found by recovery_e2e --scenario
+    # coord-restart (browser-level); invisible to source-pattern tests —
+    # this pin only keeps the fix from being "simplified" away.
+    assert "lastEventId = null;" in f
+    assert f.index("lastEventId = null;") < f.index("refetchHistory(true)")
+    assert ".finally(" in f
+    assert f.index("refetchHistory(true)") < f.index(".finally(")
+    assert "if (visHandler) connectSSE();" in f
+    # (10) heal-time sidebar refresh: once, on the successful render only
+    # (record cleared), only on the cursor-SEEDED heal (the cursorless
+    # heal's fresh-connect onopen runs the same refresh via its no-cursor
+    # arm), and standing down when a SLOW heal (past the cursor-trust
+    # window, measured off the same disconnectedAt) guarantees onopen's
+    # over-threshold refresh — the two arms are exclusive by construction.
+    # Never on the failed-fetch leg of the retry loop.
+    assert "const onopenWillRefresh =" in f
+    assert "GAP_REFRESH_THRESHOLD_MS" in f
+    assert "truncatedFromCursor == null &&" in f
+    assert "lastEventId != null &&" in f
+    assert "!onopenWillRefresh" in f
+    assert "refreshSidebarAfterGap();" in f
+    # (7) single truncatedGaps bump site (running-count console invariant).
+    assert body.count("streamHealth.truncatedGaps += 1;") == 1
+    rec = re.search(r"function recordTruncatedGap\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert rec is not None, "recordTruncatedGap not found"
+    assert "console.warn(" in rec.group(1)
+    # (9) repair-intent supersession lives in refetchHistory's success path
+    # — record + deferred latch + pending timer, all below the !hist guard
+    # — and clear_ui carries no path-local cancel.
+    assert "pendingTruncatedResync = false;" in fn
+    assert "clearTimeout(truncatedResyncTimer)" in fn
+    assert guard < fn.index("pendingTruncatedResync = false;")
+    assert guard < fn.index("clearTimeout(truncatedResyncTimer)")
+    cu = re.search(r'case "clear_ui": \{(.*?)\n      \}', body, re.S)
+    assert cu is not None, "clear_ui case not found"
+    assert "clearTimeout" not in cu.group(1)
 
 
 def test_coord_detects_server_restart_by_backwards_event_id() -> None:

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -495,11 +495,20 @@ def test_coordinator_js_seeds_resume_cursor_only_on_initial_connect():
     Pins three invariants mirroring the app.js guards:
       1. ``refetchHistory`` takes a ``seedCursor`` flag (default false) and
          seeds ``lastEventId`` from ``hist.cursor`` only when set + non-null,
-         so the clear_ui / replay_truncated re-render callers (live stream,
-         no reconnect) don't rewind the live cursor.
-      2. the initial-connect path opts in via ``refetchHistory(true)``.
-      3. ``connectSSE`` gates ``?last_event_id=`` on ``!= null`` so a cursor
-         of 0 (a brand-new ws's first-turn boundary) isn't dropped.
+         so the clear_ui re-render caller (live stream, no reconnect — the
+         one remaining seedless caller after the #882 dead-stream ruling)
+         doesn't rewind the live cursor.
+      2. every caller that reconnects opts in: init via
+         ``await refetchHistory(true)``, and the truncated resync via
+         ``loadHistoryThenReconnect``'s ``refetchHistory(true).finally``
+         (cursor adoption is the #882 fix core — /history trims the
+         in-flight turn whenever it returns a cursor).
+      3. ``connectSSE`` gates ``?last_event_id=`` on ``connectCursor !=
+         null`` so a cursor of 0 (a brand-new ws's first-turn boundary)
+         isn't dropped — where ``connectCursor`` presents a recorded
+         truncation gap over the advanced live cursor (the gap-repair
+         chokepoint; see the truncated fresh-connect test in
+         test_app_js.py).
     """
     import re
     from pathlib import Path
@@ -510,7 +519,7 @@ def test_coordinator_js_seeds_resume_cursor_only_on_initial_connect():
     body = coord_js.read_text(encoding="utf-8")
     assert "async function refetchHistory(seedCursor = false)" in body, (
         "refetchHistory must take a seedCursor flag (default false) so only "
-        "the initial-connect caller seeds the resume cursor."
+        "the reconnecting callers seed the resume cursor."
     )
     assert re.search(
         r"if\s*\(\s*seedCursor\s*&&\s*hist\.cursor\s*!=\s*null\s*\)\s*"
@@ -520,10 +529,44 @@ def test_coordinator_js_seeds_resume_cursor_only_on_initial_connect():
     assert "await refetchHistory(true)" in body, (
         "the initial-connect path must call refetchHistory(true) to seed the cursor."
     )
+    flow = re.search(r"function loadHistoryThenReconnect\(\)\s*\{(.*?)\n  \}", body, re.S)
+    assert flow is not None, "loadHistoryThenReconnect not found"
+    assert "refetchHistory(true)" in flow.group(1) and ".finally(" in flow.group(1), (
+        "the truncated resync (loadHistoryThenReconnect) must seed via "
+        "refetchHistory(true) and reconnect in .finally."
+    )
     assert re.search(
-        r"if\s*\(\s*lastEventId\s*!=\s*null\s*\)\s*\{\s*url\s*\+=\s*\"\?last_event_id=\"",
+        r"if\s*\(\s*connectCursor\s*!=\s*null\s*\)\s*\{\s*url\s*\+=\s*\"\?last_event_id=\"",
         body,
-    ), "connectSSE must gate ?last_event_id= on lastEventId != null (so cursor 0 isn't dropped)."
+    ), "connectSSE must gate ?last_event_id= on connectCursor != null (so cursor 0 isn't dropped)."
+
+
+def test_coordinator_refetch_failure_preserves_the_pane():
+    """A FAILED /history fetch must leave the message column and the
+    tool-row/batch tracking untouched (#882 G3): refetchHistory's wipe +
+    resets must sit AFTER the ``if (!hist) return`` guard.  Pre-fix the
+    wipe ran first, so a failed fetch — likeliest exactly during the
+    restart windows that trigger truncated resyncs — left an EMPTY pane
+    on a live stream with no retry record.  Stale-but-real beats blank,
+    and the maps stay valid against the untouched DOM."""
+    import re
+    from pathlib import Path
+
+    coord_js = Path(__file__).resolve().parent.parent / (
+        "turnstone/console/static/coordinator/coordinator.js"
+    )
+    body = coord_js.read_text(encoding="utf-8")
+    start = body.index("async function refetchHistory(seedCursor = false)")
+    fn = body[start : start + 3000]
+    guard = fn.index("if (!hist) return;")
+    wipe = fn.index("messagesEl.replaceChildren();")
+    resets = fn.index("toolRows.clear();")
+    assert guard < wipe and guard < resets, (
+        "refetchHistory must bail on a failed fetch BEFORE wiping the "
+        "pane or clearing the tool-row maps — a failed /history must be "
+        "a DOM no-op."
+    )
+    assert re.search(r"if \(!hist\) return;", fn), "failure guard missing"
 
 
 def test_coordinator_js_early_paints_pending_tool_calls():

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -56,6 +56,7 @@ import {
   DEGRADED_COOLDOWN_BASE_MS,
   DEGRADED_COOLDOWN_MAX_MS,
   DEGRADED_COOLDOWN_RESET_MS,
+  TRUNCATED_RESYNC_JITTER_MS,
   overflowWindowTripped,
   degradedCooldownStep,
 } from "/shared/sse_overflow.js";
@@ -641,6 +642,30 @@ function createCoordinatorPane(root, wsId, opts) {
   // also catches a turn stranded by close-on-hide (finished while hidden, its
   // stream_end evicted before the show-edge reconnect).
   let pendingTruncatedResync = false;
+  // The cursor position a replay_truncated envelope was received AT — i.e.
+  // "a gap of lost events exists BELOW this cursor".  Keep-oldest: set only
+  // when null (repeated envelopes for the same unrepaired gap must not
+  // advance it), cleared by any successful full-history render
+  // (refetchHistory — the truncated resync and a clear_ui rebuild both
+  // repair the gap).  NOT cleared by teardown or turn boundaries, and —
+  // unlike interactive.js — never dropped for a ws switch: this pane is
+  // single-wsId for life (a ws-switch feature would have to reset it
+  // alongside lastEventId).  The connectSSE chokepoint is its
+  // cursor-presenting consumer: while set, every manual (re)connect
+  // presents THIS cursor (not the since-advanced live lastEventId), so the
+  // server re-answers replay_truncated and the resync re-arms no matter
+  // which teardown cancelled the pending jittered timer — the gap-repair
+  // guarantee survives any interleaving of hide/show, degraded cooldowns,
+  // CLOSED-state retries, and failed /history fetches.  Three more sites
+  // read it purely as a null-sentinel for "is an unrepaired gap on
+  // record": the replay_truncated case (dedup the sidebar refresh per
+  // gap), loadHistoryThenReconnect's heal-time sidebar refresh, and
+  // onopen's post-gap sidebar-refresh gate (stands down while a gap is on
+  // record — the gap machinery owns recovery).  Cleared — together with
+  // the deferred latch and any pending resync timer — only by
+  // refetchHistory's success-path supersession.  Mirrors interactive.js's
+  // _truncatedFromCursor.
+  let truncatedFromCursor = null;
   // Saved high-water mark for the manual-reconnect path.  The
   // EventSource constructor can't set custom headers, so when we
   // construct a fresh source we thread ``?last_event_id=N`` instead
@@ -657,13 +682,31 @@ function createCoordinatorPane(root, wsId, opts) {
   // class) vs client dispatch/render throws (wedge class).  The console line
   // at each increment carries the running count, so a field report shows which
   // class fired without a debugger attached.
-  const streamHealth = { overflows: 0, renderThrows: 0, malformedFrames: 0 };
-  // Rolling timestamps of stream_overflow closes feeding the degraded-catchup
-  // limiter (overflowWindowTripped); plus the cooldown-ladder state, keyed off
-  // the last-trip timestamp via degradedCooldownStep — never off overflowTimes
-  // (enterDegradedCatchup clears it each trip).  See enterDegradedCatchup.
+  // ``truncatedGaps`` counts replay-window misses (truncated envelopes acted
+  // on), NOT resyncs performed — a degraded-catchup trip records the gap but
+  // skips its resync.  Pairs with the node-side ws.events.replay_truncated
+  // log line for field forensics.
+  const streamHealth = {
+    overflows: 0,
+    renderThrows: 0,
+    malformedFrames: 0,
+    truncatedGaps: 0,
+  };
+  // Rolling timestamps of heavyweight-recovery churn — stream_overflow closes
+  // AND truncated resyncs (both via recordChurnAndMaybeTrip) — feeding the
+  // degraded-catchup limiter (overflowWindowTripped); plus the cooldown-ladder
+  // state, keyed off the last-trip timestamp via degradedCooldownStep — never
+  // off overflowTimes (enterDegradedCatchup clears it each trip).  See
+  // enterDegradedCatchup.
   const overflowTimes = [];
   let degradedTimer = null;
+  // Pending jittered truncated-resync (see scheduleTruncatedResync).
+  // Cancelled by closeStreamTransport alongside degradedTimer, so any path
+  // that tears the transport down (redial, close-on-hide, degraded entry,
+  // close-session, destroy) also discards a resync scheduled for the OLD
+  // stream — the next connect's own truncated envelope reschedules if the
+  // gap still exists (truncatedFromCursor re-presents it).
+  let truncatedResyncTimer = null;
   let degradedCooldownMs = DEGRADED_COOLDOWN_BASE_MS;
   let lastDegradedAt = 0;
   // Close-on-hide / replay-on-show bookkeeping.  A hidden tab's throttled event
@@ -2426,15 +2469,21 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   // The transport-teardown chokepoint: close + null the EventSource and
-  // cancel BOTH pending retry timers (reconnect backoff + degraded catch-up).
-  // Every teardown path routes through here — connectSSE's redial prologue,
-  // suspendStream (overflow / hide / close-session), destroy — so a new
-  // transport timer gets cancelled in one place instead of by hand at each
-  // call site.  Cancelling the degraded timer on redial also keeps a pending
-  // catch-up retry from firing mid-stream and double-opening;
-  // enterDegradedCatchup re-arms AFTER its own suspend, so this never cancels
-  // the timer it is about to set.  Gap accounting stays OUT of this helper —
-  // a redial is not itself a gap (suspendStream layers markStreamGap on top).
+  // cancel the pending retry timers (reconnect backoff, degraded catch-up,
+  // truncated resync).  Every teardown path routes through here —
+  // connectSSE's redial prologue, suspendStream (overflow / hide /
+  // close-session / truncated resync), destroy — so a new transport timer
+  // gets cancelled in one place instead of by hand at each call site.
+  // Cancelling the degraded timer on redial also keeps a pending catch-up
+  // retry from firing mid-stream and double-opening; enterDegradedCatchup
+  // re-arms AFTER its own suspend, so this never cancels the timer it is
+  // about to set.  Likewise the truncated-resync fire path nulls its own
+  // handle BEFORE calling loadHistoryThenReconnect, so the teardown inside
+  // that flow never cancels the work it is part of; cancelling a merely
+  // PENDING resync here is always safe because truncatedFromCursor (not the
+  // timer) is the durable repair state — the next connect re-presents it.
+  // Gap accounting stays OUT of this helper — a redial is not itself a gap
+  // (suspendStream layers markStreamGap on top).
   function closeStreamTransport() {
     if (evtSource) {
       try {
@@ -2452,6 +2501,10 @@ function createCoordinatorPane(root, wsId, opts) {
       clearTimeout(degradedTimer);
       degradedTimer = null;
     }
+    if (truncatedResyncTimer) {
+      clearTimeout(truncatedResyncTimer);
+      truncatedResyncTimer = null;
+    }
   }
 
   function connectSSE() {
@@ -2467,12 +2520,31 @@ function createCoordinatorPane(root, wsId, opts) {
     // manual case (scheduleReconnect-driven reconnect after CLOSED state).
     const wasReconnecting = disconnectedAt !== 0 || reconnectAttempts > 0;
     let url = "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/events";
+    // A recorded truncation gap OVERRIDES the live cursor: while
+    // truncatedFromCursor is set (gap detected, no full render yet), every
+    // manual (re)connect presents the truncation-time cursor, so the server
+    // re-answers replay_truncated and the resync re-arms — whatever teardown
+    // cancelled the pending jittered resync in the meantime (close-on-hide,
+    // degraded entry, CLOSED-state retry, close-session resume).  This
+    // connect chokepoint is what makes the gap-repair guarantee
+    // interleaving-proof; a cancellable timer alone silently loses the
+    // repair when a hide/show cycle lands inside the jitter window after
+    // the live cursor has advanced past the truncation point.  Safe against
+    // double-render: ring eviction is forward-only, so a once-truncated
+    // cursor can never re-enter replay range — this connect always draws
+    // the envelope, never a bulk replay.  (Native EventSource
+    // auto-reconnects bypass this — the browser's header carries the
+    // advanced id — but they never run closeStreamTransport, so the pending
+    // resync timer survives them.)
+    //
     // ``!= null`` (not truthiness): a resume cursor of 0 is valid (the
     // ring buffer's first emitted event is id 1), and a brand-new ws's
     // first-turn /history cursor can be 0 — a truthiness gate would drop
     // it to the lossy fresh-snapshot path.  Mirrors ui/static/app.js.
-    if (lastEventId != null) {
-      url += "?last_event_id=" + encodeURIComponent(lastEventId);
+    const connectCursor =
+      truncatedFromCursor != null ? truncatedFromCursor : lastEventId;
+    if (connectCursor != null) {
+      url += "?last_event_id=" + encodeURIComponent(connectCursor);
     }
     // Close-on-hide / replay-on-show: install once per pane, removed by
     // destroy().  A hidden tab's throttled drain is the likeliest slow consumer
@@ -2537,8 +2609,21 @@ function createCoordinatorPane(root, wsId, opts) {
       // lying (see GAP_REFRESH_THRESHOLD_MS).  The ring-evicted case
       // announces itself — the replay_truncated handler runs the same
       // refresh on arrival (gapRefreshedAtOpen keeps the two from stacking).
+      //
+      // While a truncation gap is ON RECORD, the gap machinery owns sidebar
+      // recovery outright — the envelope refreshed at gap start and the
+      // heal-time refresh covers everything since — so this arm stands
+      // down.  Without that gate, the failed-resync retry loop re-fires
+      // this refresh once per reconnect: loadHistoryThenReconnect nulls
+      // lastEventId, a failed /history never re-seeds it, and every retry
+      // reconnect then reads as "no cursor to resume from" — the onopen
+      // half of the same un-jittered /children + /tasks stampede the
+      // envelope's per-gap dedup stops.  (On the clean cursorless heal the
+      // record is already cleared before the reconnect, so the one
+      // intended heal refresh still lands here.)
       if (
         wasReconnecting &&
+        truncatedFromCursor == null &&
         (lastEventId == null || gapMs > GAP_REFRESH_THRESHOLD_MS)
       ) {
         refreshSidebarAfterGap();
@@ -2727,15 +2812,16 @@ function createCoordinatorPane(root, wsId, opts) {
   // ------------------------------------------------------------------
 
   // Transport-only stream suspension for the overflow / visibility /
-  // close-session paths: the closeStreamTransport teardown WITHOUT the full
-  // destroy() cleanup (observers, task timers), plus gap accounting.
-  // connectSSE re-opens from the saved lastEventId, so this is lossless for
-  // committed turns.
+  // close-session / truncated-resync paths: the closeStreamTransport
+  // teardown WITHOUT the full destroy() cleanup (observers, task timers),
+  // plus gap accounting.  connectSSE re-opens from the saved lastEventId
+  // (or the recorded truncation cursor), so this is lossless for committed
+  // turns.
   function suspendStream() {
     closeStreamTransport();
     // A deliberate suspend is still a gap.  The transient-error path marks
-    // it via onerror; the overflow/hide/close-session paths self-close (no
-    // onerror fires after .close()), so mark it here instead.
+    // it via onerror; the overflow/hide/close-session/resync paths
+    // self-close (no onerror fires after .close()), so mark it here instead.
     markStreamGap();
   }
 
@@ -2750,10 +2836,14 @@ function createCoordinatorPane(root, wsId, opts) {
 
   // Replace-mode sidebar re-sync after a gap the reconnect replay could not
   // (or might not) have covered — the server is authoritative; any SSE-only
-  // child/task rows accumulated before the disconnect are stale.  Two
-  // callers: onopen (no-cursor / over-threshold gaps) and the
-  // replay_truncated handler (ring-evicted gaps).  Ordinary short gaps need
-  // neither — the ring replay redelivers child_ws_* / task events itself.
+  // child/task rows accumulated before the disconnect are stale.  Four
+  // callers: onopen (no-cursor / over-threshold gaps, standing down while a
+  // truncation gap is on record), the onmessage counter-reset detector
+  // (live id below the saved cursor = process restart), the
+  // replay_truncated handler (NEW ring-evicted gaps — deduped per gap), and
+  // loadHistoryThenReconnect's heal-time refresh (retry-window staleness on
+  // a cursor-seeded heal).  Ordinary short gaps need none of them — the
+  // ring replay redelivers child_ws_* / task events itself.
   function refreshSidebarAfterGap() {
     loadChildren({ replace: true });
     loadTasks();
@@ -2791,19 +2881,16 @@ function createCoordinatorPane(root, wsId, opts) {
     );
   }
 
-  function noteStreamOverflow() {
-    streamHealth.overflows += 1;
+  // The ONE rolling-window churn accounting step for the degraded ladder —
+  // stream_overflow closes (noteStreamOverflow) AND truncated resyncs
+  // (noteTruncatedResync) land here, so the trip parameters and the
+  // degraded-entry call have a single implementation that cannot silently
+  // diverge.  The cooldown-ladder reset lives in enterDegradedCatchup
+  // (keyed off lastDegradedAt), NOT here — this only counts and trips.
+  // Returns true when this entry ENTERED degraded catch-up.
+  function recordChurnAndMaybeTrip() {
     const now = Date.now();
     overflowTimes.push(now);
-    console.warn(
-      "coordinator: server closed the stream after a send-queue overflow " +
-        "(total " +
-        streamHealth.overflows +
-        "); reconnect will replay the gap",
-    );
-    // Trip when OVERFLOW_TRIP_COUNT closes land inside the rolling window.  The
-    // cooldown-ladder reset lives in enterDegradedCatchup (keyed off
-    // lastDegradedAt), NOT here — this only counts and trips.
     if (
       overflowWindowTripped(
         overflowTimes,
@@ -2813,7 +2900,191 @@ function createCoordinatorPane(root, wsId, opts) {
       )
     ) {
       enterDegradedCatchup();
+      return true;
     }
+    return false;
+  }
+
+  function noteStreamOverflow() {
+    streamHealth.overflows += 1;
+    console.warn(
+      "coordinator: server closed the stream after a send-queue overflow " +
+        "(total " +
+        streamHealth.overflows +
+        "); reconnect will replay the gap",
+    );
+    recordChurnAndMaybeTrip();
+  }
+
+  // The one increment+log step for the replay-window class — EVERY
+  // truncatedGaps bump goes through here so the console invariant documented
+  // at the streamHealth initializer holds (each increment carries the running
+  // count).  Class-of-event wording only: the recovery that follows differs
+  // by caller (jittered fresh-connect, idle-edge fresh-connect, or a
+  // degraded-catchup skip), so the line must not assert an action a trip may
+  // skip.  Churn accounting is deliberately NOT here — the idle-edge caller
+  // records the gap without feeding the degraded ladder.
+  function recordTruncatedGap() {
+    streamHealth.truncatedGaps += 1;
+    console.warn(
+      "coordinator: replay window could not cover the reconnect gap " +
+        "(total " +
+        streamHealth.truncatedGaps +
+        ")",
+    );
+  }
+
+  // Count a truncated-triggered full resync into the SAME rolling churn
+  // window as overflow closes (overflowTimes): both are "this consumer
+  // needed heavyweight recovery", and the degraded ladder is the bound for
+  // either loop.  Returns true when this trip ENTERED degraded catch-up —
+  // the caller must then SKIP starting its resync: the cooldown ladder just
+  // disconnected the stream, and a loadHistoryThenReconnect started now
+  // would reconnect from its .finally and defeat the cooldown it triggered.
+  // The wake-up reconnect re-arrives here via a fresh replay_truncated (the
+  // chokepoint re-presents the still-stale truncatedFromCursor), so the
+  // resync is deferred, not lost.
+  function noteTruncatedResync() {
+    recordTruncatedGap();
+    return recordChurnAndMaybeTrip();
+  }
+
+  // Start the truncated-triggered fresh connect after a random
+  // 0..TRUNCATED_RESYNC_JITTER_MS spread.  The truncated envelope is
+  // herd-shaped — a node restart makes every stale-cursor tab reconnect
+  // inside the EventSource retry jitter and each answers with a /history
+  // fetch — and the per-tab churn limiter cannot see a cross-tab herd (one
+  // resync per tab never trips it), so the spread is applied here, before
+  // the fetch.  During the wait the pane keeps painting live events from
+  // the still-open stream; the gap predates the resync either way, so the
+  // only cost is a delayed backfill.  closeStreamTransport owns
+  // cancellation (redial, hide, degraded entry, close-session, destroy —
+  // see the field comment on truncatedResyncTimer).
+  function scheduleTruncatedResync() {
+    if (truncatedResyncTimer != null) return; // one pending resync at a time
+    truncatedResyncTimer = setTimeout(() => {
+      // Null the handle BEFORE loading — loadHistoryThenReconnect tears the
+      // transport down (closeStreamTransport cancels this timer), and a
+      // still-set handle would cancel the work it is part of.
+      truncatedResyncTimer = null;
+      loadHistoryThenReconnect();
+    }, Math.random() * TRUNCATED_RESYNC_JITTER_MS);
+  }
+
+  // The dead-stream truncated resync (#882): mirror of interactive.js's
+  // _loadHistoryThenConnect, minus the ws-switch machinery — this pane is
+  // single-wsId for life, so there is no load token and no cross-ws
+  // truncated-cursor drop (see the clear_ui handler's ruling on the
+  // same-ws render race).  The reference's lastEventId reset is KEPT —
+  // not as ws-switch machinery but for reborn-ring convergence (see the
+  // note in the body; deleting it reintroduces the envelope→resync loop
+  // the coord-restart e2e scenario exists to catch).  Order matters:
+  //   1. suspendStream — tear the transport down FIRST so no live events
+  //      paint into the pane mid-rebuild, and mark the gap so a slow
+  //      /history fetch (>60s) re-enters onopen's cursor-trust-window
+  //      refresh on reconnect.
+  //   2. Null the streaming refs + buffers: refetchHistory replaceChildren()s
+  //      the DOM but does NOT null them, and the envelope's own synthetic
+  //      in_progress_snapshot may have re-created a live bubble between
+  //      scheduling and this fire — a stale ref would strand the rebuilt
+  //      turn's tokens into a detached node, and stale buffers would make
+  //      the reconnect's snapshot length-guards skip the repaint.  Safe
+  //      here because the transport is already down (no delta can race the
+  //      null).
+  //   3. refetchHistory(true): full render + adopt hist.cursor (/history
+  //      trims the trailing in-flight turn whenever it returns a cursor,
+  //      expecting the caller to replay from it — adoption is the #882 fix
+  //      core).  A successful render also clears truncatedFromCursor.
+  //   4. Reconnect in .finally — runs on success, failure, AND a render
+  //      throw.  The failed-fetch retry rides the connect chokepoint, not a
+  //      callback: a failure leaves truncatedFromCursor set (only a
+  //      successful render clears it), so this reconnect presents the
+  //      truncation-time cursor, draws replay_truncated again, and the
+  //      resync retries — bounded by the churn limiter + degraded ladder.
+  //      The old transcript survives a failed fetch (the wipe sits below
+  //      refetchHistory's !hist guard), so the retry window shows
+  //      stale-but-real content, not an empty pane.
+  //      ``if (visHandler)``: destroy() and coordCloseSession release the
+  //      stream lifecycle by removing the visibility handler — the same
+  //      sentinel that keeps a show edge from resurrecting a deliberately
+  //      closed stream keeps this async tail from reopening one on a
+  //      destroyed pane (close-session's own resumeSse re-arms on its
+  //      failure paths).
+  function loadHistoryThenReconnect() {
+    suspendStream();
+    currentAssistantEl = null;
+    currentAssistantBuf = "";
+    currentReasoningEl = null;
+    currentReasoningBuf = "";
+    // Drop the live cursor for the reconnect: the full render below
+    // supersedes it (refetchHistory re-seeds from hist.cursor when the
+    // server hands one back).  This is NOT just interactive parity — it is
+    // what makes the resync CONVERGE against a reborn ring: after a node
+    // restart, a successful /history on an idle ws returns NO cursor, and
+    // without this null the reconnect re-presents the frozen pre-restart
+    // cursor against the empty reseeded ring, which honestly answers
+    // replay_truncated — again and again, an envelope→resync→envelope loop
+    // that trips the churn ladder and parks the pane in degraded cooldown
+    // cycles forever (an idle ws emits no frames to ever advance the
+    // cursor).  Caught by scripts/recovery_e2e.py --scenario coord-restart;
+    // invisible to source-pattern tests.  On the FAILED-fetch leg the
+    // reconnect still retries correctly: truncatedFromCursor (not
+    // lastEventId) is the durable repair state the chokepoint presents.
+    lastEventId = null;
+    // A pending deferred resync is superseded by this full refetch — without
+    // this clear, the next idle edge would run a second, pointless full
+    // resync.
+    pendingTruncatedResync = false;
+    refetchHistory(true)
+      .then(() => {
+        // Successful heal only (a failed fetch resolves too, but leaves the
+        // record set; a render throw skips .then entirely): refresh the
+        // sidebar once.  The envelope refreshed it at gap START; this
+        // covers child_ws_* / task events that landed in the retry loop's
+        // suspend→fetch→reconnect windows, which no SSE replay can
+        // redeliver (each retry reconnect presents the stale record
+        // cursor) — the sidebar heals here exactly the way the transcript
+        // heals via /history.  Gated to the cursor-SEEDED heal
+        // (lastEventId != null): the cursorless heal reconnects fresh and
+        // onopen's own no-cursor arm runs this same refresh — skipping
+        // here keeps it to one refresh per heal on both shapes.
+        // Slow-heal exclusivity: when the fetch itself outlived the
+        // cursor-trust window, onopen's over-threshold arm WILL refresh —
+        // measured off the same disconnectedAt read here — so stand down.
+        // The implication holds up to the connect handshake: a fetch
+        // landing within one handshake of the threshold measures under it
+        // here and over it at onopen and double-fires (accepted:
+        // replace-mode loads are last-writer-wins, and closing the
+        // handshake-wide window at a 60s boundary would take a heal-scoped
+        // flag that survives onopen's per-connection reset — more state
+        // than the dedup is worth).  A heal followed by a long hidden
+        // deferral before the reconnect legitimately gets both: the hide
+        // opened a NEW coverage gap after this one healed.
+        //
+        // RULED (2026-07-21, #882 review): on a ZERO-retry seeded heal
+        // this refresh duplicates what the seeded replay_ok reconnect
+        // redelivers from the ring anyway.  Accepted: telling K=0 from
+        // K>=1 needs a per-episode attempt counter whose reset lifecycle
+        // spans schedule/trip/latch/failure paths, and ~3 jitter-spread
+        // REST per healed gap is cheaper than that state; the deeper fix
+        // for restart-herd sidebar load is server-side coalescing (#884).
+        // visHandler: same destroyed/close-session sentinel as the
+        // reconnect below.
+        const onopenWillRefresh =
+          disconnectedAt !== 0 &&
+          Date.now() - disconnectedAt > GAP_REFRESH_THRESHOLD_MS;
+        if (
+          visHandler &&
+          truncatedFromCursor == null &&
+          lastEventId != null &&
+          !onopenWillRefresh
+        ) {
+          refreshSidebarAfterGap();
+        }
+      })
+      .finally(() => {
+        if (visHandler) connectSSE();
+      });
   }
 
   function enterDegradedCatchup() {
@@ -3172,17 +3443,33 @@ function createCoordinatorPane(root, wsId, opts) {
           // settled and /history is complete.  Also repairs a turn stranded by
           // close-on-hide — hidden mid-turn, its stream_end evicted, so the
           // show-edge replay_truncated latched the flag and the live bubble
-          // never finalized.  Reset the streaming refs first: refetchHistory
-          // replaceChildren()s the DOM but does NOT null them, and a dangling
-          // ref would strand the NEXT turn's tokens into a detached node.
-          // Mirrors interactive.js.
+          // never finalized.  Same dead-stream flow as the immediate branch
+          // (full fresh connect, cursor adoption; the streaming-ref reset
+          // lives inside loadHistoryThenReconnect) — but NOT counted into
+          // the degraded-churn window, and NOT herd-jittered: this branch
+          // fires once per latch, and the latch only re-arms via a NEW
+          // truncated envelope followed by a full turn-settle — inherently
+          // rate-limited AND per-pane staggered by turn timing, unlike the
+          // immediate branch's reconnect loop (which the limiter bounds and
+          // scheduleTruncatedResync spreads).  Usually /history returns no
+          // cursor here (no orphan at idle) and the reconnect is a plain
+          // fresh connect.  Mirrors interactive.js.
+          //
+          // RULED (2026-07-21, #882 review): the turn-timing stagger does
+          // NOT cover the restart herd — N mid-turn tabs all latch, then
+          // all consume when the reconnect's synthetic idle replay lands
+          // inside the same retry window — but this branch stays
+          // un-jittered anyway: it is byte-for-byte the converged
+          // interactive.js shape, a coordinator-only spread would fork the
+          // shared design for a one-shot-per-latch peak (identical total
+          // volume), and the tracked fix for restart-herd /history load is
+          // server-side coalescing (#884).  If that herd ever measures
+          // hot, sweep BOTH clients' idle-edge consumers together — do not
+          // patch just this one.
           if (pendingTruncatedResync) {
             pendingTruncatedResync = false;
-            currentAssistantEl = null;
-            currentAssistantBuf = "";
-            currentReasoningEl = null;
-            currentReasoningBuf = "";
-            refetchHistory();
+            recordTruncatedGap();
+            loadHistoryThenReconnect();
           }
         } else if (
           ev.state === "running" ||
@@ -3258,9 +3545,25 @@ function createCoordinatorPane(root, wsId, opts) {
         // Conversation was structurally reset (rewind / retry). Re-render
         // from REST, then dispatch any queued edit-and-resend once the (now
         // truncated) history lands. Coord is single-wsId per page, so no
-        // load-token guard is needed (unlike the interactive pane).
+        // load-token guard is needed (unlike the interactive pane): a
+        // cross-ws misroute cannot happen, and the resend below always
+        // belongs to this pane.  The remaining same-ws exposure — this
+        // seedless live re-render racing a truncated resync's seeded one —
+        // is RULED accepted without a token: both renders are
+        // server-authoritative snapshots milliseconds apart, last-writer
+        // wins, and refetchHistory's success-path supersession (record +
+        // deferred latch + pending timer) eliminates the dominant vector (a
+        // resync still armed when this rebuild lands); the residual
+        // fetch-overlap window is transient-cosmetic and heals on the next
+        // full render or chokepoint retry.
         refetchHistory()
           .then(() => {
+            // Repair-intent supersession (pending resync timer + deferred
+            // latch + gap record) lives inside refetchHistory's success
+            // path — a successful rebuild here clears all three, a FAILED
+            // fetch (which also resolves) clears none, and a mid-render
+            // throw skips this .then entirely — so the pending resync
+            // stays the repair owner exactly when the pane still needs it.
             if (!_pendingEditSend) return;
             const editText = _pendingEditSend;
             _pendingEditSend = null;
@@ -3288,37 +3591,75 @@ function createCoordinatorPane(root, wsId, opts) {
           });
         break;
       }
-      case "replay_truncated":
-        // Reconnect buffer evicted past our last-seen id — re-sync from REST.
-        // Skip while a turn is mid-stream (BOTH a content bubble and a
-        // reasoning-only one are detachable): the recovery floor's
-        // in_progress_snapshot repaints it, and an async refetch's
-        // replaceChildren() would detach the live bubble so deltas render
-        // nowhere.  Mid-stream the resync is DEFERRED, not dropped — skipping
-        // outright left the ring-evicted gap unrepaired for the rest of the
-        // session (no clean reconnect may come for hours); the idle edge
-        // consumes the flag.
+      case "replay_truncated": {
+        // The stream just admitted losing events past recovery — treat the
+        // connection as DEAD and run the full fresh-connect flow
+        // (loadHistoryThenReconnect: disconnect first, REST /history,
+        // rebuild, adopt the returned resume cursor, reconnect).  The cursor
+        // adoption is the point (#882 — ruled with interactive.js, do not
+        // revert to an in-place refetch): /history TRIMS the trailing
+        // in-flight turn whenever it hands back a cursor
+        // (_resume_cursor_and_trim), on the assumption the caller replays
+        // from that cursor.  The old in-place refetch here discarded the
+        // cursor, so a mid-run truncation wiped the executing turn's rows
+        // with no redelivery — later tool results then orphaned into
+        // standalone top-level bubbles.  Disconnect-first also removes the
+        // flush-vs-reconnect ambiguity: no live events arrive during the
+        // rebuild, so nothing double-renders.  The rehydrate-triggered
+        // truncation (empty reborn ring) rides the same flow — a rehydrated
+        // ws has no in-flight orphan to trim, so /history returns no cursor
+        // and the reconnect is a plain fresh connect (the load drops the
+        // stale cursor — see loadHistoryThenReconnect's reborn-ring note).
         //
-        // KNOWN GAP (#882): this refetch discards the /history ``cursor``
-        // and stays on the live stream, so a MID-RUN truncation loses the
-        // trailing in-flight turn (/history trims it whenever it returns a
-        // cursor, expecting the caller to replay from that cursor).
-        // interactive.js now treats truncated as a dead stream (disconnect
-        // → refetch with cursor adoption → reconnect); mirroring that here
-        // is #882.  The rehydrate-triggered truncation (empty reborn ring)
-        // recovers correctly today — a rehydrated ws has no in-flight
-        // orphan to trim.
+        // Skip while a turn is mid-stream (BOTH a content bubble and a
+        // reasoning-only one are detachable): an async refetch's
+        // replaceChildren() would detach the live bubble so deltas render
+        // nowhere.  Mid-stream the resync is DEFERRED, not dropped —
+        // skipping outright left the ring-evicted gap unrepaired for the
+        // rest of the session; the idle edge consumes the flag.
+        //
+        // Record WHERE the gap sits before either branch: the envelope
+        // arrived at the connect cursor, but by the time the resync's
+        // /history fetch runs (after the jitter, or at the idle edge) the
+        // live stream has advanced lastEventId well past it — the
+        // failed-fetch retry needs this truncation-time value, not the
+        // advanced one (see truncatedFromCursor's field comment).
+        // Keep-oldest: a retry reconnect re-delivers an envelope for the
+        // SAME unrepaired gap and must not advance the record.  Whether
+        // this envelope OPENED the gap (vs. re-announcing one already on
+        // record) also drives the sidebar-refresh dedup below.
+        const isNewTruncationGap = truncatedFromCursor == null;
+        if (isNewTruncationGap) {
+          truncatedFromCursor = lastEventId;
+        }
         if (!currentAssistantEl && !currentReasoningEl) {
-          refetchHistory();
+          // Limiter check BEFORE scheduling the resync — a trip has just
+          // disconnected the stream for a cooldown, and a resync started
+          // now would reconnect from its .finally and defeat the cooldown
+          // (see noteTruncatedResync).  No trip → the fresh connect starts
+          // after a herd-spreading jitter (scheduleTruncatedResync).
+          if (!noteTruncatedResync()) {
+            scheduleTruncatedResync();
+          }
         } else {
           pendingTruncatedResync = true;
         }
         // The evicted slice may have carried child_ws_* / task events the
         // sidebar will never see replayed — this is the server saying the
-        // gap was NOT covered, so pull authoritative state (unless onopen
-        // already did, milliseconds ago, for this same reconnect).
-        if (!gapRefreshedAtOpen) refreshSidebarAfterGap();
+        // gap was NOT covered, so pull authoritative state.  Deduped two
+        // ways: per open against onopen's refresh (gapRefreshedAtOpen —
+        // milliseconds apart on the same reconnect), and per GAP against
+        // the failed-resync retry loop — each retry reconnect re-draws the
+        // envelope for the SAME unrepaired gap (keep-oldest record still
+        // set), and re-refreshing then would hit /children + /tasks + the
+        // live-badge bulk fetch un-jittered once per retry, across every
+        // open tab of a console that is already struggling (only /history
+        // rides the herd spread).  Sidebar staleness accrued DURING the
+        // retry loop's teardown windows is covered by the heal-time
+        // refresh in loadHistoryThenReconnect.
+        if (isNewTruncationGap && !gapRefreshedAtOpen) refreshSidebarAfterGap();
         break;
+      }
       case "tool_pending":
         // Early paint — render the batch the instant the model commits to
         // a tool call, BEFORE the intent judge / Smart Approvals verdict and
@@ -5215,13 +5556,16 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   // Fetch /history and (re)render the message column from scratch.  Used for
-  // first paint AND for the clear_ui / replay_truncated re-render after a
-  // rewind/retry truncates the conversation.  The fetch is wrapped; the
+  // first paint, the clear_ui re-render after a rewind/retry truncates the
+  // conversation, and the truncated resync (via loadHistoryThenReconnect,
+  // which seeds the cursor and reconnects).  The fetch is wrapped; the
   // render runs after the clear so a render bug surfaces loudly instead of
   // masking as an empty pane.  The message column + tool-tracking state
-  // (toolRows / activeBatch, which the render rebuilds) reset up front so a
-  // mid-session re-render leaves no stale call_id→row mappings pointing at
-  // detached DOM.  On first paint they're already empty — harmless no-ops.
+  // (toolRows / activeBatch, which the render rebuilds) reset alongside the
+  // wipe — after the fetch guard — so a mid-session re-render leaves no stale
+  // call_id→row mappings pointing at detached DOM, while a FAILED fetch
+  // leaves both DOM and maps untouched.  On first paint they're already
+  // empty — harmless no-ops.
   async function refetchHistory(seedCursor = false) {
     let hist = null;
     try {
@@ -5232,21 +5576,55 @@ function createCoordinatorPane(root, wsId, opts) {
       console.warn("coord history fetch failed", e);
       hist = null;
     }
+    // A FAILED fetch keeps the pane intact: the wipe + tracking resets
+    // run only once a payload actually arrived.  (Pre-#882 the wipe ran
+    // before this guard, so a failed /history — likeliest during the
+    // restart windows that trigger truncated resyncs — left an EMPTY
+    // pane on a live stream with no retry record.  Stale-but-real
+    // content beats blank, and the tool-row/batch maps stay valid
+    // against the untouched DOM.  On the clear_ui caller a failure now
+    // shows the pre-rewind transcript instead of an empty pane — also
+    // stale-but-real; the rewound truth lands on the next successful
+    // refetch.)  Success ordering is unchanged: the wipe always ran
+    // after the await, never as immediate feedback.
+    if (!hist) return;
     messagesEl.replaceChildren();
+    // A full committed-history render repairs any recorded truncation gap —
+    // whether this render came from the truncated resync itself or from an
+    // unrelated clear_ui rebuild — so it supersedes ALL pending repair
+    // intent in one place: the retry cursor (a LATER failed reload must not
+    // rewind onto a gap that no longer exists), the deferred mid-turn
+    // latch, and any still-pending jittered timer.  Leaving the latch or
+    // timer armed past a heal fired a phantom resync against the repaired
+    // gap — a false truncatedGaps bump plus a needless teardown, and on
+    // that redundant load's FAILED-fetch leg the cursor had been dropped
+    // with no record set, so the reconnect came back cursorless with
+    // nothing armed to re-cover the suspend window.  (Only a render clears
+    // any of these — a failed fetch returned above with the record intact,
+    // which is what arms the connect chokepoint's retry; and cancelling
+    // the timer here is safe precisely because the gap it was scheduled
+    // for was just rendered away.)
+    truncatedFromCursor = null;
+    pendingTruncatedResync = false;
+    if (truncatedResyncTimer) {
+      clearTimeout(truncatedResyncTimer);
+      truncatedResyncTimer = null;
+    }
     toolRows.clear();
     activeBatch = null;
     renderedSystemEventIds.clear();
     resetCompactionHolder(compactionHolder);
-    if (!hist) return;
     // Fresh-connect fast-forward: when the trailing turn is an executing
     // in-flight tool batch the server can replay, /history returns a
     // non-null ``cursor`` and OMITS that turn. Seed ``lastEventId`` so the
-    // connectSSE on the initial-connect path (seedCursor=true) opens with
+    // connectSSE on the reconnecting paths (seedCursor=true: init first
+    // paint AND the truncated resync's loadHistoryThenReconnect) opens with
     // ?last_event_id= and the replay_ok delta rebuilds the in-flight turn
     // — otherwise the trimmed turn would be neither in /history nor
-    // replayed. The clear_ui / replay_truncated re-render callers leave
-    // seedCursor false: they run on a live stream and must NOT rewind
-    // lastEventId off the live position. Mirrors ui/static/app.js.
+    // replayed. The clear_ui re-render caller (the one remaining seedless
+    // live-stream caller) leaves seedCursor false: it runs on a live stream
+    // with no reconnect and must NOT rewind lastEventId off the live
+    // position. Mirrors ui/static/app.js.
     if (seedCursor && hist.cursor != null) lastEventId = hist.cursor;
     // Map call_id → tool name resolved from the most recent
     // assistant tool_calls.  Storage's `tool` rows carry only
@@ -5524,7 +5902,8 @@ function createCoordinatorPane(root, wsId, opts) {
       }
     });
     // Attach the retry affordance to the last assistant turn on every render
-    // (first paint + clear_ui / replay_truncated re-render), matching the
+    // (first paint, the clear_ui re-render, and the truncated resync's
+    // rebuild via loadHistoryThenReconnect), matching the
     // interactive replayHistory() path. finishAssistantStream only covers the
     // live-turn-ends case — without this a reloaded or rewound coordinator
     // showed assistant turns with no retry button.
@@ -5537,7 +5916,8 @@ function createCoordinatorPane(root, wsId, opts) {
   function onLogin() {
     reconnectAttempts = 0;
     // connectSSE's closeStreamTransport prologue cancels any pending
-    // reconnect / degraded timers before dialling.
+    // transport retry timers (reconnect / degraded / truncated resync)
+    // before dialling.
     connectSSE();
   }
 
@@ -5545,7 +5925,8 @@ function createCoordinatorPane(root, wsId, opts) {
   // per-instance pane must release the stream + every timer/observer or a
   // backgrounded pane keeps an SSE open and fires renders into detached DOM.
   function destroy() {
-    // Stream + both retry timers (reconnect backoff, degraded catch-up).
+    // Stream + the retry timers (reconnect backoff, degraded catch-up,
+    // truncated resync).
     closeStreamTransport();
     [
       cancelTimeoutId,


### PR DESCRIPTION
Closes #882.

`replay_truncated` in the coordinator pane is now a dead-stream signal, porting the recovery design that converged in interactive.js via #887:

- **`loadHistoryThenReconnect`** — tear the transport down first, drop the live cursor, refetch `/history` with cursor adoption, reconnect in `.finally`. The old in-place refetch discarded the `/history` cursor while `/history` trims the trailing in-flight turn whenever it returns one, so a mid-run truncation wiped the executing turn with no redelivery and later tool results orphaned into top-level bubbles. Both consumption sites (immediate branch and the idle-edge deferred consumer) route through it. Post-#887 this path is reachable from every manual reconnect; hide-during-a-busy-turn → show is the common field trigger.
- **`truncatedFromCursor`** — the truncation-time cursor, recorded keep-oldest at the envelope, cleared only by a successful full render, and presented by the connect chokepoint over the advanced live cursor, so the repair survives any interleaving of hide/show, degraded cooldowns, CLOSED-state retries, and failed fetches.
- **Churn + jitter parity** — truncated resyncs feed the same rolling window as overflow closes (`recordChurnAndMaybeTrip`); a trip skips the resync and the degraded wake re-arms via the chokepoint; resyncs start behind the shared 0..10s herd jitter with cancellation owned by the teardown chokepoint.
- **Repair-intent supersession in one place** — a successful full render in `refetchHistory` clears the gap record, the deferred latch, and any pending resync timer together; a failed fetch clears none and no longer blanks the pane (the wipe sits below the `!hist` guard).
- **Sidebar refresh gap-ownership** — while a gap is on record the recovery machinery owns the sidebar: one refresh per new gap at the envelope, one at heal, onopen standing down — a failed-resync retry loop can no longer stampede `/children` + `/tasks` un-jittered once per reconnect.

Dropping the cursor before the fetch is load-bearing, not just parity: a post-restart heal on an idle workstream gets no `/history` cursor, and re-presenting the frozen pre-restart cursor against the reseeded empty ring draws `replay_truncated` forever — an envelope→resync loop that parks the pane in degraded cooldown cycles. That loop was invisible to source-pattern tests and to every review pass; the new browser scenario caught it on its first run.

**Behavioral coverage**: `scripts/recovery_e2e.py --scenario coord-restart` mounts the real coordinator pane (chrome, cookie auth, EventSource, chokepoint, resync, limiter) against the interactive recovery node (`/coord-static` + `/coord-recovery`) and drives hide → node restart → show over CDP, asserting the envelope is drawn, the hidden-window turns heal, the stream re-opens, and the pane converges.

**Review**: five unprimed full-surface rounds, four finders each. Rounds 3 and 4 surfaced one confirmed correctness finding apiece (slow-heal double refresh; latch surviving a heal), each resolved by re-deriving the seam; round 5 came back empty across all finders. Declined findings carry their rulings in comments at the site.

**Tests**: the two tests that pinned the in-place shape are revised; the overflow and sidebar-gate pins evolved minimally (forced by the churn extraction and the new onopen gate, mirroring how #887 evolved interactive's own pins); a comprehensive coordinator mirror of interactive's fresh-connect/churn-limit pins is added. Full suite, the `e2e_recovery` lane, and all three browser scenarios are green.

**Follow-up**: interactive.js shares one latent shape this PR fixes on the coordinator side — its clear_ui rebuild does not supersede `_pendingTruncatedResync` / a pending `_resyncTimer`, so a heal can strand a phantom idle-edge resync. Sibling fix is branched off this PR.
