### PR TITLE
fix(server): boot-epoch staleness signal on the global SSE stream (#881)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,11 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    # Cap a hung run at 20 min instead of riding GitHub's 6-hour default
-    # (a flaky-hang run otherwise streams -v output for hours).
-    timeout-minutes: 20
+    # Cap a hung run at 30 min instead of riding GitHub's 6-hour default
+    # (a flaky-hang run otherwise streams -v output for hours).  Was 20;
+    # the suite's growth (~9.7k tests, coverage-instrumented, 3-version
+    # matrix) started brushing the old cap on healthy runs.
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
@@ -66,7 +68,7 @@ jobs:
 
   test-postgres:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:18

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -23,6 +23,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario rewind-window     # E2 (#890)
     python3 scripts/recovery_e2e.py --scenario rewind-failed-window  # E3 (#890)
     python3 scripts/recovery_e2e.py --scenario stale-backstop    # E4 (#890)
+    python3 scripts/recovery_e2e.py --scenario roster-restart    # F (#881)
     python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
     python3 scripts/recovery_e2e.py --keep-open 8971  # serve the storm page
                                                       # for manual inspection
@@ -167,6 +168,41 @@ coordinator ring lives there), show the tab, and verify: the pane draws
 one truncated full rebuild (no blank pane), the mid-run turn's tool rows
 re-appear inside their batch (no standalone top-level orphan bubbles),
 and turns committed while hidden are present.
+
+Scenario F (roster-restart, #881): the REAL node dashboard (``/`` +
+ui/static/app.js) driven through a node restart on the GLOBAL stream —
+the last silent-gap class from the truncated-recovery campaign.  Unlike
+the pane scenarios there is no custom page: the runner navigates to the
+production dashboard and injects transport instrumentation via CDP
+``Page.addScriptToEvaluateOnNewDocument`` (an EventSource wrapper scoped
+to ``/events/global`` URLs — app.js's stream + cursor are module-private
+and the roster machinery exposes no counters).  Phase A (negative
+control): two live workstreams render as roster rows; a scripted turn on
+one drives global ``ws_state`` frames, proving the page holds a live
+epoch-tagged cursor with ZERO ``replay_truncated`` observed — the live
+cursor must not false-positive.  Phase B: hide, close the global
+EventSource (the browser-gave-up CLOSED state — a closed source never
+auto-retries, so the show edge's MANUAL reconnect is the only
+reconnect), restart the node on the same port re-opening only ONE
+workstream, show.  ``_reconnectDeadSSEs`` fires ``connectGlobalSSE``,
+which presents the stored pre-restart cursor via ``?last_event_id=``
+(counted off the wrapper's URL — the item-6 client half); the reborn
+node's epoch mismatch draws ``replay_truncated`` (``reason:
+boot_epoch``) + a fresh node_snapshot, and the in-stream snapshot's
+``evict`` sweep removes the not-reopened workstream's row — the exact
+ghost-roster field symptom (pre-#881 the reborn ring answered
+``replay_ok``-empty: no envelope, no snapshot, ghost row forever).
+Asserted: browser-observed trunc>=1 + cursor-presented>=1 (transport
+wrapper), ghost GONE + keeper PRESENT in the roster MODEL
+(``TS_APP.getClusterState()``) and the RAIL (``fireRender``'s surface) —
+deliberately not the dashboard TABLE, whose membership refreshes only on
+interaction by design (see ``_roster_has_ws``) — and the backend proof
+``global_events_requests>=1`` on the restarted node (the reconnect hit
+the real endpoint).  The NATIVE header path (browser echoes the
+epoch-tagged id on auto-reconnect) differs only in cursor transport and
+is pinned both-transports by Tier-1
+``test_global_sse_boot_epoch::test_query_param_fallback_matches_header_semantics``.
+Stamps/returns ``RECOVERY-READY-ROSTER-trunc<n>-cursor<n>``.
 """
 
 from __future__ import annotations
@@ -1168,6 +1204,197 @@ def run_restart(chrome: str) -> str:
         node.stop()
 
 
+# Injected into the REAL dashboard page via Page.addScriptToEvaluateOnNewDocument
+# (runs before any page script on every navigation).  Same transport-level
+# discipline as the coord page's inline wrapper, but scoped to GLOBAL-stream
+# URLs only — the dashboard also opens per-ws EventSources whose frames and
+# truncated envelopes must not pollute the roster counters.  ``__globalES``
+# keeps the live instance reachable so the runner can force the CLOSED state
+# (app.js's module-private ``globalEvtSource`` is otherwise untouchable);
+# ``new CountingES(...)`` returns the REAL EventSource, so app.js's
+# ``readyState`` checks and handlers see the genuine object.
+ROSTER_INJECT_JS = r"""
+window.__globalTruncated = 0;
+window.__globalIdFrames = 0;
+window.__globalCursorPresented = 0;
+window.__globalES = null;
+window.__hide = function () {
+  Object.defineProperty(document, "hidden", { configurable: true, value: true });
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+window.__show = function () {
+  Object.defineProperty(document, "hidden", { configurable: true, value: false });
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+(function () {
+  const RealES = window.EventSource;
+  function CountingES(url, opts) {
+    const es = new RealES(url, opts);
+    if (String(url).indexOf("/events/global") !== -1) {
+      window.__globalES = es;
+      if (String(url).indexOf("last_event_id=") !== -1) {
+        window.__globalCursorPresented += 1;
+      }
+      es.addEventListener("message", function (e) {
+        if (e.lastEventId != null && e.lastEventId !== "") {
+          window.__globalIdFrames += 1;
+        }
+        try {
+          const d = JSON.parse(e.data);
+          if (d && d.type === "replay_truncated") window.__globalTruncated += 1;
+        } catch (_) {}
+      });
+    }
+    return es;
+  }
+  CountingES.prototype = RealES.prototype;
+  CountingES.CONNECTING = RealES.CONNECTING;
+  CountingES.OPEN = RealES.OPEN;
+  CountingES.CLOSED = RealES.CLOSED;
+  window.EventSource = CountingES;
+})();
+"""
+
+
+def _roster_has_ws(cdp: CDP, ws_id: str, name: str) -> bool:
+    """The ws is in the healed roster: present in the MODEL
+    (``TS_APP.getClusterState()`` — the projection of app.js's
+    ``workstreams`` map, the state the snapshot evict mutates) AND
+    rendered in the RAIL (``fireRender``'s surface; rows are name-keyed
+    via ``title``).  Deliberately NOT the dashboard TABLE
+    (``#dash-ws-table``): its MEMBERSHIP refreshes only on interaction
+    (``loadDashboard`` on show/boot/delete) for live ws_created/ws_closed
+    too — only existing rows live-patch (see app.js
+    ``updateTabIndicator``) — so a lingering dash row is the table's
+    documented refresh model, not a failed heal."""
+    in_model = bool(
+        cdp.evaluate(
+            "(window.TS_APP && window.TS_APP.getClusterState) ? "
+            "window.TS_APP.getClusterState().nodes.local.workstreams.some("
+            f"function (w) {{ return w.id === {json.dumps(ws_id)}; }}) : false"
+        )
+    )
+    in_rail = bool(
+        cdp.evaluate(
+            "Array.prototype.some.call(document.querySelectorAll('button.row'), "
+            f"function (b) {{ return (b.title || '').indexOf({json.dumps(name)}) === 0; }})"
+        )
+    )
+    return in_model and in_rail
+
+
+def run_roster_restart(chrome: str) -> str:
+    from tests._sse_recovery_server import bash_toolcall_script, final_text_script
+
+    port = _free_port()
+    node = _boot_node(port=port)
+    # keeper FIRST (its pending scripted client is never consumed — no send
+    # targets it), then ghost so the ghost's turn script is the pending one
+    # its /send consumes.
+    keeper_id = node.create_workstream(final_text_script("keeper idle"), name="roster-keeper")
+    ghost_id = node.create_workstream(
+        bash_toolcall_script("g1", "echo ghost-activity"),
+        final_text_script("ghost done"),
+        name="roster-ghost",
+    )
+    profile = Path(_scratch()) / "chrome-roster"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        cdp.cmd("Page.enable")
+        cdp.cmd("Page.addScriptToEvaluateOnNewDocument", {"source": ROSTER_INJECT_JS})
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, node.base_url + "/")
+
+        # -- Phase A: live roster + live cursor, zero false truncated -------
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if _roster_has_ws(cdp, ghost_id, "roster-ghost") and _roster_has_ws(
+                cdp, keeper_id, "roster-keeper"
+            ):
+                break
+            time.sleep(0.3)
+        else:
+            return "RECOVERY-FAILED-ROSTER-rows-never-rendered"
+        # A scripted turn on the ghost drives ws_state frames down the global
+        # stream — the id-bearing frames that make the page's stored cursor
+        # (and the wrapper's count) real.
+        node.send(ghost_id)
+        node.wait_turn(ghost_id, timeout=30)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            frames = cdp.evaluate("window.__globalIdFrames || 0")
+            if isinstance(frames, int) and frames >= 1:
+                break
+            time.sleep(0.3)
+        else:
+            return "RECOVERY-FAILED-ROSTER-no-global-id-frames"
+        # Negative control: a LIVE cursor over a live ring must not draw the
+        # envelope, and no manual reconnect has happened yet.
+        if cdp.evaluate("window.__globalTruncated || 0") != 0:
+            return "RECOVERY-FAILED-ROSTER-truncated-false-positive"
+        if cdp.evaluate("window.__globalCursorPresented || 0") != 0:
+            return "RECOVERY-FAILED-ROSTER-premature-cursor-presentation"
+
+        # -- Phase B: deaf browser -> restart -> manual stale-cursor heal ---
+        cdp.evaluate("window.__hide && window.__hide()")
+        # Force the browser-gave-up state: a CLOSED source never auto-retries,
+        # so the show edge's manual ``connectGlobalSSE`` is the ONLY reconnect
+        # and the ``?last_event_id=`` presentation is deterministic (a native
+        # retry landing first would consume the staleness and clear the
+        # stored cursor — the native transport is Tier-1-pinned instead).
+        cdp.evaluate("window.__globalES && window.__globalES.close()")
+        node.stop()
+        node = _boot_node(port=port)
+        # Only the keeper comes back — the ghost stays unloaded, exactly a
+        # restarted node's roster truth the pre-#881 silent gap never showed.
+        node.open_workstream(keeper_id)
+        cdp.evaluate("window.__show && window.__show()")
+
+        deadline = time.monotonic() + 15
+        healed = False
+        while time.monotonic() < deadline:
+            trunc = cdp.evaluate("window.__globalTruncated || 0")
+            cursor = cdp.evaluate("window.__globalCursorPresented || 0")
+            ghost_gone = not _roster_has_ws(cdp, ghost_id, "roster-ghost")
+            keeper_here = _roster_has_ws(cdp, keeper_id, "roster-keeper")
+            if (
+                isinstance(trunc, int)
+                and trunc >= 1
+                and isinstance(cursor, int)
+                and cursor >= 1
+                and ghost_gone
+                and keeper_here
+            ):
+                healed = True
+                break
+            time.sleep(0.3)
+        if not healed:
+            trunc = cdp.evaluate("window.__globalTruncated || 0")
+            cursor = cdp.evaluate("window.__globalCursorPresented || 0")
+            return (
+                f"RECOVERY-FAILED-ROSTER-trunc{trunc}-cursor{cursor}"
+                f"-ghost{'0' if not _roster_has_ws(cdp, ghost_id, 'roster-ghost') else '1'}"
+                f"-keeper{'1' if _roster_has_ws(cdp, keeper_id, 'roster-keeper') else '0'}"
+            )
+        # Backend proof: the reconnect hit the restarted node's REAL global
+        # endpoint (the counter lives on the reborn server, so >=1 can only
+        # come from a post-restart connection).
+        if node.global_events_requests < 1:
+            return "RECOVERY-FAILED-ROSTER-no-backend-global-connect"
+        verdict = f"RECOVERY-READY-ROSTER-trunc{trunc}-cursor{cursor}"
+        # Stamp the title too so the manual runbook flow reads the same way.
+        cdp.evaluate(f"document.title = {json.dumps(verdict)}")
+        return verdict
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 def run_coord_restart(chrome: str) -> str:
     from tests._sse_recovery_server import final_text_script, parallel_bash_script
 
@@ -1871,6 +2098,7 @@ def main() -> None:
             "rewind-window",
             "rewind-failed-window",
             "stale-backstop",
+            "roster-restart",
             "both",
             "all",
         ],
@@ -1921,6 +2149,10 @@ def main() -> None:
     if args.scenario in ("stale-backstop", "all"):
         verdict = run_stale_backstop(chrome)
         print(f"scenario E4 (stalebackstop): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("roster-restart", "all"):
+        verdict = run_roster_restart(chrome)
+        print(f"scenario F (roster): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     raise SystemExit(1 if failures else 0)
 

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -23,7 +23,8 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario rewind-window     # E2 (#890)
     python3 scripts/recovery_e2e.py --scenario rewind-failed-window  # E3 (#890)
     python3 scripts/recovery_e2e.py --scenario stale-backstop    # E4 (#890)
-    python3 scripts/recovery_e2e.py --scenario roster-restart    # F (#881)
+    python3 scripts/recovery_e2e.py --scenario roster-restart    # F1 (#881)
+    python3 scripts/recovery_e2e.py --scenario roster-restart-native  # F2 (#881)
     python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
     python3 scripts/recovery_e2e.py --keep-open 8971  # serve the storm page
                                                       # for manual inspection
@@ -169,7 +170,7 @@ one truncated full rebuild (no blank pane), the mid-run turn's tool rows
 re-appear inside their batch (no standalone top-level orphan bubbles),
 and turns committed while hidden are present.
 
-Scenario F (roster-restart, #881): the REAL node dashboard (``/`` +
+Scenario F1 (roster-restart, #881): the REAL node dashboard (``/`` +
 ui/static/app.js) driven through a node restart on the GLOBAL stream —
 the last silent-gap class from the truncated-recovery campaign.  Unlike
 the pane scenarios there is no custom page: the runner navigates to the
@@ -198,11 +199,32 @@ wrapper), ghost GONE + keeper PRESENT in the roster MODEL
 deliberately not the dashboard TABLE, whose membership refreshes only on
 interaction by design (see ``_roster_has_ws``) — and the backend proof
 ``global_events_requests>=1`` on the restarted node (the reconnect hit
-the real endpoint).  The NATIVE header path (browser echoes the
-epoch-tagged id on auto-reconnect) differs only in cursor transport and
-is pinned both-transports by Tier-1
-``test_global_sse_boot_epoch::test_query_param_fallback_matches_header_semantics``.
+the real endpoint).  Server-side, both cursor transports run the same
+parse (header-using tests cover it in Tier-1
+``test_global_sse_boot_epoch``); the CLIENT-side native path is a
+different animal and is Scenario F2's job.
 Stamps/returns ``RECOVERY-READY-ROSTER-trunc<n>-cursor<n>``.
+
+Scenario F2 (roster-restart-native, #881): the NATIVE-transport sibling
+of F1, and the only behavioral coverage of two pure-browser semantics no
+Tier-1 harness can express (the mechanism-5 lesson): the auto-reconnect
+header echo, and id-less frames inheriting the connection's persisted
+``lastEventId`` (WHATWG) — the mechanism that forced app.js's
+node_snapshot-branch cursor clear.  Phase A as F1.  Phase B: restart
+with the tab VISIBLE and the EventSource left OPEN, so the browser's own
+retry carries the stale pre-restart header — ``trunc>=1`` with
+``cursor==0`` IS the header-transport proof (only a presented-and-stale
+cursor draws the envelope; the query-param counter stays untouched) —
+and the heal must evict the ghost from model+rail.  Phase C (the
+round-3 fix's discriminator): immediately after the heal — guarded by
+an idFrames-unchanged precondition so the ~10s aggregate tick cannot
+race in unnoticed — force a manual reconnect (close the wrapper-held
+EventSource + hide/show).  It must go CURSORLESS with ``trunc`` still at
+1: pre-fix, the id-less snapshot frame re-captured the dead cursor and
+this reconnect presented it for a redundant second truncated round
+(``cursor1-trunc2``).  ``__globalOpens`` proves the second connection
+happened at the transport.  Stamps/returns
+``RECOVERY-READY-ROSTERNATIVE-trunc<n>-cursor0-opens<n>``.
 """
 
 from __future__ import annotations
@@ -1034,7 +1056,7 @@ def _coord_routes() -> list[Any]:
     ]
 
 
-def _boot_node(port: int = 0) -> Any:
+def _boot_node(port: int = 0, sock: Any = None) -> Any:
     from tests._sse_recovery_server import RecoveryServer
     from turnstone.core.storage import init_storage, reset_storage
 
@@ -1042,9 +1064,11 @@ def _boot_node(port: int = 0) -> Any:
     # runner via CDP BEFORE navigation), so make it public by prefixing under
     # a public path is unavailable here; instead the runner sets the cookie so
     # /recovery passes the middleware. init storage per boot (shared singleton).
+    # ``sock``: a pre-bound placeholder for the gap-free restart handoff
+    # (see RecoveryServer's ``sock`` parameter).
     reset_storage()
     init_storage("sqlite", path=os.path.join(_scratch(), "recovery_e2e.db"), run_migrations=True)
-    return RecoveryServer(extra_routes=[_page_route(), *_coord_routes()], port=port)
+    return RecoveryServer(extra_routes=[_page_route(), *_coord_routes()], port=port, sock=sock)
 
 
 def _scratch() -> str:
@@ -1217,6 +1241,7 @@ ROSTER_INJECT_JS = r"""
 window.__globalTruncated = 0;
 window.__globalIdFrames = 0;
 window.__globalCursorPresented = 0;
+window.__globalOpens = 0;
 window.__globalES = null;
 window.__hide = function () {
   Object.defineProperty(document, "hidden", { configurable: true, value: true });
@@ -1234,6 +1259,7 @@ window.__show = function () {
     const es = new RealES(url, opts);
     if (String(url).indexOf("/events/global") !== -1) {
       window.__globalES = es;
+      window.__globalOpens += 1;
       if (String(url).indexOf("last_event_id=") !== -1) {
         window.__globalCursorPresented += 1;
       }
@@ -1283,6 +1309,30 @@ def _roster_has_ws(cdp: CDP, ws_id: str, name: str) -> bool:
         )
     )
     return in_model and in_rail
+
+
+def _roster_absent_ws(cdp: CDP, ws_id: str, name: str) -> bool:
+    """The ws is fully evicted: absent from BOTH the model and the rail.
+
+    NOT ``not _roster_has_ws(...)`` — that De Morgans into
+    "absent from EITHER surface", which would stamp a heal HEALED while
+    a model-evicted ghost's row still lingers in the rail DOM (the exact
+    render-propagation regression the roster scenarios exist to catch;
+    round-4 review)."""
+    in_model = bool(
+        cdp.evaluate(
+            "(window.TS_APP && window.TS_APP.getClusterState) ? "
+            "window.TS_APP.getClusterState().nodes.local.workstreams.some("
+            f"function (w) {{ return w.id === {json.dumps(ws_id)}; }}) : true"
+        )
+    )
+    in_rail = bool(
+        cdp.evaluate(
+            "Array.prototype.some.call(document.querySelectorAll('button.row'), "
+            f"function (b) {{ return (b.title || '').indexOf({json.dumps(name)}) === 0; }})"
+        )
+    )
+    return not in_model and not in_rail
 
 
 def run_roster_restart(chrome: str) -> str:
@@ -1358,7 +1408,7 @@ def run_roster_restart(chrome: str) -> str:
         while time.monotonic() < deadline:
             trunc = cdp.evaluate("window.__globalTruncated || 0")
             cursor = cdp.evaluate("window.__globalCursorPresented || 0")
-            ghost_gone = not _roster_has_ws(cdp, ghost_id, "roster-ghost")
+            ghost_gone = _roster_absent_ws(cdp, ghost_id, "roster-ghost")
             keeper_here = _roster_has_ws(cdp, keeper_id, "roster-keeper")
             if (
                 isinstance(trunc, int)
@@ -1376,7 +1426,7 @@ def run_roster_restart(chrome: str) -> str:
             cursor = cdp.evaluate("window.__globalCursorPresented || 0")
             return (
                 f"RECOVERY-FAILED-ROSTER-trunc{trunc}-cursor{cursor}"
-                f"-ghost{'0' if not _roster_has_ws(cdp, ghost_id, 'roster-ghost') else '1'}"
+                f"-ghost{'0' if _roster_absent_ws(cdp, ghost_id, 'roster-ghost') else '1'}"
                 f"-keeper{'1' if _roster_has_ws(cdp, keeper_id, 'roster-keeper') else '0'}"
             )
         # Backend proof: the reconnect hit the restarted node's REAL global
@@ -1386,6 +1436,148 @@ def run_roster_restart(chrome: str) -> str:
             return "RECOVERY-FAILED-ROSTER-no-backend-global-connect"
         verdict = f"RECOVERY-READY-ROSTER-trunc{trunc}-cursor{cursor}"
         # Stamp the title too so the manual runbook flow reads the same way.
+        cdp.evaluate(f"document.title = {json.dumps(verdict)}")
+        return verdict
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def run_roster_restart_native(chrome: str) -> str:
+    from tests._sse_recovery_server import bash_toolcall_script, final_text_script
+
+    port = _free_port()
+    node = _boot_node(port=port)
+    keeper_id = node.create_workstream(final_text_script("keeper idle"), name="roster-keeper")
+    ghost_id = node.create_workstream(
+        bash_toolcall_script("g1", "echo ghost-activity"),
+        final_text_script("ghost done"),
+        name="roster-ghost",
+    )
+    profile = Path(_scratch()) / "chrome-roster-native"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        cdp.cmd("Page.enable")
+        cdp.cmd("Page.addScriptToEvaluateOnNewDocument", {"source": ROSTER_INJECT_JS})
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, node.base_url + "/")
+
+        # -- Phase A: identical to F1 ---------------------------------------
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if _roster_has_ws(cdp, ghost_id, "roster-ghost") and _roster_has_ws(
+                cdp, keeper_id, "roster-keeper"
+            ):
+                break
+            time.sleep(0.3)
+        else:
+            return "RECOVERY-FAILED-ROSTERNATIVE-rows-never-rendered"
+        node.send(ghost_id)
+        node.wait_turn(ghost_id, timeout=30)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            frames = cdp.evaluate("window.__globalIdFrames || 0")
+            if isinstance(frames, int) and frames >= 1:
+                break
+            time.sleep(0.3)
+        else:
+            return "RECOVERY-FAILED-ROSTERNATIVE-no-global-id-frames"
+        if cdp.evaluate("window.__globalTruncated || 0") != 0:
+            return "RECOVERY-FAILED-ROSTERNATIVE-truncated-false-positive"
+        if cdp.evaluate("window.__globalCursorPresented || 0") != 0:
+            return "RECOVERY-FAILED-ROSTERNATIVE-premature-cursor-presentation"
+
+        # -- Phase B: NATIVE heal — visible tab, EventSource left open ------
+        # The browser's own retry (the server's 2.5-4.5s ``retry:``
+        # directive) carries the persisted pre-restart id as the
+        # Last-Event-ID HEADER — the transport no manual path can
+        # exercise.  ``trunc>=1`` with the query-param counter still 0
+        # is itself the header proof: only a presented-and-stale cursor
+        # draws the envelope (a cursorless fresh connect draws
+        # snapshot-only).
+        #
+        # Gap-free handoff: a failed EventSource reconnect ATTEMPT is
+        # terminal per WHATWG (fail-the-connection → CLOSED, no second
+        # retry), so the single retry must never hit a refused port.
+        # The placeholder binds (SO_REUSEPORT) while node1 still lives,
+        # its backlog completes the retry's TCP handshake during the
+        # boot, and node2's uvicorn drains it once serving.
+        from tests._sse_recovery_server import make_listen_socket
+
+        placeholder = make_listen_socket(port)
+        node.stop()
+        node = _boot_node(port=port, sock=placeholder)
+        node.open_workstream(keeper_id)
+
+        deadline = time.monotonic() + 25
+        healed = False
+        while time.monotonic() < deadline:
+            trunc = cdp.evaluate("window.__globalTruncated || 0")
+            ghost_gone = _roster_absent_ws(cdp, ghost_id, "roster-ghost")
+            keeper_here = _roster_has_ws(cdp, keeper_id, "roster-keeper")
+            if isinstance(trunc, int) and trunc >= 1 and ghost_gone and keeper_here:
+                healed = True
+                break
+            time.sleep(0.4)
+        if not healed:
+            trunc = cdp.evaluate("window.__globalTruncated || 0")
+            # es state: 0/1 = the retry is still pending (boot too slow /
+            # stream never dropped), 2 = the browser gave up (a refused
+            # window reached the single terminal retry).
+            es_state = cdp.evaluate("window.__globalES ? window.__globalES.readyState : -1")
+            return (
+                f"RECOVERY-FAILED-ROSTERNATIVE-trunc{trunc}"
+                f"-ghost{'0' if _roster_absent_ws(cdp, ghost_id, 'roster-ghost') else '1'}"
+                f"-keeper{'1' if _roster_has_ws(cdp, keeper_id, 'roster-keeper') else '0'}"
+                f"-es{es_state}"
+            )
+        if cdp.evaluate("window.__globalCursorPresented || 0") != 0:
+            return "RECOVERY-FAILED-ROSTERNATIVE-native-leg-used-query-cursor"
+        if node.global_events_requests < 1:
+            return "RECOVERY-FAILED-ROSTERNATIVE-no-backend-global-connect"
+
+        # -- Phase C: the round-3 fix's discriminator -----------------------
+        # The heal's id-less snapshot frame re-captured the dead cursor
+        # on THIS (native) path until app.js's node_snapshot-branch
+        # clear; prove the clear works by forcing a manual reconnect
+        # NOW and asserting it goes CURSORLESS with no second truncated
+        # round.  Precondition: no id-bearing frame may have landed
+        # since the heal (an aggregate tick would legitimately re-arm a
+        # LIVE cursor and void the probe — ~10s cadence vs this
+        # sub-second window; a distinct verdict keeps a freak race
+        # readable as environment, not regression).
+        frames_at_heal = cdp.evaluate("window.__globalIdFrames || 0")
+        opens_before = cdp.evaluate("window.__globalOpens || 0")
+        cdp.evaluate("window.__globalES && window.__globalES.close()")
+        cdp.evaluate("window.__hide && window.__hide()")
+        cdp.evaluate("window.__show && window.__show()")
+        if cdp.evaluate("window.__globalIdFrames || 0") != frames_at_heal:
+            return "RECOVERY-FAILED-ROSTERNATIVE-tick-raced-the-probe"
+
+        deadline = time.monotonic() + 10
+        reopened = False
+        while time.monotonic() < deadline:
+            opens = cdp.evaluate("window.__globalOpens || 0")
+            if isinstance(opens, int) and isinstance(opens_before, int) and opens > opens_before:
+                reopened = True
+                break
+            time.sleep(0.3)
+        if not reopened:
+            return "RECOVERY-FAILED-ROSTERNATIVE-manual-reconnect-never-fired"
+        cursor = cdp.evaluate("window.__globalCursorPresented || 0")
+        trunc = cdp.evaluate("window.__globalTruncated || 0")
+        opens = cdp.evaluate("window.__globalOpens || 0")
+        if cursor != 0:
+            # Pre-fix shape: the dead cursor survived the snapshot frame
+            # and the manual reconnect presented it (cursor1 → a
+            # redundant second truncated round follows).
+            return f"RECOVERY-FAILED-ROSTERNATIVE-dead-cursor-represented-cursor{cursor}"
+        if trunc != 1:
+            return f"RECOVERY-FAILED-ROSTERNATIVE-redundant-truncated-trunc{trunc}"
+        verdict = f"RECOVERY-READY-ROSTERNATIVE-trunc{trunc}-cursor0-opens{opens}"
         cdp.evaluate(f"document.title = {json.dumps(verdict)}")
         return verdict
     finally:
@@ -2099,6 +2291,7 @@ def main() -> None:
             "rewind-failed-window",
             "stale-backstop",
             "roster-restart",
+            "roster-restart-native",
             "both",
             "all",
         ],
@@ -2152,7 +2345,11 @@ def main() -> None:
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("roster-restart", "all"):
         verdict = run_roster_restart(chrome)
-        print(f"scenario F (roster): {verdict}")
+        print(f"scenario F1 (roster-manual): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("roster-restart-native", "all"):
+        verdict = run_roster_restart_native(chrome)
+        print(f"scenario F2 (roster-native): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     raise SystemExit(1 if failures else 0)
 

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -23,15 +23,16 @@ The recipe (verified end-to-end) has four load-bearing pieces:
    every SSE event enqueued" barrier (``stream_end`` is per-LLM-call, not
    per-turn, so it is NOT a completion marker).
 
-4. **Thread hygiene.** ``create_app``'s lifespan unconditionally starts
-   two daemon fan-out threads (``_global_fanout_thread`` blocking on
-   ``global_queue.get()``, ``_aggregate_emitter_thread`` on a 10s loop)
-   with no shutdown sentinel — they would trip conftest's leaked-thread
-   guard. They serve the cluster/global lane, which the per-ws ``/events``
-   path under test never touches, so the harness swaps them for no-ops
-   before boot (restored on ``stop``). The result is a fully clean
-   teardown — no ``allow_thread_leak`` needed — with the real per-ws SSE
-   engine fully intact.
+4. **Thread hygiene.** ``create_app``'s lifespan starts daemon fan-out
+   threads (``_global_fanout_thread`` blocking on ``global_queue.get()``,
+   ``_aggregate_emitter_thread`` on a 10s loop).  The harness used to
+   swap them for no-ops (they had no shutdown and tripped conftest's
+   leaked-thread guard), which kept the global lane dead here; #885 gave
+   the lifespan a real shutdown (stop Event + a queue sentinel for the
+   fanout, joined in the lifespan exit that ``stop()``'s
+   ``should_exit``/join drives), so the harness now runs them REAL — the
+   ``roster-restart`` scenario depends on a live global lane — and
+   teardown stays clean with no ``allow_thread_leak``.
 """
 
 from __future__ import annotations
@@ -49,7 +50,6 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import uvicorn
 
-import turnstone.server as tsrv
 from tests._session_helpers import scripted_chat_client
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
 from turnstone.core.auth import JWT_AUD_SERVER, create_jwt
@@ -69,17 +69,6 @@ _JWT_SECRET = "sse-recovery-e2e-jwt-secret-minimum-32-chars!"
 # the listener-queue poison stays bounded (paired with the client's small
 # SO_RCVBUF in _sse_recovery_helpers). Harmless for prompt readers.
 _DEFAULT_SNDBUF = 8192
-
-
-def _noop_thread(*_args: object, **_kwargs: object) -> None:
-    """Stand-in for the cluster-lane daemon threads (see module docstring)."""
-
-
-# The REAL daemon-thread factories, captured once at import so restore always
-# targets them regardless of how many servers neuter/restore in a run (the
-# restart scenarios build a second server before the run ends).
-_REAL_FANOUT = tsrv._global_fanout_thread
-_REAL_AGGREGATE = tsrv._aggregate_emitter_thread
 
 
 def _fake_client(scripts: tuple[Any, ...]) -> Any:
@@ -157,10 +146,6 @@ class RecoveryServer:
         )
         self._adapter.attach(self._manager)
         WebUI._workstream_mgr = self._manager
-
-        # Neuter the cluster-lane daemons for a clean teardown (see docstring).
-        tsrv._global_fanout_thread = _noop_thread
-        tsrv._aggregate_emitter_thread = _noop_thread
 
         # Optional small listener-queue cap. The cap is a default arg on the
         # registration methods with no config/env override, so lower it by
@@ -435,9 +420,7 @@ class RecoveryServer:
             self._http.close()
         with contextlib.suppress(OSError):
             self._sock.close()
-        # Restore the cluster-lane daemon factories + any patched cap defaults.
-        tsrv._global_fanout_thread = _REAL_FANOUT
-        tsrv._aggregate_emitter_thread = _REAL_AGGREGATE
+        # Restore any patched cap defaults.
         for meth, defaults in self._orig_defaults:
             meth.__defaults__ = defaults
 

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -203,6 +203,11 @@ class RecoveryServer:
         # reload-based backstop would bump it once per reconnect (the round-5
         # storm).  Same lock-free single-writer int discipline as above.
         self.events_requests = 0
+        # Global-lane SSE connection opens (``GET …/events/global`` — the
+        # roster stream app.js's connectGlobalSSE builds).  The
+        # roster-restart scenario (#881) asserts the post-restart manual
+        # reconnect actually reached the reborn node's real endpoint.
+        self.global_events_requests = 0
         self._history_fail_remaining = 0
         self._history_delay_ms = 0
         # A thin pure-ASGI fault layer wrapping the REAL app (the production
@@ -241,6 +246,8 @@ class RecoveryServer:
                     # route the pane's EventSource hits is
                     # ``…/workstreams/{ws_id}/events`` (session_routes).
                     self.events_requests += 1
+                elif path.endswith("/events/global") and method == "GET":
+                    self.global_events_requests += 1
             await production_app(scope, receive, send)
 
         self._server = uvicorn.Server(

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -90,6 +90,7 @@ class RecoveryServer:
         listener_cap: int | None = None,
         extra_routes: list[Any] | None = None,
         port: int = 0,
+        sock: socket.socket | None = None,
     ) -> None:
         self._global_queue: _q.Queue[dict[str, Any]] = _q.Queue(maxsize=100000)
         self._global_listeners: list[_q.Queue[dict[str, Any]]] = []
@@ -180,13 +181,16 @@ class RecoveryServer:
             self._app.router.routes.extend(extra_routes)
 
         # Pre-bind a listening socket with a small SO_SNDBUF (accepted conns
-        # inherit it), then hand it to uvicorn.
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, sndbuf)
-        self._sock.bind(("127.0.0.1", port))  # port=0 -> ephemeral; fixed -> restart reuse
+        # inherit it), then hand it to uvicorn.  ``sock`` injection: the
+        # gap-free restart scenarios (roster-restart-native) bind a
+        # placeholder BEFORE stopping the prior node and hand it in here —
+        # a failed EventSource reconnect attempt is TERMINAL per WHATWG
+        # (fail-the-connection → CLOSED, no further retries), so the
+        # native-retry leg must never observe a refused-window; the
+        # placeholder's listen backlog completes the TCP handshake during
+        # the boot and uvicorn drains it once serving.
+        self._sock = sock if sock is not None else make_listen_socket(port, sndbuf=sndbuf)
         self._port = int(self._sock.getsockname()[1])
-        self._sock.listen(128)
 
         # -- fault injection (public knobs below) ----------------------------
         # In-process arming: the Tier-2 runner holds this RecoveryServer and
@@ -250,8 +254,20 @@ class RecoveryServer:
                     self.global_events_requests += 1
             await production_app(scope, receive, send)
 
+        # ``timeout_graceful_shutdown``: an SSE stream that is still open
+        # at ``stop()`` would otherwise park uvicorn's graceful drain
+        # indefinitely (the 20s thread-join just expires and the browser
+        # stays attached to the zombie server — the roster-restart-native
+        # scenario is the one caller that stops a node mid-stream).  A
+        # bounded drain force-closes the stream after 2s and the lifespan
+        # shutdown (#885's daemon-thread teardown) still runs after it.
         self._server = uvicorn.Server(
-            uvicorn.Config(_fault_app, log_level="warning", lifespan="on")
+            uvicorn.Config(
+                _fault_app,
+                log_level="warning",
+                lifespan="on",
+                timeout_graceful_shutdown=2,
+            )
         )
         self._thread = threading.Thread(
             target=self._serve, name=f"uvicorn-recovery-{self._port}", daemon=True
@@ -430,6 +446,25 @@ class RecoveryServer:
         # Restore any patched cap defaults.
         for meth, defaults in self._orig_defaults:
             meth.__defaults__ = defaults
+
+
+def make_listen_socket(port: int, *, sndbuf: int = _DEFAULT_SNDBUF) -> socket.socket:
+    """Bound + listening socket the way :class:`RecoveryServer` binds its own.
+
+    ``SO_REUSEPORT`` on every listener (same process, same uid) is what
+    lets a restart scenario bind the successor's socket while the prior
+    node still holds the port — the seam behind the gap-free handoff
+    documented at the ``sock`` parameter.  ``SO_SNDBUF`` matches the
+    server's small send buffer so accepted connections inherit identical
+    backpressure behavior regardless of which side bound the socket.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, sndbuf)
+    s.bind(("127.0.0.1", port))  # port=0 -> ephemeral; fixed -> restart reuse
+    s.listen(128)
+    return s
 
 
 def _tcp_ready(port: int, timeout: float) -> bool:

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2252,7 +2252,13 @@ def test_sse_cursor_captured_from_message_event_never_the_source_object() -> Non
     — the epoch prefix would NaN any numeric read), presented via
     ``?last_event_id=`` (EventSource cannot set the header manually),
     and cleared where the record dies: the ``replay_truncated``
-    handler and ``onLogout``.
+    handler, the ``node_snapshot`` recovery floor (required, not
+    belt-and-braces — that id-less frame's MessageEvent inherits the
+    connection's stale pre-restart cursor on NATIVE reconnects, so the
+    pre-dispatch capture re-stores it and only a branch-level clear
+    kills it), and ``onLogout``.  All three clears are pinned below —
+    a simplify pass dropping one reintroduces the redundant
+    dead-cursor truncated round.
 
     Comments are stripped before the scan (module-level, string-aware
     stripper) so documentation may name the anti-pattern verbatim — the
@@ -2302,6 +2308,24 @@ def test_sse_cursor_captured_from_message_event_never_the_source_object() -> Non
     assert not re.search(r"(?:Number|parseInt)\(\s*globalLastEventId", app_code), (
         "app.js: the global cursor is an opaque epoch-tagged string — "
         "never interpret it numerically"
+    )
+    # Dead-record clears (see docstring): truncated envelope, snapshot
+    # recovery floor (BEFORE the roster rebuild), and logout.
+    assert re.search(
+        r"globalLastEventId = null;\s*resyncRoster\(\);",
+        app_code,
+    ), "app.js: the replay_truncated handler must clear the spent cursor"
+    assert re.search(
+        r"globalLastEventId = null;\s*applyRosterSnapshot\(",
+        app_code,
+    ), (
+        "app.js: the node_snapshot branch must clear the cursor — on "
+        "native reconnects this id-less frame re-captured the stale one"
+    )
+    logout_body = re.search(r"window\.onLogout = function \(\) \{(.*?)\n\};", app_code, re.S)
+    assert logout_body is not None, "app.js: window.onLogout not found"
+    assert "globalLastEventId = null;" in logout_body.group(1), (
+        "app.js: onLogout must reset the cursor (roster identity reset)"
     )
 
 

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2241,12 +2241,18 @@ def test_sse_cursor_captured_from_message_event_never_the_source_object() -> Non
     every cursor guard keeps a future editor from "simplifying" the
     numeric ones to match a terser string form.
 
-    The GLOBAL stream (app.js) is the deliberate exception: its manual
-    reconnects are pinned CURSORLESS — the global ring's counter reboots
-    at 0 on restart (KNOWN GAP #881), so a stale cursor draws
-    ``replay_ok``-empty with no node_snapshot and the roster ghosts;
-    cursorless always draws the fresh snapshot.  Revisit when #881
-    lands.
+    The GLOBAL stream (app.js) was pinned CURSORLESS here until #881
+    landed its boot-epoch signal: global ids are now
+    ``"{boot_epoch}-{counter}"``, so a cursor from a prior boot
+    mismatches the live epoch and draws ``replay_truncated`` + a fresh
+    node_snapshot instead of the old ``replay_ok``-empty ghost-roster
+    shape — the reason for cursorlessness is gone, and app.js now
+    captures/presents the cursor like the per-ws clients.  Its cursor
+    stays an OPAQUE STRING end to end (never ``parseInt``/``Number``
+    — the epoch prefix would NaN any numeric read), presented via
+    ``?last_event_id=`` (EventSource cannot set the header manually),
+    and cleared where the record dies: the ``replay_truncated``
+    handler and ``onLogout``.
 
     Comments are stripped before the scan (module-level, string-aware
     stripper) so documentation may name the anti-pattern verbatim — the
@@ -2262,6 +2268,11 @@ def test_sse_cursor_captured_from_message_event_never_the_source_object() -> Non
             _COORD_JS,
             r'if \(event\.lastEventId != null && event\.lastEventId !== ""\) \{',
         ),
+        (
+            _APP_JS,
+            r'if \(e\.lastEventId != null && e\.lastEventId !== ""\) \{\s*'
+            r"globalLastEventId = e\.lastEventId;",
+        ),
     ):
         body = path.read_text(encoding="utf-8")
         code = _strip_js_comments(body)
@@ -2275,14 +2286,22 @@ def test_sse_cursor_captured_from_message_event_never_the_source_object() -> Non
             '``!= null && !== ""`` guard) not found'
         )
     app_code = _strip_js_comments(_APP_JS.read_text(encoding="utf-8"))
-    assert not dead_form.search(app_code), (
-        "app.js: dead EventSource-object cursor read must not return"
+    # Presentation: manual reconnects carry the stored cursor as a query
+    # param, behind the same string-guard idiom (see docstring above for
+    # why the explicit form is pinned).
+    assert re.search(
+        r'if \(globalLastEventId != null && globalLastEventId !== ""\) \{\s*'
+        r'globalUrl \+= "\?last_event_id=" \+ encodeURIComponent\(globalLastEventId\);',
+        app_code,
+    ), (
+        "app.js: manual global reconnect must present the stored cursor "
+        "via ?last_event_id= behind the house string guard"
     )
-    assert "lastEventId" not in app_code and "last_event_id" not in app_code, (
-        "app.js global stream must stay CURSORLESS on manual reconnects "
-        "until #881's boot-epoch staleness signal lands — a stale cursor "
-        "on the reborn global ring draws replay_ok-empty with no "
-        "node_snapshot (ghost roster)."
+    # The cursor is opaque — any numeric interpretation of it is a bug
+    # (the epoch prefix turns Number()/parseInt() into NaN silently).
+    assert not re.search(r"(?:Number|parseInt)\(\s*globalLastEventId", app_code), (
+        "app.js: the global cursor is an opaque epoch-tagged string — "
+        "never interpret it numerically"
     )
 
 

--- a/tests/test_global_sse_boot_epoch.py
+++ b/tests/test_global_sse_boot_epoch.py
@@ -31,6 +31,7 @@ import collections
 import json
 import queue
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace as SimpleNS
 from typing import Any
 
@@ -204,14 +205,42 @@ def test_same_epoch_cursor_at_head_is_caught_up_replay_ok(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A cursor at the newest id is the normal caught-up reconnect:
-    nothing to replay, no snapshot, and crucially no false truncated."""
-    yields = _drain(
-        monkeypatch,
-        buffered=[_ev(4), _ev(5)],
-        headers={"Last-Event-ID": f"{EPOCH}-5"},
-        max_yields=1,
-    )
-    assert _types(yields) == []
+    nothing to replay, no snapshot, and crucially no false truncated.
+
+    Asserted POSITIVELY: a sentinel live event is queued to the
+    registered listener before draining, so the drain runs through the
+    live loop and the sentinel must be the FIRST data frame — a spurious
+    envelope or snapshot would land ahead of it.  (A drain truncated at
+    the always-first ``retry`` frame asserts nothing — round-2 review.)
+    """
+    monkeypatch.setattr(server_mod, "_build_node_snapshot", lambda _s: dict(_SNAPSHOT_STUB))
+    app_state = _make_app_state(buffered=[_ev(4), _ev(5)])
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="boot-epoch-test")
+    app_state.sse_executor = executor
+    req = _fake_request(app_state, headers={"Last-Event-ID": f"{EPOCH}-5"})
+
+    async def _run() -> list[dict[str, Any]]:
+        async with asyncio.timeout(10):
+            resp: Any = await server_mod.global_events_sse(req)
+            # Registered by handler-await time; the live sentinel the
+            # drain below must reach as its first data frame.
+            app_state.global_listeners[0].put_nowait(
+                {"type": "ws_state", "ws_id": "sentinel", "_event_id": 6}
+            )
+            out: list[dict[str, Any]] = []
+            async for chunk in resp.body_iterator:
+                out.append(chunk)
+                if len(out) >= 2:
+                    break
+            await resp.body_iterator.aclose()
+            return out
+
+    try:
+        yields = asyncio.run(_run())
+    finally:
+        executor.shutdown(wait=True)
+    frames = _data_frames(yields)
+    assert [f.get("ws_id") for f in frames] == ["sentinel"]
 
 
 def test_same_epoch_ring_miss_is_truncated_with_honest_counts(
@@ -375,6 +404,65 @@ def test_epoch_is_hex_and_dashless_by_construction() -> None:
 
     src = inspect.getsource(server_mod)
     assert "app.state.global_boot_epoch = secrets.token_hex(" in src
+
+
+def test_snapshot_builds_after_registration_outside_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins the branch's concurrency contract AT THE BUILD SITE: when
+    ``_build_node_snapshot`` runs, (1) the listener is already
+    REGISTERED — registration-before-build is the no-loss ordering
+    (every event from registration on is queued, so the newer snapshot
+    plus the queued deltas covers everything), and (2)
+    ``global_listeners_lock`` is RELEASED — the O(workstreams) build
+    must not stall the fan-out thread.  A refactor "harmonizing" this
+    lane with the per-ws build-under-lock shape, or reordering
+    registration after the build, fails here and nowhere else."""
+    app_state = _make_app_state(buffered=[_ev(1)])
+    probed: dict[str, Any] = {}
+
+    def _probe(_s: Any) -> dict[str, Any]:
+        probed["registered"] = len(app_state.global_listeners)
+        acquired = app_state.global_listeners_lock.acquire(blocking=False)
+        probed["lock_free"] = acquired
+        if acquired:
+            app_state.global_listeners_lock.release()
+        return dict(_SNAPSHOT_STUB)
+
+    monkeypatch.setattr(server_mod, "_build_node_snapshot", _probe)
+    req = _fake_request(app_state, headers={"Last-Event-ID": "deadbeef-1"})
+
+    async def _run() -> None:
+        resp: Any = await server_mod.global_events_sse(req)
+        await resp.body_iterator.aclose()
+
+    asyncio.run(_run())
+    assert probed == {"registered": 1, "lock_free": True}
+
+
+def test_raising_snapshot_build_deregisters_the_listener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The registration-window guard (#881 round-2 review): registration
+    precedes the build, so a raising ``_build_node_snapshot`` fires
+    before the generator — whose ``finally`` is the normal owner of
+    de-registration — ever exists.  The window guard must remove the
+    queue, or it sits dead in the fan-out list forever (the fan-out
+    thread never removes listeners)."""
+    app_state = _make_app_state(buffered=[_ev(1)])
+
+    def _boom(_s: Any) -> dict[str, Any]:
+        raise RuntimeError("storage hiccup")
+
+    monkeypatch.setattr(server_mod, "_build_node_snapshot", _boom)
+    req = _fake_request(app_state, headers={"Last-Event-ID": "deadbeef-1"})
+
+    async def _run() -> None:
+        await server_mod.global_events_sse(req)
+
+    with pytest.raises(RuntimeError, match="storage hiccup"):
+        asyncio.run(_run())
+    assert app_state.global_listeners == []
 
 
 def test_listener_registered_exactly_once_per_connect(

--- a/tests/test_global_sse_boot_epoch.py
+++ b/tests/test_global_sse_boot_epoch.py
@@ -50,8 +50,13 @@ def _make_app_state(
     """Minimal ``app.state`` for the global SSE handler.
 
     Real lock / deque / list so registration and slicing run the
-    production code paths; only the snapshot builder is stubbed (its
-    composition has its own coverage in ``test_console.py``).
+    production code paths; only the snapshot builder is stubbed — the
+    replay-branch decisions under test never depend on its composition.
+    The real ``_build_node_snapshot`` is exercised end-to-end by
+    ``scripts/recovery_e2e.py --scenario roster-restart`` (snapshot
+    membership + evict); its full field projection has no direct unit
+    test today (``test_console.py`` covers only the CONSUMER side,
+    feeding hand-built snapshot dicts to the collector).
     """
     buf: collections.deque[tuple[int, dict[str, Any]]] = collections.deque(maxlen=50)
     for item in buffered or []:

--- a/tests/test_global_sse_boot_epoch.py
+++ b/tests/test_global_sse_boot_epoch.py
@@ -398,7 +398,7 @@ def test_epoch_is_hex_and_dashless_by_construction() -> None:
     import secrets
 
     for _ in range(64):
-        assert "-" not in secrets.token_hex(4)
+        assert "-" not in secrets.token_hex(8)
     # And the production init uses token_hex — source-level pin.
     import inspect
 

--- a/tests/test_global_sse_boot_epoch.py
+++ b/tests/test_global_sse_boot_epoch.py
@@ -40,7 +40,7 @@ from starlette.requests import Request
 
 import turnstone.server as server_mod
 
-EPOCH = "0badf00d"  # test-pinned boot epoch (hex, like secrets.token_hex(4))
+EPOCH = "0badf00dcafebabe"  # test-pinned boot epoch (hex, like secrets.token_hex(8))
 
 
 def _make_app_state(

--- a/tests/test_global_sse_boot_epoch.py
+++ b/tests/test_global_sse_boot_epoch.py
@@ -1,0 +1,391 @@
+"""Boot-epoch staleness signal on the node-global SSE stream (#881).
+
+The global ring buffer and its event counter are process-local: unlike the
+per-ws lane (whose counter ``_seed_event_id_from_storage`` seeds from
+``MAX(conversations.event_id)``), ``global_event_id_holder`` reboots at 0
+with the process.  A bare integer cursor therefore cannot prove which boot
+minted it — after a restart it is first "ahead" of the reborn ring (empty
+replay slice) and then aliases into the new id space as the counter
+re-grows, both of which used to draw ``replay_ok`` and silently skip the
+restart boundary.
+
+The fix stamps every global SSE ``id:`` as ``"{boot_epoch}-{counter}"``
+and treats any cursor that does not carry the live epoch as stale,
+answering ``replay_truncated`` (``reason="boot_epoch"``) plus the
+``node_snapshot`` recovery floor.  These tests walk the reconnect matrix
+at the :func:`turnstone.server.global_events_sse` boundary:
+
+  cursor ∈ {absent, same-epoch, stale-epoch, legacy bare-int, garbage,
+            negative, forged-against-empty-ring}
+  ×  ring ∈ {empty, covers cursor, evicted past cursor}
+
+The browser half (app.js capture/presentation) is pinned in
+``test_app_js.py``; the end-to-end restart loop is
+``scripts/recovery_e2e.py --scenario roster-restart``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import json
+import queue
+import threading
+from types import SimpleNamespace as SimpleNS
+from typing import Any
+
+import pytest
+from starlette.requests import Request
+
+import turnstone.server as server_mod
+
+EPOCH = "0badf00d"  # test-pinned boot epoch (hex, like secrets.token_hex(4))
+
+
+def _make_app_state(
+    *,
+    buffered: list[tuple[int, dict[str, Any]]] | None = None,
+    epoch: str = EPOCH,
+) -> SimpleNS:
+    """Minimal ``app.state`` for the global SSE handler.
+
+    Real lock / deque / list so registration and slicing run the
+    production code paths; only the snapshot builder is stubbed (its
+    composition has its own coverage in ``test_console.py``).
+    """
+    buf: collections.deque[tuple[int, dict[str, Any]]] = collections.deque(maxlen=50)
+    for item in buffered or []:
+        buf.append(item)
+    return SimpleNS(
+        node_id="node-under-test",
+        global_listeners=[],
+        global_listeners_lock=threading.Lock(),
+        global_event_buffer=buf,
+        global_boot_epoch=epoch,
+        sse_executor=None,  # live loop is never entered by these tests
+    )
+
+
+def _fake_request(
+    app_state: SimpleNS,
+    *,
+    headers: dict[str, str] | None = None,
+    query: dict[str, str] | None = None,
+) -> Request:
+    """ASGI-scope-honest request carrying a service-scoped principal."""
+    header_list = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    query_string = "&".join(f"{k}={v}" for k, v in query.items()).encode() if query else b""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "headers": header_list,
+        "path": "/v1/api/events/global",
+        "raw_path": b"/v1/api/events/global",
+        "query_string": query_string,
+        "app": SimpleNS(state=app_state),
+        "state": {"auth_result": SimpleNS(scopes=["service"])},
+    }
+
+    async def _recv() -> dict[str, Any]:  # noqa: RUF029 — async signature required
+        return {"type": "http.disconnect"}
+
+    return Request(scope, receive=_recv)
+
+
+_SNAPSHOT_STUB = {"type": "node_snapshot", "node_id": "node-under-test", "workstreams": []}
+
+
+def _drain(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    buffered: list[tuple[int, dict[str, Any]]] | None = None,
+    headers: dict[str, str] | None = None,
+    query: dict[str, str] | None = None,
+    max_yields: int = 8,
+    epoch: str = EPOCH,
+) -> list[dict[str, Any]]:
+    """Run the handler and collect its pre-live yields as raw dicts.
+
+    ``max_yields`` must not exceed the pre-live yield count for the
+    branch under test + 1 — the live loop blocks on an executor draw,
+    so every test enumerates its expected frames and stops short.
+    """
+    monkeypatch.setattr(server_mod, "_build_node_snapshot", lambda _s: dict(_SNAPSHOT_STUB))
+    app_state = _make_app_state(buffered=buffered, epoch=epoch)
+    req = _fake_request(app_state, headers=headers, query=query)
+
+    async def _run() -> list[dict[str, Any]]:
+        # Guard against a miscounted ``max_yields`` reaching the live
+        # loop (which blocks on an executor draw and would hang the
+        # test + leak the draw thread) — fail fast and visibly instead.
+        async with asyncio.timeout(10):
+            # ``Any``: the endpoint is annotated ``-> Response``; the SSE
+            # subtype's ``body_iterator`` is what the drain consumes.
+            resp: Any = await server_mod.global_events_sse(req)
+            out: list[dict[str, Any]] = []
+            async for chunk in resp.body_iterator:
+                out.append(chunk)
+                if len(out) >= max_yields:
+                    break
+            await resp.body_iterator.aclose()
+            return out
+
+    return asyncio.run(_run())
+
+
+def _data_frames(yields: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """JSON-decoded ``data:`` payloads, in yield order."""
+    return [json.loads(y["data"]) for y in yields if "data" in y]
+
+
+def _types(yields: list[dict[str, Any]]) -> list[str]:
+    return [d.get("type", "") for d in _data_frames(yields)]
+
+
+def _ev(eid: int, **extra: Any) -> tuple[int, dict[str, Any]]:
+    """A buffered ring entry the way ``_global_fanout_thread`` stores it:
+    the event dict carries ``_event_id`` and the tuple repeats the id."""
+    return eid, {"type": "ws_state", "ws_id": f"ws-{eid}", "_event_id": eid, **extra}
+
+
+# ---------------------------------------------------------------------------
+# Fresh connect (no cursor)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_connect_gets_snapshot_no_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    yields = _drain(monkeypatch, buffered=[_ev(1)], max_yields=2)
+    assert "retry" in yields[0]
+    assert _types(yields) == ["node_snapshot"]
+
+
+# ---------------------------------------------------------------------------
+# Same-epoch cursors — ring logic must behave exactly as before
+# ---------------------------------------------------------------------------
+
+
+def test_same_epoch_cursor_replays_slice_without_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1), _ev(2), _ev(3)],
+        headers={"Last-Event-ID": f"{EPOCH}-1"},
+        max_yields=3,
+    )
+    frames = _data_frames(yields)
+    assert [f["ws_id"] for f in frames] == ["ws-2", "ws-3"]
+    assert "node_snapshot" not in _types(yields)
+    assert "replay_truncated" not in _types(yields)
+
+
+def test_replayed_and_live_ids_are_epoch_tagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every ``id:`` on the wire carries the live epoch — the browser
+    echoes it verbatim on native reconnect, which is what lets the
+    server prove cursor provenance without any client cooperation."""
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1), _ev(2)],
+        headers={"Last-Event-ID": f"{EPOCH}-0"},
+        max_yields=3,
+    )
+    ids = [y["id"] for y in yields if "id" in y]
+    assert ids == [f"{EPOCH}-1", f"{EPOCH}-2"]
+    # And the internal ``_event_id`` never leaks onto the wire.
+    assert all("_event_id" not in f for f in _data_frames(yields))
+
+
+def test_same_epoch_cursor_at_head_is_caught_up_replay_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cursor at the newest id is the normal caught-up reconnect:
+    nothing to replay, no snapshot, and crucially no false truncated."""
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(4), _ev(5)],
+        headers={"Last-Event-ID": f"{EPOCH}-5"},
+        max_yields=1,
+    )
+    assert _types(yields) == []
+
+
+def test_same_epoch_ring_miss_is_truncated_with_honest_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(10), _ev(11)],
+        headers={"Last-Event-ID": f"{EPOCH}-3"},
+        max_yields=3,
+    )
+    envelope, snapshot = _data_frames(yields)
+    assert envelope["type"] == "replay_truncated"
+    assert envelope["reason"] == "ring_evicted"
+    assert envelope["lost_count"] == 6  # ids 4..9 died with the ring
+    assert envelope["earliest_available_id"] == 10
+    assert snapshot["type"] == "node_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Stale / foreign cursors — the #881 class
+# ---------------------------------------------------------------------------
+
+
+def _assert_boot_epoch_truncated(yields: list[dict[str, Any]]) -> None:
+    """Envelope (reason=boot_epoch, no invented counts) then snapshot,
+    and no replay slice leaked around them."""
+    frames = _data_frames(yields)
+    assert [f["type"] for f in frames] == ["replay_truncated", "node_snapshot"]
+    envelope = frames[0]
+    assert envelope["reason"] == "boot_epoch"
+    assert "lost_count" not in envelope
+    assert "earliest_available_id" not in envelope
+
+
+def test_prior_boot_cursor_against_regrown_ring_is_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE restart-aliasing case: the reborn counter has re-grown past
+    the stale cursor, so pre-#881 the ring sliced from it as if the ids
+    were contiguous across the boot — silently skipping the restart
+    boundary.  The epoch mismatch must win over the plausible slice."""
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1), _ev(2), _ev(3)],
+        headers={"Last-Event-ID": "deadbeef-2"},
+        max_yields=3,
+    )
+    _assert_boot_epoch_truncated(yields)
+
+
+def test_legacy_bare_int_cursor_on_empty_ring_is_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The original #881 lie: empty reborn ring + pre-restart cursor
+    used to answer ``replay_ok`` with nothing.  A bare-int cursor (no
+    epoch half — pre-#881 client or prior-boot native echo) must draw
+    the truncated floor instead of the silent gap."""
+    yields = _drain(
+        monkeypatch,
+        buffered=[],
+        headers={"Last-Event-ID": "42"},
+        max_yields=3,
+    )
+    _assert_boot_epoch_truncated(yields)
+
+
+def test_legacy_bare_int_cursor_on_live_ring_is_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1), _ev(2)],
+        headers={"Last-Event-ID": "1"},
+        max_yields=3,
+    )
+    _assert_boot_epoch_truncated(yields)
+
+
+def test_same_epoch_cursor_against_empty_ring_fails_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same-epoch ids imply a non-empty ring (single append site, first
+    id 1, never cleared) — a same-epoch cursor over an empty ring is
+    forged or a bug, and must fail to the snapshot floor rather than
+    resurrect the silent-gap shape."""
+    yields = _drain(
+        monkeypatch,
+        buffered=[],
+        headers={"Last-Event-ID": f"{EPOCH}-5"},
+        max_yields=3,
+    )
+    _assert_boot_epoch_truncated(yields)
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        "not-a-cursor",  # wrong epoch, non-numeric counter
+        f"{EPOCH}-xyz",  # live epoch, garbage counter
+        f"{EPOCH}--5",  # live epoch, negative (forged) counter
+        "-",  # empty epoch, empty counter
+    ],
+)
+def test_unusable_cursor_shapes_all_draw_the_truncated_floor(
+    monkeypatch: pytest.MonkeyPatch, cursor: str
+) -> None:
+    """A present-but-unusable cursor must NOT fall back to ``fresh``:
+    fresh is the no-loss shape, and these callers provably lost events.
+    (Pre-#881 the unparseable arm silently became fresh — the semantic
+    shift is deliberate and this test pins it.)"""
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1)],
+        headers={"Last-Event-ID": cursor},
+        max_yields=3,
+    )
+    _assert_boot_epoch_truncated(yields)
+
+
+# ---------------------------------------------------------------------------
+# Transport details
+# ---------------------------------------------------------------------------
+
+
+def test_query_param_fallback_matches_header_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manual browser reconnects can't set headers on ``new
+    EventSource(url)`` — the ``?last_event_id=`` fallback must run the
+    same epoch logic (app.js presents its stored cursor this way)."""
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1), _ev(2)],
+        query={"last_event_id": f"{EPOCH}-1"},
+        max_yields=2,
+    )
+    frames = _data_frames(yields)
+    assert [f["ws_id"] for f in frames] == ["ws-2"]
+
+    yields = _drain(
+        monkeypatch,
+        buffered=[_ev(1), _ev(2)],
+        query={"last_event_id": "deadbeef-1"},
+        max_yields=3,
+    )
+    _assert_boot_epoch_truncated(yields)
+
+
+def test_epoch_is_hex_and_dashless_by_construction() -> None:
+    """The parse splits on the FIRST ``-``; the epoch half must never
+    contain one.  ``secrets.token_hex`` guarantees pure hex — this pin
+    exists so a future 'readable epoch' refactor (timestamps, uuids
+    with dashes) fails here instead of corrupting cursor parsing."""
+    import secrets
+
+    for _ in range(64):
+        assert "-" not in secrets.token_hex(4)
+    # And the production init uses token_hex — source-level pin.
+    import inspect
+
+    src = inspect.getsource(server_mod)
+    assert "app.state.global_boot_epoch = secrets.token_hex(" in src
+
+
+def test_listener_registered_exactly_once_per_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registration is atomic with the replay decision for every branch
+    (stale cursors included) — the truncated floor must not skip or
+    double the listener append."""
+    monkeypatch.setattr(server_mod, "_build_node_snapshot", lambda _s: dict(_SNAPSHOT_STUB))
+    app_state = _make_app_state(buffered=[_ev(1)])
+    req = _fake_request(app_state, headers={"Last-Event-ID": "deadbeef-1"})
+
+    async def _run() -> None:
+        resp: Any = await server_mod.global_events_sse(req)
+        assert len(app_state.global_listeners) == 1
+        assert isinstance(app_state.global_listeners[0], queue.Queue)
+        await resp.body_iterator.aclose()
+
+    asyncio.run(_run())

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -186,7 +186,13 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "Emits a node_snapshot event on connect (workstreams, health, aggregate), "
         "followed by real-time delta events (ws_state, ws_activity, ws_created, "
         "ws_closed, ws_rename, health_changed, aggregate). "
-        "Pass ?expected_node_id=X for identity verification (returns 409 on mismatch).",
+        "Pass ?expected_node_id=X for identity verification (returns 409 on mismatch). "
+        "Every event's SSE id is an opaque '{boot_epoch}-{counter}' string; presenting "
+        "it on reconnect (Last-Event-ID header or ?last_event_id=) replays missed "
+        "events, or emits a replay_truncated event (reason: ring_evicted with "
+        "lost_count + earliest_available_id, or boot_epoch when the cursor predates "
+        "this server process) followed by a fresh node_snapshot. Treat the id as "
+        "opaque — its format may change.",
         tags=["Streaming"],
     ),
     EndpointSpec(

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -284,8 +284,9 @@ class ClusterCollector:
         ``node_snapshot`` and the collector rebuilds wholesale.  That is
         this consumer's recovery model (idempotent state-of-world, not
         append-only history), it side-steps cursor staleness across node
-        restarts entirely, and it means the epoch-tagged ids and the
-        ``replay_truncated`` envelope on this stream can never fire here.
+        restarts entirely, and it means the epoch staleness check and
+        the ``replay_truncated`` envelope can never fire here — the
+        epoch-tagged ids themselves are on the wire, just never read.
         If a cursor is ever adopted, present the SSE ``id:`` VERBATIM
         (opaque ``"{boot_epoch}-{counter}"`` — never parse it) and handle
         ``replay_truncated`` explicitly; today an unknown event type

--- a/turnstone/console/collector.py
+++ b/turnstone/console/collector.py
@@ -277,7 +277,20 @@ class ClusterCollector:
                 await task
 
     async def _node_sse_task(self, node_id: str, stop_event: asyncio.Event) -> None:
-        """Persistent SSE connection to a single server node."""
+        """Persistent SSE connection to a single server node.
+
+        DELIBERATELY cursorless (#881 audit ruling): every (re)connect is
+        fresh — no ``Last-Event-ID``, so the node answers with a full
+        ``node_snapshot`` and the collector rebuilds wholesale.  That is
+        this consumer's recovery model (idempotent state-of-world, not
+        append-only history), it side-steps cursor staleness across node
+        restarts entirely, and it means the epoch-tagged ids and the
+        ``replay_truncated`` envelope on this stream can never fire here.
+        If a cursor is ever adopted, present the SSE ``id:`` VERBATIM
+        (opaque ``"{boot_epoch}-{counter}"`` — never parse it) and handle
+        ``replay_truncated`` explicitly; today an unknown event type
+        no-ops in ``_apply_delta`` by design.
+        """
         backoff = 1.0
         while not stop_event.is_set() and self._running:
             url = self._get_node_url(node_id)

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1160,37 +1160,17 @@ async def global_events_sse(request: Request) -> Response:
                     replay_events = [ev for eid, ev in buffered if eid > last_event_id]
         listeners.append(client_queue)
 
-    if replay_status != "replay_ok":
-        # Snapshot built AFTER the lock: ``_build_node_snapshot`` is an
-        # O(workstreams) walk taking each ws's ``_ws_lock``, and under
-        # ``global_listeners_lock`` it would stall the fanout thread's
-        # per-event stamping for EVERY listener — N-fold during a
-        # restart herd of stale-cursor reconnects, exactly when the
-        # reborn node is emitting its re-open events.  Registration
-        # already happened under the lock above, so every event from
-        # that instant on is queued to this listener: nothing is lost,
-        # and deltas stamped while the snapshot builds re-apply
-        # idempotently over the (newer) snapshot at the consumer
-        # (state-of-world contract — see the endpoint docstring).
-        # ``replay_ok`` is by design exactly the no-snapshot shape
-        # (truncated always carries the snapshot floor, fresh always
-        # snapshots), so this predicate and the generator's emission
-        # branch stay one rule.
-        snapshot = _build_node_snapshot(request.app.state)
+    def _deregister() -> None:
+        """Remove this connection's queue from the fan-out list.
 
-    if replay_status == "truncated":
-        # Envelope chokepoint log, analog of ``ws.events.replay_truncated``
-        # on the per-ws lane — one line per gap detection, the operator
-        # signal that clients are being told to resync (a burst of
-        # ``reason=boot_epoch`` right after startup is the restart herd
-        # healing; sustained ``reason=ring_evicted`` means the ring cap
-        # is being outrun).
-        log.info(
-            "global.events.replay_truncated",
-            reason=truncated_reason,
-            lost_count=lost_count if truncated_reason == "ring_evicted" else None,
-            cursor=(last_event_id_raw or "")[:64],
-        )
+        Idempotent (``in`` check under the lock).  Two owners share it:
+        the generator's ``finally`` on every stream exit, and the
+        registration-window guard below for exits that fire before the
+        generator exists.
+        """
+        with listeners_lock:
+            if client_queue in listeners:
+                listeners.remove(client_queue)
 
     async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
         _metrics.record_sse_connect()
@@ -1262,11 +1242,62 @@ async def global_events_sse(request: Request) -> Response:
                     pass  # poll timeout, retry
         finally:
             _metrics.record_sse_disconnect()
-            with listeners_lock:
-                if client_queue in listeners:
-                    listeners.remove(client_queue)
+            _deregister()
 
-    return EventSourceResponse(event_generator(), ping=5)
+    # Registration-window guard (#881 round-2 review): from the append
+    # above until the return below, THIS frame owns the listener — the
+    # generator's ``finally`` (the normal owner) cannot run before the
+    # generator exists, so any exit in this window must de-register or
+    # the queue leaks into the fan-out loop forever (the fan-out thread
+    # never removes dead listeners; pre-#881 the append was the LAST
+    # statement of the locked block precisely so a raising snapshot
+    # build could not strand it).  Everything that can raise lives
+    # inside the try — the snapshot build (storage reads + per-ws
+    # locks), the log call, and response construction; the two ``def``s
+    # above are pure bindings and cannot.  ``BaseException``: the
+    # window is await-free today, so a cancellation cannot land inside
+    # it, but the guard must not silently narrow if a future edit
+    # introduces an await.  Ownership passes to the generator's
+    # ``finally`` once the return succeeds.
+    try:
+        if replay_status != "replay_ok":
+            # Snapshot built AFTER the lock: ``_build_node_snapshot``
+            # is an O(workstreams) walk taking each ws's ``_ws_lock``,
+            # and under ``global_listeners_lock`` it would stall the
+            # fanout thread's per-event stamping for EVERY listener —
+            # N-fold during a restart herd of stale-cursor reconnects,
+            # exactly when the reborn node is emitting its re-open
+            # events.  Registration already happened under the lock
+            # above, so every event from that instant on is queued to
+            # this listener: nothing is lost, and deltas stamped while
+            # the snapshot builds re-apply idempotently over the
+            # (newer) snapshot at the consumer (state-of-world
+            # contract — see the endpoint docstring).  ``replay_ok``
+            # is by design exactly the no-snapshot shape (truncated
+            # always carries the snapshot floor, fresh always
+            # snapshots), so this predicate and the generator's
+            # emission branch stay one rule.
+            snapshot = _build_node_snapshot(request.app.state)
+
+        if replay_status == "truncated":
+            # Envelope chokepoint log, analog of
+            # ``ws.events.replay_truncated`` on the per-ws lane — one
+            # line per gap detection, the operator signal that clients
+            # are being told to resync (a burst of ``reason=boot_epoch``
+            # right after startup is the restart herd healing; sustained
+            # ``reason=ring_evicted`` means the ring cap is being
+            # outrun).
+            log.info(
+                "global.events.replay_truncated",
+                reason=truncated_reason,
+                lost_count=lost_count if truncated_reason == "ring_evicted" else None,
+                cursor=(last_event_id_raw or "")[:64],
+            )
+
+        return EventSourceResponse(event_generator(), ping=5)
+    except BaseException:
+        _deregister()
+        raise
 
 
 async def dashboard(request: Request) -> JSONResponse:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4312,14 +4312,19 @@ def _aggregate_emitter_thread(
     mgr: SessionManager,
     global_queue: queue.Queue[dict[str, Any]],
     interval: float = 10.0,
+    stop: threading.Event | None = None,
 ) -> None:
     """Periodically emit aggregate token/tool_call totals on the global SSE queue.
 
     Runs as a daemon thread so the console receives periodic updates without
-    having to poll ``/v1/api/dashboard``.
+    having to poll ``/v1/api/dashboard``.  ``stop`` (#885) is the lifespan
+    shutdown signal — ``wait(interval)`` doubles as the tick sleep, so a
+    set wakes the thread immediately instead of stranding shutdown behind
+    a sleep.
     """
-    while True:
-        time.sleep(interval)
+    if stop is None:
+        stop = threading.Event()
+    while not stop.wait(interval):
         total_tokens = 0
         total_tool_calls = 0
         active_count = 0
@@ -4356,6 +4361,7 @@ def _idle_cleanup_thread(
     timeout_sec: float,
     global_queue: queue.Queue[dict[str, Any]],
     rate_limiter: Any = None,
+    stop: threading.Event | None = None,
 ) -> None:
     """Periodically close IDLE workstreams and clean up rate limiter buckets.
 
@@ -4364,14 +4370,27 @@ def _idle_cleanup_thread(
     ``reason="closed"``. The old manual emission here (``reason="idle"``)
     is gone — the frontend didn't differentiate "idle" from "closed"
     anyway and the duplicate event caused spurious UI flicker.
+
+    ``stop`` (#885): lifespan shutdown signal, same ``wait``-as-sleep
+    pattern as :func:`_aggregate_emitter_thread`.
     """
     del global_queue  # adapter handles the emission
+    if stop is None:
+        stop = threading.Event()
     check_every = min(300.0, timeout_sec / 4)  # check at 1/4 of timeout, max 5 min
-    while True:
-        time.sleep(check_every)
+    while not stop.wait(check_every):
         mgr.close_idle(timeout_sec)
         if rate_limiter is not None:
             rate_limiter.cleanup()
+
+
+# Shutdown sentinel for ``_global_fanout_thread`` (#885): the lifespan
+# puts THIS object on the global queue and the thread exits when it draws
+# it.  Identity-checked (``is``), so an event that merely equals it can't
+# spoof a shutdown; dict-typed so the queue's type stays honest.  FIFO
+# gives clean drain semantics — everything enqueued before the sentinel
+# still stamps + fans out.
+_FANOUT_SHUTDOWN: dict[str, Any] = {"type": "_fanout_shutdown"}
 
 
 def _global_fanout_thread(
@@ -4392,10 +4411,14 @@ def _global_fanout_thread(
     event lands in ONLY the buffer or ONLY the listener queue across
     the registration boundary.  Mirrors :meth:`SessionUIBase._enqueue`'s
     contract for the global lane.
+
+    Exits when it draws :data:`_FANOUT_SHUTDOWN` from the queue (#885).
     """
     while True:
         try:
             event = source_queue.get()
+            if event is _FANOUT_SHUTDOWN:
+                return
             with lock:
                 counter_holder[0] += 1
                 event_id = counter_holder[0]
@@ -4420,6 +4443,12 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     # Dedicated executor for SSE queue polling so it doesn't compete
     # with the default asyncio executor (which caps at ~32 workers).
     app.state.sse_executor = ThreadPoolExecutor(max_workers=200, thread_name_prefix="sse")
+    # Lifespan daemon-thread shutdown (#885): one shared Event for the
+    # sleep-loop threads plus the queue sentinel for the fanout; refs
+    # kept so the shutdown tail below can join them.  ``daemon=True``
+    # stays — it is the backstop if a join times out, not the shutdown
+    # mechanism.
+    daemon_stop = threading.Event()
     # Start global event fan-out thread
     fanout = threading.Thread(
         target=_global_fanout_thread,
@@ -4437,10 +4466,12 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     agg_emitter = threading.Thread(
         target=_aggregate_emitter_thread,
         args=(app.state.workstreams, app.state.global_queue),
+        kwargs={"stop": daemon_stop},
         daemon=True,
     )
     agg_emitter.start()
     # Start idle cleanup thread if configured
+    cleanup: threading.Thread | None = None
     if app.state.idle_timeout > 0:
         cleanup = threading.Thread(
             target=_idle_cleanup_thread,
@@ -4450,6 +4481,7 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
                 app.state.global_queue,
                 app.state.rate_limiter,
             ),
+            kwargs={"stop": daemon_stop},
             daemon=True,
         )
         cleanup.start()
@@ -4668,6 +4700,21 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     from turnstone.core.oidc import close_oidc_state
 
     await close_oidc_state(app.state)
+    # Stop the lifespan daemon threads (#885).  Sessions are already
+    # closed above, so their final ws_closed events sit ahead of the
+    # sentinel in the queue and still fan out (FIFO drain); the Event
+    # wakes the sleep-loop threads immediately.  Joins are bounded and
+    # off-loop; a thread that outlives its budget is logged and left to
+    # the daemon flag rather than wedging shutdown.
+    daemon_stop.set()
+    with contextlib.suppress(queue.Full):
+        app.state.global_queue.put(_FANOUT_SHUTDOWN, timeout=1)
+    for _t in (fanout, agg_emitter, cleanup):
+        if _t is None:
+            continue
+        await asyncio.to_thread(_t.join, 5)
+        if _t.is_alive():
+            log.warning("server.daemon_thread_join_timeout", thread=_t.name)
     app.state.sse_executor.shutdown(wait=True, cancel_futures=True)
 
 

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4763,6 +4763,11 @@ async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
     # off-loop; a thread that outlives its budget is logged and left to
     # the daemon flag rather than wedging shutdown.
     daemon_stop.set()
+    # The sentinel put stays inline (unlike the off-loop joins below): the
+    # fanout consumer is still alive here — it exits only on drawing this
+    # sentinel — and fans out with non-blocking put_nowait, so the bounded
+    # queue drains fast and put() returns at once; timeout=1 is a ceiling
+    # that never binds. Off-loop is reserved for the multi-second joins.
     with contextlib.suppress(queue.Full):
         app.state.global_queue.put(_FANOUT_SHUTDOWN, timeout=1)
     for _t in (fanout, agg_emitter, cleanup):

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1029,7 +1029,10 @@ async def global_events_sse(request: Request) -> Response:
     from any other epoch — a prior boot, another node, a pre-#881
     bare-int client — gets ``replay_truncated`` with
     ``reason="boot_epoch"`` followed by a fresh ``node_snapshot``, since
-    the events it missed died with the process that minted it.  Clients
+    the events it missed died with the process that minted it.
+    ``boot_epoch`` is not exclusively a foreign-epoch signal: a
+    same-epoch cursor over an EMPTY ring (impossible from our own ids —
+    forged or a bug) also draws it via the fail-safe branch below.  Clients
     treat the cursor as an opaque string; only this handler parses it.
     """
     # -- Service-scope gate ---------------------------------------------------
@@ -5172,8 +5175,13 @@ def create_app(
     # differs from the live process is stale by construction and draws
     # the ``replay_truncated`` + node_snapshot recovery floor in
     # :func:`global_events_sse`.  Hex nonce (never contains ``-``), so
-    # ``partition("-")`` splits the id unambiguously.
-    app.state.global_boot_epoch = secrets.token_hex(4)
+    # ``partition("-")`` splits the id unambiguously.  64 bits: the
+    # equality check is the ONLY thing standing between a prior-boot
+    # cursor and a silent ``replay_ok``-empty alias, and the collision
+    # event is per same-node restart-pair — 2^-64 keeps a
+    # fleet-lifetime of restarts engineered far below threshold where
+    # 32 bits left it merely unlikely (review round 4).
+    app.state.global_boot_epoch = secrets.token_hex(8)
     app.state.skip_permissions = skip_permissions
     app.state.jwt_secret = jwt_secret
     app.state.auth_storage = auth_storage

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1009,7 +1009,15 @@ async def global_events_sse(request: Request) -> Response:
 
     On connect, emits a ``node_snapshot`` event with the full node state
     (workstreams, health, aggregate) followed by real-time delta events.
-    The snapshot and listener registration are atomic — no events are lost.
+    Listener registration happens under the fan-out lock BEFORE the
+    snapshot is built (the O(workstreams) build must not stall the
+    fan-out thread), so no event is lost: a delta stamped while the
+    snapshot builds is both reflected in the (newer) snapshot and queued
+    behind it, and consumers absorb the double-representation because
+    the stream is state-of-world — app.js re-applies deltas over the
+    snapshot idempotently, the console collector rebuilds wholesale.
+    The visible cost is at most a transient stale tick during the build
+    window, healed by the next delta.
 
     Resume contract (#881): every event's SSE ``id:`` is
     ``"{boot_epoch}-{counter}"``, where ``boot_epoch`` is a per-process
@@ -1127,10 +1135,8 @@ async def global_events_sse(request: Request) -> Response:
         if cursor_stale:
             replay_status = "truncated"
             truncated_reason = "boot_epoch"
-            snapshot = _build_node_snapshot(request.app.state)
         elif last_event_id is None:
             replay_status = "fresh"
-            snapshot = _build_node_snapshot(request.app.state)
         else:
             buffered = list(event_buffer)
             if not buffered:
@@ -1144,17 +1150,33 @@ async def global_events_sse(request: Request) -> Response:
                 # nothing and ghost the roster (#881's original lie).
                 replay_status = "truncated"
                 truncated_reason = "boot_epoch"
-                snapshot = _build_node_snapshot(request.app.state)
             else:
                 earliest_available_id = buffered[0][0]
                 if last_event_id < earliest_available_id - 1:
                     replay_status = "truncated"
                     lost_count = (earliest_available_id - 1) - last_event_id
-                    snapshot = _build_node_snapshot(request.app.state)
                 else:
                     replay_status = "replay_ok"
                     replay_events = [ev for eid, ev in buffered if eid > last_event_id]
         listeners.append(client_queue)
+
+    if replay_status != "replay_ok":
+        # Snapshot built AFTER the lock: ``_build_node_snapshot`` is an
+        # O(workstreams) walk taking each ws's ``_ws_lock``, and under
+        # ``global_listeners_lock`` it would stall the fanout thread's
+        # per-event stamping for EVERY listener — N-fold during a
+        # restart herd of stale-cursor reconnects, exactly when the
+        # reborn node is emitting its re-open events.  Registration
+        # already happened under the lock above, so every event from
+        # that instant on is queued to this listener: nothing is lost,
+        # and deltas stamped while the snapshot builds re-apply
+        # idempotently over the (newer) snapshot at the consumer
+        # (state-of-world contract — see the endpoint docstring).
+        # ``replay_ok`` is by design exactly the no-snapshot shape
+        # (truncated always carries the snapshot floor, fresh always
+        # snapshots), so this predicate and the generator's emission
+        # branch stay one rule.
+        snapshot = _build_node_snapshot(request.app.state)
 
     if replay_status == "truncated":
         # Envelope chokepoint log, analog of ``ws.events.replay_truncated``

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -22,6 +22,7 @@ import os
 import queue
 import random
 import re
+import secrets
 import sys
 import textwrap
 import threading
@@ -1009,6 +1010,19 @@ async def global_events_sse(request: Request) -> Response:
     On connect, emits a ``node_snapshot`` event with the full node state
     (workstreams, health, aggregate) followed by real-time delta events.
     The snapshot and listener registration are atomic — no events are lost.
+
+    Resume contract (#881): every event's SSE ``id:`` is
+    ``"{boot_epoch}-{counter}"``, where ``boot_epoch`` is a per-process
+    nonce and ``counter`` is the process-local monotonic event id.  A
+    reconnect presenting a cursor (``Last-Event-ID`` header or
+    ``?last_event_id=``) whose epoch matches gets the ring replay
+    (``replay_ok`` past the counter, or a ``replay_truncated`` envelope
+    with ``reason="ring_evicted"`` when the ring has moved on); a cursor
+    from any other epoch — a prior boot, another node, a pre-#881
+    bare-int client — gets ``replay_truncated`` with
+    ``reason="boot_epoch"`` followed by a fresh ``node_snapshot``, since
+    the events it missed died with the process that minted it.  Clients
+    treat the cursor as an opaque string; only this handler parses it.
     """
     # -- Service-scope gate ---------------------------------------------------
     # The global stream carries cluster-wide workstream inventory across
@@ -1036,14 +1050,44 @@ async def global_events_sse(request: Request) -> Response:
     # Native EventSource sets the header on auto-reconnect; the
     # manual-reconnect path (which can't set custom headers on
     # ``new EventSource(url)``) uses the query-param fallback.
+    #
+    # Global ids are ``"{boot_epoch}-{counter}"`` (#881): the epoch half
+    # proves the cursor was minted by THIS process.  The counter reboots
+    # at 0 with the process, so without the epoch a pre-restart cursor is
+    # first invisibly "ahead" of the reborn ring (empty replay slice) and
+    # then, as the counter re-grows past it, aliases into the new id
+    # space — both draw ``replay_ok`` and silently skip the restart
+    # boundary.  Parse outcomes:
+    #   - no cursor            → ``last_event_id = None`` (fresh);
+    #   - epoch matches        → ``last_event_id = counter`` (ring logic);
+    #   - anything else        → ``cursor_stale = True`` (a cursor was
+    #     presented but is unusable: prior-boot epoch, another node's
+    #     epoch, a bare-int cursor from a pre-#881 client, or garbage)
+    #     → the ``replay_truncated`` + node_snapshot floor below.  A
+    #     present-but-unusable cursor must NOT fall back to ``fresh``:
+    #     fresh is the no-loss shape, and this caller has provably
+    #     lost the events between its cursor and this boot.
+    boot_epoch: str = request.app.state.global_boot_epoch
     last_event_id_raw = request.headers.get("Last-Event-ID") or request.query_params.get(
         "last_event_id"
     )
-    last_event_id: int | None
-    try:
-        last_event_id = int(last_event_id_raw) if last_event_id_raw else None
-    except (TypeError, ValueError):
-        last_event_id = None
+    last_event_id: int | None = None
+    cursor_stale = False
+    if last_event_id_raw:
+        cursor_epoch, sep, counter_raw = last_event_id_raw.partition("-")
+        if sep and cursor_epoch == boot_epoch:
+            try:
+                last_event_id = int(counter_raw)
+            except ValueError:
+                cursor_stale = True
+            else:
+                if last_event_id < 0:
+                    # Our counters start at 1; a negative counter can
+                    # only be forged.  Same floor as garbage.
+                    last_event_id = None
+                    cursor_stale = True
+        else:
+            cursor_stale = True
 
     # -- Atomic snapshot / replay-slice + listener registration ---------------
     client_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=1000)
@@ -1053,40 +1097,54 @@ async def global_events_sse(request: Request) -> Response:
         request.app.state.global_event_buffer
     )
 
-    # Three replay shapes, matching :func:`make_events_handler`:
+    # Four replay shapes (the first three matching :func:`make_events_handler`):
     #   - ``last_event_id is None`` → ``"fresh"``: emit node_snapshot
     #     then live.
     #   - ``last_event_id`` + buffer covers gap → ``"replay_ok"``:
     #     emit buffered events past the id, SKIP node_snapshot, then
     #     live.
-    #   - ``last_event_id`` + buffer too short → ``"truncated"``: emit
-    #     a ``replay_truncated`` envelope then fall through to
-    #     ``"fresh"`` (node_snapshot is the recovery floor).
+    #   - ``last_event_id`` + buffer too short → ``"truncated"``
+    #     (``reason="ring_evicted"``, honest ``lost_count``): emit a
+    #     ``replay_truncated`` envelope then fall through to ``"fresh"``
+    #     (node_snapshot is the recovery floor).
+    #   - ``cursor_stale`` (#881) → ``"truncated"``
+    #     (``reason="boot_epoch"``): the cursor is from another boot —
+    #     the prior ring died with its process, so what was lost is
+    #     unknowable; the envelope omits ``lost_count`` /
+    #     ``earliest_available_id`` rather than guess.  The per-ws
+    #     stream never needs this arm: its counter is storage-seeded
+    #     across restarts, so plain counter comparison detects staleness
+    #     there (see ``register_listener_with_replay``); the global
+    #     counter is process-local and reboots at 0, hence the epoch.
     replay_status: str
+    truncated_reason = "ring_evicted"
     replay_events: list[dict[str, Any]] = []
     lost_count = 0
     earliest_available_id = 0
     snapshot: dict[str, Any] | None = None
 
     with listeners_lock:
-        if last_event_id is None:
+        if cursor_stale:
+            replay_status = "truncated"
+            truncated_reason = "boot_epoch"
+            snapshot = _build_node_snapshot(request.app.state)
+        elif last_event_id is None:
             replay_status = "fresh"
             snapshot = _build_node_snapshot(request.app.state)
         else:
             buffered = list(event_buffer)
             if not buffered:
-                # KNOWN GAP (#881): an empty ring after a node restart
-                # reports ``replay_ok`` even when the client's cursor is
-                # stale, silently skipping the events lost with the old
-                # process.  The per-ws stream fixes this by deriving
-                # staleness from its storage-seeded ``_event_id`` counter
-                # (see ``register_listener_with_replay``); the global
-                # counter (``global_event_id_holder``) resets to 0 at
-                # boot, so the same rule cannot apply — a boot-epoch
-                # staleness signal is the fix direction tracked in #881.
-                # Tolerable meanwhile: consumers are idempotent roster
-                # state refreshed periodically, not append-only history.
-                replay_status = "replay_ok"
+                # Same-epoch cursor against an empty ring is impossible
+                # by construction (ids are only minted by the fanout
+                # thread's single append site, first id 1, and the ring
+                # is never cleared — an id implies a non-empty ring), so
+                # a cursor landing here is forged or a bug.  Fail SAFE
+                # to the truncated floor: the snapshot rebuild is
+                # idempotent, whereas trusting the cursor would replay
+                # nothing and ghost the roster (#881's original lie).
+                replay_status = "truncated"
+                truncated_reason = "boot_epoch"
+                snapshot = _build_node_snapshot(request.app.state)
             else:
                 earliest_available_id = buffered[0][0]
                 if last_event_id < earliest_available_id - 1:
@@ -1098,16 +1156,40 @@ async def global_events_sse(request: Request) -> Response:
                     replay_events = [ev for eid, ev in buffered if eid > last_event_id]
         listeners.append(client_queue)
 
+    if replay_status == "truncated":
+        # Envelope chokepoint log, analog of ``ws.events.replay_truncated``
+        # on the per-ws lane — one line per gap detection, the operator
+        # signal that clients are being told to resync (a burst of
+        # ``reason=boot_epoch`` right after startup is the restart herd
+        # healing; sustained ``reason=ring_evicted`` means the ring cap
+        # is being outrun).
+        log.info(
+            "global.events.replay_truncated",
+            reason=truncated_reason,
+            lost_count=lost_count if truncated_reason == "ring_evicted" else None,
+            cursor=(last_event_id_raw or "")[:64],
+        )
+
     async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
         _metrics.record_sse_connect()
 
         def _format_event(event: dict[str, Any]) -> dict[str, str]:
-            """Strip ``_event_id`` from the wire dict, attach SSE ``id:``."""
+            """Strip ``_event_id`` from the wire dict, attach SSE ``id:``.
+
+            The id is ``"{boot_epoch}-{counter}"`` — GLOBAL-LANE ONLY
+            (#881).  Do not propagate the epoch tag to the per-ws
+            formatter in ``make_events_handler``: per-ws ids must stay
+            bare ints — their counter is storage-seeded across restarts
+            (epoch unnecessary), clients seed cursors from ``/history``'s
+            integer ``cursor``, and coordinator.js's counter-reset
+            detector does ``Number(event.lastEventId)`` comparisons that
+            an epoch prefix would turn into ``NaN`` and silently kill.
+            """
             ev_copy = dict(event)
             eid = ev_copy.pop("_event_id", None)
             out: dict[str, str] = {"data": json.dumps(ev_copy)}
             if eid is not None:
-                out["id"] = str(eid)
+                out["id"] = f"{boot_epoch}-{eid}"
             return out
 
         try:
@@ -1117,15 +1199,23 @@ async def global_events_sse(request: Request) -> Response:
             yield {"retry": random.randint(2500, 4500)}
 
             if replay_status == "truncated":
-                yield {
-                    "data": json.dumps(
-                        {
-                            "type": "replay_truncated",
-                            "lost_count": lost_count,
-                            "earliest_available_id": earliest_available_id,
-                        }
-                    )
+                # ``reason`` distinguishes an in-epoch ring overrun
+                # (``ring_evicted`` — ``lost_count`` /
+                # ``earliest_available_id`` are honest) from a
+                # cross-boot cursor (``boot_epoch`` — the prior ring
+                # died with its process, so the loss is unknowable and
+                # the numeric fields are OMITTED rather than invented).
+                # No first-party consumer reads the numeric fields
+                # (app.js reads only ``type`` and resyncs), so the
+                # conditional shape is wire-safe.
+                envelope: dict[str, Any] = {
+                    "type": "replay_truncated",
+                    "reason": truncated_reason,
                 }
+                if truncated_reason == "ring_evicted":
+                    envelope["lost_count"] = lost_count
+                    envelope["earliest_available_id"] = earliest_available_id
+                yield {"data": json.dumps(envelope)}
             if replay_status == "replay_ok":
                 for ev in replay_events:
                     yield _format_event(ev)
@@ -4972,6 +5062,18 @@ def create_app(
     # Single-element list as a mutable int holder so the fanout
     # thread can ``counter_holder[0] += 1`` under the lock.
     app.state.global_event_id_holder = [0]
+    # Per-process boot epoch for the global SSE lane (#881).  The
+    # counter above reboots at 0 with the process (unlike the per-ws
+    # counters, which ``_seed_event_id_from_storage`` seeds from
+    # ``MAX(conversations.event_id)``), so a bare integer cursor from a
+    # prior boot is indistinguishable from — and eventually aliases
+    # into — the new id space.  Every global SSE ``id:`` is therefore
+    # stamped ``"{epoch}-{counter}"``; a reconnect cursor whose epoch
+    # differs from the live process is stale by construction and draws
+    # the ``replay_truncated`` + node_snapshot recovery floor in
+    # :func:`global_events_sse`.  Hex nonce (never contains ``-``), so
+    # ``partition("-")`` splits the id unambiguously.
+    app.state.global_boot_epoch = secrets.token_hex(4)
     app.state.skip_permissions = skip_permissions
     app.state.jwt_secret = jwt_secret
     app.state.auth_storage = auth_storage

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -20,9 +20,11 @@ let globalRetryDelay = 1000;
 // OPAQUE ``"{boot_epoch}-{counter}"`` string (#881).  Captured from the
 // MessageEvent in the global onmessage, presented as ``?last_event_id=``
 // on manual reconnects, and cleared when the record is dead: on a
-// ``replay_truncated`` envelope (the gap is being healed by snapshot +
-// resync) and on logout (roster identity reset).  Never parsed here —
-// only the server can interpret it.
+// ``replay_truncated`` envelope (the gap is being healed), on a
+// ``node_snapshot`` (the recovery floor — required, not belt-and-braces:
+// that id-less frame re-captures the connection's stale cursor on native
+// reconnects, see the branch comment) and on logout (roster identity
+// reset).  Never parsed here — only the server can interpret it.
 let globalLastEventId = null;
 let dashboardVisible = false;
 let _historyNavigation = false;
@@ -1816,6 +1818,18 @@ function connectGlobalSSE() {
       // through their own Tier-2 streams.  Eviction is safe here (and only
       // here): the snapshot is serialized with ws_created/ws_closed on the
       // stream itself.
+      //
+      // The pre-snapshot cursor is dead in every case that draws a
+      // snapshot (fresh has none; truncated's is spent) — and this frame
+      // is id-less, so on a NATIVE reconnect the capture above just
+      // re-stored the connection's stale pre-restart cursor, undoing the
+      // truncated branch's clear (id-less frames inherit the persisted
+      // last-event-ID string; a manual reconnect's fresh EventSource
+      // starts empty and the "" guard blocks it).  Clear it here so a
+      // manual reconnect racing in before the next id-bearing frame goes
+      // cursorless instead of re-presenting the dead cursor for a
+      // redundant truncated round.
+      globalLastEventId = null;
       applyRosterSnapshot(data.workstreams || [], { evict: true });
     } else if (data.type === "replay_truncated") {
       // Events between our cursor and the buffer head (reason

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -16,6 +16,14 @@ let workstreams = {};
 let currentWsId = null;
 let globalEvtSource = null;
 let globalRetryDelay = 1000;
+// Resume cursor for the global stream — the last SSE id observed, an
+// OPAQUE ``"{boot_epoch}-{counter}"`` string (#881).  Captured from the
+// MessageEvent in the global onmessage, presented as ``?last_event_id=``
+// on manual reconnects, and cleared when the record is dead: on a
+// ``replay_truncated`` envelope (the gap is being healed by snapshot +
+// resync) and on logout (roster identity reset).  Never parsed here —
+// only the server can interpret it.
+let globalLastEventId = null;
 let dashboardVisible = false;
 let _historyNavigation = false;
 let _lastHealth = null;
@@ -115,6 +123,10 @@ window.onLogout = function () {
     globalEvtSource.close();
     globalEvtSource = null;
   }
+  // Roster identity reset — the next principal starts cursorless
+  // (fresh snapshot) rather than resuming from this session's stream
+  // position.
+  globalLastEventId = null;
   fireRender();
 };
 
@@ -1752,29 +1764,42 @@ function connectGlobalSSE() {
     globalEvtSource.close();
     globalEvtSource = null;
   }
-  // Manual reconnects on the GLOBAL stream are DELIBERATELY cursorless
-  // (no ``?last_event_id=`` — do not add a MessageEvent lastEventId
-  // capture here like the per-ws streams'): the global ring cannot
-  // report truncation for a stale cursor after a node restart (its
-  // counter reboots at 0 — KNOWN GAP #881), so presenting one draws
-  // ``replay_ok``-empty with NO node_snapshot and the roster ghosts
-  // exactly when a full rebuild is most needed.  Cursorless manual
-  // reconnects always draw the fresh node_snapshot — lossless for
-  // roster STATE (unlike per-ws append-only history, where the
-  // storage-seeded counter makes a stale cursor report ``truncated``
-  // and the cursor is therefore safe to track).  Native auto-reconnect
-  // keeps its browser-internal header either way.  Revisit when #881's
-  // boot-epoch staleness signal lands.
-  globalEvtSource = new EventSource("/v1/api/events/global");
+  // Manual reconnects present the stored cursor (an opaque
+  // ``"{boot_epoch}-{counter}"`` string) via the query param — a
+  // ``new EventSource(url)`` cannot set the ``Last-Event-ID`` header.
+  // Safe since #881: a cursor from another boot (or another node, or a
+  // pre-epoch client) mismatches the server's live epoch and draws
+  // ``replay_truncated`` + a fresh node_snapshot — the ghost-roster
+  // shape that once forced these reconnects cursorless (a stale cursor
+  // drew ``replay_ok``-empty with NO snapshot against the reborn ring)
+  // can no longer occur.  A live cursor skips the wholesale snapshot
+  // rebuild and replays just the missed deltas.  Native auto-reconnect
+  // keeps its browser-internal header either way; the string guard is
+  // the house cursor-guard idiom (see test_app_js.py).
+  let globalUrl = "/v1/api/events/global";
+  if (globalLastEventId != null && globalLastEventId !== "") {
+    globalUrl += "?last_event_id=" + encodeURIComponent(globalLastEventId);
+  }
+  globalEvtSource = new EventSource(globalUrl);
   globalEvtSource.onopen = function () {
     globalRetryDelay = 1000;
   };
   globalEvtSource.onmessage = function (e) {
-    // Guarded parse: native auto-reconnect's header cursor has already
-    // advanced past this frame, so a parse failure is a permanently-lost
-    // roster mutation — resync the roster from REST instead of silently
-    // drifting (a dropped ws_created renders as a conversation that
-    // never appears; a dropped ws_closed as a ghost row forever).
+    // Cursor capture BEFORE the parse, mirroring the browser: native
+    // reconnect's header cursor advances past every id-bearing frame
+    // whether or not its JSON parses, and the manual cursor must agree
+    // with it (both recover a lost frame the same way — the resync
+    // below).  MessageEvent property, never the EventSource object
+    // (which has no such property — see the test_app_js.py tripwire).
+    if (e.lastEventId != null && e.lastEventId !== "") {
+      globalLastEventId = e.lastEventId;
+    }
+    // Guarded parse: the cursor (native header and stored copy alike)
+    // has already advanced past this frame, so a parse failure is a
+    // permanently-lost roster mutation — resync the roster from REST
+    // instead of silently drifting (a dropped ws_created renders as a
+    // conversation that never appears; a dropped ws_closed as a ghost
+    // row forever).
     let data = null;
     try {
       data = JSON.parse(e.data);
@@ -1793,9 +1818,15 @@ function connectGlobalSSE() {
       // stream itself.
       applyRosterSnapshot(data.workstreams || [], { evict: true });
     } else if (data.type === "replay_truncated") {
-      // Events between our cursor and the buffer head are gone for good.
-      // The node_snapshot that follows rebuilds the roster; refetch too so
-      // recovery doesn't depend on event ordering.
+      // Events between our cursor and the buffer head (reason
+      // "ring_evicted"), or everything since another boot minted the
+      // cursor (reason "boot_epoch"), are gone for good.  The cursor is
+      // spent — clear it so a manual reconnect racing in before the
+      // next id-bearing frame draws a fresh snapshot instead of
+      // re-presenting the dead cursor for a redundant truncated round.
+      // The node_snapshot that follows rebuilds the roster; refetch too
+      // so recovery doesn't depend on event ordering.
+      globalLastEventId = null;
       resyncRoster();
     } else if (data.type === "ws_state") {
       updateTabIndicator(data.ws_id, data.state, {


### PR DESCRIPTION
Closes #881. Closes #885 (rider).

## The bug

`/v1/api/events/global`'s ring counter is process-local and reboots at 0, so after a node restart a pre-restart cursor was first invisibly ahead of the reborn ring (`replay_ok` with an empty slice) and then aliased into the new id space as the counter re-grew — both shapes silently skipped the restart boundary and ghosted dashboards (the last silent-gap class from the truncated-recovery campaign).

## The design

- Every global SSE id is now `"{boot_epoch}-{counter}"` — a per-process 64-bit hex nonce attached at the single `_format_event` chokepoint. The browser echoes the opaque id verbatim on **native** auto-reconnects, so cursor provenance rides every reconnect path with zero client cooperation (a handshake-carried epoch could never cover the native path, which is the dominant one after a restart).
- Three-way cursor parse: absent → fresh; same-epoch → existing ring logic unchanged; anything else (prior boot, another node, pre-epoch bare-int, garbage, any cursor over an empty ring) → `replay_truncated` with `reason="boot_epoch"` (loss unknowable, numeric fields omitted) + the `node_snapshot` recovery floor. In-epoch ring misses keep honest `lost_count` under `reason="ring_evicted"`. Chokepoint log line on every truncated draw.
- Concurrency: listener registration stays under the fan-out lock (atomic with the buffer slice — the no-loss ordering); the O(workstreams) snapshot builds after release inside a registration-window guard that de-registers on any early exit (`_deregister` shared with the generator's `finally`). Contract documented at the endpoint docstring.
- app.js activates the manual-reconnect cursor: captured pre-dispatch from the MessageEvent, presented via `?last_event_id=`, cleared at three pinned sites — the truncated branch, the `node_snapshot` branch (required, not belt-and-braces: id-less frames inherit the connection's stale cursor on native reconnects), and `onLogout`. The tripwire that pinned app.js cursorless now pins the capture, presentation, opacity, and all three clears.
- Per-ws ids deliberately stay bare ints (storage-seeded counter; asymmetry ruling at `_format_event` — an epoch prefix would NaN coordinator.js's reset detector). Collector stays cursorless (ruling at `_node_sse_task`). SDKs are fresh-only and id-blind (audited).

## Rider #885

The three lifespan daemon threads (`_global_fanout_thread`, `_aggregate_emitter_thread`, `_idle_cleanup_thread`) get a real shutdown: a shared Event whose `wait()` doubles as the tick sleep, an identity-checked queue sentinel for the fanout (FIFO drain — session-close events still fan out), bounded off-loop joins. The recovery harness drops its thread-neutering workaround, which is what lets the global lane run real in e2e.

## Verification

- 18-test unit matrix at the handler boundary (every cursor shape × ring state, ordering probe pinning registration-before-build + lock-released-at-build, leak guard on the early-exit path).
- Two new real-browser scenarios: **F1** (manual transport: `RECOVERY-READY-ROSTER-trunc1-cursor1`) and **F2** (native transport: `RECOVERY-READY-ROSTERNATIVE-trunc1-cursor0-opens2`) — F2 is the only behavioral coverage of the auto-reconnect header echo and the WHATWG id-less `lastEventId` inheritance, and its phase C discriminates the snapshot-branch clear (pre-fix shape: `cursor1-trunc2`). Earned two documented harness seams: a `SO_REUSEPORT` placeholder handoff (a failed EventSource reconnect attempt is terminal, so the single retry must never see a refused port) and `timeout_graceful_shutdown=2` (an open SSE stream otherwise parks uvicorn's drain at stop).
- Review: 4 full multi-finder rounds with adversarial verify on every finding + a targeted delta review of the post-convergence commits; rounds 3-4 zero confirmed correctness findings. Full suite 9732 passed; all 10 e2e scenarios green on the shipped tree.
- CI rider: test job timeout 20 → 30 min (suite growth was brushing the cap on healthy runs).