### PR TITLE
fix(interactive): supersede all repair intent on a full history render

### DIFF
--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -601,8 +601,26 @@ def test_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None:
         "a ws switch must drop the old ws's truncation record"
     )
     replay_fn = body.index("replayHistory(messages) {")
-    assert "this._truncatedFromCursor = null;" in body[replay_fn : replay_fn + 900], (
+    replay_head = body[replay_fn : replay_fn + 1200]
+    assert "this._truncatedFromCursor = null;" in replay_head, (
         "a successful full-history render must clear the truncation record"
+    )
+    # (8b) ...and supersede ALL pending repair intent in the same breath —
+    # the deferred mid-turn latch and any pending jittered timer.  Without
+    # these, a clear_ui heal left them armed and the next idle edge fired a
+    # phantom _loadHistoryThenConnect against the repaired gap (false
+    # truncatedGaps bump; on its failed-fetch leg, a cursorless reconnect
+    # with nothing armed).  Every _loadHistoryThenConnect flavor
+    # clears both BEFORE its fetch, so these are no-ops on the load paths —
+    # the clear_ui heal is the path they exist for.  Mirrors the
+    # coordinator's refetchHistory supersession.
+    assert "this._pendingTruncatedResync = false;" in replay_head, (
+        "replayHistory must clear the deferred-resync latch — a latch "
+        "surviving a heal fires a phantom resync at the next idle edge"
+    )
+    assert "clearTimeout(this._resyncTimer)" in replay_head, (
+        "replayHistory must cancel a pending jittered resync — the render "
+        "just repaired the gap it was scheduled for"
     )
     conn = body.index("connectSSE(wsId) {")
     conn_seg = body[conn : body.index("this.evtSource = new EventSource", conn)]
@@ -624,6 +642,9 @@ def test_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None:
     )
     assert "this._pendingEditSend = null;" in cl
     assert "this.setBusy(false);" in cl
+    # Supersession is centralized at the render (replayHistory) — clear_ui
+    # must not grow a path-local resync cancel of its own.
+    assert "clearTimeout(this._resyncTimer)" not in cl
 
 
 def test_degraded_catchup_stops_live_stream_and_retries() -> None:

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -290,7 +290,11 @@ class Pane {
     this._streamElIndex = new Map();
     this._resizeObs = null;
     // Set when replay_truncated arrives mid-stream (refetching then would
-    // detach the live bubble); consumed on the next idle edge.
+    // detach the live bubble); consumed on the next idle edge.  Cleared by
+    // _loadHistoryThenConnect at load start AND by replayHistory's
+    // supersession (a successful full render obsoletes the deferred
+    // resync — without that clear, a clear_ui heal left the latch armed
+    // and the next idle edge fired a phantom full resync).
     this._pendingTruncatedResync = false;
     // The cursor position a replay_truncated envelope was received AT —
     // i.e. "a gap of lost events exists BELOW this cursor".  Keep-oldest:
@@ -329,7 +333,19 @@ class Pane {
     // tears the transport down (ws switch via _loadHistoryThenConnect,
     // close-on-hide, degraded entry, destroy) also discards a resync
     // scheduled for the OLD stream — the next connect's own truncated
-    // envelope reschedules if the gap still exists.
+    // envelope reschedules if the gap still exists.  Also cancelled by
+    // replayHistory's supersession: a successful full render obsoletes a
+    // pending resync (a clear_ui heal keeps the stream live, so no
+    // teardown would otherwise catch the timer).  The heal-time cancel is
+    // safe against dropping a NEEDED repair because every clear_ui
+    // emitter is turn-free at emission — rewind/retry are busy-gated
+    // server-side, and the open post-load replay fires only on rehydrate,
+    // behind the already-loaded shortcut — so a heal render is never a
+    // cursor-trimmed snapshot of a pre-existing executing turn, and a
+    // turn STARTING mid-heal rides the replay quiesce (its events land
+    // after these clears and re-arm if truncated).  If a clear_ui emitter
+    // that can coexist with an executing turn is ever added, the heal
+    // must instead re-arm the resync when /history returns a cursor.
     this._resyncTimer = null;
     this._degradedCooldownMs = DEGRADED_COOLDOWN_BASE_MS;
     // Timestamp of the last degraded-catchup trip; drives the cooldown
@@ -1556,7 +1572,8 @@ class Pane {
     // spread is applied here, before the fetch.  During the wait the
     // pane keeps painting live events from the still-open stream; the
     // gap predates the resync either way, so the only cost is a
-    // delayed backfill.  disconnectSSE owns cancellation (ws switch,
+    // delayed backfill.  disconnectSSE cancels teardown-orphaned resyncs
+    // and replayHistory supersedes on a heal (ws switch,
     // hide, degraded entry, destroy — see the field comment).
     if (this._resyncTimer != null) return; // one pending resync at a time
     this._resyncTimer = setTimeout(() => {
@@ -2979,11 +2996,25 @@ class Pane {
   replayHistory(messages) {
     this.messagesEl.replaceChildren();
     // A full committed-history render repairs any recorded truncation
-    // gap — whether this render came from the truncated resync itself or
-    // from an unrelated clear_ui rebuild.  Clear the retry cursor so a
-    // LATER failed reload doesn't rewind onto a gap that no longer
-    // exists.
+    // gap — from the resync itself or an unrelated clear_ui rebuild — so
+    // it supersedes ALL pending repair intent in one place: retry cursor,
+    // deferred mid-turn latch, pending jittered timer.  The latch/timer
+    // clears do real work ONLY on the clear_ui heal (every
+    // _loadHistoryThenConnect flavor cleared both before the fetch); a
+    // latch or timer surviving that heal fired a phantom load at the next
+    // idle edge — false truncatedGaps bump, needless teardown, and a
+    // cursorless reconnect with nothing armed on its failed-fetch leg.
+    // The timer's fire path nulls its handle before loading, so this
+    // cancel never cancels work it is part of.  Safe on the heal path
+    // because clear_ui emitters are turn-free at emission (see the
+    // _resyncTimer field comment).  Mirrors coordinator.js
+    // refetchHistory's supersession.
     this._truncatedFromCursor = null;
+    this._pendingTruncatedResync = false;
+    if (this._resyncTimer) {
+      clearTimeout(this._resyncTimer);
+      this._resyncTimer = null;
+    }
     // The rebuild just orphaned any in-flight streaming targets — reset them,
     // and release the agent-card/orphan maps whose entries now point at
     // replaced subtrees (detached-DOM retention).


### PR DESCRIPTION
Sibling sweep of the repair-intent supersession that the #882 coordinator port established — closing the same latent shape in interactive.js, where it originated. Found by that review's round-4 pass and confirmed against this file.

**The defect**: a mid-stream `replay_truncated` latches `_pendingTruncatedResync`; a clear_ui rebuild (rewind / retry / rehydrate replay) heals the gap but left the latch — and any pending jittered `_resyncTimer` — armed, because clear_ui keeps the stream live and only `disconnectSSE` cancelled the timer. The next idle edge then fired a phantom `_loadHistoryThenConnect` against the already-repaired gap: a false `truncatedGaps` bump and a needless teardown, and on the phantom's failed-fetch leg the reconnect went cursorless (`_lastEventId` nulled, no record armed) with nothing left to re-cover the suspend window.

**The fix**: `replayHistory` now clears the gap record, the deferred latch, and the pending timer together — the same one-site supersession as the coordinator's `refetchHistory`. The latch/timer clears are provably no-ops on every `_loadHistoryThenConnect` flavor (each clears both before its fetch); the clear_ui heal is the path they exist for. A failed fetch still clears none, keeping the connect chokepoint's retry armed.

**Safety of cancelling at the heal** (adjudicated during review and documented at the `_resyncTimer` field comment): every clear_ui emitter is turn-free at emission — rewind and retry are busy-gated server-side, and the open post-load replay fires only on rehydrate, behind the already-loaded shortcut — so a heal render is never a cursor-trimmed snapshot of a pre-existing executing turn, and a turn starting mid-heal rides the replay quiesce, re-arming after the clears if truncated. The comment carries a tripwire for any future emitter that could coexist with an executing turn.

**Review**: one full round, four finders, on this three-line pre-mapped change (the design carries five converged rounds of pedigree from the coordinator side). Security and performance: zero findings — performance verified the change strictly reduces fetch/reconnect counts and that the quiesce ordering makes the envelope-during-heal interleaving structurally safe. Quality: two wording corrections, applied. The bug finder's one candidate (cancelling a needed repair on a cursor-trimmed heal) was adjudicated unreachable at the emitters, with the ruling written into the code.

**Evidence**: contract suites 320 passed; full suite 9676 passed; `e2e_recovery` lane 6 passed; all three browser recovery scenarios (`storm`, `restart`, `coord-restart`) stamp READY with this change in place — scenario B drives this file's own truncated resync through the modified `replayHistory`. Pinned: the supersession triplet inside `replayHistory` and a guard that clear_ui never grows a path-local cancel.
