### PR TITLE
coordinator: historyStale latch + render-time gate close the clear_ui over-rewind window

### DIFF
--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -28,6 +28,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-heal-midturn         # G4 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-hidden-retry         # G5 (#894)
+    python3 scripts/recovery_e2e.py --scenario coord-orphan-rewind        # G6 (#894 r6)
     python3 scripts/recovery_e2e.py --scenario roster-restart    # F1 (#881)
     python3 scripts/recovery_e2e.py --scenario roster-restart-native  # F2 (#881)
     python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
@@ -140,6 +141,19 @@ until the runner drives an ORGANIC settle with a plain send; that idle edge fire
 stream (exactly ONE new SSE open across show + heal — the user-driven
 reconnect; the heal adds zero).  Stamps
 ``RECOVERY-READY-COORDHIDDENRETRY-hidden0-heal1``.
+
+Scenario G6 (coord-orphan-rewind, #894 r6): the orphan-synthesis
+tripwire.  The r6 review traced the poisoned-pane hazard — an unresulted
+committed tool_calls turn renders as a ``--running`` placeholder no
+result ever strips, and a DOM-probed gate read it as live, killing every
+seedless render.  The server keeps that state unreachable by
+synthesizing results for interrupted calls at recovery (verified via
+post-kill /history); the client is hardened independently (event-driven
+live-call set, pinned render-untouchable).  This scenario pins the
+SERVER invariant: after a mid-bash kill + reboot the batch renders
+RESULTED (no residue) and the seedless rewind flow works (rows 0,
+``history_requests`` grew, posts 1).  Stamps
+``RECOVERY-READY-COORDORPHANREWIND-posts1-rows0``.
 
 Scenario A (storm): the page connects, POSTs ``/send`` on stream-open (so
 the listener is registered first), the node runs a 4-parallel-bash
@@ -1033,9 +1047,11 @@ COORD_PAGE_HTML = r"""<!doctype html>
       // G5 — the retry's stream-liveness fire guard (#894 r4): a retry
       // armed before a close-on-hide must NOT fetch while the transport
       // is down (hiddenDelta 0 — a seedless render past the frozen
-      // cursor double-renders on the show-edge replay); the show edge's
-      // synthetic idle hands the heal to the backstop (one user-driven
-      // SSE open, rows healed, gate reopened).
+      // cursor double-renders on the show-edge replay); the show edge
+      // only restores the transport (replay_ok carries no synthetic
+      // state_change), and the heal rides the next ORGANIC settle — the
+      // runner's plain send (one user-driven SSE open, rows healed,
+      // gate reopened).
       window.__verifyCoordHiddenRetry = function (
         hiddenDelta,
         healed,
@@ -1056,6 +1072,33 @@ COORD_PAGE_HTML = r"""<!doctype html>
             posts +
             "-rows" +
             userRows;
+      };
+
+      // G6 — the orphan-synthesis tripwire (#894 r6): the server must
+      // synthesize a result for tool calls interrupted by a node death
+      // (else the recovery render paints a --running placeholder no
+      // result ever strips — the poisoned-pane precondition the r6
+      // review traced; the client is hardened via the event-driven
+      // live-call set, but this server invariant keeps the state
+      // unreachable).  Post-recovery the seedless rewind flow must work
+      // end to end: rows 0, no --running residue, posts 1.
+      window.__verifyCoordOrphanRewind = function (posts, histDelta) {
+        const userRows = _coordUserRows();
+        const orphan =
+          document
+            .getElementById("coord-messages")
+            .querySelector(".conv-batch--running") !== null;
+        const ok = posts === 1 && histDelta >= 1 && userRows === 0 && !orphan;
+        document.title = ok
+          ? "RECOVERY-READY-COORDORPHANREWIND-posts1-rows0"
+          : "RECOVERY-FAILED-COORDORPHANREWIND-posts" +
+            posts +
+            "-hist" +
+            histDelta +
+            "-rows" +
+            userRows +
+            "-orphan" +
+            (orphan ? 1 : 0);
       };
 
       window.__verifyCoordRestart = function () {
@@ -2808,10 +2851,10 @@ def run_coord_heal_midturn(chrome: str) -> str:
     episode; exactly TWO /history fetches (the skipped one + the heal).
 
     Detector honesty: ``history_delta == 2`` is the DISCRIMINATING bit,
-    and the skip it witnesses rides the ``.conv-batch--running`` DOM
-    marker — turn 5 is in its TOOL phase at resolution (content refs
-    null), so this scenario is the behavioral detector for the gate's
-    tool-phase branch (the content-ref branch and the liveness statement
+    and the skip it witnesses rides the event-driven live-tool-call set
+    (fed by turn 5's live tool_pending announce) — turn 5 is in its TOOL
+    phase at resolution (content refs null), so this scenario is the
+    behavioral detector for the gate's tool-phase branch (the content-ref branch and the liveness statement
     carry structural pins; G5 covers the hidden-retry liveness path).
     Gate-stripped code renders the held fetch early, which CLEARS the
     latch, kills the backstop refire, and stamps ``hist1`` (plus
@@ -2937,8 +2980,10 @@ def run_coord_hidden_retry(chrome: str) -> str:
     ``lastEventId``; the show-edge reconnect replays from that frozen
     cursor and double-renders every turn the hidden render already painted.
     The ``evtSource`` fire-guard term skips the hidden firing instead
-    (hiddenDelta 0); on show, the reconnect's synthetic idle re-fires the
-    TRANSPORT-FREE backstop, which heals on the live stream.
+    (hiddenDelta 0); the show edge only restores the transport
+    (replay_ok carries no synthetic state_change), and the heal rides
+    the runner's plain send, whose organic turn-settle idle edge fires
+    the TRANSPORT-FREE backstop on the live stream.
 
     A replay_ok reconnect (frozen cursor, nothing lost) carries no
     synthetic state_change — only fresh/truncated replays do — so the
@@ -3032,6 +3077,125 @@ def run_coord_hidden_retry(chrome: str) -> str:
         node.stop()
 
 
+def run_coord_orphan_rewind(chrome: str) -> str:
+    """Scenario G6 — the orphan-synthesis tripwire (#894 r6).  The r6
+    review traced a client-side hazard: an unresulted committed
+    tool_calls turn ("orphan") would render as a ``.conv-batch--running``
+    placeholder no result ever strips, and the r5 DOM-probed gate read
+    that residue as live — poisoning every seedless render for the life
+    of the page.  Empirically the trigger state is UNREACHABLE today:
+    the server synthesizes a result for interrupted tool calls at
+    recovery ("Cancelled by user. Outcome UNKNOWN" — verified via
+    post-kill /history), so no persisted orphan exists.  The client was
+    hardened anyway (the gate's tool-phase term is the EVENT-DRIVEN
+    live-call set, pinned render-untouchable), because that server
+    invariant is all that stands between a future crash path and the
+    poisoned-pane state.
+
+    THIS SCENARIO PINS THE SERVER INVARIANT, not the client encoding
+    (with synthesis present a DOM-probe gate also passes — the client
+    discipline is carried by the static pin set): after a mid-bash node
+    kill + reboot, the recovery render must show the batch RESULTED (no
+    --running residue) and the seedless rewind flow must work end to
+    end (rows 0, posts 1, history_requests grew).  If recovery
+    synthesis ever regresses, this stamps the residue — surfacing
+    exactly the state that would re-expose the hardened client."""
+    from tests._sse_recovery_server import final_text_script, parallel_bash_script
+
+    port = _free_port()
+    node = _boot_node(port=port)
+    paced = parallel_bash_script({"g6": "for i in $(seq 1 60); do echo g6-$i; sleep 0.05; done"})
+    ws_id = node.create_workstream(paced, final_text_script("g6-done"), name="browser-coord-orphan")
+    profile = Path(_scratch()) / "chrome-coord-orphan-rewind"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-orphan-rewind"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # First poll on this page (no seeded rows to wait for), so the
+        # evaluate can race the page load and return None — coalesce.
+        if not _poll_until(lambda: (cdp.evaluate("window.__esOpens") or 0) >= 1, 15, 0.05):
+            raise AssertionError("coord-orphan-rewind: SSE stream never opened")
+        # Drive the paced turn and kill the node while its bash streams —
+        # the tool rows on screen prove the batch was mid-flight.
+        _send_in_page(cdp, "run a turn")
+        if not _poll_until(
+            lambda: (
+                cdp.evaluate(
+                    "document.getElementById('coord-messages')"
+                    ".querySelectorAll('.conv-row[data-call-id]').length"
+                )
+                >= 1
+            ),
+            15,
+            0.2,
+        ):
+            raise AssertionError("coord-orphan-rewind: tool rows never painted")
+        node.stop()
+        node = _boot_node(port=port)
+        node.open_workstream(ws_id)
+        # The pane's reconnect machinery (native retry -> truncated resync
+        # -> seeded render) repaints the interrupted turn.  The SERVER
+        # INVARIANT under test: recovery synthesized a result for the
+        # killed call, so the batch renders RESULTED — one user row, tool
+        # rows present, NO --running residue.
+        if not _poll_until(
+            lambda: (
+                cdp.evaluate(_COORD_ROWS_JS) == 1
+                and (
+                    cdp.evaluate(
+                        "document.getElementById('coord-messages')"
+                        ".querySelectorAll('.conv-row[data-call-id]').length"
+                    )
+                    or 0
+                )
+                >= 1
+                and not cdp.evaluate(
+                    "document.getElementById('coord-messages')"
+                    ".querySelector('.conv-batch--running') !== null"
+                )
+            ),
+            30,
+            0.3,
+        ):
+            raise AssertionError(
+                "coord-orphan-rewind: recovery never rendered the synthesized "
+                "(resulted) batch — either the reconnect failed or recovery "
+                "synthesis regressed (a --running residue is exactly the "
+                "poisoned-pane precondition)"
+            )
+        hist_baseline = node.history_requests
+        # Rewind the sole user row — the full seedless flow must work
+        # after a kill+reboot recovery (clear_ui render lands, latch
+        # clears).
+        if not cdp.evaluate("window.__clickCoordRewind(0)"):
+            raise AssertionError("coord-orphan-rewind: rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("coord-orphan-rewind: rewind never POSTed")
+        healed = _poll_until(
+            lambda: (
+                cdp.evaluate(_COORD_ROWS_JS) == 0
+                and not cdp.evaluate(
+                    "document.getElementById('coord-messages')"
+                    ".querySelector('.conv-batch--running') !== null"
+                )
+            ),
+            15,
+            0.2,
+        )
+        hist_delta = node.history_requests - hist_baseline
+        posts = node.rewind_requests
+        print(f"  coord-orphan-rewind healed={healed} hist_delta={hist_delta} posts={posts}")
+        cdp.evaluate(f"window.__verifyCoordOrphanRewind({posts}, {hist_delta})")
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 def _wait_state(node: Any, ws_id: str, state: str, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -3082,6 +3246,7 @@ def main() -> None:
             "coord-stale-backstop",
             "coord-heal-midturn",
             "coord-hidden-retry",
+            "coord-orphan-rewind",
             "roster-restart",
             "roster-restart-native",
             "both",
@@ -3154,6 +3319,10 @@ def main() -> None:
     if args.scenario in ("coord-hidden-retry", "all"):
         verdict = run_coord_hidden_retry(chrome)
         print(f"scenario G5 (coord-hiddenretry): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-orphan-rewind", "all"):
+        verdict = run_coord_orphan_rewind(chrome)
+        print(f"scenario G6 (coord-orphanrewind): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("roster-restart", "all"):
         verdict = run_roster_restart(chrome)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -142,18 +142,19 @@ stream (exactly ONE new SSE open across show + heal — the user-driven
 reconnect; the heal adds zero).  Stamps
 ``RECOVERY-READY-COORDHIDDENRETRY-hidden0-heal1``.
 
-Scenario G6 (coord-orphan-rewind, #894 r6): the orphan-synthesis
-tripwire.  The r6 review traced the poisoned-pane hazard — an unresulted
-committed tool_calls turn renders as a ``--running`` placeholder no
-result ever strips, and a DOM-probed gate read it as live, killing every
-seedless render.  The server keeps that state unreachable by
-synthesizing results for interrupted calls at recovery (verified via
-post-kill /history); the client is hardened independently (event-driven
-live-call set, pinned render-untouchable).  This scenario pins the
-SERVER invariant: after a mid-bash kill + reboot the batch renders
-RESULTED (no residue) and the seedless rewind flow works (rows 0,
-``history_requests`` grew, posts 1).  Stamps
-``RECOVERY-READY-COORDORPHANREWIND-posts1-rows0``.
+Scenario G6 (coord-orphan-rewind, #894 r6/r7): the poisoned-pane
+detector.  A HARD mid-tool node kill (``stop(hard=True)`` — graceful
+close would synthesize a cancel result and mask the state; boot-time
+rehydration synthesizes nothing, r7-verified) leaves the committed
+tool_calls turn unresulted; recovery paints it as a ``--running``
+placeholder no result ever strips.  The r5 DOM-probed gate read that
+residue as live and skipped every seedless render — rewind/edit
+permanently dead.  The event-driven live-call set is empty for the
+orphan, so the rewind must render THROUGH it: residue asserted PRESENT
+post-recovery, then the orphan is wiped and the rewound truth paints
+(the server keeps the user message and removes the unresulted assistant
+turn), posts 1, ``history_requests`` grew.  Stamps
+``RECOVERY-READY-COORDORPHANREWIND-posts1-rows1-orphan0``.
 
 Scenario A (storm): the page connects, POSTs ``/send`` on stream-open (so
 the listener is registered first), the node runs a 4-parallel-bash
@@ -1074,23 +1075,28 @@ COORD_PAGE_HTML = r"""<!doctype html>
             userRows;
       };
 
-      // G6 — the orphan-synthesis tripwire (#894 r6): the server must
-      // synthesize a result for tool calls interrupted by a node death
-      // (else the recovery render paints a --running placeholder no
-      // result ever strips — the poisoned-pane precondition the r6
-      // review traced; the client is hardened via the event-driven
-      // live-call set, but this server invariant keeps the state
-      // unreachable).  Post-recovery the seedless rewind flow must work
-      // end to end: rows 0, no --running residue, posts 1.
+      // G6 — the poisoned-pane detector (#894 r6/r7): a HARD node kill
+      // leaves the tool call genuinely unresulted (only a graceful
+      // close synthesizes a cancel result), so recovery paints a
+      // --running orphan no result ever strips.  The event-driven
+      // live-call set is empty for it, so the seedless rewind flow
+      // must work THROUGH the residue: orphan wiped, rewound truth
+      // painted (the user message stays — rewind-for-retry), posts 1.
+      // A DOM-probed gate reads the residue as live and never renders.
       window.__verifyCoordOrphanRewind = function (posts, histDelta) {
         const userRows = _coordUserRows();
         const orphan =
           document
             .getElementById("coord-messages")
             .querySelector(".conv-batch--running") !== null;
-        const ok = posts === 1 && histDelta >= 1 && userRows === 0 && !orphan;
+        // Rewound truth: the server removes the UNRESULTED assistant turn
+        // but keeps the user message (rewind-for-retry), so success is
+        // ONE user row with the residue gone.  The failure mode (a gate
+        // that reads the residue as live and skips) is rows1 WITH
+        // orphan1 and no render — the orphan bit discriminates.
+        const ok = posts === 1 && histDelta >= 1 && userRows === 1 && !orphan;
         document.title = ok
-          ? "RECOVERY-READY-COORDORPHANREWIND-posts1-rows0"
+          ? "RECOVERY-READY-COORDORPHANREWIND-posts1-rows1-orphan0"
           : "RECOVERY-FAILED-COORDORPHANREWIND-posts" +
             posts +
             "-hist" +
@@ -2693,6 +2699,33 @@ def run_coord_rewind_failed_window(chrome: str) -> str:
         node.stop()
 
 
+def _coord_stick_latch(cdp: CDP, node: Any, tag: str) -> None:
+    """The shared G3/G4 prologue: paint three rows, gate on the SSE open,
+    then stick the staleness latch — fail_history(2) exhausts the rewind's
+    clear_ui refetch AND its one bounded 2s retry, so only an organic
+    idle-edge heal can clear it.  Extracted so G4's premise (latch stuck
+    exactly as in G3) is enforced by construction, the same rationale
+    _seed_three_completed_turns documents for the E family."""
+    if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+        raise AssertionError(f"{tag}: three user rows never rendered")
+    if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
+        raise AssertionError(f"{tag}: SSE stream never opened")
+    node.fail_history(2)
+    if not cdp.evaluate("window.__clickCoordRewind(1)"):
+        raise AssertionError(f"{tag}: second-row rewind button missing")
+    if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+        raise AssertionError(f"{tag}: first rewind never POSTed")
+    if not _poll_until(lambda: node.history_fail_remaining == 0, 20):
+        raise AssertionError(f"{tag}: the two forced /history failures never both fired")
+    assert node.history_fail_remaining == 0, f"{tag}: fail budget not consumed"
+    stale_rows = cdp.evaluate(_COORD_ROWS_JS)
+    if stale_rows != 3:
+        raise AssertionError(
+            f"{tag}: failed fetches did not preserve the transcript "
+            f"(user rows={stale_rows}, expected 3)"
+        )
+
+
 def run_coord_stale_backstop(chrome: str) -> str:
     """Scenario G3 — the coordinator ``historyStale`` latch's TRANSPORT-FREE
     idle-edge backstop (#894, the coord port of E4).  The DOUBLE-failure
@@ -2732,39 +2765,7 @@ def run_coord_stale_backstop(chrome: str) -> str:
         _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
         # Wait for the initial /history to paint all three user rows.  This
         # load MUST succeed, so arm the forced failures only AFTERWARDS.
-        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
-            raise AssertionError("coord-stale-backstop: three user rows never rendered")
-        # SSE-open gate — see run_coord_rewind_window: a pre-connect rewind
-        # drops its clear_ui and false-fails the scenario.
-        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
-            raise AssertionError("coord-stale-backstop: SSE stream never opened")
-        # Arm TWO forced /history 500s: the rewind's clear_ui refetch AND its
-        # one bounded 2s retry both fail, so ONLY the organic idle-edge
-        # backstop can clear the latch.
-        node.fail_history(2)
-        # Click #1 — the REAL rewind on the SECOND user row: POSTs (the
-        # authoritative rewind commits server-side to ONE user turn), the
-        # server emits clear_ui, and its refetch 500s (fault 2 -> 1).
-        if not cdp.evaluate("window.__clickCoordRewind(1)"):
-            raise AssertionError("coord-stale-backstop: second-row rewind button missing")
-        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
-            raise AssertionError("coord-stale-backstop: first rewind never POSTed")
-        # Both the clear_ui refetch AND the 2s retry must fire and fail
-        # (fault 2 -> 1 -> 0): history_fail_remaining == 0 proves both
-        # consumed.  The retry fires ~2s after the first failure.
-        if not _poll_until(lambda: node.history_fail_remaining == 0, 20):
-            raise AssertionError(
-                "coord-stale-backstop: the two forced /history failures never both fired"
-            )
-        # Backend proof the failures actually happened (never scripted absence).
-        assert node.history_fail_remaining == 0, "coord-stale-backstop: fail budget not consumed"
-        # The stale transcript is intact — the failed fetches wiped nothing.
-        stale_rows = cdp.evaluate(_COORD_ROWS_JS)
-        if stale_rows != 3:
-            raise AssertionError(
-                f"coord-stale-backstop: failed fetches did not preserve the "
-                f"transcript (user rows={stale_rows}, expected 3)"
-            )
+        _coord_stick_latch(cdp, node, "coord-stale-backstop")
         # Click #2 — rewind on the FIRST user row while the latch is set:
         # gated, POST non-occurrence confirmed over a bounded window.
         if not cdp.evaluate("window.__clickCoordRewind(0)"):
@@ -2881,25 +2882,7 @@ def run_coord_heal_midturn(chrome: str) -> str:
         cdp = CDP(_page_ws_url(cdp_port))
         url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-heal-midturn"
         _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
-        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
-            raise AssertionError("coord-heal-midturn: three user rows never rendered")
-        # SSE-open gate — see run_coord_rewind_window.
-        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
-            raise AssertionError("coord-heal-midturn: SSE stream never opened")
-        # G3 prologue: latch stuck after clear_ui refetch + retry both 500.
-        node.fail_history(2)
-        if not cdp.evaluate("window.__clickCoordRewind(1)"):
-            raise AssertionError("coord-heal-midturn: second-row rewind button missing")
-        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
-            raise AssertionError("coord-heal-midturn: first rewind never POSTed")
-        if not _poll_until(lambda: node.history_fail_remaining == 0, 20):
-            raise AssertionError("coord-heal-midturn: the two forced failures never both fired")
-        stale_rows = cdp.evaluate(_COORD_ROWS_JS)
-        if stale_rows != 3:
-            raise AssertionError(
-                f"coord-heal-midturn: failed fetches did not preserve the transcript "
-                f"(user rows={stale_rows}, expected 3)"
-            )
+        _coord_stick_latch(cdp, node, "coord-heal-midturn")
         events_baseline = node.events_requests
         history_baseline = node.history_requests
         # Hold every /history long enough for turn 5 to start under it, but
@@ -3078,33 +3061,39 @@ def run_coord_hidden_retry(chrome: str) -> str:
 
 
 def run_coord_orphan_rewind(chrome: str) -> str:
-    """Scenario G6 — the orphan-synthesis tripwire (#894 r6).  The r6
-    review traced a client-side hazard: an unresulted committed
-    tool_calls turn ("orphan") would render as a ``.conv-batch--running``
-    placeholder no result ever strips, and the r5 DOM-probed gate read
-    that residue as live — poisoning every seedless render for the life
-    of the page.  Empirically the trigger state is UNREACHABLE today:
-    the server synthesizes a result for interrupted tool calls at
-    recovery ("Cancelled by user. Outcome UNKNOWN" — verified via
-    post-kill /history), so no persisted orphan exists.  The client was
-    hardened anyway (the gate's tool-phase term is the EVENT-DRIVEN
-    live-call set, pinned render-untouchable), because that server
-    invariant is all that stands between a future crash path and the
-    poisoned-pane state.
+    """Scenario G6 — the poisoned-pane detector (#894 r6/r7).  A node
+    killed MID-TOOL leaves the committed tool_calls turn genuinely
+    unresulted in storage (r7-verified: only a GRACEFUL close synthesizes
+    the "Cancelled by user" result via session.cancel(); boot-time
+    rehydration synthesizes nothing — so ``stop(hard=True)`` models the
+    real SIGKILL/OOM crash).  The recovery render paints that orphan as
+    a ``.conv-batch--running`` placeholder no result will ever strip.
+    The r5 DOM-probed gate read the residue as "live" and skipped every
+    subsequent SEEDLESS render for the life of the page: rewinds
+    committed server-side but never rendered, the latch stuck, and
+    rewind/edit went permanently dead.  The event-driven live-call set
+    is EMPTY for an orphan (nothing announced it on the live stream
+    since the reconnect), so the rewind's clear_ui render must proceed
+    THROUGH the residue: the orphan batch is wiped, the rewound truth
+    paints (the server keeps the user message and removes the unresulted
+    assistant turn — rewind-for-retry), and the latch clears.
 
-    THIS SCENARIO PINS THE SERVER INVARIANT, not the client encoding
-    (with synthesis present a DOM-probe gate also passes — the client
-    discipline is carried by the static pin set): after a mid-bash node
-    kill + reboot, the recovery render must show the batch RESULTED (no
-    --running residue) and the seedless rewind flow must work end to
-    end (rows 0, posts 1, history_requests grew).  If recovery
-    synthesis ever regresses, this stamps the residue — surfacing
-    exactly the state that would re-expose the hardened client."""
+    This is the client hardening's behavioral detector: the runner
+    asserts the residue IS present after recovery (the poisoned-pane
+    precondition manifested), then that the seedless rewind flow works
+    end to end regardless (posts 1, history_requests grew, one user row
+    and no residue in the end state).  DOM-probe gate code fails the
+    heal poll with the residue still standing — the orphan bit is the
+    discriminator."""
     from tests._sse_recovery_server import final_text_script, parallel_bash_script
 
     port = _free_port()
     node = _boot_node(port=port)
-    paced = parallel_bash_script({"g6": "for i in $(seq 1 60); do echo g6-$i; sleep 0.05; done"})
+    # 60s of pacing: the hard-killed node's session thread keeps running
+    # this bash in-process and persists its result at natural completion —
+    # it must outlive the whole post-kill observation window or the
+    # "unresulted orphan" silently resolves mid-scenario.
+    paced = parallel_bash_script({"g6": "for i in $(seq 1 1200); do echo g6-$i; sleep 0.05; done"})
     ws_id = node.create_workstream(paced, final_text_script("g6-done"), name="browser-coord-orphan")
     profile = Path(_scratch()) / "chrome-coord-orphan-rewind"
     proc, cdp_port = _launch_chrome(chrome, profile)
@@ -3132,26 +3121,26 @@ def run_coord_orphan_rewind(chrome: str) -> str:
             0.2,
         ):
             raise AssertionError("coord-orphan-rewind: tool rows never painted")
-        node.stop()
+        node.stop(hard=True)
         node = _boot_node(port=port)
         node.open_workstream(ws_id)
+        # A hard-crashed reborn node answers the page's stale-high cursor
+        # with a SILENT fresh stream — no replay_truncated (the honest-
+        # truncation signal rides state a graceful stop persists; a crash
+        # never writes it — pre-existing server hole, tracked separately).
+        # The realistic operator recovery is a page RELOAD: init's seeded
+        # /history render paints the orphan deterministically.
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
         # The pane's reconnect machinery (native retry -> truncated resync
-        # -> seeded render) repaints the interrupted turn.  The SERVER
-        # INVARIANT under test: recovery synthesized a result for the
-        # killed call, so the batch renders RESULTED — one user row, tool
-        # rows present, NO --running residue.
+        # -> seeded render) repaints the interrupted turn.  With a HARD
+        # kill the tool call is genuinely unresulted, so the recovery
+        # render shows the ORPHAN: one user row, a --running placeholder
+        # batch no result will ever strip — the poisoned-pane
+        # precondition, now manifested for real.
         if not _poll_until(
             lambda: (
                 cdp.evaluate(_COORD_ROWS_JS) == 1
-                and (
-                    cdp.evaluate(
-                        "document.getElementById('coord-messages')"
-                        ".querySelectorAll('.conv-row[data-call-id]').length"
-                    )
-                    or 0
-                )
-                >= 1
-                and not cdp.evaluate(
+                and cdp.evaluate(
                     "document.getElementById('coord-messages')"
                     ".querySelector('.conv-batch--running') !== null"
                 )
@@ -3160,10 +3149,9 @@ def run_coord_orphan_rewind(chrome: str) -> str:
             0.3,
         ):
             raise AssertionError(
-                "coord-orphan-rewind: recovery never rendered the synthesized "
-                "(resulted) batch — either the reconnect failed or recovery "
-                "synthesis regressed (a --running residue is exactly the "
-                "poisoned-pane precondition)"
+                "coord-orphan-rewind: recovery never painted the orphan "
+                "--running residue (hard kill did not leave the tool call "
+                "unresulted, or the reconnect failed)"
             )
         hist_baseline = node.history_requests
         # Rewind the sole user row — the full seedless flow must work
@@ -3173,9 +3161,12 @@ def run_coord_orphan_rewind(chrome: str) -> str:
             raise AssertionError("coord-orphan-rewind: rewind button missing")
         if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
             raise AssertionError("coord-orphan-rewind: rewind never POSTed")
+        # Rewound truth: the server removes the unresulted assistant turn
+        # and KEEPS the user message — success is one user row, residue
+        # gone (a skipped render leaves the residue standing instead).
         healed = _poll_until(
             lambda: (
-                cdp.evaluate(_COORD_ROWS_JS) == 0
+                cdp.evaluate(_COORD_ROWS_JS) == 1
                 and not cdp.evaluate(
                     "document.getElementById('coord-messages')"
                     ".querySelector('.conv-batch--running') !== null"

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -2747,7 +2747,16 @@ def _coord_stick_latch(cdp: CDP, node: Any, tag: str) -> None:
     clear_ui refetch AND its one bounded 2s retry, so only an organic
     idle-edge heal can clear it.  Extracted so G4's premise (latch stuck
     exactly as in G3) is enforced by construction, the same rationale
-    _seed_three_completed_turns documents for the E family."""
+    _seed_three_completed_turns documents for the E family.
+
+    RULED (r10): G2/G5 deliberately keep their single-failure prologues
+    inline rather than adopting this helper — their baseline captures
+    and phase timings interleave INTO the prologue steps (G2 snapshots
+    history_requests before the click; G5 hides the instant the fail
+    budget drains), so a parameterized version would need a flag per
+    divergence and obscure the choreography it exists to clarify.  The
+    helper serves the two double-failure scenarios whose premise must
+    match exactly."""
     if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
         raise AssertionError(f"{tag}: three user rows never rendered")
     if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -1771,7 +1771,7 @@ def _poll_until(pred: Any, timeout: float, interval: float = 0.1) -> bool:
 def _send_in_page(cdp: CDP, message: str) -> None:
     """POST /send from inside the page via the pane's own authFetch (cookie
     auth, node-proxy base) — the one shared shape for scenarios that drive a
-    turn mid-flight (E1/E4).  A raw POST emits no live user row, so the sent
+    turn mid-flight (E1/E4/G3).  A raw POST emits no live user row, so the sent
     turn appears only via the next /history render."""
     cdp.evaluate(
         "window.authFetch('/v1/api/workstreams/' + "

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -29,6 +29,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario coord-heal-midturn         # G4 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-hidden-retry         # G5 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-orphan-rewind        # G6 (#894 r6)
+    python3 scripts/recovery_e2e.py --scenario coord-joined-flight        # G7 (#894 r8)
     python3 scripts/recovery_e2e.py --scenario roster-restart    # F1 (#881)
     python3 scripts/recovery_e2e.py --scenario roster-restart-native  # F2 (#881)
     python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
@@ -155,6 +156,19 @@ post-recovery, then the orphan is wiped and the rewound truth paints
 (the server keeps the user message and removes the unresulted assistant
 turn), posts 1, ``history_requests`` grew.  Stamps
 ``RECOVERY-READY-COORDORPHANREWIND-posts1-rows1-orphan0``.
+
+Scenario G7 (coord-joined-flight, #894 r8): the joined-flight window.
+Two browsers on one ws; ``delay_load`` parks B's pre-rewind /history
+flight open INSIDE ``load_messages`` (the flight layer — the fault
+layer's ``delay_history`` cannot overlap flights); A rewinds mid-hold.
+A's clear_ui refetch must MISS the held flight — the server folds the
+truncation generation into the #884 flight key — proven by
+``load_calls`` growing TWO (a joined request never enters
+``load_messages``) and A rendering the post-rewind single row.
+Pre-fix, A JOINED the pre-rewind flight (loads1), painted three stale
+rows as fresh truth, and cleared the latch — the over-rewind window
+through the server seam.  Stamps
+``RECOVERY-READY-COORDJOINEDFLIGHT-posts1-loads2-rows1``.
 
 Scenario A (storm): the page connects, POSTs ``/send`` on stream-open (so
 the listener is registered first), the node runs a 4-parallel-bash
@@ -1105,6 +1119,31 @@ COORD_PAGE_HTML = r"""<!doctype html>
             userRows +
             "-orphan" +
             (orphan ? 1 : 0);
+      };
+
+      // G7 — the joined-flight window (#894 r8): a clear_ui refetch
+      // dispatched after a rewind must MISS any in-flight pre-rewind
+      // /history reconstruction (the server folds the truncation
+      // generation into its #884 flight key).  Pre-fix, the join handed
+      // A a pre-rewind payload that painted as fresh truth and cleared
+      // the latch — histDelta 1 (joined, one reconstruction) and three
+      // stale rows; fixed, A draws its own flight — histDelta 2, the
+      // rewound single row.
+      window.__verifyCoordJoinedFlight = function (posts, loadDelta) {
+        const userRows = _coordUserRows();
+        // loadDelta === 2: A's post-rewind dispatch entered load_messages
+        // itself (a joined request never does — the flight-layer miss
+        // proof).  userRows === 1: the post-rewind truth painted; the
+        // joined pre-rewind payload paints three.
+        const ok = posts === 1 && loadDelta === 2 && userRows === 1;
+        document.title = ok
+          ? "RECOVERY-READY-COORDJOINEDFLIGHT-posts1-loads2-rows1"
+          : "RECOVERY-FAILED-COORDJOINEDFLIGHT-posts" +
+            posts +
+            "-loads" +
+            loadDelta +
+            "-rows" +
+            userRows;
       };
 
       window.__verifyCoordRestart = function () {
@@ -3189,6 +3228,90 @@ def run_coord_orphan_rewind(chrome: str) -> str:
         node.stop()
 
 
+def run_coord_joined_flight(chrome: str) -> str:
+    """Scenario G7 — the joined-flight window (#894 r8).  The #884
+    /history single-flight coalesces concurrent requests per
+    (ws_id, limit); before the r8 server fix a clear_ui refetch
+    dispatched AFTER a rewind could JOIN a flight whose load_messages
+    ran BEFORE the truncation committed — the joined pre-rewind payload
+    painted as fresh truth (the client's dispatch stamp is current; the
+    staleness is the flight's transaction point) and cleared the latch:
+    the original over-rewind window, resurrected through the server
+    seam.  The fix folds ChatSession._history_generation (bumped in
+    _persist_truncation, the shared rewind/retry chokepoint) into the
+    flight key, so post-truncation dispatches can never join
+    pre-truncation flights.
+
+    Choreography: page A paints three rows; ``delay_load`` then holds
+    every reconstruction open INSIDE ``load_messages`` (the flight
+    layer — ``delay_history`` sleeps in the fault layer, before the
+    route, where flights never overlap); page B (a second browser on
+    the SAME ws) navigates, parking a pre-rewind flight; A rewinds
+    mid-hold — its clear_ui refetch must MISS B's held flight
+    (``load_calls`` grows by TWO: a joined request never enters
+    ``load_messages`` — the e2e twin of the unit test's proof) and
+    render the POST-rewind single row once the holds release.  Pre-fix
+    stamps loads1 (joined) with three stale rows painted as fresh
+    truth."""
+    node, ws_id = _seed_three_completed_turns("browser-coord-joined-flight")
+    profile_a = Path(_scratch()) / "chrome-coord-joined-a"
+    profile_b = Path(_scratch()) / "chrome-coord-joined-b"
+    proc_a, cdp_port_a = _launch_chrome(chrome, profile_a)
+    proc_b = None
+    cdp_a: CDP | None = None
+    cdp_b: CDP | None = None
+    try:
+        cdp_a = CDP(_page_ws_url(cdp_port_a))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-joined-flight"
+        _set_cookie_and_navigate(cdp_a, node.base_url, node.token, url)
+        if not _poll_until(lambda: cdp_a.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("coord-joined-flight: A's three user rows never rendered")
+        if not _poll_until(lambda: (cdp_a.evaluate("window.__esOpens") or 0) >= 1, 10, 0.05):
+            raise AssertionError("coord-joined-flight: A's SSE stream never opened")
+        load_baseline = node.load_calls
+        # Hold every reconstruction open INSIDE load_messages (the flight
+        # layer — delay_history sleeps in the fault layer, before the
+        # route, where flights never overlap), then park B's pre-rewind
+        # flight under the hold.
+        node.delay_load(3000)
+        proc_b, cdp_port_b = _launch_chrome(chrome, profile_b)
+        cdp_b = CDP(_page_ws_url(cdp_port_b))
+        _set_cookie_and_navigate(cdp_b, node.base_url, node.token, url)
+        if not _poll_until(lambda: node.load_calls == load_baseline + 1, 15, 0.05):
+            raise AssertionError("coord-joined-flight: B's flight never entered load_messages")
+        # A rewinds mid-hold: second row -> 2 turns -> server keeps one
+        # user turn.  Its clear_ui refetch must MISS B's pre-rewind
+        # flight (fresh arrival = baseline + 2, the join-miss proof).
+        if not cdp_a.evaluate("window.__clickCoordRewind(1)"):
+            raise AssertionError("coord-joined-flight: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("coord-joined-flight: rewind never POSTed")
+        # The MISS proof at the flight layer: A's post-rewind dispatch
+        # must enter load_messages itself (a JOINED request never does) —
+        # the e2e twin of the unit test's load_calls == 2.
+        joined_miss = _poll_until(lambda: node.load_calls == load_baseline + 2, 8, 0.05)
+        # The holds release (~3s); A must render the POST-rewind truth
+        # (pre-fix, the joined pre-rewind payload paints THREE rows).
+        healed = _poll_until(lambda: cdp_a.evaluate(_COORD_ROWS_JS) == 1, 12, 0.2)
+        load_delta = node.load_calls - load_baseline
+        posts = node.rewind_requests
+        print(
+            f"  coord-joined-flight joined_miss={joined_miss} healed={healed} "
+            f"load_delta={load_delta} posts={posts}"
+        )
+        cdp_a.evaluate(f"window.__verifyCoordJoinedFlight({posts}, {load_delta})")
+        return _poll_title(cdp_a, 15)
+    finally:
+        if cdp_a is not None:
+            cdp_a.close()
+        if cdp_b is not None:
+            cdp_b.close()
+        _kill(proc_a)
+        if proc_b is not None:
+            _kill(proc_b)
+        node.stop()
+
+
 def _wait_state(node: Any, ws_id: str, state: str, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -3240,6 +3363,7 @@ def main() -> None:
             "coord-heal-midturn",
             "coord-hidden-retry",
             "coord-orphan-rewind",
+            "coord-joined-flight",
             "roster-restart",
             "roster-restart-native",
             "both",
@@ -3316,6 +3440,10 @@ def main() -> None:
     if args.scenario in ("coord-orphan-rewind", "all"):
         verdict = run_coord_orphan_rewind(chrome)
         print(f"scenario G6 (coord-orphanrewind): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-joined-flight", "all"):
+        verdict = run_coord_joined_flight(chrome)
+        print(f"scenario G7 (coord-joinedflight): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("roster-restart", "all"):
         verdict = run_roster_restart(chrome)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -133,10 +133,10 @@ Scenario G5 (coord-hidden-retry, #894 r4): the retry's stream-liveness
 fire guard.  A retry armed before close-on-hide must NOT fetch while the
 transport is down (a seedless render past the frozen ``lastEventId``
 double-renders on the show-edge replay): ``history_requests`` UNCHANGED
-across the hidden fire window (``hidden0``).  A quiet reconnect delivers
-no state_change edge, so post-show the latch stays closed (the accepted
-liveness-lag residual) until the runner drives an ORGANIC settle with a
-plain send; that idle edge fires the TRANSPORT-FREE backstop on the live
+across the hidden fire window (``hidden0``).  A replay_ok reconnect
+carries no synthetic state_change (only fresh/truncated replays do), so
+post-show the latch stays closed (the accepted liveness-lag residual)
+until the runner drives an ORGANIC settle with a plain send; that idle edge fires the TRANSPORT-FREE backstop on the live
 stream (exactly ONE new SSE open across show + heal — the user-driven
 reconnect; the heal adds zero).  Stamps
 ``RECOVERY-READY-COORDHIDDENRETRY-hidden0-heal1``.
@@ -958,6 +958,42 @@ COORD_PAGE_HTML = r"""<!doctype html>
             userRows;
       };
 
+      // G3 — the TRANSPORT-FREE idle-edge backstop.  Mirrors
+      // __verifyStaleBackstop; the storm assertion is sseDelta === 0 (the
+      // heal opened ZERO EventSource connections — a reconnecting backstop
+      // bumps events_requests once per reconnect and self-triggers).  The
+      // latch-cleared proof is the reopen POST (posts 2), not a field read:
+      // coord's latch is closure-private.
+      window.__verifyCoordStaleBackstop = function (
+        healed,
+        sseDelta,
+        histDelta,
+        gatedPosts,
+        posts,
+      ) {
+        const userRows = _coordUserRows();
+        const ok =
+          healed &&
+          sseDelta === 0 &&
+          histDelta === 1 &&
+          gatedPosts === 1 &&
+          posts === 2;
+        document.title = ok
+          ? "RECOVERY-READY-COORDSTALEBACKSTOP-heal1-sse0"
+          : "RECOVERY-FAILED-COORDSTALEBACKSTOP-heal" +
+            (healed ? 1 : 0) +
+            "-sse" +
+            sseDelta +
+            "-hist" +
+            histDelta +
+            "-gated" +
+            gatedPosts +
+            "-posts" +
+            posts +
+            "-rows" +
+            userRows;
+      };
+
       // G4 — the render-time gate (#894 r4): a turn that STARTS during a
       // heal's in-flight /history must SURVIVE its resolution (the gate
       // skips the wipe; pre-gate code detached the live turn into a
@@ -1022,42 +1058,6 @@ COORD_PAGE_HTML = r"""<!doctype html>
             userRows;
       };
 
-      // G3 — the TRANSPORT-FREE idle-edge backstop.  Mirrors
-      // __verifyStaleBackstop; the storm assertion is sseDelta === 0 (the
-      // heal opened ZERO EventSource connections — a reconnecting backstop
-      // bumps events_requests once per reconnect and self-triggers).  The
-      // latch-cleared proof is the reopen POST (posts 2), not a field read:
-      // coord's latch is closure-private.
-      window.__verifyCoordStaleBackstop = function (
-        healed,
-        sseDelta,
-        histDelta,
-        gatedPosts,
-        posts,
-      ) {
-        const userRows = _coordUserRows();
-        const ok =
-          healed &&
-          sseDelta === 0 &&
-          histDelta === 1 &&
-          gatedPosts === 1 &&
-          posts === 2;
-        document.title = ok
-          ? "RECOVERY-READY-COORDSTALEBACKSTOP-heal1-sse0"
-          : "RECOVERY-FAILED-COORDSTALEBACKSTOP-heal" +
-            (healed ? 1 : 0) +
-            "-sse" +
-            sseDelta +
-            "-hist" +
-            histDelta +
-            "-gated" +
-            gatedPosts +
-            "-posts" +
-            posts +
-            "-rows" +
-            userRows;
-      };
-
       window.__verifyCoordRestart = function () {
         // Same contract as Scenario B, read off the coordinator's public
         // chrome + the transport wrapper (idle is asserted SERVER-side by
@@ -1091,7 +1091,6 @@ COORD_PAGE_HTML = r"""<!doctype html>
   </body>
 </html>
 """
-
 
 # ---------------------------------------------------------------------------
 # Minimal dependency-free CDP client (WebSocket over a raw socket).
@@ -2808,17 +2807,19 @@ def run_coord_heal_midturn(chrome: str) -> str:
     seeds two/three gone.  Storm proof: zero SSE opens across the whole
     episode; exactly TWO /history fetches (the skipped one + the heal).
 
-    Detector honesty: ``history_delta == 2`` is the DISCRIMINATING bit.
+    Detector honesty: ``history_delta == 2`` is the DISCRIMINATING bit,
+    and the skip it witnesses rides the ``.conv-batch--running`` DOM
+    marker — turn 5 is in its TOOL phase at resolution (content refs
+    null), so this scenario is the behavioral detector for the gate's
+    tool-phase branch (the content-ref branch and the liveness statement
+    carry structural pins; G5 covers the hidden-retry liveness path).
     Gate-stripped code renders the held fetch early, which CLEARS the
     latch, kills the backstop refire, and stamps ``hist1`` (plus
     downstream posts/rows drift).  The ``mid1`` bit alone cannot
-    discriminate here: the early render repaints all three user rows from
-    the snapshot (the rewind pre-dates turn 4, so /history already
-    carries turns 4 and 5's user rows), and turn 5's tool phase has null
-    content refs — its per-token loss surface is the TOOL rows, which
-    this scenario does not fingerprint.  On gated code ``mid1`` asserts
-    the stronger continuous-visibility claim (nothing wiped at any
-    point)."""
+    discriminate: the early render repaints all three user rows from the
+    snapshot (the rewind pre-dates turn 4, so /history already carries
+    turns 4 and 5's user rows).  On gated code ``mid1`` asserts the
+    stronger continuous-visibility claim (nothing wiped at any point)."""
     from tests._sse_recovery_server import final_text_script, parallel_bash_script
 
     paced5 = parallel_bash_script({"g4": "for i in $(seq 1 50); do echo g4-$i; sleep 0.05; done"})
@@ -2939,8 +2940,9 @@ def run_coord_hidden_retry(chrome: str) -> str:
     (hiddenDelta 0); on show, the reconnect's synthetic idle re-fires the
     TRANSPORT-FREE backstop, which heals on the live stream.
 
-    A quiet reconnect delivers NO state_change edge, so the latch stays
-    closed after __show until the next ORGANIC settle — exactly the
+    A replay_ok reconnect (frozen cursor, nothing lost) carries no
+    synthetic state_change — only fresh/truncated replays do — so the
+    latch stays closed after __show until the next ORGANIC settle — exactly the
     accepted-residual ruling (heals ride organic edges; no timer may
     shortcut the lag).  The runner drives that settle with a plain send
     (sends are never latch-gated), whose turn-settle idle edge fires the
@@ -2987,9 +2989,11 @@ def run_coord_hidden_retry(chrome: str) -> str:
         # (the hidden fetch lands) and hiddenDelta stamps 1.
         _poll_until(lambda: node.history_requests != hidden_baseline, 3.5, 0.1)
         hidden_delta = node.history_requests - hidden_baseline
-        # Show: the reconnect presents the frozen cursor.  A quiet
-        # reconnect delivers NO state_change edge (the latch-closed lag is
-        # the accepted residual), so wait for the reconnect itself, then
+        # Show: the reconnect presents the frozen cursor and replays
+        # replay_ok (nothing lost), which carries NO synthetic
+        # state_change (only fresh/truncated replays do — the
+        # latch-closed lag is the accepted residual).  Wait for the
+        # reconnect itself, then
         # drive an ORGANIC settle with a plain send — its idle edge fires
         # the TRANSPORT-FREE backstop on the live stream and the heal
         # renders the rewound (ONE) + sent (a second) transcript.

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -158,8 +158,9 @@ turn), posts 1, ``history_requests`` grew.  Stamps
 ``RECOVERY-READY-COORDORPHANREWIND-posts1-rows1-orphan0``.
 
 Scenario G7 (coord-joined-flight, #894 r8): the joined-flight window.
-Two browsers on one ws; ``delay_load`` parks B's pre-rewind /history
-flight open INSIDE ``load_messages`` (the flight layer — the fault
+One browser plus a background GET ("viewer B") on one ws;
+``delay_load`` parks B's pre-rewind /history flight open INSIDE
+``load_messages`` (the flight layer — the fault
 layer's ``delay_history`` cannot overlap flights); A rewinds mid-hold.
 A's clear_ui refetch must MISS the held flight — the server folds the
 truncation generation into the #884 flight key — proven by
@@ -319,6 +320,7 @@ import socket
 import struct
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from pathlib import Path
@@ -1978,7 +1980,8 @@ def _poll_until(pred: Any, timeout: float, interval: float = 0.1) -> bool:
 def _send_in_page(cdp: CDP, message: str) -> None:
     """POST /send from inside the page via the pane's own authFetch (cookie
     auth, node-proxy base) — the one shared shape for scenarios that drive a
-    turn mid-flight (E1/E4/G3).  A raw POST emits no live user row, so the sent
+    turn mid-flight (the shared shape for every scenario that drives a
+    turn outside the composer).  A raw POST emits no live user row, so the sent
     turn appears only via the next /history render."""
     cdp.evaluate(
         "window.authFetch('/v1/api/workstreams/' + "
@@ -3245,9 +3248,10 @@ def run_coord_joined_flight(chrome: str) -> str:
     Choreography: page A paints three rows; ``delay_load`` then holds
     every reconstruction open INSIDE ``load_messages`` (the flight
     layer — ``delay_history`` sleeps in the fault layer, before the
-    route, where flights never overlap); page B (a second browser on
-    the SAME ws) navigates, parking a pre-rewind flight; A rewinds
-    mid-hold — its clear_ui refetch must MISS B's held flight
+    route, where flights never overlap); a background authenticated GET
+    ("viewer B" — a raw request enters ``load_messages`` identically,
+    without a second browser's cost) parks a pre-rewind flight; A
+    rewinds mid-hold — its clear_ui refetch must MISS B's held flight
     (``load_calls`` grows by TWO: a joined request never enters
     ``load_messages`` — the e2e twin of the unit test's proof) and
     render the POST-rewind single row once the holds release.  Pre-fix
@@ -3255,11 +3259,8 @@ def run_coord_joined_flight(chrome: str) -> str:
     truth."""
     node, ws_id = _seed_three_completed_turns("browser-coord-joined-flight")
     profile_a = Path(_scratch()) / "chrome-coord-joined-a"
-    profile_b = Path(_scratch()) / "chrome-coord-joined-b"
     proc_a, cdp_port_a = _launch_chrome(chrome, profile_a)
-    proc_b = None
     cdp_a: CDP | None = None
-    cdp_b: CDP | None = None
     try:
         cdp_a = CDP(_page_ws_url(cdp_port_a))
         url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-joined-flight"
@@ -3271,12 +3272,23 @@ def run_coord_joined_flight(chrome: str) -> str:
         load_baseline = node.load_calls
         # Hold every reconstruction open INSIDE load_messages (the flight
         # layer — delay_history sleeps in the fault layer, before the
-        # route, where flights never overlap), then park B's pre-rewind
-        # flight under the hold.
+        # route, where flights never overlap), then park the pre-rewind
+        # flight under the hold.  The parked "viewer B" is a plain
+        # authenticated GET on a background thread: a raw request enters
+        # load_messages identically, and a second headless browser added
+        # ~300 MB + seconds of launch for no additional proof.
         node.delay_load(3000)
-        proc_b, cdp_port_b = _launch_chrome(chrome, profile_b)
-        cdp_b = CDP(_page_ws_url(cdp_port_b))
-        _set_cookie_and_navigate(cdp_b, node.base_url, node.token, url)
+
+        def _b_get() -> None:
+            req = urllib.request.Request(
+                f"{node.base_url}/v1/api/workstreams/{ws_id}/history",
+                headers={"Cookie": f"turnstone_auth_server={node.token}"},
+            )
+            with contextlib.suppress(Exception):
+                urllib.request.urlopen(req, timeout=30).read()
+
+        b_thread = threading.Thread(target=_b_get, daemon=True)
+        b_thread.start()
         if not _poll_until(lambda: node.load_calls == load_baseline + 1, 15, 0.05):
             raise AssertionError("coord-joined-flight: B's flight never entered load_messages")
         # A rewinds mid-hold: second row -> 2 turns -> server keeps one
@@ -3304,11 +3316,7 @@ def run_coord_joined_flight(chrome: str) -> str:
     finally:
         if cdp_a is not None:
             cdp_a.close()
-        if cdp_b is not None:
-            cdp_b.close()
         _kill(proc_a)
-        if proc_b is not None:
-            _kill(proc_b)
         node.stop()
 
 

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -23,6 +23,9 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario rewind-window     # E2 (#890)
     python3 scripts/recovery_e2e.py --scenario rewind-failed-window  # E3 (#890)
     python3 scripts/recovery_e2e.py --scenario stale-backstop    # E4 (#890)
+    python3 scripts/recovery_e2e.py --scenario coord-rewind-window        # G1 (#894)
+    python3 scripts/recovery_e2e.py --scenario coord-rewind-failed-window # G2 (#894)
+    python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
     python3 scripts/recovery_e2e.py --scenario roster-restart    # F1 (#881)
     python3 scripts/recovery_e2e.py --scenario roster-restart-native  # F2 (#881)
     python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
@@ -795,6 +798,7 @@ COORD_PAGE_HTML = r"""<!doctype html>
       const q = new URLSearchParams(location.search);
       const wsId = q.get("ws_id");
       const healedSentinel = q.get("healed") || "";
+      const scenario = q.get("scenario") || "coord-restart";
 
       const pane = createCoordinatorPane(document.body, wsId, {
         standalone: true,
@@ -816,7 +820,9 @@ COORD_PAGE_HTML = r"""<!doctype html>
       // Drive /send once the stream has OPENED at the transport (__esOpens —
       // the pane's listener is registered by then, so no events are missed).
       // The chrome has no SSE pill to poll: the header was deliberately
-      // dropped (see buildCoordChrome's comment).
+      // dropped (see buildCoordChrome's comment).  coord-restart only: the
+      // #894 rewind scenarios (G1-G3) seed their turns server-side before
+      // navigation and must not inject an extra one.
       let sent = false;
       function sendOnce(msg) {
         if (sent) return;
@@ -829,12 +835,108 @@ COORD_PAGE_HTML = r"""<!doctype html>
           })
           .catch((e) => { document.title = "RECOVERY-FAILED-COORD-send-" + e; });
       }
-      const sendPoll = setInterval(() => {
-        if (window.__esOpens >= 1) {
-          clearInterval(sendPoll);
-          sendOnce("run a turn");
-        }
-      }, 100);
+      if (scenario === "coord-restart") {
+        const sendPoll = setInterval(() => {
+          if (window.__esOpens >= 1) {
+            clearInterval(sendPoll);
+            sendOnce("run a turn");
+          }
+        }, 100);
+      }
+
+      // Shared by the #894 rewind scenarios (G1/G2/G3): click the REAL
+      // rewind button on the idx-th user row.  The coordinator pane object
+      // exposes NO messagesEl and NO latch/quiesce fields (closure-private
+      // state, unlike interactive's class) — every probe on this page reads
+      // the public #coord-messages container, and the runner threads the
+      // authoritative fault-layer counters into the verdicts.
+      window.__clickCoordRewind = function (idx) {
+        const rows = document
+          .getElementById("coord-messages")
+          .querySelectorAll(".msg.user");
+        const row = rows[idx];
+        if (!row) return false;
+        const icon = row.querySelector(".icon-rewind");
+        const btn = icon ? icon.closest("button") : null;
+        if (!btn) return false;
+        btn.click();
+        return true;
+      };
+      function _coordUserRows() {
+        return document
+          .getElementById("coord-messages")
+          .querySelectorAll(".msg.user").length;
+      }
+
+      // G1 — the row affordance gate (busy || historyStale) under a
+      // HELD-OPEN clear_ui refetch.  Mirrors __verifyRewindWindow; coord has
+      // no quiesce, so the runner's in-flight edge is the fault layer's
+      // history_requests bump (counted on arrival, before the hold).
+      window.__verifyCoordRewindWindow = function (posts) {
+        const userRows = _coordUserRows();
+        // One rewind took effect (2nd-of-3 user row = rewind 2 turns => one
+        // user row left); the gated 1st-row click never reached the server
+        // (posts stays 1).  A broken gate => posts 2, rows 0.
+        const ok = posts === 1 && userRows === 1;
+        document.title = ok
+          ? "RECOVERY-READY-COORDREWINDWIN-posts" + posts
+          : "RECOVERY-FAILED-COORDREWINDWIN-posts" + posts + "-rows" + userRows;
+      };
+
+      // G2 — the FAILED clear_ui refetch aftermath.  Mirrors
+      // __verifyRewindFail: the latch (not a refetch-in-flight flag) must
+      // hold the gate closed AFTER the failed fetch, then the bounded 2s
+      // retry heals and reopens.  Pre-latch coord regresses to closed2.
+      window.__verifyCoordRewindFail = function (posts, closedPosts, healed) {
+        const userRows = _coordUserRows();
+        const ok = closedPosts === 1 && healed && posts === 2;
+        document.title = ok
+          ? "RECOVERY-READY-COORDREWINDFAIL-posts2-heal1"
+          : "RECOVERY-FAILED-COORDREWINDFAIL-closed" +
+            closedPosts +
+            "-heal" +
+            (healed ? 1 : 0) +
+            "-posts" +
+            posts +
+            "-rows" +
+            userRows;
+      };
+
+      // G3 — the TRANSPORT-FREE idle-edge backstop.  Mirrors
+      // __verifyStaleBackstop; the storm assertion is sseDelta === 0 (the
+      // heal opened ZERO EventSource connections — a reconnecting backstop
+      // bumps events_requests once per reconnect and self-triggers).  The
+      // latch-cleared proof is the reopen POST (posts 2), not a field read:
+      // coord's latch is closure-private.
+      window.__verifyCoordStaleBackstop = function (
+        healed,
+        sseDelta,
+        histDelta,
+        gatedPosts,
+        posts,
+      ) {
+        const userRows = _coordUserRows();
+        const ok =
+          healed &&
+          sseDelta === 0 &&
+          histDelta === 1 &&
+          gatedPosts === 1 &&
+          posts === 2;
+        document.title = ok
+          ? "RECOVERY-READY-COORDSTALEBACKSTOP-heal1-sse0"
+          : "RECOVERY-FAILED-COORDSTALEBACKSTOP-heal" +
+            (healed ? 1 : 0) +
+            "-sse" +
+            sseDelta +
+            "-hist" +
+            histDelta +
+            "-gated" +
+            gatedPosts +
+            "-posts" +
+            posts +
+            "-rows" +
+            userRows;
+      };
 
       window.__verifyCoordRestart = function () {
         // Same contract as Scenario B, read off the coordinator's public
@@ -2245,6 +2347,311 @@ def run_stale_backstop(chrome: str) -> str:
         node.stop()
 
 
+_COORD_ROWS_JS = "document.getElementById('coord-messages').querySelectorAll('.msg.user').length"
+
+
+def run_coord_rewind_window(chrome: str) -> str:
+    """Scenario G1 — the coordinator row affordance gate (``busy ||
+    historyStale``, #894, the coord port of E2).  Three completed turns =>
+    three user rows; a REAL rewind click on the second row POSTs and its
+    clear_ui refetch is held open by node.delay_history; a second REAL rewind
+    click (first row) mid-hold must return before POSTing.  Coord has no
+    quiesce to observe (its latch is closure-private), so the in-flight edge
+    is the fault layer's ``history_requests`` bump — counted on ARRIVAL,
+    before the hold sleeps — and the latch is set synchronously BEFORE that
+    fetch dispatches, so the bump proves the gate is closed.  Backend proof:
+    node.rewind_requests == 1 (only the first click reached the server)."""
+    node, ws_id = _seed_three_completed_turns("browser-coord-rewind-window")
+    profile = Path(_scratch()) / "chrome-coord-rewind-window"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-rewind-window"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # Wait for the initial /history to paint all three user rows.
+        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("coord-rewind-window: three user rows never rendered")
+        # Relative baseline (never assume how many /history the boot ran).
+        hist_baseline = node.history_requests
+        # Hold every /history 3s so the clear_ui refetch keeps the latch's
+        # only clear site — the success render — from running while the
+        # second click lands.
+        node.delay_history(3000)
+        # Click #1 — the REAL rewind button on the SECOND user row: POSTs,
+        # server emits clear_ui, the refetch is now held.
+        if not cdp.evaluate("window.__clickCoordRewind(1)"):
+            raise AssertionError("coord-rewind-window: second-row rewind button missing")
+        # The held refetch ARRIVED (counter bumps before the delay sleep) —
+        # the clear_ui handler set historyStale synchronously before
+        # dispatching this fetch, so from here the gate is provably closed.
+        if not _poll_until(lambda: node.history_requests == hist_baseline + 1, 5, 0.05):
+            raise AssertionError("coord-rewind-window: clear_ui refetch never arrived")
+        # Click #2 — the rewind button on the FIRST user row WHILE the
+        # refetch is held: the #894 gate must return before POSTing.
+        if not cdp.evaluate("window.__clickCoordRewind(0)"):
+            raise AssertionError("coord-rewind-window: first-row rewind button missing")
+        # The gate leaves no positive edge (a POST that never happens), so
+        # confirm the NON-occurrence over a bounded window: a failed gate's
+        # /rewind is NOT delayed and would land within ~200ms.
+        _poll_until(lambda: node.rewind_requests != 1, 1.5, 0.05)
+        posts = node.rewind_requests
+        # Release the hold and let the single in-flight rewind settle to one
+        # user row (2nd-of-3 row rewound 2 turns => one user turn remains).
+        node.delay_history(0)
+        _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 1, 8)
+        print(f"  coord-rewind-window rewind_requests={posts}")
+        cdp.evaluate(f"window.__verifyCoordRewindWindow({posts})")
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def run_coord_rewind_failed_window(chrome: str) -> str:
+    """Scenario G2 — the coordinator FAILED clear_ui refetch aftermath
+    (#894, the coord port of E3).  The rewind's clear_ui refetch is forced to
+    500; the historyStale LATCH (set at clear_ui, cleared ONLY by a
+    successful refetchHistory render) must keep the row affordances gated
+    over the stale-but-real transcript after the failed fetch — the exact
+    aftermath where a refetch-in-flight flag would reopen the gate and let a
+    second rewind over-rewind.  The bounded 2s retry then heals and reopens.
+
+    Coord's latch is closure-private, so the closed phase is proven by
+    observables: rewind #1 POSTed + the fail budget consumed => the clear_ui
+    handler ran (the latch was set synchronously before its fetch), and the
+    gated click's POST NON-occurrence is the gate assertion itself.  Backend
+    proofs: rewind_requests 1 -> (gated) 1 -> 2, history_fail_remaining == 0,
+    history_requests >= baseline + 2 (failed refetch + the retry's fetch)."""
+    node, ws_id = _seed_three_completed_turns("browser-coord-rewind-failed-window")
+    profile = Path(_scratch()) / "chrome-coord-rewind-failed-window"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-rewind-failed-window"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # Wait for the initial /history to paint all three user rows.  This
+        # load MUST succeed, so arm the forced failure only AFTERWARDS.
+        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("coord-rewind-failed-window: three user rows never rendered")
+        hist_baseline = node.history_requests
+        # Arm ONE forced /history 500: the NEXT /history — the rewind's
+        # clear_ui refetch — fails.
+        node.fail_history(1)
+        # Click #1 — the REAL rewind on the SECOND user row: POSTs (the
+        # authoritative rewind commits server-side), the server emits
+        # clear_ui, and its refetch 500s.  The stale transcript survives
+        # (#882 guard-before-wipe) and the historyStale latch stays SET.
+        if not cdp.evaluate("window.__clickCoordRewind(1)"):
+            raise AssertionError("coord-rewind-failed-window: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("coord-rewind-failed-window: first rewind never POSTed")
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 15):
+            raise AssertionError("coord-rewind-failed-window: forced /history failure never fired")
+        # Backend proof the failure actually happened (never scripted absence).
+        assert node.history_fail_remaining == 0, (
+            "coord-rewind-failed-window: fail budget not consumed"
+        )
+        # Hold the bounded retry's /history open: the retry is a fixed 2s
+        # timer, so delaying its fetch defers the latch's only clear site to
+        # ~failure+5s — a wide, CDP-speed-independent window for the gated
+        # click below.  Armed AFTER the failure (the first refetch fails
+        # fast) and ~1.8s BEFORE the retry fires.
+        node.delay_history(3000)
+        # CLOSED-PHASE — the stale transcript is intact (the failed fetch
+        # wiped nothing: guard-before-wipe), and the latch survived the
+        # failed exit (its clear sits below ``if (!hist) return``).
+        stale_rows = cdp.evaluate(_COORD_ROWS_JS)
+        if stale_rows != 3:
+            raise AssertionError(
+                f"coord-rewind-failed-window: failed fetch did not preserve the "
+                f"transcript (user rows={stale_rows}, expected 3)"
+            )
+        # Click #2 — rewind on the FIRST user row while the latch is set:
+        # the #894 gate (busy || historyStale) must return before POSTing.
+        if not cdp.evaluate("window.__clickCoordRewind(0)"):
+            raise AssertionError("coord-rewind-failed-window: first-row rewind button missing")
+        # Non-occurrence over a bounded window — the assertion that
+        # regresses to closed2 on pre-latch code.
+        _poll_until(lambda: node.rewind_requests != 1, 1.5, 0.05)
+        closed_posts = node.rewind_requests
+        # HEAL-PHASE — the bounded retry fires at ~2s (pane idle,
+        # turn-free), its held /history completes (~failure+5s) and rebuilds
+        # the rewound transcript: index 1 of 3 user rows rewinds 2 turns =>
+        # ONE user row.  Poll to a deadline rather than sleeping.
+        healed = _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 1, 10, 0.2)
+        # The retry re-fetched: failed refetch + the retry's success = two
+        # more than the paint baseline.  The 3->1 DOM transition above is
+        # the load-bearing proof the retry RENDERED.  Load-bearing counter —
+        # do not let history_requests drop back to write-only.
+        assert node.history_requests >= hist_baseline + 2, (
+            f"coord-rewind-failed-window: retry did not re-fetch "
+            f"(history_requests={node.history_requests}, baseline={hist_baseline})"
+        )
+        # Release the hold — the reopen's own clear_ui refetch must not be
+        # delayed.
+        node.delay_history(0)
+        # REOPEN-PHASE — the healing render cleared the latch.  A rewind on
+        # the remaining user row must land with a FRESH count
+        # (rewind_requests -> 2).  On a heal failure the verdict is already
+        # lost; skip the click and stamp the observed counts.
+        if healed:
+            if not cdp.evaluate("window.__clickCoordRewind(0)"):
+                raise AssertionError("coord-rewind-failed-window: healed-row rewind button missing")
+            _poll_until(lambda: node.rewind_requests == 2, 8, 0.05)
+        posts = node.rewind_requests
+        print(
+            f"  coord-rewind-failed-window closed_posts={closed_posts} "
+            f"healed={healed} posts={posts}"
+        )
+        cdp.evaluate(
+            f"window.__verifyCoordRewindFail({posts}, {closed_posts}, "
+            f"{'true' if healed else 'false'})"
+        )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def run_coord_stale_backstop(chrome: str) -> str:
+    """Scenario G3 — the coordinator ``historyStale`` latch's TRANSPORT-FREE
+    idle-edge backstop (#894, the coord port of E4).  The DOUBLE-failure
+    sibling of G2: the rewind's clear_ui refetch AND its one bounded 2s retry
+    are BOTH forced to 500 (``node.fail_history(2)``), so the latch cannot
+    self-heal and rewind/edit stay gated over the stale-but-real transcript.
+    A plain send (never latch-gated; raw authFetch here) runs the fourth
+    scripted turn whose ORGANIC turn-settle idle edge fires the backstop: a
+    plain seedless REST ``refetchHistory`` — deliberately NOT
+    ``loadHistoryThenReconnect`` (a reconnecting heal draws the server's
+    synthetic ``state_change:idle`` back into its own trigger: a
+    zero-backoff reconnect/refetch storm).
+
+    THE STORM PROOF (both counted at the fault layer): ``events_requests``
+    is UNCHANGED across the whole heal (``sse0`` — zero new EventSource
+    connections) and ``history_requests`` grew by exactly ONE (the
+    backstop's single fetch; the plain fourth turn emits no clear_ui).
+    Coord's latch is closure-private, so the latch-cleared proof is the
+    reopen POST (rewind_requests -> 2), not a field read.  Every poll is
+    deadline-bounded so a regressed looping backstop stamps a clean FAILED,
+    never a hang."""
+    from tests._sse_recovery_server import final_text_script
+
+    # Seed three turns and queue a FOURTH final_text (the sentinel-bearing
+    # turn the backstop-driving send below runs) — the shared helper keeps
+    # the seeding byte-identical to G1/G2 so the rewind arithmetic matches.
+    node, ws_id = _seed_three_completed_turns(
+        "browser-coord-stale-backstop",
+        extra_scripts=(final_text_script(BACKSTOP_SENTINEL),),
+    )
+    profile = Path(_scratch()) / "chrome-coord-stale-backstop"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-stale-backstop"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # Wait for the initial /history to paint all three user rows.  This
+        # load MUST succeed, so arm the forced failures only AFTERWARDS.
+        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("coord-stale-backstop: three user rows never rendered")
+        # Arm TWO forced /history 500s: the rewind's clear_ui refetch AND its
+        # one bounded 2s retry both fail, so ONLY the organic idle-edge
+        # backstop can clear the latch.
+        node.fail_history(2)
+        # Click #1 — the REAL rewind on the SECOND user row: POSTs (the
+        # authoritative rewind commits server-side to ONE user turn), the
+        # server emits clear_ui, and its refetch 500s (fault 2 -> 1).
+        if not cdp.evaluate("window.__clickCoordRewind(1)"):
+            raise AssertionError("coord-stale-backstop: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("coord-stale-backstop: first rewind never POSTed")
+        # Both the clear_ui refetch AND the 2s retry must fire and fail
+        # (fault 2 -> 1 -> 0): history_fail_remaining == 0 proves both
+        # consumed.  The retry fires ~2s after the first failure.
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 20):
+            raise AssertionError(
+                "coord-stale-backstop: the two forced /history failures never both fired"
+            )
+        # Backend proof the failures actually happened (never scripted absence).
+        assert node.history_fail_remaining == 0, "coord-stale-backstop: fail budget not consumed"
+        # The stale transcript is intact — the failed fetches wiped nothing.
+        stale_rows = cdp.evaluate(_COORD_ROWS_JS)
+        if stale_rows != 3:
+            raise AssertionError(
+                f"coord-stale-backstop: failed fetches did not preserve the "
+                f"transcript (user rows={stale_rows}, expected 3)"
+            )
+        # Click #2 — rewind on the FIRST user row while the latch is set:
+        # gated, POST non-occurrence confirmed over a bounded window.
+        if not cdp.evaluate("window.__clickCoordRewind(0)"):
+            raise AssertionError("coord-stale-backstop: first-row rewind button missing")
+        _poll_until(lambda: node.rewind_requests != 1, 1.5, 0.05)
+        gated_posts = node.rewind_requests  # must still be 1 (latch gated it)
+        # Baselines captured the instant BEFORE the send: the heal must add
+        # exactly ZERO SSE opens and exactly ONE /history fetch from here.
+        events_baseline = node.events_requests
+        history_baseline = node.history_requests
+        # Drive a plain send via in-page authFetch — sends are NOT
+        # latch-gated, so this reaches the server, runs the fourth scripted
+        # turn (BACKSTOP_SENTINEL), and its ORGANIC turn-settle idle edge
+        # fires the backstop.
+        _send_in_page(cdp, "fourth turn")
+        # HEAL: the fourth turn settles -> idle edge -> plain REST refetch
+        # (fault exhausted) succeeds -> the render rebuilds the rewound (ONE
+        # user turn) + sent (a second) transcript to TWO user rows, SENTINEL
+        # present.  The 3->2 transition is the load-bearing proof the
+        # backstop RENDERED; the latch-cleared proof is the reopen POST
+        # below (the latch itself is closure-private).
+        healed = _poll_until(
+            lambda: cdp.evaluate(
+                _COORD_ROWS_JS + " === 2 && (document.getElementById('coord-messages')"
+                ".textContent||'').includes(" + json.dumps(BACKSTOP_SENTINEL) + ")"
+            ),
+            20,
+            0.2,
+        )
+        # THE STORM DELTAS, captured BEFORE the reopen click's own clear_ui
+        # refetch so the arithmetic is exactly the backstop's:
+        #  - events_delta MUST be 0: the backstop is a REST refetchHistory,
+        #    ZERO EventSource connections (a reload backstop's connectSSE
+        #    bumps events_requests per reconnect — the storm).
+        #  - history_delta MUST be 1: the plain fourth turn emits no
+        #    clear_ui, so the ONLY /history in the send+heal window is the
+        #    backstop's fetch.
+        events_delta = node.events_requests - events_baseline
+        history_delta = node.history_requests - history_baseline
+        # REOPEN: the healing render cleared the latch, so a rewind on a
+        # remaining user row is legitimate and lands (rewind_requests -> 2).
+        # On a heal failure the verdict is already lost; skip the click and
+        # stamp the observed counts.
+        if healed:
+            if not cdp.evaluate("window.__clickCoordRewind(0)"):
+                raise AssertionError("coord-stale-backstop: healed-row rewind button missing")
+            _poll_until(lambda: node.rewind_requests == 2, 8, 0.05)
+        posts = node.rewind_requests
+        print(
+            f"  coord-stale-backstop gated_posts={gated_posts} healed={healed} "
+            f"events_delta={events_delta} history_delta={history_delta} posts={posts}"
+        )
+        cdp.evaluate(
+            "window.__verifyCoordStaleBackstop("
+            f"{'true' if healed else 'false'}, "
+            f"{events_delta}, {history_delta}, {gated_posts}, {posts})"
+        )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 def _wait_state(node: Any, ws_id: str, state: str, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -2290,6 +2697,9 @@ def main() -> None:
             "rewind-window",
             "rewind-failed-window",
             "stale-backstop",
+            "coord-rewind-window",
+            "coord-rewind-failed-window",
+            "coord-stale-backstop",
             "roster-restart",
             "roster-restart-native",
             "both",
@@ -2342,6 +2752,18 @@ def main() -> None:
     if args.scenario in ("stale-backstop", "all"):
         verdict = run_stale_backstop(chrome)
         print(f"scenario E4 (stalebackstop): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-rewind-window", "all"):
+        verdict = run_coord_rewind_window(chrome)
+        print(f"scenario G1 (coord-rewindwin): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-rewind-failed-window", "all"):
+        verdict = run_coord_rewind_failed_window(chrome)
+        print(f"scenario G2 (coord-rewindfail): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-stale-backstop", "all"):
+        verdict = run_coord_stale_backstop(chrome)
+        print(f"scenario G3 (coord-stalebackstop): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("roster-restart", "all"):
         verdict = run_roster_restart(chrome)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -3089,11 +3089,13 @@ def run_coord_orphan_rewind(chrome: str) -> str:
 
     port = _free_port()
     node = _boot_node(port=port)
-    # 60s of pacing: the hard-killed node's session thread keeps running
+    # ~200s of pacing: the hard-killed node's session thread keeps running
     # this bash in-process and persists its result at natural completion —
-    # it must outlive the whole post-kill observation window or the
-    # "unresulted orphan" silently resolves mid-scenario.
-    paced = parallel_bash_script({"g6": "for i in $(seq 1 1200); do echo g6-$i; sleep 0.05; done"})
+    # it must outlive the scenario's WORST-CASE deadline sum (join 20s +
+    # boot 10s + orphan 30s + rewind 5s + heal 15s + verdict 15s ≈ 95s,
+    # plus setup) or the "unresulted orphan" silently resolves
+    # mid-scenario and the detector degrades to a false READY.
+    paced = parallel_bash_script({"g6": "for i in $(seq 1 4000); do echo g6-$i; sleep 0.05; done"})
     ws_id = node.create_workstream(paced, final_text_script("g6-done"), name="browser-coord-orphan")
     profile = Path(_scratch()) / "chrome-coord-orphan-rewind"
     proc, cdp_port = _launch_chrome(chrome, profile)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -26,14 +26,16 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario coord-rewind-window        # G1 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-failed-window # G2 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
+    python3 scripts/recovery_e2e.py --scenario coord-heal-midturn         # G4 (#894)
+    python3 scripts/recovery_e2e.py --scenario coord-hidden-retry         # G5 (#894)
     python3 scripts/recovery_e2e.py --scenario roster-restart    # F1 (#881)
     python3 scripts/recovery_e2e.py --scenario roster-restart-native  # F2 (#881)
     python3 scripts/recovery_e2e.py --scenario both   # A+B only (legacy)
     python3 scripts/recovery_e2e.py --keep-open 8971  # serve the storm page
                                                       # for manual inspection
 
-The #890 guard-before-wipe family (all against the interactive pane, no
-coordinator):
+The #890 guard-before-wipe family (against the interactive pane; the
+coordinator ports are the G family below):
 
 Scenario D (fail-refetch): clones B, but arms one forced /history 500
 (``RecoveryServer.fail_history``) just before the show edge so the first
@@ -92,6 +94,52 @@ by exactly ONE (the backstop's single fetch — the plain fourth turn emits no
 clear_ui).  All polls are deadline-bounded so a regressed looping backstop
 stamps a clean FAILED, never a hang.  Stamps
 ``RECOVERY-READY-STALEBACKSTOP-heal1-sse0``.
+
+The #894 coordinator ports (G family — the coord pane's ``historyStale``
+latch; coord state is closure-private, so where E2-E4 read pane fields the
+G runners read the fault layer's authoritative counters and prove gate
+closure by POST NON-occurrence; the latch-cleared proof is the reopen POST):
+
+Scenario G1 (coord-rewind-window): E2's port.  The clear_ui refetch is held
+open; the in-flight edge is the ``history_requests`` bump (counted on
+arrival, before the hold sleeps — the latch was set synchronously before
+that fetch dispatched).  A second rewind click mid-hold must be gated by
+``busy || historyStale``.  Stamps ``RECOVERY-READY-COORDREWINDWIN-posts1``.
+
+Scenario G2 (coord-rewind-failed-window): E3's port.  The failed refetch
+keeps the latch set (its only clear sits below the ``if (!hist) return``
+failure guard); the retry's held /history defers the heal so the gated
+click provably lands in the aftermath window; the bounded 2s retry then
+heals and reopens.  Stamps ``RECOVERY-READY-COORDREWINDFAIL-posts2-heal1``.
+
+Scenario G3 (coord-stale-backstop): E4's port.  Double failure exhausts
+clear_ui refetch + retry; a plain send's ORGANIC settle fires the
+TRANSPORT-FREE backstop (plain seedless ``refetchHistory``, never
+``loadHistoryThenReconnect``).  Same storm proof: ``events_requests``
+UNCHANGED, ``history_requests`` +1.  Stamps
+``RECOVERY-READY-COORDSTALEBACKSTOP-heal1-sse0``.
+
+Scenario G4 (coord-heal-midturn, #894 r4): the render-time gate.  A turn
+STARTED during a heal's held /history must survive the fetch resolution —
+the gate skips the wipe (pre-gate code detached the live turn's DOM into
+dangling refs and lost it), the latch stays set, and the turn's own settle
+re-fires the backstop, which heals.  Proofs: turn 5's sentinel paints into
+the still-stale transcript (``mid1``), the heal lands with the rewound-away
+seeds gone, ``events_requests`` UNCHANGED, ``history_requests`` +2 exactly
+(the skipped fetch + the heal).  Stamps
+``RECOVERY-READY-COORDHEALMIDTURN-heal1-mid1-sse0``.
+
+Scenario G5 (coord-hidden-retry, #894 r4): the retry's stream-liveness
+fire guard.  A retry armed before close-on-hide must NOT fetch while the
+transport is down (a seedless render past the frozen ``lastEventId``
+double-renders on the show-edge replay): ``history_requests`` UNCHANGED
+across the hidden fire window (``hidden0``).  A quiet reconnect delivers
+no state_change edge, so post-show the latch stays closed (the accepted
+liveness-lag residual) until the runner drives an ORGANIC settle with a
+plain send; that idle edge fires the TRANSPORT-FREE backstop on the live
+stream (exactly ONE new SSE open across show + heal — the user-driven
+reconnect; the heal adds zero).  Stamps
+``RECOVERY-READY-COORDHIDDENRETRY-hidden0-heal1``.
 
 Scenario A (storm): the page connects, POSTs ``/send`` on stream-open (so
 the listener is registered first), the node runs a 4-parallel-bash
@@ -270,6 +318,14 @@ SECOND_SENTINEL = "SECOND-a7f3"
 # proves the sent turn reached the healed /history render, distinct from
 # everything else on screen.
 BACKSTOP_SENTINEL = "BACKSTOP-b2e4"
+
+# Scenario G4 (coord-heal-midturn) sentinels: turn 4's final text (the
+# settle that fires the held backstop fetch) and turn 5's final text (the
+# turn that STARTS during that held fetch and must survive its resolution).
+# Same collision-proof discipline as the sentinels above; turn 5's bash
+# command output is ``g4-N`` lines, which contain neither token.
+MIDTURN_T4_SENTINEL = "MIDT4-c9d1"
+MIDTURN_T5_SENTINEL = "MIDT5-f47a"
 
 # ---------------------------------------------------------------------------
 # The recovery page — served same-origin by the node at /recovery.
@@ -896,6 +952,70 @@ COORD_PAGE_HTML = r"""<!doctype html>
             closedPosts +
             "-heal" +
             (healed ? 1 : 0) +
+            "-posts" +
+            posts +
+            "-rows" +
+            userRows;
+      };
+
+      // G4 — the render-time gate (#894 r4): a turn that STARTS during a
+      // heal's in-flight /history must SURVIVE its resolution (the gate
+      // skips the wipe; pre-gate code detached the live turn into a
+      // dangling ref and lost it).  midturnSurvived is the runner's
+      // observation that turn 5's sentinel painted while the stale
+      // transcript was still up — the not-wiped proof.
+      window.__verifyCoordHealMidturn = function (
+        healed,
+        midturnSurvived,
+        sseDelta,
+        histDelta,
+        posts,
+      ) {
+        const userRows = _coordUserRows();
+        const ok =
+          healed &&
+          midturnSurvived &&
+          sseDelta === 0 &&
+          histDelta === 2 &&
+          posts === 2;
+        document.title = ok
+          ? "RECOVERY-READY-COORDHEALMIDTURN-heal1-mid1-sse0"
+          : "RECOVERY-FAILED-COORDHEALMIDTURN-heal" +
+            (healed ? 1 : 0) +
+            "-mid" +
+            (midturnSurvived ? 1 : 0) +
+            "-sse" +
+            sseDelta +
+            "-hist" +
+            histDelta +
+            "-posts" +
+            posts +
+            "-rows" +
+            userRows;
+      };
+
+      // G5 — the retry's stream-liveness fire guard (#894 r4): a retry
+      // armed before a close-on-hide must NOT fetch while the transport
+      // is down (hiddenDelta 0 — a seedless render past the frozen
+      // cursor double-renders on the show-edge replay); the show edge's
+      // synthetic idle hands the heal to the backstop (one user-driven
+      // SSE open, rows healed, gate reopened).
+      window.__verifyCoordHiddenRetry = function (
+        hiddenDelta,
+        healed,
+        showSse,
+        posts,
+      ) {
+        const userRows = _coordUserRows();
+        const ok = hiddenDelta === 0 && healed && showSse === 1 && posts === 2;
+        document.title = ok
+          ? "RECOVERY-READY-COORDHIDDENRETRY-hidden0-heal1"
+          : "RECOVERY-FAILED-COORDHIDDENRETRY-hidden" +
+            hiddenDelta +
+            "-heal" +
+            (healed ? 1 : 0) +
+            "-sse" +
+            showSse +
             "-posts" +
             posts +
             "-rows" +
@@ -2372,6 +2492,14 @@ def run_coord_rewind_window(chrome: str) -> str:
         # Wait for the initial /history to paint all three user rows.
         if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
             raise AssertionError("coord-rewind-window: three user rows never rendered")
+        # Rows paint from init's ``await refetchHistory(true)`` and the pane
+        # dials SSE only AFTERWARDS — a rewind clicked in that gap emits
+        # clear_ui into a channel nobody joined (a cursorless connect takes
+        # the fresh no-replay branch), the latch never sets, and the
+        # scenario false-fails.  Gate on the transport wrapper's counter,
+        # like the coord page's coord-restart send gate.
+        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
+            raise AssertionError("coord-rewind-window: SSE stream never opened")
         # Relative baseline (never assume how many /history the boot ran).
         hist_baseline = node.history_requests
         # Hold every /history 3s so the clear_ui refetch keeps the latch's
@@ -2437,6 +2565,10 @@ def run_coord_rewind_failed_window(chrome: str) -> str:
         # load MUST succeed, so arm the forced failure only AFTERWARDS.
         if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
             raise AssertionError("coord-rewind-failed-window: three user rows never rendered")
+        # SSE-open gate — see run_coord_rewind_window: a pre-connect rewind
+        # drops its clear_ui and false-fails the scenario.
+        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
+            raise AssertionError("coord-rewind-failed-window: SSE stream never opened")
         hist_baseline = node.history_requests
         # Arm ONE forced /history 500: the NEXT /history — the rewind's
         # clear_ui refetch — fails.
@@ -2560,6 +2692,10 @@ def run_coord_stale_backstop(chrome: str) -> str:
         # load MUST succeed, so arm the forced failures only AFTERWARDS.
         if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
             raise AssertionError("coord-stale-backstop: three user rows never rendered")
+        # SSE-open gate — see run_coord_rewind_window: a pre-connect rewind
+        # drops its clear_ui and false-fails the scenario.
+        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
+            raise AssertionError("coord-stale-backstop: SSE stream never opened")
         # Arm TWO forced /history 500s: the rewind's clear_ui refetch AND its
         # one bounded 2s retry both fail, so ONLY the organic idle-edge
         # backstop can clear the latch.
@@ -2652,6 +2788,246 @@ def run_coord_stale_backstop(chrome: str) -> str:
         node.stop()
 
 
+def run_coord_heal_midturn(chrome: str) -> str:
+    """Scenario G4 — the render-time gate (#894 r4).  A turn that STARTS
+    while a heal's /history is in flight must SURVIVE the fetch resolution:
+    pre-gate code ran ``replaceChildren`` under the live turn, detaching its
+    bubble/tool rows into dangling refs (every remaining token rendered
+    invisibly, the optimistic user row was destroyed, and nothing
+    re-rendered the lost turn).  The gate skips the wipe instead — the
+    latch stays set and the turn's OWN settle re-fires the backstop.
+
+    Choreography: G3's double-failure prologue leaves the latch stuck;
+    ``delay_history`` then holds the backstop fetch that turn 4's settle
+    fires; the moment the held fetch ARRIVES (history_requests bumps before
+    the hold sleeps) the runner sends turn 5 — a paced bash turn (~2.5s)
+    that is still mid-stream when the hold (1.5s) releases.  The gate must
+    skip that resolution (turn 5's sentinel paints into the still-stale
+    transcript = midturnSurvived), and turn 5's settle re-fires the
+    backstop, which now heals: transcript = rewound turn + turns 4 and 5,
+    seeds two/three gone.  Storm proof: zero SSE opens across the whole
+    episode; exactly TWO /history fetches (the skipped one + the heal).
+
+    Detector honesty: ``history_delta == 2`` is the DISCRIMINATING bit.
+    Gate-stripped code renders the held fetch early, which CLEARS the
+    latch, kills the backstop refire, and stamps ``hist1`` (plus
+    downstream posts/rows drift).  The ``mid1`` bit alone cannot
+    discriminate here: the early render repaints all three user rows from
+    the snapshot (the rewind pre-dates turn 4, so /history already
+    carries turns 4 and 5's user rows), and turn 5's tool phase has null
+    content refs — its per-token loss surface is the TOOL rows, which
+    this scenario does not fingerprint.  On gated code ``mid1`` asserts
+    the stronger continuous-visibility claim (nothing wiped at any
+    point)."""
+    from tests._sse_recovery_server import final_text_script, parallel_bash_script
+
+    paced5 = parallel_bash_script({"g4": "for i in $(seq 1 50); do echo g4-$i; sleep 0.05; done"})
+    node, ws_id = _seed_three_completed_turns(
+        "browser-coord-heal-midturn",
+        extra_scripts=(
+            final_text_script(MIDTURN_T4_SENTINEL),
+            paced5,
+            final_text_script(MIDTURN_T5_SENTINEL),
+        ),
+    )
+    profile = Path(_scratch()) / "chrome-coord-heal-midturn"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-heal-midturn"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("coord-heal-midturn: three user rows never rendered")
+        # SSE-open gate — see run_coord_rewind_window.
+        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
+            raise AssertionError("coord-heal-midturn: SSE stream never opened")
+        # G3 prologue: latch stuck after clear_ui refetch + retry both 500.
+        node.fail_history(2)
+        if not cdp.evaluate("window.__clickCoordRewind(1)"):
+            raise AssertionError("coord-heal-midturn: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("coord-heal-midturn: first rewind never POSTed")
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 20):
+            raise AssertionError("coord-heal-midturn: the two forced failures never both fired")
+        stale_rows = cdp.evaluate(_COORD_ROWS_JS)
+        if stale_rows != 3:
+            raise AssertionError(
+                f"coord-heal-midturn: failed fetches did not preserve the transcript "
+                f"(user rows={stale_rows}, expected 3)"
+            )
+        events_baseline = node.events_requests
+        history_baseline = node.history_requests
+        # Hold every /history long enough for turn 5 to start under it, but
+        # shorter than turn 5's ~2.5s bash phase, so the held fetch resolves
+        # MID-turn — the exact window the gate exists for.
+        node.delay_history(1500)
+        # Turn 4: settles -> idle edge -> backstop fires -> its fetch is
+        # HELD.  history_requests bumps on ARRIVAL (before the hold sleeps),
+        # which is the observable that the window is open.
+        _send_in_page(cdp, "fourth turn")
+        if not _poll_until(lambda: node.history_requests == history_baseline + 1, 20, 0.05):
+            raise AssertionError("coord-heal-midturn: backstop fetch never arrived")
+        # Turn 5, INSIDE the hold: paced bash keeps it mid-stream when the
+        # held fetch resolves.  The gate must skip that render.
+        _send_in_page(cdp, "fifth turn")
+        # midturnSurvived: turn 5's final sentinel paints into the
+        # still-stale transcript (user rows unchanged at 3) — a wiped pane
+        # would have dropped to 1 row and swallowed the sentinel into a
+        # detached ref.  Poll spans the hold release (+1.5s) and turn 5's
+        # full run.
+        midturn_survived = _poll_until(
+            lambda: cdp.evaluate(
+                "(document.getElementById('coord-messages').textContent||'')"
+                ".includes(" + json.dumps(MIDTURN_T5_SENTINEL) + ") && " + _COORD_ROWS_JS + " === 3"
+            ),
+            20,
+            0.2,
+        )
+        # Release the hold so turn 5's settle-driven backstop refire heals
+        # promptly.
+        node.delay_history(0)
+        # HEAL: the refire renders the rewound truth — turn "first" + turns
+        # 4 and 5; the rewound-away seeds are GONE.  Text discriminators,
+        # not row counts: the healed pane also has 3 user rows.
+        healed = _poll_until(
+            lambda: cdp.evaluate(
+                "(function(){var t=document.getElementById('coord-messages')"
+                ".textContent||'';return t.includes("
+                + json.dumps(MIDTURN_T4_SENTINEL)
+                + ")&&t.includes("
+                + json.dumps(MIDTURN_T5_SENTINEL)
+                + ")&&!t.includes('second');})()"
+            ),
+            20,
+            0.2,
+        )
+        events_delta = node.events_requests - events_baseline
+        history_delta = node.history_requests - history_baseline
+        # REOPEN: the heal cleared the latch; a fresh rewind lands.
+        if healed:
+            if not cdp.evaluate("window.__clickCoordRewind(0)"):
+                raise AssertionError("coord-heal-midturn: healed-row rewind button missing")
+            _poll_until(lambda: node.rewind_requests == 2, 8, 0.05)
+        posts = node.rewind_requests
+        print(
+            f"  coord-heal-midturn midturn_survived={midturn_survived} healed={healed} "
+            f"events_delta={events_delta} history_delta={history_delta} posts={posts}"
+        )
+        cdp.evaluate(
+            "window.__verifyCoordHealMidturn("
+            f"{'true' if healed else 'false'}, "
+            f"{'true' if midturn_survived else 'false'}, "
+            f"{events_delta}, {history_delta}, {posts})"
+        )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def run_coord_hidden_retry(chrome: str) -> str:
+    """Scenario G5 — the retry's stream-liveness fire guard (#894 r4).  The
+    2s retry deliberately survives close-on-hide (transport redials keep
+    heal intent), so it can FIRE while the tab is hidden and the transport
+    is down.  A seedless fetch then would render the pane past the frozen
+    ``lastEventId``; the show-edge reconnect replays from that frozen
+    cursor and double-renders every turn the hidden render already painted.
+    The ``evtSource`` fire-guard term skips the hidden firing instead
+    (hiddenDelta 0); on show, the reconnect's synthetic idle re-fires the
+    TRANSPORT-FREE backstop, which heals on the live stream.
+
+    A quiet reconnect delivers NO state_change edge, so the latch stays
+    closed after __show until the next ORGANIC settle — exactly the
+    accepted-residual ruling (heals ride organic edges; no timer may
+    shortcut the lag).  The runner drives that settle with a plain send
+    (sends are never latch-gated), whose turn-settle idle edge fires the
+    TRANSPORT-FREE backstop on the live stream.
+
+    Proofs: history_requests UNCHANGED across the hidden retry window (the
+    non-occurrence detector that regresses to hidden1 without the guard);
+    exactly ONE new SSE open across show + heal (the user-driven reconnect
+    — the heal itself adds zero); the healed render carries the rewound
+    turn + the sent turn (TWO user rows, sentinel present); the reopen
+    click lands."""
+    from tests._sse_recovery_server import final_text_script
+
+    node, ws_id = _seed_three_completed_turns(
+        "browser-coord-hidden-retry",
+        extra_scripts=(final_text_script(BACKSTOP_SENTINEL),),
+    )
+    profile = Path(_scratch()) / "chrome-coord-hidden-retry"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/coord-recovery?ws_id={ws_id}&scenario=coord-hidden-retry"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        if not _poll_until(lambda: cdp.evaluate(_COORD_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("coord-hidden-retry: three user rows never rendered")
+        # SSE-open gate — see run_coord_rewind_window.
+        if not _poll_until(lambda: cdp.evaluate("window.__esOpens") >= 1, 10, 0.05):
+            raise AssertionError("coord-hidden-retry: SSE stream never opened")
+        node.fail_history(1)
+        if not cdp.evaluate("window.__clickCoordRewind(1)"):
+            raise AssertionError("coord-hidden-retry: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("coord-hidden-retry: first rewind never POSTed")
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 15):
+            raise AssertionError("coord-hidden-retry: forced /history failure never fired")
+        # Hide IMMEDIATELY — well inside the 2s arm window (the poll above
+        # settles ~0.3s after the failure).  close-on-hide tears the
+        # transport down but deliberately leaves the retry timer armed.
+        cdp.evaluate("window.__hide && window.__hide()")
+        hidden_baseline = node.history_requests
+        # NON-occurrence window: the retry fires at ~2s post-failure; give
+        # it 3.5s.  Without the evtSource guard this poll returns True
+        # (the hidden fetch lands) and hiddenDelta stamps 1.
+        _poll_until(lambda: node.history_requests != hidden_baseline, 3.5, 0.1)
+        hidden_delta = node.history_requests - hidden_baseline
+        # Show: the reconnect presents the frozen cursor.  A quiet
+        # reconnect delivers NO state_change edge (the latch-closed lag is
+        # the accepted residual), so wait for the reconnect itself, then
+        # drive an ORGANIC settle with a plain send — its idle edge fires
+        # the TRANSPORT-FREE backstop on the live stream and the heal
+        # renders the rewound (ONE) + sent (a second) transcript.
+        events_before_show = node.events_requests
+        cdp.evaluate("window.__show && window.__show()")
+        if not _poll_until(lambda: node.events_requests == events_before_show + 1, 10, 0.05):
+            raise AssertionError("coord-hidden-retry: show-edge reconnect never arrived")
+        _send_in_page(cdp, "fourth turn")
+        healed = _poll_until(
+            lambda: cdp.evaluate(
+                _COORD_ROWS_JS + " === 2 && (document.getElementById('coord-messages')"
+                ".textContent||'').includes(" + json.dumps(BACKSTOP_SENTINEL) + ")"
+            ),
+            20,
+            0.2,
+        )
+        show_sse = node.events_requests - events_before_show
+        if healed:
+            if not cdp.evaluate("window.__clickCoordRewind(0)"):
+                raise AssertionError("coord-hidden-retry: healed-row rewind button missing")
+            _poll_until(lambda: node.rewind_requests == 2, 8, 0.05)
+        posts = node.rewind_requests
+        print(
+            f"  coord-hidden-retry hidden_delta={hidden_delta} healed={healed} "
+            f"show_sse={show_sse} posts={posts}"
+        )
+        cdp.evaluate(
+            f"window.__verifyCoordHiddenRetry({hidden_delta}, "
+            f"{'true' if healed else 'false'}, {show_sse}, {posts})"
+        )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 def _wait_state(node: Any, ws_id: str, state: str, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -2700,6 +3076,8 @@ def main() -> None:
             "coord-rewind-window",
             "coord-rewind-failed-window",
             "coord-stale-backstop",
+            "coord-heal-midturn",
+            "coord-hidden-retry",
             "roster-restart",
             "roster-restart-native",
             "both",
@@ -2764,6 +3142,14 @@ def main() -> None:
     if args.scenario in ("coord-stale-backstop", "all"):
         verdict = run_coord_stale_backstop(chrome)
         print(f"scenario G3 (coord-stalebackstop): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-heal-midturn", "all"):
+        verdict = run_coord_heal_midturn(chrome)
+        print(f"scenario G4 (coord-healmidturn): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("coord-hidden-retry", "all"):
+        verdict = run_coord_hidden_retry(chrome)
+        print(f"scenario G5 (coord-hiddenretry): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("roster-restart", "all"):
         verdict = run_roster_restart(chrome)

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -148,6 +148,29 @@ class RecoveryServer:
         self._adapter.attach(self._manager)
         WebUI._workstream_mgr = self._manager
 
+        # delay_load knob state (see the method): wraps the storage
+        # singleton's load_messages; restored in stop().
+        self._load_delay_ms = 0
+        self._load_calls = 0
+        _storage_obj = get_storage()
+        self._orig_load_messages = _storage_obj.load_messages
+
+        def _delayed_load(*a: Any, **k: Any) -> Any:
+            self._load_calls += 1
+            result = self._orig_load_messages(*a, **k)
+            # Sleep AFTER the load: the held flight must hold the data it
+            # actually read (its transaction point), so a flight parked
+            # across a rewind genuinely carries PRE-rewind rows — a
+            # pre-load sleep would read post-rewind storage and mask a
+            # wrongly-joined flight as fresh truth.
+            d = self._load_delay_ms
+            if d > 0:
+                time.sleep(d / 1000.0)
+            return result
+
+        _storage_obj.load_messages = _delayed_load  # type: ignore[method-assign]
+        self._patched_storage = _storage_obj
+
         # Optional small listener-queue cap. The cap is a default arg on the
         # registration methods with no config/env override, so lower it by
         # patching their ``__defaults__`` (restored on stop). fix-3's
@@ -413,6 +436,28 @@ class RecoveryServer:
     # increment/decrement and the runner thread's read each atomic, and the
     # arm-then-consume ordering means they never race.
 
+    def delay_load(self, ms: int) -> None:
+        """Hold ``storage.load_messages`` itself open for ``ms`` (0 = off).
+
+        ``delay_history`` sleeps in the FAULT LAYER — before the route —
+        so two delayed requests never overlap inside the #884 flight
+        machinery (the first flight completes and pops before the second
+        arrives at the route).  This knob sleeps INSIDE the shared
+        reconstruction's ``load_messages`` (sync, called via
+        ``asyncio.to_thread`` — the sleep parks only that worker), which
+        is the same layer the unit tests gate, so held flights genuinely
+        overlap and join/miss behavior is observable end to end via
+        ``load_calls``.
+        """
+        self._load_delay_ms = ms
+
+    @property
+    def load_calls(self) -> int:
+        """``load_messages`` entries (pre-sleep) — the flight-layer twin
+        of ``history_requests`` (which counts HTTP arrivals): a JOINED
+        request never enters ``load_messages``, so join=1 / miss=2."""
+        return self._load_calls
+
     def fail_history(self, count: int) -> None:
         """Make the next ``count`` ``GET …/history`` responses a 500 — the
         failed refetch the #890 guard-before-wipe must survive."""
@@ -470,6 +515,9 @@ class RecoveryServer:
         # Restore any patched cap defaults.
         for meth, defaults in self._orig_defaults:
             meth.__defaults__ = defaults
+        # Restore the storage singleton's load_messages (delay_load knob).
+        with contextlib.suppress(Exception):
+            self._patched_storage.load_messages = self._orig_load_messages  # type: ignore[method-assign]
 
 
 def make_listen_socket(port: int, *, sndbuf: int = _DEFAULT_SNDBUF) -> socket.socket:

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -152,11 +152,18 @@ class RecoveryServer:
         # singleton's load_messages; restored in stop().
         self._load_delay_ms = 0
         self._load_calls = 0
+        # load_messages runs on asyncio.to_thread WORKERS, and delay_load
+        # exists precisely to overlap two of them — unlike the
+        # single-writer HTTP counters, this one has genuine concurrent
+        # writers, so the increment takes a lock (a lost update would
+        # false-FAIL G7's load_delta === 2, or mask a third load).
+        self._load_calls_lock = threading.Lock()
         _storage_obj = get_storage()
         self._orig_load_messages = _storage_obj.load_messages
 
         def _delayed_load(*a: Any, **k: Any) -> Any:
-            self._load_calls += 1
+            with self._load_calls_lock:
+                self._load_calls += 1
             result = self._orig_load_messages(*a, **k)
             # Sleep AFTER the load: the held flight must hold the data it
             # actually read (its transaction point), so a flight parked

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -432,11 +432,34 @@ class RecoveryServer:
 
     # -- teardown ------------------------------------------------------------
 
-    def stop(self) -> None:
-        with contextlib.suppress(Exception):
-            for ws in list(self._manager.list_all()):
-                with contextlib.suppress(Exception):
-                    self._manager.close(ws.id)
+    def stop(self, *, hard: bool = False) -> None:
+        """Stop the node.
+
+        ``hard=True`` skips the per-workstream ``manager.close`` sweep — a
+        graceful close routes through ``cleanup_session_ui`` →
+        ``session.cancel()``, whose bash cancel path PERSISTS a
+        synthesized "Cancelled by user" result while the old node is
+        still alive, which masks crash states.  A hard stop leaves any
+        in-flight tool call genuinely unresulted in storage, modelling a
+        SIGKILL/OOM death (the coord-orphan-rewind scenario's premise).
+        Everything else (server exit, sockets, patched-default restore)
+        is identical.
+        """
+        if not hard:
+            with contextlib.suppress(Exception):
+                for ws in list(self._manager.list_all()):
+                    with contextlib.suppress(Exception):
+                        self._manager.close(ws.id)
+        else:
+            # A crash does not drain open SSE streams: force_exit makes
+            # uvicorn drop live connections instead of waiting on them
+            # (graceful shutdown would hang on the pane's EventSource and
+            # the 20s join below would time out with the old server still
+            # serving).  NOTE: the killed workstream's in-flight tool keeps
+            # executing on this process's session thread and will persist
+            # its result at natural completion — hard-kill scenarios must
+            # use a paced tool that outlives their observation window.
+            self._server.force_exit = True
         self._server.should_exit = True
         self._thread.join(timeout=20)
         with contextlib.suppress(Exception):

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -442,24 +442,25 @@ class RecoveryServer:
         still alive, which masks crash states.  A hard stop leaves any
         in-flight tool call genuinely unresulted in storage, modelling a
         SIGKILL/OOM death (the coord-orphan-rewind scenario's premise).
-        Everything else (server exit, sockets, patched-default restore)
-        is identical.
+        The 2s graceful-shutdown timeout (uvicorn config) force-closes
+        open SSE streams, and the lifespan teardown still runs, so the
+        #885 daemon threads are joined on both paths.
         """
         if not hard:
             with contextlib.suppress(Exception):
                 for ws in list(self._manager.list_all()):
                     with contextlib.suppress(Exception):
                         self._manager.close(ws.id)
-        else:
-            # A crash does not drain open SSE streams: force_exit makes
-            # uvicorn drop live connections instead of waiting on them
-            # (graceful shutdown would hang on the pane's EventSource and
-            # the 20s join below would time out with the old server still
-            # serving).  NOTE: the killed workstream's in-flight tool keeps
-            # executing on this process's session thread and will persist
-            # its result at natural completion — hard-kill scenarios must
-            # use a paced tool that outlives their observation window.
-            self._server.force_exit = True
+        # hard=True relies on ``timeout_graceful_shutdown=2`` (set in the
+        # uvicorn config above) to force-close the pane's EventSource:
+        # should_exit alone still runs the ASGI lifespan teardown, so the
+        # #885 daemon threads and the sse_executor are joined either way
+        # (``force_exit`` would SKIP the lifespan and leak them — the
+        # fanout thread blocks on queue.get() forever).  NOTE: the killed
+        # workstream's in-flight tool keeps executing on this process's
+        # session thread and persists its result at natural completion —
+        # hard-kill scenarios must use a paced tool that outlives their
+        # observation window.
         self._server.should_exit = True
         self._thread.join(timeout=20)
         with contextlib.suppress(Exception):

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2093,11 +2093,11 @@ def test_coord_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None
         body,
     ), "connectSSE must gate ?last_event_id= on connectCursor != null"
     # (2) cleared only by a successful full render — below the !hist guard,
-    # riding the wipe — and never by the teardown paths.  (Window sized
-    # past the #894 latch/render-gate comment blocks; the invariant is the
-    # ORDER, not the density.)
+    # riding the wipe — and never by the teardown paths.  (Sliced to the
+    # next function boundary; the invariant is the ORDER, not the
+    # density, and a char-count window rots as at-site comments grow.)
     start = body.index("async function refetchHistory(seedCursor = false)")
-    fn = body[start : start + 8000]
+    fn = body[start : body.index("\n  function ", start + 1)]
     guard = fn.index("if (!hist) return;")
     clear = fn.index("truncatedFromCursor = null;")
     assert guard < clear, "the record must only clear once a payload rendered"

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2093,9 +2093,11 @@ def test_coord_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None
         body,
     ), "connectSSE must gate ?last_event_id= on connectCursor != null"
     # (2) cleared only by a successful full render — below the !hist guard,
-    # riding the wipe — and never by the teardown paths.
+    # riding the wipe — and never by the teardown paths.  (Window sized
+    # past the #894 latch/render-gate comment blocks; the invariant is the
+    # ORDER, not the density.)
     start = body.index("async function refetchHistory(seedCursor = false)")
-    fn = body[start : start + 4500]
+    fn = body[start : start + 8000]
     guard = fn.index("if (!hist) return;")
     clear = fn.index("truncatedFromCursor = null;")
     assert guard < clear, "the record must only clear once a payload rendered"

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -2190,14 +2190,18 @@ def test_coord_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None
     assert "console.warn(" in rec.group(1)
     # (9) repair-intent supersession lives in refetchHistory's success path
     # — record + deferred latch + pending timer, all below the !hist guard
-    # — and clear_ui carries no path-local cancel.
+    # — and clear_ui carries no path-local cancel of the TRUNCATED repair
+    # intent.  Pin the specific timer, not all clearTimeout: #894's
+    # staleRetryTimer re-arm cancel in clear_ui is the staleness latch's
+    # own machinery, deliberately armed there (see the coord latch-contract
+    # test), not a truncated-repair cancel.
     assert "pendingTruncatedResync = false;" in fn
     assert "clearTimeout(truncatedResyncTimer)" in fn
     assert guard < fn.index("pendingTruncatedResync = false;")
     assert guard < fn.index("clearTimeout(truncatedResyncTimer)")
     cu = re.search(r'case "clear_ui": \{(.*?)\n      \}', body, re.S)
     assert cu is not None, "clear_ui case not found"
-    assert "clearTimeout" not in cu.group(1)
+    assert "clearTimeout(truncatedResyncTimer)" not in cu.group(1)
 
 
 def test_coord_detects_server_restart_by_backwards_event_id() -> None:

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -670,16 +670,33 @@ def test_coordinator_history_stale_latch_contract():
         "(mirrors interactive's !_replayQueue pin)."
     )
 
-    # 5. Bounded retry: exactly one arm site, and its fire guard yields to
-    #    an in-flight fetch.
+    # 5. Bounded retry: exactly one arm site; the ARM is teardown-gated;
+    #    the fire guard yields to an in-flight fetch and carries the
+    #    teardown sentinel.
     assert body.count("staleRetryTimer = setTimeout") == 1, (
         "the stale retry must be armed in exactly one place (clear_ui "
         ".then) — bounded by construction."
     )
+    assert body.count("if (historyStale && visHandler) {") == 1, (
+        "the arm must be gated on the teardown sentinel too — the "
+        "clear_ui .then can settle after destroy()/coordCloseSession, "
+        "and an ungated arm recreates the orphan timer destroy's cancel "
+        "exists to kill."
+    )
     retry_arm = body.index("staleRetryTimer = setTimeout")
-    assert "!refetchesInFlight" in body[retry_arm : retry_arm + 700], (
+    retry_fire = body[retry_arm : retry_arm + 700]
+    assert "!refetchesInFlight" in retry_fire, (
         "the retry's fire guard must yield to an in-flight refetch "
         "(mirrors interactive's !_replayQueue pin)."
+    )
+    assert "visHandler" in retry_fire, (
+        "the retry's fire guard must carry the teardown sentinel — it is "
+        "the SOLE protection for the coordCloseSession path, which nulls "
+        "visHandler but does not cancel the timer."
+    )
+    assert "if (staleRetryTimer) clearTimeout(staleRetryTimer);" in body, (
+        "re-arming on a newer clear_ui must cancel the pending timer "
+        "first, or a double clear_ui leaks a timer."
     )
 
     # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -557,10 +557,10 @@ def test_coordinator_refetch_failure_preserves_the_pane():
     )
     body = coord_js.read_text(encoding="utf-8")
     start = body.index("async function refetchHistory(seedCursor = false)")
-    # Window sized to reach the early-reset block past the #894 latch-clear
-    # and render-gate comments; the pinned invariant is the ORDER below,
-    # not the density.
-    fn = body[start : start + 8000]
+    # Slice to the next function boundary — the pinned invariant is the
+    # ORDER below, not the density, and a char-count window dies with a
+    # bare ValueError every time an at-site comment grows.
+    fn = body[start : body.index("\n  function ", start + 1)]
     guard = fn.index("if (!hist) return;")
     wipe = fn.index("messagesEl.replaceChildren();")
     resets = fn.index("toolRows.clear();")
@@ -600,13 +600,15 @@ def test_coordinator_history_stale_latch_contract():
       6. destroy() cancels staleRetryTimer (terminal-only) while
          closeStreamTransport does NOT (transport redials keep the heal
          intent alive).
-      7. The render-time gate (r5-derived): refetchHistory re-checks
-         DOM-live-state (content refs / the --running batch marker / the optimistic-send
-         flavor of busy — never plain busy, the r5 critical), dispatch
-         currency (seq), and seedless stream-OPENness AFTER the await and
-         BEFORE the wipe — and the latch-clear sits below every skip
-         point, so a skipped render can never reopen the affordances over
-         a stale DOM.
+      7. The render-time gate (r5/r6-derived): refetchHistory re-checks,
+         AFTER the await and BEFORE the wipe, the UNIVERSAL terms —
+         dispatch currency (seq) and the content refs — and the
+         SEEDLESS-only terms: the event-driven live-tool-call set (never
+         a DOM probe, which the render's own orphan repaint can forge —
+         the r6 critical; never plain busy — the r5 critical), the
+         optimistic busySource flavor, and stream-OPENness.  The
+         latch-clear sits below every skip point, so a skipped render
+         can never reopen the affordances over a stale DOM.
     """
     from pathlib import Path
 
@@ -761,14 +763,12 @@ def test_coordinator_history_stale_latch_contract():
     )
 
     # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.
-    destroy_slice = body[body.index("function destroy()") :]
-    destroy_slice = destroy_slice[: destroy_slice.index("\n  function ")]
+    destroy_slice = _fn_slice("destroy()")
     assert "clearTimeout(staleRetryTimer)" in destroy_slice, (
         "destroy() must cancel the stale retry timer or it fires into "
         "detached DOM (and pins the closure)."
     )
-    cst_start = body.index("function closeStreamTransport()")
-    cst_slice = body[cst_start : body.index("\n  function ", cst_start + 1)]
+    cst_slice = _fn_slice("closeStreamTransport()")
     assert "clearTimeout(staleRetryTimer)" not in cst_slice, (
         "closeStreamTransport must NOT cancel the stale retry — transport "
         "redials keep the pending heal intent (terminal-only cancel)."
@@ -808,7 +808,7 @@ def test_coordinator_history_stale_latch_contract():
         ),
         ("!seedCursor &&", "seedless scoping"),
         ('busySource === "optimistic"', "optimistic-row"),
-        ('messagesEl.querySelector(".conv-batch--running")', "executing-batch"),
+        ("liveToolCalls.size > 0", "live-tool-call"),
         ("evtSource.readyState !== EventSource.OPEN", "stream-OPENness"),
     ):
         assert term in gate_code, (
@@ -823,7 +823,7 @@ def test_coordinator_history_stale_latch_contract():
     )
     for term in (
         'busySource === "optimistic"',
-        ".conv-batch--running",
+        "liveToolCalls.size",
         "evtSource.readyState !== EventSource.OPEN",
     ):
         assert seedless_at < gate_code.index(term), (
@@ -838,6 +838,47 @@ def test_coordinator_history_stale_latch_contract():
         "_editAndResend flips busy before its POST and /rewind emits no "
         "state_change, so a busy term skips the truncation render the "
         "rewind exists to produce)."
+    )
+
+    # 8. Live-set discipline (r6): the tool-phase liveness signal is fed
+    #    ONLY by live SSE events and drained at settle/teardown edges —
+    #    and NO render path may touch it.  The r6 critical: the render's
+    #    own replay paints orphan batches with the same --running class
+    #    the live path uses, so a DOM-derived probe let one orphan paint
+    #    poison every seedless heal for the life of the page.
+    assert body.count("liveToolCalls.add(") == 2, (
+        "liveToolCalls must be fed by exactly the two live announce "
+        "events (tool_pending + tool_info)."
+    )
+    assert body.count("liveToolCalls.delete(") == 1, (
+        "tool_result must retire its call_id from the live set."
+    )
+    assert body.count("liveToolCalls.clear()") == 2, (
+        "the live set must drain at the settle edge (idle/error) AND at "
+        "closeStreamTransport — leftover ids are dead calls whose "
+        "results will never arrive."
+    )
+    fetch_end = body.index("\n  function ", fetch_start + 1)
+    fetch_body = body[fetch_start:fetch_end]
+    fetch_code = "\n".join(
+        line for line in fetch_body.splitlines() if not line.lstrip().startswith("//")
+    )
+    assert fetch_code.count("liveToolCalls") == 1, (
+        "refetchHistory may READ the live set exactly once (the gate) "
+        "and never write it — a render that touched liveness could "
+        "forge the very signal that guards it (the r6 lesson)."
+    )
+    # The seq stamp's PRODUCER must sit above the await, or the
+    # last-dispatch-wins gate is permanently vacuous (a stamp captured
+    # after the await always equals refetchSeq) — the twin of the
+    # refetchesInFlight bracket pin.
+    assert body.count("const seq = ++refetchSeq;") == 1, (
+        "refetchHistory must stamp its dispatch exactly once."
+    )
+    assert body.index("const seq = ++refetchSeq;", fetch_start) < awt, (
+        "the seq stamp must be captured BEFORE the await — captured "
+        "after, it always equals refetchSeq and the currency gate never "
+        "fires."
     )
 
 

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -712,7 +712,7 @@ def test_coordinator_history_stale_latch_contract():
         "exists to kill."
     )
     retry_arm = body.index("staleRetryTimer = setTimeout")
-    retry_fire = _strip_comments(body[retry_arm : retry_arm + 900])
+    retry_fire = _strip_comments(body[retry_arm : body.index("}, 2000);", retry_arm)])
     assert "!refetchesInFlight" in retry_fire, (
         "the retry's fire guard must yield to an in-flight refetch "
         "(mirrors interactive's !_replayQueue pin)."
@@ -803,9 +803,7 @@ def test_coordinator_history_stale_latch_contract():
         "the wipe must sit between the failure guard and the latch-clear "
         "— every gate skip above the wipe then leaves the latch set."
     )
-    gate_code = "\n".join(
-        line for line in body[hist_guard:wipe].splitlines() if not line.lstrip().startswith("//")
-    )
+    gate_code = _strip_comments(body[hist_guard:wipe])
     for term, why in (
         ("if (seq !== refetchSeq) return;", "dispatch-currency (seq)"),
         (
@@ -875,9 +873,7 @@ def test_coordinator_history_stale_latch_contract():
         "anywhere else either leaks dead ids (gate stuck) or drains live "
         "ones (gate forged open)."
     )
-    cst_code = "\n".join(
-        line for line in cst_slice.splitlines() if not line.lstrip().startswith("//")
-    )
+    cst_code = _strip_comments(cst_slice)
     assert "liveToolCalls" not in cst_code, (
         "closeStreamTransport must not touch the live set (r7): transport "
         "death is not a retirement event — a stale id fails CLOSED, an "
@@ -900,18 +896,12 @@ def test_coordinator_history_stale_latch_contract():
         )
     fetch_end = body.index("\n  function ", fetch_start + 1)
     fetch_body = body[fetch_start:fetch_end]
-    fetch_code = "\n".join(
-        line for line in fetch_body.splitlines() if not line.lstrip().startswith("//")
-    )
+    fetch_code = _strip_comments(fetch_body)
     assert fetch_code.count("liveToolCalls") == 1, (
         "refetchHistory may READ the live set exactly once (the gate) "
         "and never write it — a render that touched liveness could "
         "forge the very signal that guards it (the r6 lesson)."
     )
-    # The seq stamp's PRODUCER must sit above the await, or the
-    # last-dispatch-wins gate is permanently vacuous (a stamp captured
-    # after the await always equals refetchSeq) — the twin of the
-    # refetchesInFlight bracket pin.
     # The await must be BOUNDED (r7): an accepted-but-never-answered
     # /history would pin refetchesInFlight above zero for the life of
     # the page and every heal would yield forever.
@@ -921,6 +911,10 @@ def test_coordinator_history_stale_latch_contract():
         "unbounded await pins the in-flight counter and permanently "
         "disables both heals."
     )
+    # The seq stamp's PRODUCER must sit above the await, or the
+    # last-dispatch-wins gate is permanently vacuous (a stamp captured
+    # after the await always equals refetchSeq) — the twin of the
+    # refetchesInFlight bracket pin.
     assert body.count("const seq = ++refetchSeq;") == 1, (
         "refetchHistory must stamp its dispatch exactly once."
     )
@@ -928,6 +922,62 @@ def test_coordinator_history_stale_latch_contract():
         "the seq stamp must be captured BEFORE the await — captured "
         "after, it always equals refetchSeq and the currency gate never "
         "fires."
+    )
+
+    # The bound must actually be WIRED (r8): the signal must reach
+    # getJSON and getJSON must forward its init — the pinned abort/
+    # clearTimeout strings alone survive a dead bound.
+    assert "{ signal: histCtrl.signal }" in fetch_code, (
+        "the abort signal must reach the fetch — an unforwarded "
+        "controller aborts nothing and the await is unbounded again."
+    )
+    assert "function getJSON(url, init)" in body and (
+        'Object.assign({ credentials: "include" }, init || {})' in body
+    ), (
+        "getJSON must forward its init while preserving credentials — "
+        "narrowing it back to getJSON(url) silently unwires the bound."
+    )
+    # destroy() must abort the in-flight fetch (dead-not-inert, the
+    # staleRetryTimer ruling applied to the r7 bound).
+    assert "activeHistCtrl.abort()" in _strip_comments(destroy_slice), (
+        "destroy() must abort any in-flight /history — the 15s bound "
+        "alone pins the destroyed closure until it fires."
+    )
+
+    # 9. Rewind-freshness epoch (r8): the #884 single-flight can hand a
+    #    joiner a pre-rewind payload; only a dispatch that post-dates
+    #    the latest clear_ui may CLEAR the latch.  Producer: the bump
+    #    sits in the clear_ui case before the latch set; the capture
+    #    sits beside seq, before the await; the clear is conditional.
+    assert body.count("clearUiEpoch++;") == 1, (
+        "clearUiEpoch must bump in exactly one place (clear_ui arrival)."
+    )
+    cu_case = body.index('case "clear_ui"')
+    bump = body.index("clearUiEpoch++;")
+    assert cu_case < bump < set_site, (
+        "the epoch bump must sit inside the clear_ui case BEFORE the "
+        "latch set, so the pre-rewind flight window is stamped closed "
+        "before any dispatch can capture the old epoch."
+    )
+    assert body.count("const epoch = clearUiEpoch;") == 1, (
+        "refetchHistory must capture the epoch exactly once."
+    )
+    assert body.index("const epoch = clearUiEpoch;", fetch_start) < awt, (
+        "the epoch capture must sit BEFORE the await, beside seq."
+    )
+    assert "if (epoch === clearUiEpoch) {" in fetch_code, (
+        "the latch clear must be epoch-conditional — an unconditional "
+        "clear lets a joined pre-rewind #884 flight reopen the "
+        "over-rewind window through the server seam."
+    )
+    epoch_gate = body.index("if (epoch === clearUiEpoch) {", fetch_start)
+    assert wipe < epoch_gate, (
+        "the epoch condition guards the CLEAR (below the wipe), not the "
+        "render — a pre-rewind payload may paint (stale-but-real) but "
+        "must not clear the latch."
+    )
+    assert body.index("historyStale = false;", fetch_start) > epoch_gate, (
+        "the latch clear must sit inside the epoch-conditional block."
     )
 
 

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -698,6 +698,17 @@ def test_coordinator_history_stale_latch_contract():
         "re-arming on a newer clear_ui must cancel the pending timer "
         "first, or a double clear_ui leaks a timer."
     )
+    # The consumer pins above are only meaningful while the PRODUCER
+    # brackets every fetch: without the ++/-- pair the counter is
+    # permanently 0 and both yield guards pass vacuously.
+    assert body.count("refetchesInFlight++") == 1, (
+        "refetchHistory must increment the in-flight counter before its "
+        "await — the yield guards read it."
+    )
+    assert body.count("refetchesInFlight--") == 1, (
+        "the in-flight counter must decrement in exactly one place (the "
+        "fetch finally) so every exit rebalances it."
+    )
 
     # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.
     destroy_slice = body[body.index("function destroy()") :]

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -600,6 +600,13 @@ def test_coordinator_history_stale_latch_contract():
       6. destroy() cancels staleRetryTimer (terminal-only) while
          closeStreamTransport does NOT (transport redials keep the heal
          intent alive).
+      7. The render-time gate (r5-derived): refetchHistory re-checks
+         DOM-live-state (content refs / the --running batch marker / the optimistic-send
+         flavor of busy — never plain busy, the r5 critical), dispatch
+         currency (seq), and seedless stream-OPENness AFTER the await and
+         BEFORE the wipe — and the latch-clear sits below every skip
+         point, so a skipped render can never reopen the affordances over
+         a stale DOM.
     """
     from pathlib import Path
 
@@ -704,21 +711,26 @@ def test_coordinator_history_stale_latch_contract():
         "(mirrors interactive's !_replayQueue pin)."
     )
     assert "visHandler" in retry_fire, (
-        "the retry's fire guard must carry the teardown sentinel — it is "
-        "the SOLE protection for the coordCloseSession path, which nulls "
-        "visHandler but does not cancel the timer."
+        "the retry's fire guard must carry the teardown sentinel for the "
+        "coordCloseSession path, which nulls visHandler but does not "
+        "cancel the timer (evtSource is also null there post-suspend, "
+        "but the sentinel is the durable term)."
     )
     assert "!currentAssistantEl" in retry_fire and "!currentReasoningEl" in retry_fire, (
-        "the retry's ref guards are LOAD-BEARING (coord's refetchHistory "
-        "does not reset streaming refs) — must not be deleted to match "
-        "interactive's quiesce-protected shape."
+        "the retry's ref guards skip a pointless fetch whose payload the "
+        "render-time gate would discard (the chokepoint carries the "
+        "correctness; these are the efficiency layer — keep them)."
     )
-    assert "visHandler &&\n                  evtSource\n                ) {" in body, (
-        "the retry's fire guard must require a live stream (evtSource): "
-        "close-on-hide keeps this timer armed by design, and a seedless "
-        "heal on a dead stream renders past the frozen cursor (replay "
-        "double-render on the show edge).  Exact-tail pin so a comment "
-        "mention cannot satisfy it; re-anchor if the guard reflows."
+    assert (
+        "visHandler &&\n                  evtSource &&\n"
+        "                  evtSource.readyState === EventSource.OPEN\n"
+        "                ) {" in body
+    ), (
+        "the retry's fire guard must require an OPEN stream — not handle "
+        "existence: CONNECTING keeps the handle with a frozen cursor and "
+        "a pending replay, and a seedless heal then double-renders when "
+        "the replay lands.  Exact-tail pin so a comment mention cannot "
+        "satisfy it; re-anchor if the guard reflows."
     )
     assert "if (staleRetryTimer) clearTimeout(staleRetryTimer);" in body, (
         "re-arming on a newer clear_ui must cancel the pending timer "
@@ -748,24 +760,6 @@ def test_coordinator_history_stale_latch_contract():
         "the very window the yield guards protect."
     )
 
-    # 7. Render-time gate: the post-await re-checks must sit between the
-    #    failure guard and the wipe.  The await is a real window — a turn
-    #    can START mid-fetch (refs re-check; a wipe then would detach the
-    #    live bubble and lose the turn into the dangling ref), and a
-    #    seedless render must not paint past a frozen cursor when the
-    #    stream died mid-fetch (hide/suspend) or the show-edge replay
-    #    double-renders.  Caller-side guards cannot see across the await;
-    #    only this chokepoint can.
-    hist_guard = body.index("if (!hist) return;", fetch_start)
-    ref_gate = body.index("if (currentAssistantEl || currentReasoningEl) return;", fetch_start)
-    live_gate = body.index("if (!seedCursor && (busy || !evtSource)) return;", fetch_start)
-    wipe = body.index("messagesEl.replaceChildren();", fetch_start)
-    assert hist_guard < ref_gate < wipe and hist_guard < live_gate < wipe, (
-        "refetchHistory must re-check the live-turn refs AND seedless "
-        "stream-liveness AFTER the await and BEFORE the wipe — the "
-        "render-time correctness carrier for every caller."
-    )
-
     # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.
     destroy_slice = body[body.index("function destroy()") :]
     destroy_slice = destroy_slice[: destroy_slice.index("\n  function ")]
@@ -778,6 +772,72 @@ def test_coordinator_history_stale_latch_contract():
     assert "clearTimeout(staleRetryTimer)" not in cst_slice, (
         "closeStreamTransport must NOT cancel the stale retry — transport "
         "redials keep the pending heal intent (terminal-only cancel)."
+    )
+
+    # 7. Render-time gate (r5-derived, seedless-scoped after the
+    #    coord-restart family find): the post-await re-checks sit between
+    #    the failure guard and the wipe, so the latch-clear (below the
+    #    wipe) sits below every skip point by construction.  Universal
+    #    terms: dispatch currency (seq) and the content refs (skipping
+    #    always beats stranding a ref; seeded callers null theirs before
+    #    fetching, so it never blocks them).  SEEDLESS-only terms —
+    #    keyed on the seedCursor ARG: the .conv-batch--running marker
+    #    (on a live stream it means results are streaming into those
+    #    rows; on the SEEDED resync it can be a dead turn's residue and
+    #    the render IS the recovery — a universal term wedged
+    #    coord-restart outright), the optimistic-send busySource flavor,
+    #    and stream-OPENness (CONNECTING keeps the handle with a frozen
+    #    cursor and a pending replay).  Plain ``busy`` must not appear:
+    #    it means a turn is EXECUTING, not that this DOM holds live
+    #    state (the r5 critical).
+    hist_guard = body.index("if (!hist) return;", fetch_start)
+    wipe = body.index("messagesEl.replaceChildren();", fetch_start)
+    latch_clear = body.index("historyStale = false;", fetch_start)
+    assert hist_guard < wipe < latch_clear, (
+        "the wipe must sit between the failure guard and the latch-clear "
+        "— every gate skip above the wipe then leaves the latch set."
+    )
+    gate_code = "\n".join(
+        line for line in body[hist_guard:wipe].splitlines() if not line.lstrip().startswith("//")
+    )
+    for term, why in (
+        ("if (seq !== refetchSeq) return;", "dispatch-currency (seq)"),
+        (
+            "if (currentAssistantEl || currentReasoningEl) return;",
+            "universal content-ref",
+        ),
+        ("!seedCursor &&", "seedless scoping"),
+        ('busySource === "optimistic"', "optimistic-row"),
+        ('messagesEl.querySelector(".conv-batch--running")', "executing-batch"),
+        ("evtSource.readyState !== EventSource.OPEN", "stream-OPENness"),
+    ):
+        assert term in gate_code, (
+            f"the render-time gate must carry the {why} term (in CODE, not a comment)."
+        )
+    seedless_at = gate_code.index("!seedCursor &&")
+    assert gate_code.index("if (seq !== refetchSeq) return;") < seedless_at, (
+        "seq currency must be checked before the seedless group."
+    )
+    assert gate_code.index("if (currentAssistantEl || currentReasoningEl) return;") < seedless_at, (
+        "the universal ref check must precede the seedless group."
+    )
+    for term in (
+        'busySource === "optimistic"',
+        ".conv-batch--running",
+        "evtSource.readyState !== EventSource.OPEN",
+    ):
+        assert seedless_at < gate_code.index(term), (
+            f"{term} must live INSIDE the !seedCursor group — the seeded "
+            "resync renders over a dead --running batch / an optimistic "
+            "row deliberately (blocking it wedges the coord-restart "
+            "recovery)."
+        )
+    assert not re.search(r"\bbusy\b(?!Source)", gate_code), (
+        "plain busy must not gate the render — busy means a turn is "
+        "EXECUTING, not that this DOM holds live state (the r5 critical: "
+        "_editAndResend flips busy before its POST and /rewind emits no "
+        "state_change, so a busy term skips the truncation render the "
+        "rewind exists to produce)."
     )
 
 

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -558,8 +558,9 @@ def test_coordinator_refetch_failure_preserves_the_pane():
     body = coord_js.read_text(encoding="utf-8")
     start = body.index("async function refetchHistory(seedCursor = false)")
     # Window sized to reach the early-reset block past the #894 latch-clear
-    # comments; the pinned invariant is the ORDER below, not the density.
-    fn = body[start : start + 5000]
+    # and render-gate comments; the pinned invariant is the ORDER below,
+    # not the density.
+    fn = body[start : start + 8000]
     guard = fn.index("if (!hist) return;")
     wipe = fn.index("messagesEl.replaceChildren();")
     resets = fn.index("toolRows.clear();")
@@ -651,9 +652,16 @@ def test_coordinator_history_stale_latch_contract():
     )
 
     # 4. Transport-free backstop: the arm after the truncated consumer
-    #    refetches over REST and never reconnects.
+    #    refetches over REST and never reconnects — and it must be the
+    #    ELSE-IF of the truncated consumer (mutual exclusion: the
+    #    truncated branch's own reload heals the latch too; two separate
+    #    ifs would run both heals on one idle edge).
     trunc_arm = body.index("if (pendingTruncatedResync)")
     backstop = body.index("historyStale &&", trunc_arm)
+    assert "} else if (" in body[trunc_arm:backstop], (
+        "the staleness backstop must be the else-if sibling of the "
+        "pendingTruncatedResync consumer, never an independent if."
+    )
     idle_block_end = body.index('ev.state === "running"', backstop)
     backstop_arm = body[backstop:idle_block_end]
     assert "refetchHistory();" in backstop_arm, (
@@ -668,6 +676,12 @@ def test_coordinator_history_stale_latch_contract():
         "the backstop must yield to an in-flight refetch — without the "
         "guard it stomps a same-snapshot fetch with a double render "
         "(mirrors interactive's !_replayQueue pin)."
+    )
+    assert "!currentAssistantEl" in backstop_arm and "!currentReasoningEl" in backstop_arm, (
+        "the backstop's ref guards are LOAD-BEARING (coord's "
+        "refetchHistory does not reset streaming refs, and this arm "
+        "serves error edges where no stream_end nulled them) — a "
+        "simplify-to-match-interactive edit must not delete them."
     )
 
     # 5. Bounded retry: exactly one arm site; the ARM is teardown-gated;
@@ -694,13 +708,28 @@ def test_coordinator_history_stale_latch_contract():
         "the SOLE protection for the coordCloseSession path, which nulls "
         "visHandler but does not cancel the timer."
     )
+    assert "!currentAssistantEl" in retry_fire and "!currentReasoningEl" in retry_fire, (
+        "the retry's ref guards are LOAD-BEARING (coord's refetchHistory "
+        "does not reset streaming refs) — must not be deleted to match "
+        "interactive's quiesce-protected shape."
+    )
+    assert "visHandler &&\n                  evtSource\n                ) {" in body, (
+        "the retry's fire guard must require a live stream (evtSource): "
+        "close-on-hide keeps this timer armed by design, and a seedless "
+        "heal on a dead stream renders past the frozen cursor (replay "
+        "double-render on the show edge).  Exact-tail pin so a comment "
+        "mention cannot satisfy it; re-anchor if the guard reflows."
+    )
     assert "if (staleRetryTimer) clearTimeout(staleRetryTimer);" in body, (
         "re-arming on a newer clear_ui must cancel the pending timer "
         "first, or a double clear_ui leaks a timer."
     )
     # The consumer pins above are only meaningful while the PRODUCER
     # brackets every fetch: without the ++/-- pair the counter is
-    # permanently 0 and both yield guards pass vacuously.
+    # permanently 0 and both yield guards pass vacuously.  Count alone
+    # is not enough — the ORDER is the bracket (an increment moved below
+    # the await leaves the counter 0 during every fetch with both counts
+    # intact), so pin inc < await < finally < dec inside refetchHistory.
     assert body.count("refetchesInFlight++") == 1, (
         "refetchHistory must increment the in-flight counter before its "
         "await — the yield guards read it."
@@ -708,6 +737,33 @@ def test_coordinator_history_stale_latch_contract():
     assert body.count("refetchesInFlight--") == 1, (
         "the in-flight counter must decrement in exactly one place (the "
         "fetch finally) so every exit rebalances it."
+    )
+    inc = body.index("refetchesInFlight++", fetch_start)
+    awt = body.index("await getJSON(", fetch_start)
+    fin = body.index("} finally {", fetch_start)
+    dec = body.index("refetchesInFlight--", fetch_start)
+    assert inc < awt < fin < dec, (
+        "the counter must bracket the await window: increment BEFORE the "
+        "fetch, decrement in its finally — any other order un-brackets "
+        "the very window the yield guards protect."
+    )
+
+    # 7. Render-time gate: the post-await re-checks must sit between the
+    #    failure guard and the wipe.  The await is a real window — a turn
+    #    can START mid-fetch (refs re-check; a wipe then would detach the
+    #    live bubble and lose the turn into the dangling ref), and a
+    #    seedless render must not paint past a frozen cursor when the
+    #    stream died mid-fetch (hide/suspend) or the show-edge replay
+    #    double-renders.  Caller-side guards cannot see across the await;
+    #    only this chokepoint can.
+    hist_guard = body.index("if (!hist) return;", fetch_start)
+    ref_gate = body.index("if (currentAssistantEl || currentReasoningEl) return;", fetch_start)
+    live_gate = body.index("if (!seedCursor && (busy || !evtSource)) return;", fetch_start)
+    wipe = body.index("messagesEl.replaceChildren();", fetch_start)
+    assert hist_guard < ref_gate < wipe and hist_guard < live_gate < wipe, (
+        "refetchHistory must re-check the live-turn refs AND seedless "
+        "stream-liveness AFTER the await and BEFORE the wipe — the "
+        "render-time correctness carrier for every caller."
     )
 
     # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -665,6 +665,9 @@ def test_coordinator_history_stale_latch_contract():
     #    ELSE-IF of the truncated consumer (mutual exclusion: the
     #    truncated branch's own reload heals the latch too; two separate
     #    ifs would run both heals on one idle edge).
+    def _strip_comments(text: str) -> str:
+        return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("//"))
+
     trunc_arm = body.index("if (pendingTruncatedResync)")
     backstop = body.index("historyStale &&", trunc_arm)
     assert "} else if (" in body[trunc_arm:backstop], (
@@ -672,7 +675,9 @@ def test_coordinator_history_stale_latch_contract():
         "pendingTruncatedResync consumer, never an independent if."
     )
     idle_block_end = body.index('ev.state === "running"', backstop)
-    backstop_arm = body[backstop:idle_block_end]
+    # Comment-stripped: the arm's at-site ruling comments name every
+    # guard term, so raw-window presence asserts would go vacuous.
+    backstop_arm = _strip_comments(body[backstop:idle_block_end])
     assert "refetchHistory();" in backstop_arm, (
         "the staleness backstop must heal via a plain seedless refetchHistory()."
     )
@@ -707,7 +712,7 @@ def test_coordinator_history_stale_latch_contract():
         "exists to kill."
     )
     retry_arm = body.index("staleRetryTimer = setTimeout")
-    retry_fire = body[retry_arm : retry_arm + 700]
+    retry_fire = _strip_comments(body[retry_arm : retry_arm + 900])
     assert "!refetchesInFlight" in retry_fire, (
         "the retry's fire guard must yield to an in-flight refetch "
         "(mirrors interactive's !_replayQueue pin)."
@@ -781,13 +786,14 @@ def test_coordinator_history_stale_latch_contract():
     #    terms: dispatch currency (seq) and the content refs (skipping
     #    always beats stranding a ref; seeded callers null theirs before
     #    fetching, so it never blocks them).  SEEDLESS-only terms —
-    #    keyed on the seedCursor ARG: the .conv-batch--running marker
-    #    (on a live stream it means results are streaming into those
-    #    rows; on the SEEDED resync it can be a dead turn's residue and
-    #    the render IS the recovery — a universal term wedged
-    #    coord-restart outright), the optimistic-send busySource flavor,
-    #    and stream-OPENness (CONNECTING keeps the handle with a frozen
-    #    cursor and a pending replay).  Plain ``busy`` must not appear:
+    #    keyed on the seedCursor ARG: the event-driven live-tool-call
+    #    set (liveToolCalls — never a DOM probe, which the render's own
+    #    orphan repaint forges: the r6 critical; on the SEEDED resync
+    #    even genuine residue must not block — the render IS the
+    #    recovery, and a universal term wedged coord-restart outright),
+    #    the optimistic-send busySource flavor, and stream-OPENness
+    #    (CONNECTING keeps the handle with a frozen cursor and a
+    #    pending replay).  Plain ``busy`` must not appear:
     #    it means a turn is EXECUTING, not that this DOM holds live
     #    state (the r5 critical).
     hist_guard = body.index("if (!hist) return;", fetch_start)
@@ -853,11 +859,45 @@ def test_coordinator_history_stale_latch_contract():
     assert body.count("liveToolCalls.delete(") == 1, (
         "tool_result must retire its call_id from the live set."
     )
-    assert body.count("liveToolCalls.clear()") == 2, (
-        "the live set must drain at the settle edge (idle/error) AND at "
-        "closeStreamTransport — leftover ids are dead calls whose "
-        "results will never arrive."
+    assert body.count("liveToolCalls.clear()") == 1, (
+        "the live set must drain at the settle edge ONLY — a "
+        "closeStreamTransport drain fails OPEN (the reconnect replay "
+        "does not re-announce a live batch, so an emptied set lets a "
+        "post-redial seedless render wipe the live batch: the r7 major)."
     )
+    settle_block = body[
+        body.index('if (ev.state === "idle" || ev.state === "error") {') : body.index(
+            'ev.state === "running"'
+        )
+    ]
+    assert "liveToolCalls.clear()" in settle_block, (
+        "the one drain must sit inside the idle/error settle block — "
+        "anywhere else either leaks dead ids (gate stuck) or drains live "
+        "ones (gate forged open)."
+    )
+    cst_code = "\n".join(
+        line for line in cst_slice.splitlines() if not line.lstrip().startswith("//")
+    )
+    assert "liveToolCalls" not in cst_code, (
+        "closeStreamTransport must not touch the live set (r7): transport "
+        "death is not a retirement event — a stale id fails CLOSED, an "
+        "emptied set fails OPEN into the wipe.  (The at-site ruling "
+        "comment may name it; the CODE may not.)"
+    )
+    tool_result_block = body[
+        body.index('case "tool_result":') : body.index(
+            "case ", body.index('case "tool_result":') + 10
+        )
+    ]
+    assert "liveToolCalls.delete(" in tool_result_block, (
+        "tool_result must retire its call_id inside its own case arm."
+    )
+    for case_name in ('case "tool_pending":', 'case "tool_info":'):
+        case_block = body[body.index(case_name) : body.index("break;", body.index(case_name))]
+        assert "liveToolCalls.add(" in case_block, (
+            f"{case_name} must feed the live set inside its own case arm "
+            "(the live announce events are the ONLY producers)."
+        )
     fetch_end = body.index("\n  function ", fetch_start + 1)
     fetch_body = body[fetch_start:fetch_end]
     fetch_code = "\n".join(
@@ -872,6 +912,15 @@ def test_coordinator_history_stale_latch_contract():
     # last-dispatch-wins gate is permanently vacuous (a stamp captured
     # after the await always equals refetchSeq) — the twin of the
     # refetchesInFlight bracket pin.
+    # The await must be BOUNDED (r7): an accepted-but-never-answered
+    # /history would pin refetchesInFlight above zero for the life of
+    # the page and every heal would yield forever.
+    assert "histCtrl.abort()" in fetch_code and "clearTimeout(histTimer)" in fetch_code, (
+        "refetchHistory must bound its fetch with the AbortController + "
+        "flat-timeout shape (and clear the timer in the finally) — an "
+        "unbounded await pins the in-flight counter and permanently "
+        "disables both heals."
+    )
     assert body.count("const seq = ++refetchSeq;") == 1, (
         "refetchHistory must stamp its dispatch exactly once."
     )

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -943,6 +943,21 @@ def test_coordinator_history_stale_latch_contract():
     )
     # destroy() must abort the in-flight fetch (dead-not-inert, the
     # staleRetryTimer ruling applied to the r7 bound).
+    # Producer pins first — the destroy() consumer sweep below is
+    # satisfiable by an always-empty Set without them.
+    assert body.count("histCtrls.add(histCtrl)") == 1, (
+        "every dispatch must register its controller in the abort Set."
+    )
+    assert body.count("histCtrls.delete(histCtrl)") == 1, (
+        "the fetch finally must release its own controller — without the "
+        "delete the Set grows for the life of the pane."
+    )
+    assert body.index("histCtrls.add(histCtrl)", fetch_start) < awt, (
+        "the controller must be registered BEFORE the await."
+    )
+    assert fin < body.index("histCtrls.delete(histCtrl)", fetch_start), (
+        "the controller release must sit in the fetch finally."
+    )
     destroy_code = _strip_comments(destroy_slice)
     assert "histCtrls.forEach" in destroy_code and ".abort()" in destroy_code, (
         "destroy() must abort EVERY in-flight /history (a Set — a "

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -664,11 +664,22 @@ def test_coordinator_history_stale_latch_contract():
         "reconnect — a reload's fresh reconnect draws the synthetic "
         "state_change:idle back into this trigger (zero-backoff storm)."
     )
+    assert "!refetchesInFlight" in backstop_arm, (
+        "the backstop must yield to an in-flight refetch — without the "
+        "guard it stomps a same-snapshot fetch with a double render "
+        "(mirrors interactive's !_replayQueue pin)."
+    )
 
-    # 5. Bounded retry: exactly one arm site.
+    # 5. Bounded retry: exactly one arm site, and its fire guard yields to
+    #    an in-flight fetch.
     assert body.count("staleRetryTimer = setTimeout") == 1, (
         "the stale retry must be armed in exactly one place (clear_ui "
         ".then) — bounded by construction."
+    )
+    retry_arm = body.index("staleRetryTimer = setTimeout")
+    assert "!refetchesInFlight" in body[retry_arm : retry_arm + 700], (
+        "the retry's fire guard must yield to an in-flight refetch "
+        "(mirrors interactive's !_replayQueue pin)."
     )
 
     # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -608,7 +608,11 @@ def test_coordinator_history_stale_latch_contract():
          the r6 critical; never plain busy — the r5 critical), the
          optimistic busySource flavor, and stream-OPENness.  The
          latch-clear sits below every skip point, so a skipped render
-         can never reopen the affordances over a stale DOM.
+         can never reopen the affordances over a stale DOM.  (Joined
+         pre-rewind server flights are closed SERVER-side — the #884
+         flight key folds in the truncation generation; an r8
+         client-epoch guard here was unreachable, being redundant with
+         the seq gate, and was removed in r9.)
     """
     from pathlib import Path
 
@@ -939,45 +943,12 @@ def test_coordinator_history_stale_latch_contract():
     )
     # destroy() must abort the in-flight fetch (dead-not-inert, the
     # staleRetryTimer ruling applied to the r7 bound).
-    assert "activeHistCtrl.abort()" in _strip_comments(destroy_slice), (
-        "destroy() must abort any in-flight /history — the 15s bound "
-        "alone pins the destroyed closure until it fires."
-    )
-
-    # 9. Rewind-freshness epoch (r8): the #884 single-flight can hand a
-    #    joiner a pre-rewind payload; only a dispatch that post-dates
-    #    the latest clear_ui may CLEAR the latch.  Producer: the bump
-    #    sits in the clear_ui case before the latch set; the capture
-    #    sits beside seq, before the await; the clear is conditional.
-    assert body.count("clearUiEpoch++;") == 1, (
-        "clearUiEpoch must bump in exactly one place (clear_ui arrival)."
-    )
-    cu_case = body.index('case "clear_ui"')
-    bump = body.index("clearUiEpoch++;")
-    assert cu_case < bump < set_site, (
-        "the epoch bump must sit inside the clear_ui case BEFORE the "
-        "latch set, so the pre-rewind flight window is stamped closed "
-        "before any dispatch can capture the old epoch."
-    )
-    assert body.count("const epoch = clearUiEpoch;") == 1, (
-        "refetchHistory must capture the epoch exactly once."
-    )
-    assert body.index("const epoch = clearUiEpoch;", fetch_start) < awt, (
-        "the epoch capture must sit BEFORE the await, beside seq."
-    )
-    assert "if (epoch === clearUiEpoch) {" in fetch_code, (
-        "the latch clear must be epoch-conditional — an unconditional "
-        "clear lets a joined pre-rewind #884 flight reopen the "
-        "over-rewind window through the server seam."
-    )
-    epoch_gate = body.index("if (epoch === clearUiEpoch) {", fetch_start)
-    assert wipe < epoch_gate, (
-        "the epoch condition guards the CLEAR (below the wipe), not the "
-        "render — a pre-rewind payload may paint (stale-but-real) but "
-        "must not clear the latch."
-    )
-    assert body.index("historyStale = false;", fetch_start) > epoch_gate, (
-        "the latch clear must sit inside the epoch-conditional block."
+    destroy_code = _strip_comments(destroy_slice)
+    assert "histCtrls.forEach" in destroy_code and ".abort()" in destroy_code, (
+        "destroy() must abort EVERY in-flight /history (a Set — a "
+        "newest-wins single slot left older overlapping fetches "
+        "unabortable); the 15s bound alone pins the destroyed closure "
+        "until it fires."
     )
 
 

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -557,7 +557,9 @@ def test_coordinator_refetch_failure_preserves_the_pane():
     )
     body = coord_js.read_text(encoding="utf-8")
     start = body.index("async function refetchHistory(seedCursor = false)")
-    fn = body[start : start + 3000]
+    # Window sized to reach the early-reset block past the #894 latch-clear
+    # comments; the pinned invariant is the ORDER below, not the density.
+    fn = body[start : start + 5000]
     guard = fn.index("if (!hist) return;")
     wipe = fn.index("messagesEl.replaceChildren();")
     resets = fn.index("toolRows.clear();")
@@ -567,6 +569,121 @@ def test_coordinator_refetch_failure_preserves_the_pane():
         "a DOM no-op."
     )
     assert re.search(r"if \(!hist\) return;", fn), "failure guard missing"
+
+
+def test_coordinator_history_stale_latch_contract():
+    """#894 (the #890 port): a rewind/edit clicked during a clear_ui refetch
+    window — or after a FAILED refetch — must not count the stale pre-rewind
+    DOM.  Pins the latch's structural contract:
+
+      1. clear_ui sets ``historyStale = true`` BEFORE its seedless
+         ``refetchHistory()`` call (the only set site), so the gate closes
+         for the whole fetch window.
+      2. The DOM-counting affordances gate on ``busy || historyStale``
+         (_rewindToMessage / _editAndResend / _startEdit); _rewindToTurns
+         and _retryLast stay busy-only (explicit-arg / no-DOM-count paths —
+         the at-site rulings).
+      3. ``historyStale = false`` lives ONLY below the ``if (!hist)
+         return;`` failure guard in refetchHistory: a failed fetch keeps
+         the latch set (a refetch-in-flight flag would reopen on exactly
+         that exit — the over-rewind aftermath).
+      4. The idle-edge backstop is TRANSPORT-FREE: the arm behind the
+         pendingTruncatedResync consumer heals via plain
+         ``refetchHistory()``, never ``loadHistoryThenReconnect()`` —
+         a reconnecting heal draws the server's synthetic
+         state_change:idle back into its own trigger (the #890 round-5
+         zero-backoff storm).
+      5. The retry is bounded by construction: ``staleRetryTimer =
+         setTimeout`` appears exactly once (the clear_ui .then), so no
+         path — including the retry's own — can re-arm it.
+      6. destroy() cancels staleRetryTimer (terminal-only) while
+         closeStreamTransport does NOT (transport redials keep the heal
+         intent alive).
+    """
+    from pathlib import Path
+
+    coord_js = Path(__file__).resolve().parent.parent / (
+        "turnstone/console/static/coordinator/coordinator.js"
+    )
+    body = coord_js.read_text(encoding="utf-8")
+
+    # 1. Set site: inside the clear_ui case, before the refetch call.
+    assert body.count("historyStale = true;") == 1, (
+        "historyStale must be set in exactly one place (clear_ui arrival)."
+    )
+    clear_case = body.index('case "clear_ui"')
+    set_site = body.index("historyStale = true;")
+    refetch_call = body.index("refetchHistory()", clear_case)
+    assert clear_case < set_site < refetch_call, (
+        "clear_ui must latch historyStale BEFORE calling refetchHistory() "
+        "so the gate covers the whole fetch window."
+    )
+
+    # 2. Gates: DOM-counting affordances latch-gated; explicit-arg /
+    #    no-count paths stay busy-only.
+    def _fn_slice(name: str) -> str:
+        start = body.index("function " + name)
+        return body[start : body.index("\n  function ", start + 1)]
+
+    for gated in ("_rewindToMessage", "_editAndResend", "_startEdit"):
+        assert "if (busy || historyStale) return;" in _fn_slice(gated), (
+            f"{gated} must gate on busy || historyStale (#894)."
+        )
+    for ungated in ("_rewindToTurns", "_retryLast"):
+        sl = _fn_slice(ungated)
+        assert "if (busy) return;" in sl and "busy || historyStale" not in sl, (
+            f"{ungated} must stay busy-only (at-site ruling: explicit turn "
+            "count / no DOM count — latch-gating it blocks legitimate calls)."
+        )
+
+    # 3. Clear site: exactly one assignment to false (past the decl),
+    #    below the failure guard.
+    clears = re.findall(r"(?<!let )historyStale = false;", body)
+    assert len(clears) == 1, (
+        "historyStale must clear in exactly one place (refetchHistory's success path)."
+    )
+    fetch_start = body.index("async function refetchHistory(seedCursor = false)")
+    guard = body.index("if (!hist) return;", fetch_start)
+    clear_site = body.index("historyStale = false;", fetch_start)
+    assert guard < clear_site, (
+        "the latch clear must sit BELOW the failure guard — a failed fetch "
+        "keeps the latch set (that survival arms the retry/backstop)."
+    )
+
+    # 4. Transport-free backstop: the arm after the truncated consumer
+    #    refetches over REST and never reconnects.
+    trunc_arm = body.index("if (pendingTruncatedResync)")
+    backstop = body.index("historyStale &&", trunc_arm)
+    idle_block_end = body.index('ev.state === "running"', backstop)
+    backstop_arm = body[backstop:idle_block_end]
+    assert "refetchHistory();" in backstop_arm, (
+        "the staleness backstop must heal via a plain seedless refetchHistory()."
+    )
+    assert "loadHistoryThenReconnect();" not in backstop_arm, (
+        "TRANSPORT-FREE ruling: the staleness backstop must never "
+        "reconnect — a reload's fresh reconnect draws the synthetic "
+        "state_change:idle back into this trigger (zero-backoff storm)."
+    )
+
+    # 5. Bounded retry: exactly one arm site.
+    assert body.count("staleRetryTimer = setTimeout") == 1, (
+        "the stale retry must be armed in exactly one place (clear_ui "
+        ".then) — bounded by construction."
+    )
+
+    # 6. Teardown: terminal cancel in destroy(); NOT in closeStreamTransport.
+    destroy_slice = body[body.index("function destroy()") :]
+    destroy_slice = destroy_slice[: destroy_slice.index("\n  function ")]
+    assert "clearTimeout(staleRetryTimer)" in destroy_slice, (
+        "destroy() must cancel the stale retry timer or it fires into "
+        "detached DOM (and pins the closure)."
+    )
+    cst_start = body.index("function closeStreamTransport()")
+    cst_slice = body[cst_start : body.index("\n  function ", cst_start + 1)]
+    assert "clearTimeout(staleRetryTimer)" not in cst_slice, (
+        "closeStreamTransport must NOT cancel the stale retry — transport "
+        "redials keep the pending heal intent (terminal-only cancel)."
+    )
 
 
 def test_coordinator_js_early_paints_pending_tool_calls():

--- a/tests/test_rewind_retry.py
+++ b/tests/test_rewind_retry.py
@@ -422,3 +422,66 @@ class TestRewindDBSync:
         assert len(db_msgs) == 2
         assert db_msgs[0]["content"] == "Hello"
         assert db_msgs[1]["content"] == "Hi!"
+
+
+def test_truncation_bumps_history_generation(tmp_db) -> None:
+    """#894: the /history single-flight keys on _history_generation, so a
+    truncation that DELETED storage rows must bump it — and a truncation
+    that could not delete (storage count unavailable/empty — the
+    error-path early returns) must NOT, because flights rebuild from
+    storage and an unbumped generation on error is the safe direction (a
+    stale-keyed flight reading post-delete rows is spuriously fresh; a
+    new-keyed flight reading pre-delete rows would be wrongly joinable).
+    The endpoint-level flight test mocks the counter, so this is the
+    PRODUCER pin: delete the bump in _persist_truncation and the first
+    arm fails while everything else stays green."""
+    from turnstone.core.storage import get_storage
+
+    storage = get_storage()
+    storage.register_workstream("ws-gen-pin", kind="interactive", user_id="test-user")
+    session = ChatSession(
+        client=MagicMock(),
+        model="test-model",
+        ui=NullUI(),
+        instructions="",
+        temperature=0.5,
+        max_tokens=4096,
+        tool_timeout=30,
+        ws_id="ws-gen-pin",
+    )
+    _populate_simple(session)
+    for role, content in (
+        ("user", "Hello"),
+        ("assistant", "Hi there!"),
+        ("user", "How are you?"),
+        ("assistant", "I'm fine."),
+    ):
+        storage.save_message("ws-gen-pin", role, content)
+
+    g0 = session._history_generation
+    assert session.rewind(1) > 0
+    assert session._history_generation == g0 + 1, (
+        "a storage-deleting rewind must bump the history generation"
+    )
+
+    # retry: re-persist the tail the rewind removed, then drop the last
+    # assistant turn.
+    storage.save_message("ws-gen-pin", "user", "How are you?")
+    storage.save_message("ws-gen-pin", "assistant", "I'm fine.")
+    _populate_simple(session)
+    g1 = session._history_generation
+    assert session.retry() is not None
+    assert session._history_generation == g1 + 1, (
+        "a storage-deleting retry must bump the history generation"
+    )
+
+    # Error-path arm: an in-memory-only session (no persisted rows — the
+    # count<=0 early return skips the delete) must NOT bump.
+    bare = _make_session(tmp_db)
+    _populate_simple(bare)
+    g2 = bare._history_generation
+    assert bare.rewind(1) > 0
+    assert bare._history_generation == g2, (
+        "a truncation that could not delete storage rows must leave the "
+        "generation unbumped (fail-safe direction)"
+    )

--- a/tests/test_rewind_retry.py
+++ b/tests/test_rewind_retry.py
@@ -77,7 +77,7 @@ class NullUI:
         pass
 
 
-def _make_session(tmp_db) -> ChatSession:
+def _make_session(tmp_db, ws_id: str | None = None) -> ChatSession:
     return ChatSession(
         client=MagicMock(),
         model="test-model",
@@ -86,6 +86,7 @@ def _make_session(tmp_db) -> ChatSession:
         temperature=0.5,
         max_tokens=4096,
         tool_timeout=30,
+        ws_id=ws_id,
     )
 
 
@@ -439,16 +440,7 @@ def test_truncation_bumps_history_generation(tmp_db) -> None:
 
     storage = get_storage()
     storage.register_workstream("ws-gen-pin", kind="interactive", user_id="test-user")
-    session = ChatSession(
-        client=MagicMock(),
-        model="test-model",
-        ui=NullUI(),
-        instructions="",
-        temperature=0.5,
-        max_tokens=4096,
-        tool_timeout=30,
-        ws_id="ws-gen-pin",
-    )
+    session = _make_session(tmp_db, ws_id="ws-gen-pin")
     _populate_simple(session)
     for role, content in (
         ("user", "Hello"),

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1659,6 +1659,55 @@ class TestHistoryCoalescing:
         assert contents == ["hello", "hi there"]
         assert gated.load_calls == 1
 
+    def test_history_rewind_mid_flight_starts_fresh_flight(
+        self, _inject_storage: Any, caplog: Any
+    ) -> None:
+        """#894: the flight key folds in the ws's truncation generation, so
+        a request dispatched AFTER a rewind/retry can never join a flight
+        whose ``load_messages`` ran before it.  A joined pre-rewind payload
+        reads as fresh truth client-side (the client's dispatch stamp is
+        current — the staleness is the flight's transaction point, which
+        only the server can see) and reopened the coordinator's
+        over-rewind window through this seam.
+
+        Choreography mirrors the join test's positive edges: the owner
+        parks in ``load_messages`` under generation 0; the mid-flight
+        rewind commit is simulated by bumping ``_history_generation``
+        (``ChatSession._persist_truncation``'s bump, the shared
+        rewind/retry chokepoint); the second request must MISS the held
+        flight (``load_calls`` -> 2, no ``ws.history.coalesced`` record)
+        and draw its own reconstruction."""
+        gated, _tenant_calls, app, url = self._scaffold(_inject_storage, "ws-flight-gen")
+        # The scaffold's MagicMock ws: pin the generation to a real int so
+        # the key is deterministic, as the live session attribute is.
+        mock_ws = app.state.workstreams.get("ws-flight-gen")
+        mock_ws._history_generation = 0
+
+        async def drive() -> tuple[httpx.Response, httpx.Response]:
+            caplog.set_level(logging.DEBUG, logger="turnstone.core.session_routes")
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+                t1 = asyncio.create_task(c.get(url))
+                await _until(lambda: gated.load_calls == 1)
+                # The rewind commits mid-flight: the truncation chokepoint
+                # bumps the generation.
+                mock_ws._history_generation = 1
+                t2 = asyncio.create_task(c.get(url))
+                # Positive edge for the MISS: t2's own load_messages entry
+                # bumps the counter before the gate can park it.
+                await _until(lambda: gated.load_calls == 2)
+                gated.gate.set()
+                r1, r2 = await asyncio.gather(t1, t2)
+                return r1, r2
+
+        r1, r2 = asyncio.run(drive())
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # Two reconstructions, zero joins: the post-rewind request never
+        # shared the pre-rewind flight.
+        assert gated.load_calls == 2
+        assert not any("ws.history.coalesced ws=" in rec.getMessage() for rec in caplog.records)
+
     def test_failed_shared_draw_not_fanned_out_to_joiner(
         self, _inject_storage: Any, caplog: Any
     ) -> None:

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1548,8 +1548,9 @@ class TestHistoryCoalescing:
     """Single-flight coalescing of concurrent ``/history`` requests (#884).
 
     The matrix these tests assert: join-vs-miss × gates-per-request ×
-    failed-vs-clean shared draw × key isolation × no cross-flight
-    caching × owner cancellation.  Driven through ``httpx.ASGITransport``
+    failed-vs-clean shared draw × key isolation (ws, limit, AND the
+    #894 truncation generation) × no cross-flight caching × owner
+    cancellation.  Driven through ``httpx.ASGITransport``
     on a private loop because ``TestClient`` cannot hold two requests in
     flight at once.
 

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -2401,6 +2401,9 @@ class TestHistoryReasoningRehydration:
         provider_data = json.dumps([{"type": "thinking", "thinking": "hidden", "signature": "s"}])
         _inject_storage.save_message(ws_id, "assistant", "Answer.", provider_data=provider_data)
         live_session = SimpleNamespace(
+            # The real Workstream carries .session (ChatSession | None);
+            # the flight key's typed generation read requires the shape.
+            session=None,
             id=ws_id,
             _registry=SimpleNamespace(
                 get_config=lambda alias: SimpleNamespace(surface_persisted_reasoning=False)

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -1681,7 +1681,12 @@ class TestHistoryCoalescing:
         # The scaffold's MagicMock ws: pin the generation to a real int so
         # the key is deterministic, as the live session attribute is.
         mock_ws = app.state.workstreams.get("ws-flight-gen")
-        mock_ws._history_generation = 0
+        # The counter lives on the WRAPPED ChatSession (ws.session), not
+        # the workstream — pin the real shape so a route reading the
+        # wrong object cannot pass against this mock (the G7 harness
+        # caught exactly that: a direct getattr on the wrapper defaulted
+        # to 0 forever and re-enabled joining).
+        mock_ws.session._history_generation = 0
 
         async def drive() -> tuple[httpx.Response, httpx.Response]:
             caplog.set_level(logging.DEBUG, logger="turnstone.core.session_routes")
@@ -1691,7 +1696,7 @@ class TestHistoryCoalescing:
                 await _until(lambda: gated.load_calls == 1)
                 # The rewind commits mid-flight: the truncation chokepoint
                 # bumps the generation.
-                mock_ws._history_generation = 1
+                mock_ws.session._history_generation = 1
                 t2 = asyncio.create_task(c.get(url))
                 # Positive edge for the MISS: t2's own load_messages entry
                 # bumps the counter before the gate can park it.

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -677,6 +677,29 @@ function createCoordinatorPane(root, wsId, opts) {
   // an older snapshot landing late can neither double-render nor clear
   // the staleness latch over a newer truth.
   let refetchSeq = 0;
+  // call_ids of tool calls whose results are still ARRIVING ON THE LIVE
+  // STREAM — the render-time gate's tool-phase liveness signal.  Fed
+  // ONLY by live SSE events (tool_pending / tool_info add, tool_result
+  // deletes) and drained at every settle edge (state_change idle/error —
+  // a leftover id there is a dead call whose result will never come) and
+  // at closeStreamTransport (a dead transport delivers no more results;
+  // a live batch re-announces through the reconnect's replay).  NEVER
+  // touched by any render: that is the r6 lesson — refetchHistory's own
+  // replay path paints orphan batches (committed tool_calls with no
+  // persisted result) with the same .conv-batch--running class the live
+  // path uses, and nothing ever strips a dead orphan's class, so a
+  // DOM-derived liveness probe would let one orphan paint poison every
+  // seedless heal for the life of the page (rewind/edit permanently
+  // dead).  Reachability ruling (r6, verified against post-kill
+  // /history): TODAY no persisted orphan exists — the server
+  // synthesizes a result for interrupted tool calls at recovery
+  // ("Cancelled by user. Outcome UNKNOWN"), and the G6 harness scenario
+  // pins that server invariant.  The event-driven encoding stands
+  // regardless, as the client-side backstop for any future crash path
+  // that skips synthesis: liveness is read from the channel that
+  // creates the hazard — the stream — never from DOM the render path
+  // can forge.
+  const liveToolCalls = new Set();
   // The cursor position a replay_truncated envelope was received AT — i.e.
   // "a gap of lost events exists BELOW this cursor".  Keep-oldest: set only
   // when null (repeated envelopes for the same unrepaired gap must not
@@ -2553,6 +2576,11 @@ function createCoordinatorPane(root, wsId, opts) {
       clearTimeout(truncatedResyncTimer);
       truncatedResyncTimer = null;
     }
+    // A dead transport delivers no more results: drain the live-call set
+    // so stale ids can't hold the render gate closed.  A genuinely live
+    // batch re-announces through the reconnect's replay (tool_pending /
+    // tool_info redeliver), which re-adds its ids.
+    liveToolCalls.clear();
     // staleRetryTimer is deliberately NOT cancelled here — it is a
     // REST-refetch heal, not transport state, and a transport-only redial
     // must keep the pending heal intent (terminal-only cancel; see its
@@ -3276,6 +3304,7 @@ function createCoordinatorPane(root, wsId, opts) {
         noteStreamOverflow();
         break;
       case "tool_result":
+        liveToolCalls.delete(ev.call_id || "");
         appendToolResult(
           ev.name || "tool",
           ev.call_id || "",
@@ -3518,6 +3547,11 @@ function createCoordinatorPane(root, wsId, opts) {
           // server-side coalescing (#884).  If that herd ever measures
           // hot, sweep BOTH clients' idle-edge consumers together — do not
           // patch just this one.
+          // Settle edge: the turn is over, so any id still in the live
+          // set is a dead call whose result will never arrive — drain it
+          // or the residue would hold the render gate's tool-phase term
+          // closed forever (see liveToolCalls' decl).
+          liveToolCalls.clear();
           if (pendingTruncatedResync) {
             pendingTruncatedResync = false;
             recordTruncatedGap();
@@ -3849,6 +3883,9 @@ function createCoordinatorPane(root, wsId, opts) {
         // Reuses the --running placeholder (subtle accent rail, no actions)
         // the replay path already knows how to upgrade; the ``announce`` flag
         // only swaps the kicker to "Evaluating" while the judge runs.
+        (ev.items || []).forEach((it) => {
+          if (it.call_id) liveToolCalls.add(it.call_id);
+        });
         appendToolBatch(ev.items || [], {
           announce: true,
           running: true,
@@ -3870,6 +3907,9 @@ function createCoordinatorPane(root, wsId, opts) {
         // — the tool starts executing the moment auto-approval lands,
         // and the batch should show the same RUNNING indicator the
         // replay path renders for an unresolved committed turn.
+        (ev.items || []).forEach((it) => {
+          if (it.call_id) liveToolCalls.add(it.call_id);
+        });
         appendToolBatch(ev.items || [], { auto: true, running: true });
         break;
       // Child-workstream fan-out routed through the coordinator's own
@@ -5825,19 +5865,25 @@ function createCoordinatorPane(root, wsId, opts) {
     // - SEEDLESS-only, because the seeded flows deliberately render
     //   over/instead-of these states (keying on the seedCursor ARG, not
     //   caller identity):
-    //   . .conv-batch--running — an executing tool batch
-    //     (_setBatchRunning / _unsetBatchRunningIfAllResults strip the
-    //     class only when every row has its result).  NOT activeBatch —
-    //     that is the pending-APPROVAL tracker (set only for
-    //     opts.pending batches; the r5 re-derivation initially made
-    //     exactly that mistake).  On a seedless caller the stream is
-    //     live, so the class means results are still streaming into
-    //     those rows — wiping orphans them.  On the SEEDED resync the
-    //     marker can be a DEAD turn's residue (node died mid-batch; no
-    //     result will ever strip the class) and the render IS the
-    //     recovery — the replay adopts hist.cursor and rebuilds any
-    //     genuinely live turn.  Blocking that render wedged the
-    //     coord-restart recovery outright (r5 family-run find).
+    //   . liveToolCalls.size — a tool batch whose results are still
+    //     arriving on the live stream; wiping would orphan the rows the
+    //     stream keeps writing into.  EVENT-DRIVEN by construction (see
+    //     the decl): the r5 shape probed the DOM for
+    //     .conv-batch--running, but this render's own replay path
+    //     paints orphan batches (committed tool_calls, no persisted
+    //     result) with that same class and nothing ever strips a dead
+    //     orphan's — one orphan paint would poison every seedless heal
+    //     for the life of the page (the r6 find; unreachable today
+    //     because recovery synthesizes results for interrupted calls —
+    //     G6 pins that server invariant — but the encoding stands as
+    //     the client-side backstop).  NOT activeBatch either — that is
+    //     the pending-APPROVAL tracker (the r5 re-derivation's first
+    //     mistake).  Liveness comes from the stream, never from DOM a
+    //     render can forge.  The SEEDED resync bypasses the term: after
+    //     a node dies mid-batch the render IS the recovery — the replay
+    //     adopts hist.cursor and rebuilds any genuinely live turn
+    //     (blocking that render wedged coord-restart outright, the r5
+    //     family-run find).
     //   . busySource === "optimistic" — coordSend's pre-POST flip, the
     //     one busy flavor that marks un-committed DOM (an optimistic
     //     row the snapshot may not carry; see setBusy's contract).  The
@@ -5865,7 +5911,7 @@ function createCoordinatorPane(root, wsId, opts) {
     if (
       !seedCursor &&
       (busySource === "optimistic" ||
-        messagesEl.querySelector(".conv-batch--running") ||
+        liveToolCalls.size > 0 ||
         !evtSource ||
         evtSource.readyState !== EventSource.OPEN)
     )

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -5998,7 +5998,7 @@ function createCoordinatorPane(root, wsId, opts) {
     if (staleRetryTimer) {
       clearTimeout(staleRetryTimer);
       staleRetryTimer = null;
-  
+
     }
     toolRows.clear();
     activeBatch = null;

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -642,6 +642,33 @@ function createCoordinatorPane(root, wsId, opts) {
   // also catches a turn stranded by close-on-hide (finished while hidden, its
   // stream_end evicted before the show-edge reconnect).
   let pendingTruncatedResync = false;
+  // Transcript-staleness latch (#894, the port of interactive.js's #890
+  // _historyStale).  Set at clear_ui arrival — from that moment the visible
+  // transcript is the PRE-rewind one and no longer matches the server's
+  // restructured conversation — and cleared in EXACTLY ONE place:
+  // refetchHistory's success-path render.  It gates the DOM-counting
+  // affordances (_rewindToMessage / _editAndResend / _startEdit, via
+  // ``busy || historyStale``) so a turn count computed off the stale DOM
+  // can't reach POST /rewind during the refetch window OR after a failed
+  // refetch.  LATCH, not a refetch-in-flight flag: a flag reopens on the
+  // failed exit, which is exactly the over-rewind window (the bug
+  // interactive.js hit in its round-3 review).  Heals: one bounded
+  // turn-free retry armed by the clear_ui handler, then the idle-edge
+  // backstop in the state_change consumer — both plain REST refetches
+  // (TRANSPORT-FREE; the ruling lives at the backstop).
+  let historyStale = false;
+  // Count of refetchHistory calls currently awaiting /history.  The
+  // staleness heals (retry + backstop) read it to YIELD to any in-flight
+  // fetch — clear_ui's own, a sibling heal's, or a resync's — instead of
+  // stomping it with a same-snapshot double render.  Coord's quiesce-free
+  // substitute for interactive.js's !_replayQueue yield guard.  A COUNT,
+  // not a boolean: overlapping fetches are reachable (another actor's
+  // rewind can emit clear_ui while a heal fetch is in flight), and a
+  // boolean would clear on the first finisher's exit with a fetch still
+  // live.  Only the await window needs bracketing — the render after
+  // ``if (!hist)`` is synchronous, so no timer or SSE handler can observe
+  // the counter mid-render.
+  let refetchesInFlight = 0;
   // The cursor position a replay_truncated envelope was received AT — i.e.
   // "a gap of lost events exists BELOW this cursor".  Keep-oldest: set only
   // when null (repeated envelopes for the same unrepaired gap must not
@@ -707,6 +734,17 @@ function createCoordinatorPane(root, wsId, opts) {
   // stream — the next connect's own truncated envelope reschedules if the
   // gap still exists (truncatedFromCursor re-presents it).
   let truncatedResyncTimer = null;
+  // The ONE bounded clear_ui-failure retry (#894; mirrors interactive.js's
+  // _staleRetryTimer).  Armed only from the clear_ui handler's .then when
+  // the latch survived the refetch; never re-armed from its own firing
+  // (bounded by construction).  Cancelled by refetchHistory's success path
+  // and destroy() ONLY — deliberately NOT by closeStreamTransport beside
+  // the transport timers above: this is a REST-refetch timer, not a
+  // transport timer, and a transport-only redial (hide/show, degraded
+  // cooldown, reconnect backoff) must keep the pending heal intent alive.
+  // A firing after coordCloseSession no-ops via the visHandler fire-time
+  // guard.
+  let staleRetryTimer = null;
   let degradedCooldownMs = DEGRADED_COOLDOWN_BASE_MS;
   let lastDegradedAt = 0;
   // Close-on-hide / replay-on-show bookkeeping.  A hidden tab's throttled event
@@ -2507,6 +2545,10 @@ function createCoordinatorPane(root, wsId, opts) {
       clearTimeout(truncatedResyncTimer);
       truncatedResyncTimer = null;
     }
+    // staleRetryTimer is deliberately NOT cancelled here — it is a
+    // REST-refetch heal, not transport state, and a transport-only redial
+    // must keep the pending heal intent (terminal-only cancel; see its
+    // decl and destroy()).
   }
 
   function connectSSE() {
@@ -3472,6 +3514,55 @@ function createCoordinatorPane(root, wsId, opts) {
             pendingTruncatedResync = false;
             recordTruncatedGap();
             loadHistoryThenReconnect();
+          } else if (
+            historyStale &&
+            !refetchesInFlight &&
+            !currentAssistantEl &&
+            !currentReasoningEl
+          ) {
+            // Staleness-latch backstop (#894): the clear_ui refetch and its
+            // one bounded retry both failed, so the transcript still doesn't
+            // match the server and rewind/edit stay latch-closed.  The turn
+            // just settled — refetch now.
+            //
+            // TRANSPORT-FREE BY DESIGN (ruled, do not "upgrade" this to
+            // loadHistoryThenReconnect): the heal must never touch the
+            // stream.  A reload's fresh reconnect draws the server's
+            // synthetic state_change:idle, which lands back in THIS branch —
+            // with /history down that is a zero-backoff disconnect/refetch/
+            // reconnect storm against a recovering node (interactive.js's
+            // round-5 critical), self-sustaining until /history recovers.
+            // A plain REST refetch emits zero SSE events, so the trigger
+            // edge is only ever organic (turn-settle driven; the server
+            // pushes no state_change heartbeats) and the loop is
+            // structurally impossible.  Stream death has its own owners
+            // (EventSource native auto-reconnect, the truncated resync in
+            // the branch above — whose heal legitimately IS a reconnect:
+            // its stream is dead, this arm's is alive) and the else-if
+            // keeps the truncated branch's reload from doubling up (its
+            // render clears this latch too).
+            //
+            // The ref guards are a DELIBERATE divergence from the
+            // interactive template (which omits them on its backstop):
+            // interactive's replayHistory resets the streaming refs on
+            // every render, coord's refetchHistory does not — and this arm
+            // also serves state_change:error edges, where no stream_end ran
+            // finishAssistantStream and a live-bubble ref can survive.
+            // Firing then would replaceChildren the bubble out from under
+            // the dangling ref; skipping defers the heal to the next
+            // organic settle (that turn's stream_end nulls the refs).
+            // Correctness never rides this arm — the busy||historyStale
+            // gate carries it; heals are liveness only.  Accepted liveness
+            // lag (ruled): if /history recovers while the pane sits idle
+            // untouched, rewind/edit stay closed until the next organic
+            // settle — strictly safer than the storm.  Do not add ANY
+            // transport-touching timer to shorten it.
+            //
+            // Fire-and-forget, seedless: the stream is alive so lastEventId
+            // must not rewind; no composer state rides this heal (that is
+            // the clear_ui caller's .catch), so a render throw stays loud;
+            // and nothing here re-arms the retry, keeping it bounded.
+            refetchHistory();
           }
         } else if (
           ev.state === "running" ||
@@ -3558,6 +3649,14 @@ function createCoordinatorPane(root, wsId, opts) {
         // resync still armed when this rebuild lands); the residual
         // fetch-overlap window is transient-cosmetic and heals on the next
         // full render or chokepoint retry.
+        //
+        // Latch transcript staleness FIRST (#894): from this moment until a
+        // successful render the visible DOM is the PRE-rewind transcript
+        // and must not feed a rewind/edit turn count (see historyStale's
+        // decl).  The cosmetic [data-busy] grey-out for this window stays a
+        // deferred parity item (#890 PR ruling) — the handler-side
+        // ``busy || historyStale`` gate carries the correctness.
+        historyStale = true;
         refetchHistory()
           .then(() => {
             // Repair-intent supersession (pending resync timer + deferred
@@ -3566,6 +3665,43 @@ function createCoordinatorPane(root, wsId, opts) {
             // fetch (which also resolves) clears none, and a mid-render
             // throw skips this .then entirely — so the pending resync
             // stays the repair owner exactly when the pane still needs it.
+            //
+            // Failed fetch (the latch survived — only the success render
+            // clears it): arm the ONE bounded turn-free retry (#894).
+            // Armed here rather than in a failure branch so the retry's own
+            // failure cannot re-arm (bounded by construction); a NEWER
+            // clear_ui replaces the pending timer via the clearTimeout
+            // below, so at most one retry is ever pending.  Fire-time
+            // guards make a stale firing a no-op: healed or superseded
+            // (historyStale — coord has no load token; single-wsId, so the
+            // latch itself is the still-current signal), a fetch already
+            // in flight (!refetchesInFlight — yield instead of stomping it
+            // with a same-snapshot double render), mid-turn (!busy — the
+            // idle-edge backstop owns the busy case, e.g. the edit-resend
+            // dispatched below), a live bubble (the ref guards are
+            // LOAD-BEARING: refetchHistory does not reset streaming refs,
+            // so a wipe would strand a dangling ref), or torn down
+            // (visHandler — destroy() also cancels this timer outright,
+            // but coordCloseSession only nulls visHandler).
+            if (historyStale) {
+              if (staleRetryTimer) clearTimeout(staleRetryTimer);
+              staleRetryTimer = setTimeout(() => {
+                staleRetryTimer = null;
+                if (
+                  historyStale &&
+                  !refetchesInFlight &&
+                  !busy &&
+                  !currentAssistantEl &&
+                  !currentReasoningEl &&
+                  visHandler
+                ) {
+                  // Fire-and-forget, seedless (live stream — lastEventId
+                  // must not rewind); a render throw stays loud, as on the
+                  // backstop.
+                  refetchHistory();
+                }
+              }, 2000);
+            }
             if (!_pendingEditSend) return;
             const editText = _pendingEditSend;
             _pendingEditSend = null;
@@ -5280,6 +5416,10 @@ function createCoordinatorPane(root, wsId, opts) {
   // ------------------------------------------------------------------
 
   function _rewindToTurns(turns) {
+    // Deliberately busy-only, NOT latch-gated (#894 ruling): the caller
+    // passes an explicit turn count, so transcript staleness cannot
+    // corrupt it, and programmatic rewinds must keep working while a heal
+    // is pending.  The DOM-counting wrappers below carry the latch.
     if (busy) return;
     if (!Number.isInteger(turns) || turns < 1) return;
     authFetch("/v1/api/workstreams/" + encodeURIComponent(wsId) + "/rewind", {
@@ -5293,16 +5433,14 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   function _rewindToMessage(msgEl) {
-    // KNOWN GAP (#894, do not re-derive): from clear_ui arrival until
-    // the next SUCCESSFUL refetchHistory render — the fetch window AND
-    // the failed-fetch aftermath — the stale transcript is visible
-    // with busy false, so this DOM count can over-rewind.  Port
-    // interactive.js's #890 shape: a transcript-staleness latch set at
-    // clear_ui, cleared only by the full render, gating the mutating
-    // affordances (a plain refetch-in-flight flag is NOT enough — it
-    // reopens on the failed exit, the bug interactive hit).  The
-    // retry leg needs a quiesce-free variant here.
-    if (busy) return;
+    // busy || historyStale (#894, the #890 port): from clear_ui arrival
+    // until the next SUCCESSFUL refetchHistory render — the fetch window
+    // AND the failed-fetch aftermath — the visible transcript is the
+    // stale PRE-rewind DOM with busy false, so the .msg.user count below
+    // would over-rewind the already-restructured server conversation.
+    // The latch closes exactly that window; see historyStale's decl for
+    // the heal paths that reopen the affordances.
+    if (busy || historyStale) return;
     const userMsgs = messagesEl.querySelectorAll(".msg.user");
     const idx = Array.prototype.indexOf.call(userMsgs, msgEl);
     if (idx < 0) return;
@@ -5311,6 +5449,10 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   function _retryLast() {
+    // Deliberately busy-only, NOT latch-gated (#894 ruling): no DOM count
+    // feeds this POST — /retry re-runs the server's own last turn, which
+    // is authoritative regardless of what the pane shows.  Mirrors
+    // interactive.js, whose retry is equally ungated.
     if (busy) return;
     authFetch("/v1/api/workstreams/" + encodeURIComponent(wsId) + "/retry", {
       method: "POST",
@@ -5321,7 +5463,10 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   function _editAndResend(msgEl, newText) {
-    if (busy) return;
+    // busy || historyStale (#894): same stale-DOM hazard as
+    // _rewindToMessage — the turn count AND the _pendingEditSend latch
+    // would both bind to a transcript the server no longer has.
+    if (busy || historyStale) return;
     const userMsgs = messagesEl.querySelectorAll(".msg.user");
     const idx = Array.prototype.indexOf.call(userMsgs, msgEl);
     if (idx < 0) return;
@@ -5373,7 +5518,11 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   function _startEdit(msgEl, originalText) {
-    if (busy) return;
+    // busy || historyStale (#894): entering edit mode on a stale row would
+    // let the user type into a message the pending re-render is about to
+    // replaceChildren away — and _editAndResend would refuse the submit
+    // anyway.  Gate at entry so the affordance and the action agree.
+    if (busy || historyStale) return;
     // Save current child nodes so Cancel can restore them.
     const savedNodes = [];
     while (msgEl.firstChild) {
@@ -5579,6 +5728,12 @@ function createCoordinatorPane(root, wsId, opts) {
   // empty — harmless no-ops.
   async function refetchHistory(seedCursor = false) {
     let hist = null;
+    // Count the await window so the staleness heals can yield to an
+    // in-flight fetch (see refetchesInFlight's decl).  Only the fetch
+    // needs bracketing: the render below runs synchronously after the
+    // await, so no timer or SSE handler can observe the counter
+    // mid-render.
+    refetchesInFlight++;
     try {
       hist = await getJSON(
         "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/history",
@@ -5586,6 +5741,8 @@ function createCoordinatorPane(root, wsId, opts) {
     } catch (e) {
       console.warn("coord history fetch failed", e);
       hist = null;
+    } finally {
+      refetchesInFlight--;
     }
     // A FAILED fetch keeps the pane intact: the wipe + tracking resets
     // run only once a payload actually arrived.  (Pre-#882 the wipe ran
@@ -5620,6 +5777,19 @@ function createCoordinatorPane(root, wsId, opts) {
     if (truncatedResyncTimer) {
       clearTimeout(truncatedResyncTimer);
       truncatedResyncTimer = null;
+    }
+    // A successful full render also restores transcript truth: clear the
+    // staleness latch and cancel the pending heal retry (#894).  These sit
+    // HERE — below the ``if (!hist) return`` and beside the other repair
+    // clears, BEFORE the long render loop — so a FAILED fetch leaves the
+    // latch set (which is what arms the retry/backstop), while a mid-render
+    // throw doesn't re-close a pane whose replaceChildren already
+    // committed (a partially painted FRESH transcript at worst
+    // UNDER-counts, the safe direction).  The ONLY latch-clear site.
+    historyStale = false;
+    if (staleRetryTimer) {
+      clearTimeout(staleRetryTimer);
+      staleRetryTimer = null;
     }
     toolRows.clear();
     activeBatch = null;
@@ -5939,6 +6109,16 @@ function createCoordinatorPane(root, wsId, opts) {
     // Stream + the retry timers (reconnect backoff, degraded catch-up,
     // truncated resync).
     closeStreamTransport();
+    // The clear_ui-failure retry deliberately survives closeStreamTransport
+    // (transport-only redials keep the heal intent — see its decl), so it
+    // must die HERE, the terminal path: destroy() bumps no generation, and
+    // while the visHandler fire-time guard would render a post-destroy
+    // firing inert, a timer into a destroyed pane must be dead, not merely
+    // inert — it pins the closure for its remaining delay.
+    if (staleRetryTimer) {
+      clearTimeout(staleRetryTimer);
+      staleRetryTimer = null;
+    }
     [
       cancelTimeoutId,
       forceTimeoutId,

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -677,26 +677,13 @@ function createCoordinatorPane(root, wsId, opts) {
   // an older snapshot landing late can neither double-render nor clear
   // the staleness latch over a newer truth.
   let refetchSeq = 0;
-  // Rewind-freshness epoch (r8): bumped at every clear_ui ARRIVAL.  A
-  // refetch dispatch captures it, and only a render whose dispatch
-  // post-dates the latest clear_ui may CLEAR the staleness latch.  The
-  // server's #884 /history single-flight can hand a joiner a payload
-  // whose load_messages ran BEFORE the rewind committed (the flight
-  // key is (ws_id, limit); joining is invisible to the client) — that
-  // pre-rewind payload may still PAINT (stale-but-real posture, the
-  // affordance gate holds) but must not clear the latch, or the exact
-  // over-rewind window this latch exists to close reopens through the
-  // server seam.  The un-cleared latch arms the retry, whose fresh
-  // dispatch starts a NEW flight (the old one popped at settle) and
-  // heals with post-rewind truth.
-  let clearUiEpoch = 0;
-  // The newest in-flight /history's AbortController — destroy() aborts it
+  // EVERY in-flight /history AbortController — destroy() aborts them all
   // so a slow fetch cannot pin the destroyed pane's closure for the
   // bound's full 15s (the same dead-not-inert ruling destroy() applies
-  // to staleRetryTimer).  Overlapping dispatches: each finally releases
-  // only its OWN handle, so the newest in-flight controller stays
-  // reachable for the teardown abort.
-  let activeHistCtrl = null;
+  // to staleRetryTimer).  A Set, not a single slot (r9): overlapping
+  // dispatches settle in any order, and a newest-wins slot nulled by
+  // the newer dispatch's finally left the OLDER fetch unabortable.
+  const histCtrls = new Set();
   // call_ids of tool calls whose results are still ARRIVING ON THE LIVE
   // STREAM — the render-time gate's tool-phase liveness signal.  Fed
   // ONLY by live SSE events (tool_pending / tool_info add, tool_result
@@ -3744,7 +3731,6 @@ function createCoordinatorPane(root, wsId, opts) {
         // decl).  The cosmetic [data-busy] grey-out for this window stays a
         // deferred parity item (#890 PR ruling) — the handler-side
         // ``busy || historyStale`` gate carries the correctness.
-        clearUiEpoch++;
         historyStale = true;
         refetchHistory()
           .then(() => {
@@ -5853,7 +5839,6 @@ function createCoordinatorPane(root, wsId, opts) {
     // mid-render.  The seq stamp makes overlapping dispatches resolve
     // last-dispatch-wins at the render-time gate.
     const seq = ++refetchSeq;
-    const epoch = clearUiEpoch;
     refetchesInFlight++;
     // Bound the await (r7): the counter and both heals gate on this
     // fetch settling.  A /history that is accepted and never answered
@@ -5865,7 +5850,7 @@ function createCoordinatorPane(root, wsId, opts) {
     // retry on later organic edges against a fresh attempt.
     const histCtrl =
       typeof AbortController === "function" ? new AbortController() : null;
-    activeHistCtrl = histCtrl;
+    if (histCtrl) histCtrls.add(histCtrl);
     const histTimer = histCtrl
       ? setTimeout(() => histCtrl.abort(), 15000)
       : null;
@@ -5879,7 +5864,7 @@ function createCoordinatorPane(root, wsId, opts) {
       hist = null;
     } finally {
       if (histTimer) clearTimeout(histTimer);
-      if (activeHistCtrl === histCtrl) activeHistCtrl = null;
+      if (histCtrl) histCtrls.delete(histCtrl);
       refetchesInFlight--;
     }
     // A FAILED fetch keeps the pane intact: the wipe + tracking resets
@@ -6000,18 +5985,20 @@ function createCoordinatorPane(root, wsId, opts) {
     // latch set (which is what arms the retry/backstop), while a mid-render
     // throw doesn't re-close a pane whose replaceChildren already
     // committed (a partially painted FRESH transcript at worst
-    // UNDER-counts, the safe direction).  The ONLY latch-clear site —
-    // and epoch-conditional (r8): a dispatch that PREDATES the latest
-    // clear_ui may have joined a pre-rewind #884 server flight; its
-    // payload may paint (stale-but-real) but must not clear the latch
-    // (see clearUiEpoch's decl) — the surviving latch arms the retry,
-    // whose fresh dispatch heals with post-rewind truth.
-    if (epoch === clearUiEpoch) {
-      historyStale = false;
-      if (staleRetryTimer) {
-        clearTimeout(staleRetryTimer);
-        staleRetryTimer = null;
-      }
+    // UNDER-counts, the safe direction).  The ONLY latch-clear site.
+    // Freshness layers (r9 accounting): a dispatch that PREDATES the
+    // latest clear_ui never reaches here at all — clear_ui always
+    // dispatches immediately after arriving, so a stale-epoch dispatch
+    // is also a stale-SEQ dispatch and the currency gate above discards
+    // it (an r8 epoch guard here was unreachable and was removed).  The
+    // remaining freshness hazard — a CURRENT dispatch joining a
+    // pre-rewind server flight — is closed server-side: the #884 flight
+    // key folds in the ws's truncation generation.
+    historyStale = false;
+    if (staleRetryTimer) {
+      clearTimeout(staleRetryTimer);
+      staleRetryTimer = null;
+  
     }
     toolRows.clear();
     activeBatch = null;
@@ -6341,17 +6328,17 @@ function createCoordinatorPane(root, wsId, opts) {
       clearTimeout(staleRetryTimer);
       staleRetryTimer = null;
     }
-    // Abort any in-flight /history for the same reason: the 15s bound
+    // Abort every in-flight /history for the same reason: the 15s bound
     // alone would keep the detached pane's closure alive until it fired
-    // (the settled fetch's render then discards via the !hist path).
-    if (activeHistCtrl) {
+    // (the settled fetches' renders then discard via the !hist path).
+    histCtrls.forEach((c) => {
       try {
-        activeHistCtrl.abort();
+        c.abort();
       } catch (_) {
         /* noop */
       }
-      activeHistCtrl = null;
-    }
+    });
+    histCtrls.clear();
     [
       cancelTimeoutId,
       forceTimeoutId,

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -680,10 +680,15 @@ function createCoordinatorPane(root, wsId, opts) {
   // call_ids of tool calls whose results are still ARRIVING ON THE LIVE
   // STREAM — the render-time gate's tool-phase liveness signal.  Fed
   // ONLY by live SSE events (tool_pending / tool_info add, tool_result
-  // deletes) and drained at every settle edge (state_change idle/error —
-  // a leftover id there is a dead call whose result will never come) and
-  // at closeStreamTransport (a dead transport delivers no more results;
-  // a live batch re-announces through the reconnect's replay).  NEVER
+  // deletes) and drained at the settle edge ONLY (state_change
+  // idle/error — a leftover id there is a dead call whose result will
+  // never come).  Retirement policy (r7): an id leaves on its RESULT,
+  // at the SETTLE edge, or with pane death — transport death is NOT a
+  // retirement event, because the reconnect replay does not re-announce
+  // a live batch (verified: replay_ok yields only events past the
+  // cursor; the fresh/truncated replay yields no tool_pending/tool_info)
+  // — a stale id fails CLOSED (skip, latch survives, settle heals),
+  // while an empty set fails OPEN into the wipe.  NEVER
   // touched by any render: that is the r6 lesson — refetchHistory's own
   // replay path paints orphan batches (committed tool_calls with no
   // persisted result) with the same .conv-batch--running class the live
@@ -2507,12 +2512,14 @@ function createCoordinatorPane(root, wsId, opts) {
     });
   }
 
-  function getJSON(url) {
+  function getJSON(url, init) {
     const fn = typeof authFetch === "function" ? authFetch : fetch;
-    return fn(url, { credentials: "include" }).then((r) => {
-      if (!r.ok) throw new Error("HTTP " + r.status);
-      return r.json();
-    });
+    return fn(url, Object.assign({ credentials: "include" }, init || {})).then(
+      (r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.json();
+      },
+    );
   }
 
   // ------------------------------------------------------------------
@@ -2576,11 +2583,20 @@ function createCoordinatorPane(root, wsId, opts) {
       clearTimeout(truncatedResyncTimer);
       truncatedResyncTimer = null;
     }
-    // A dead transport delivers no more results: drain the live-call set
-    // so stale ids can't hold the render gate closed.  A genuinely live
-    // batch re-announces through the reconnect's replay (tool_pending /
-    // tool_info redeliver), which re-adds its ids.
-    liveToolCalls.clear();
+    // liveToolCalls is deliberately NOT drained here (r7 ruling): the
+    // reconnect replay does NOT re-announce a live batch — replay_ok
+    // yields only events past lastEventId (the announce sits below it)
+    // and the coord fresh/truncated replay yields connected/status/
+    // pending-cards/verdicts, never tool_pending or tool_info — so a
+    // drain here left the render gate's tool-phase term EMPTY across
+    // every mid-batch redial and a slow seedless refetch resolving
+    // after the reopen wiped the live batch (fails OPEN).  A stale id
+    // instead fails CLOSED — a skipped render leaves the staleness
+    // latch set and heals at the next organic settle — and retirement
+    // is fully covered without this site: results still arrive through
+    // replay_ok (tool_result deletes), every fresh/truncated reconnect
+    // carries a synthetic state_change whose settle edge clears, and
+    // destroy() ends the closure.
     // staleRetryTimer is deliberately NOT cancelled here — it is a
     // REST-refetch heal, not transport state, and a transport-only redial
     // must keep the pending heal intent (terminal-only cancel; see its
@@ -5817,14 +5833,29 @@ function createCoordinatorPane(root, wsId, opts) {
     // last-dispatch-wins at the render-time gate.
     const seq = ++refetchSeq;
     refetchesInFlight++;
+    // Bound the await (r7): the counter and both heals gate on this
+    // fetch settling.  A /history that is accepted and never answered
+    // (wedged node, stalled response body) would otherwise pin
+    // refetchesInFlight above zero for the life of the page and every
+    // heal would yield forever — beyond the ruled settle-lag.  Same
+    // AbortController + flat-timeout shape as coordSend's /send bound;
+    // an abort lands in the catch, the latch survives, and the heals
+    // retry on later organic edges against a fresh attempt.
+    const histCtrl =
+      typeof AbortController === "function" ? new AbortController() : null;
+    const histTimer = histCtrl
+      ? setTimeout(() => histCtrl.abort(), 15000)
+      : null;
     try {
       hist = await getJSON(
         "/v1/api/workstreams/" + encodeURIComponent(wsId) + "/history",
+        histCtrl ? { signal: histCtrl.signal } : undefined,
       );
     } catch (e) {
       console.warn("coord history fetch failed", e);
       hist = null;
     } finally {
+      if (histTimer) clearTimeout(histTimer);
       refetchesInFlight--;
     }
     // A FAILED fetch keeps the pane intact: the wipe + tracking resets

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -669,6 +669,14 @@ function createCoordinatorPane(root, wsId, opts) {
   // ``if (!hist)`` is synchronous, so no timer or SSE handler can observe
   // the counter mid-render.
   let refetchesInFlight = 0;
+  // Monotonic refetchHistory dispatch stamp.  Each call captures
+  // ``++refetchSeq`` before its await; the render-time gate discards any
+  // payload whose stamp is no longer current, so overlapping fetches
+  // (reachable via another actor's clear_ui racing a heal) resolve
+  // last-DISPATCH-wins deterministically instead of last-RESPONSE-wins —
+  // an older snapshot landing late can neither double-render nor clear
+  // the staleness latch over a newer truth.
+  let refetchSeq = 0;
   // The cursor position a replay_truncated envelope was received AT — i.e.
   // "a gap of lost events exists BELOW this cursor".  Keep-oldest: set only
   // when null (repeated envelopes for the same unrepaired gap must not
@@ -3532,31 +3540,41 @@ function createCoordinatorPane(root, wsId, opts) {
             // with /history down that is a zero-backoff disconnect/refetch/
             // reconnect storm against a recovering node (interactive.js's
             // round-5 critical), self-sustaining until /history recovers.
-            // A plain REST refetch emits zero SSE events, so the trigger
-            // edge is only ever organic (turn-settle driven; the server
-            // pushes no state_change heartbeats) and the loop is
-            // structurally impossible.  Stream death has its own owners
-            // (EventSource native auto-reconnect, the truncated resync in
-            // the branch above — whose heal legitimately IS a reconnect:
-            // its stream is dead, this arm's is alive) and the else-if
-            // keeps the truncated branch's reload from doubling up (its
-            // render clears this latch too).
+            // A plain REST refetch emits zero SSE events, so this heal
+            // never CAUSES its own trigger and the self-loop is
+            // structurally impossible.  Precision on the trigger edges
+            // (r5): turn settles are the main one, but fresh/truncated
+            // SSE replays also carry a synthetic state_change (replay_ok
+            // does not) — so a latched pane pays one refetch per
+            // reconnect too.  That edge is bounded by the reconnect
+            // machinery's own jitter/backoff, is user/transport-driven
+            // rather than heal-driven, and the restart-herd /history load
+            // is bounded server-side by #884's single-flight — ruled
+            // acceptable; do NOT bolt a client-side limiter onto this arm
+            // (and never a transport-touching one).  Stream death has its
+            // own owners (EventSource native auto-reconnect, the
+            // truncated resync in the branch above — whose heal
+            // legitimately IS a reconnect: its stream is dead, this arm's
+            // is alive) and the else-if keeps the truncated branch's
+            // reload from doubling up (its render clears this latch too).
             //
             // The ref guards are a DELIBERATE divergence from the
             // interactive template (which omits them on its backstop):
             // interactive's replayHistory resets the streaming refs on
             // every render, coord's refetchHistory does not — and this arm
-            // also serves state_change:error edges, where no stream_end ran
-            // finishAssistantStream and a live-bubble ref can survive.
-            // Firing then would replaceChildren the bubble out from under
-            // the dangling ref; skipping defers the heal to the next
-            // organic settle (that turn's stream_end nulls the refs).
-            // Correctness never rides this arm — the busy||historyStale
-            // gate carries it; heals are liveness only.  Accepted liveness
-            // lag (ruled): if /history recovers while the pane sits idle
-            // untouched, rewind/edit stay closed until the next organic
-            // settle — strictly safer than the storm.  Do not add ANY
-            // transport-touching timer to shorten it.
+            // also serves state_change:error edges, where no stream_end
+            // ran finishAssistantStream and a live-bubble ref can
+            // survive.  Post-r5 the render-time gate in refetchHistory
+            // carries the wipe-safety correctness; these fire-time guards
+            // are the efficiency layer — they skip a fetch whose payload
+            // the gate would discard (a latched pane draining a K-deep
+            // send queue still pays one discarded fetch per settle edge
+            // it loses the race on; ruled acceptable — per-pane cost
+            // rides organic edges only and #884 coalesces the herd).
+            // Accepted liveness lag (ruled): if /history recovers while
+            // the pane sits idle untouched, rewind/edit stay closed until
+            // the next organic settle — strictly safer than the storm.
+            // Do not add ANY transport-touching timer to shorten it.
             //
             // Fire-and-forget, seedless: the stream is alive so lastEventId
             // must not rewind; no composer state rides this heal (that is
@@ -3678,11 +3696,12 @@ function createCoordinatorPane(root, wsId, opts) {
             // in flight (!refetchesInFlight — yield instead of stomping it
             // with a same-snapshot double render), mid-turn (!busy — the
             // idle-edge backstop owns the busy case, e.g. the edit-resend
-            // dispatched below), a live bubble (the ref guards are
-            // LOAD-BEARING: refetchHistory does not reset streaming refs,
-            // so a wipe would strand a dangling ref), or torn down
-            // (visHandler — destroy() also cancels this timer outright,
-            // but coordCloseSession only nulls visHandler).
+            // dispatched below), a live bubble (the ref guards skip a
+            // fetch whose payload refetchHistory's render-time gate would
+            // discard — the gate carries the wipe-safety correctness,
+            // these are the efficiency layer), or torn down (visHandler —
+            // destroy() also cancels this timer outright, but
+            // coordCloseSession only nulls visHandler).
             //
             // The ARM is visHandler-gated too: this .then can settle AFTER
             // a teardown (destroy/close-session during the in-flight
@@ -3703,17 +3722,20 @@ function createCoordinatorPane(root, wsId, opts) {
                   !currentAssistantEl &&
                   !currentReasoningEl &&
                   visHandler &&
-                  evtSource
+                  evtSource &&
+                  evtSource.readyState === EventSource.OPEN
                 ) {
-                  // evtSource: a seedless heal must not render past a
-                  // frozen cursor (close-on-hide keeps this timer armed by
-                  // design, so the fire can land with the transport down)
-                  // — skip; the latch survives and the show-edge
-                  // reconnect's synthetic idle hands the heal to the
-                  // backstop.  The backstop itself needs no such term: it
-                  // runs inside SSE dispatch, so its stream is live by
+                  // Stream must be OPEN, not merely present: close-on-hide
+                  // keeps this timer armed by design (the fire can land
+                  // with the transport down), and a CONNECTING source has
+                  // a frozen cursor with a pending replay — a seedless
+                  // fetch then would render past it (double-render when
+                  // the replay lands).  Skip instead; the latch survives
+                  // and the next organic settle re-fires the backstop.
+                  // The backstop itself needs no such term: it runs
+                  // inside SSE dispatch, so its stream is live by
                   // construction.  refetchHistory's render-time gate
-                  // re-checks both invariants across the await window.
+                  // re-checks every invariant across the await window.
                   // Fire-and-forget, seedless (live stream — lastEventId
                   // must not rewind); a render throw stays loud, as on the
                   // backstop.
@@ -5751,7 +5773,9 @@ function createCoordinatorPane(root, wsId, opts) {
     // in-flight fetch (see refetchesInFlight's decl).  Only the fetch
     // needs bracketing: the render below runs synchronously after the
     // await, so no timer or SSE handler can observe the counter
-    // mid-render.
+    // mid-render.  The seq stamp makes overlapping dispatches resolve
+    // last-dispatch-wins at the render-time gate.
+    const seq = ++refetchSeq;
     refetchesInFlight++;
     try {
       hist = await getJSON(
@@ -5775,41 +5799,77 @@ function createCoordinatorPane(root, wsId, opts) {
     // refetch.)  Success ordering is unchanged: the wipe always ran
     // after the await, never as immediate feedback.
     if (!hist) return;
-    // RENDER-TIME gate (#894 r4): the await above is a real window — pane
-    // state can change between a caller's fire-time checks and this
-    // render, and only THIS site can see across it (chokepoint, not
-    // per-caller guards).  Two invariants must hold at the wipe itself:
+    // RENDER-TIME gate (#894 r4, re-derived r5): the await above is a
+    // real window — pane state can change between a caller's fire-time
+    // checks and this render, and only THIS site can see across it
+    // (chokepoint, not per-caller guards).  The gate reads DOM-LIVE-STATE
+    // signals, never plain ``busy`` — that distinction is the r5 lesson:
+    // ``busy`` means "a turn is executing", not "this DOM holds live turn
+    // state", and the two diverge exactly where it hurt.  _editAndResend
+    // flips busy BEFORE its POST and /rewind emits only clear_ui (no
+    // state_change), so a busy term skipped the truncation render the
+    // rewind exists to produce and appended the resent bubble onto the
+    // PRE-rewind transcript; /retry's regenerated turn likewise raced its
+    // own clear_ui refetch.  A skipped render must only ever mean "the
+    // wipe would destroy live DOM" or "the paint would outrun the
+    // cursor":
     //
-    // 1. No live turn mid-stream.  A turn can START during the fetch (the
-    //    server drains queued sends at exactly the idle edges the
-    //    backstop rides; another operator on a shared coordinator can
-    //    send any time; coordSend paints an optimistic user row).  This
-    //    render does not reset the streaming refs, so replaceChildren
-    //    would detach the live bubble — every remaining token renders
-    //    into the dangling ref (invisible), and the optimistic user row
-    //    is destroyed with nothing to repaint it.  Skip instead: if the
-    //    staleness latch is set it stays set (clear is below), the gate
-    //    stays closed, and the turn's own settle re-fires the backstop.
-    // 2. Seedless renders need an IDLE pane on a LIVE stream.  busy: the
-    //    ref check above only sees the CONTENT phase — a turn in its tool
-    //    phase has null content refs but live tool rows, and the wipe +
-    //    toolRows.clear() below would orphan them mid-stream identically.
-    //    evtSource: a seedless render must not advance the DOM past a
-    //    frozen lastEventId (hide/suspend can land mid-fetch) — the
-    //    show-edge reconnect replays from the frozen cursor and every
-    //    turn this render already painted would render twice.  Seeded
-    //    callers (init, loadHistoryThenReconnect) own their reconnect
-    //    flow — they adopt hist.cursor below, and the truncated resync
-    //    legitimately rebuilds MID-turn — so both requirements key on the
-    //    seedCursor ARG, not caller identity.  On skip the latch
-    //    survives; the next organic settle (or the show-edge reconnect's
-    //    synthetic idle) re-fires the backstop.
+    // - seq (universal): a newer dispatch supersedes this payload
+    //   (last-DISPATCH-wins; see refetchSeq's decl).
+    // - content refs (universal): a live bubble ref means the stream is
+    //   mid-CONTENT — wiping detaches the node every remaining token
+    //   renders into.  Universal because skipping always beats
+    //   stranding a ref, and the seeded callers null their refs before
+    //   fetching anyway (loadHistoryThenReconnect explicitly; init
+    //   pre-connect), so this never blocks them.
+    // - SEEDLESS-only, because the seeded flows deliberately render
+    //   over/instead-of these states (keying on the seedCursor ARG, not
+    //   caller identity):
+    //   . .conv-batch--running — an executing tool batch
+    //     (_setBatchRunning / _unsetBatchRunningIfAllResults strip the
+    //     class only when every row has its result).  NOT activeBatch —
+    //     that is the pending-APPROVAL tracker (set only for
+    //     opts.pending batches; the r5 re-derivation initially made
+    //     exactly that mistake).  On a seedless caller the stream is
+    //     live, so the class means results are still streaming into
+    //     those rows — wiping orphans them.  On the SEEDED resync the
+    //     marker can be a DEAD turn's residue (node died mid-batch; no
+    //     result will ever strip the class) and the render IS the
+    //     recovery — the replay adopts hist.cursor and rebuilds any
+    //     genuinely live turn.  Blocking that render wedged the
+    //     coord-restart recovery outright (r5 family-run find).
+    //   . busySource === "optimistic" — coordSend's pre-POST flip, the
+    //     one busy flavor that marks un-committed DOM (an optimistic
+    //     row the snapshot may not carry; see setBusy's contract).  The
+    //     seeded resync renders through it: dead-stream recovery
+    //     outranks a transient row, matching pre-#894 behavior.  The
+    //     clear_ui .then's edit-resend paints under plain "server" busy
+    //     instead; its narrower wipe window (a second actor's clear_ui
+    //     inside the resend's commit gap) is accepted — the resent
+    //     message re-appears at its turn's settle heal, and pre-#894
+    //     behavior there was an over-rewind.
+    //   . stream-OPENness — CONNECTING is NOT live (native
+    //     auto-reconnect keeps the handle with a frozen lastEventId and
+    //     a pending replay; painting past the cursor double-renders
+    //     when that replay lands; hide/suspend null the handle
+    //     outright).  The seeded flows own their reconnect and adopt
+    //     hist.cursor below.
     //
-    // The callers' fire-time ref/stream guards remain as the efficiency
-    // layer (skip the pointless fetch); THIS gate is the correctness
-    // carrier.
+    // On every skip the staleness latch survives (clear is below), the
+    // affordance gate stays closed, and the next organic settle re-fires
+    // the backstop.  The callers' fire-time guards remain as the
+    // efficiency layer (skip the pointless fetch); THIS gate is the
+    // correctness carrier.
+    if (seq !== refetchSeq) return;
     if (currentAssistantEl || currentReasoningEl) return;
-    if (!seedCursor && (busy || !evtSource)) return;
+    if (
+      !seedCursor &&
+      (busySource === "optimistic" ||
+        messagesEl.querySelector(".conv-batch--running") ||
+        !evtSource ||
+        evtSource.readyState !== EventSource.OPEN)
+    )
+      return;
     messagesEl.replaceChildren();
     // A full committed-history render repairs any recorded truncation gap —
     // whether this render came from the truncated resync itself or from an

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -677,6 +677,26 @@ function createCoordinatorPane(root, wsId, opts) {
   // an older snapshot landing late can neither double-render nor clear
   // the staleness latch over a newer truth.
   let refetchSeq = 0;
+  // Rewind-freshness epoch (r8): bumped at every clear_ui ARRIVAL.  A
+  // refetch dispatch captures it, and only a render whose dispatch
+  // post-dates the latest clear_ui may CLEAR the staleness latch.  The
+  // server's #884 /history single-flight can hand a joiner a payload
+  // whose load_messages ran BEFORE the rewind committed (the flight
+  // key is (ws_id, limit); joining is invisible to the client) — that
+  // pre-rewind payload may still PAINT (stale-but-real posture, the
+  // affordance gate holds) but must not clear the latch, or the exact
+  // over-rewind window this latch exists to close reopens through the
+  // server seam.  The un-cleared latch arms the retry, whose fresh
+  // dispatch starts a NEW flight (the old one popped at settle) and
+  // heals with post-rewind truth.
+  let clearUiEpoch = 0;
+  // The newest in-flight /history's AbortController — destroy() aborts it
+  // so a slow fetch cannot pin the destroyed pane's closure for the
+  // bound's full 15s (the same dead-not-inert ruling destroy() applies
+  // to staleRetryTimer).  Overlapping dispatches: each finally releases
+  // only its OWN handle, so the newest in-flight controller stays
+  // reachable for the teardown abort.
+  let activeHistCtrl = null;
   // call_ids of tool calls whose results are still ARRIVING ON THE LIVE
   // STREAM — the render-time gate's tool-phase liveness signal.  Fed
   // ONLY by live SSE events (tool_pending / tool_info add, tool_result
@@ -695,15 +715,15 @@ function createCoordinatorPane(root, wsId, opts) {
   // path uses, and nothing ever strips a dead orphan's class, so a
   // DOM-derived liveness probe would let one orphan paint poison every
   // seedless heal for the life of the page (rewind/edit permanently
-  // dead).  Reachability ruling (r6, verified against post-kill
-  // /history): TODAY no persisted orphan exists — the server
-  // synthesizes a result for interrupted tool calls at recovery
-  // ("Cancelled by user. Outcome UNKNOWN"), and the G6 harness scenario
-  // pins that server invariant.  The event-driven encoding stands
-  // regardless, as the client-side backstop for any future crash path
-  // that skips synthesis: liveness is read from the channel that
-  // creates the hazard — the stream — never from DOM the render path
-  // can forge.
+  // dead).  Reachability ruling (r7, superseding r6's): the persisted
+  // orphan is REAL — a hard crash (SIGKILL/OOM) leaves the committed
+  // tool_calls turn genuinely unresulted; only a GRACEFUL close
+  // synthesizes the "Cancelled by user" result (session.cancel()), and
+  // boot rehydration synthesizes nothing (both verified empirically).
+  // The G6 harness scenario hard-kills a node and proves the seedless
+  // rewind renders THROUGH the painted residue.  Liveness is read from
+  // the channel that creates the hazard — the stream — never from DOM
+  // the render path can forge.
   const liveToolCalls = new Set();
   // The cursor position a replay_truncated envelope was received AT — i.e.
   // "a gap of lost events exists BELOW this cursor".  Keep-oldest: set only
@@ -3724,6 +3744,7 @@ function createCoordinatorPane(root, wsId, opts) {
         // decl).  The cosmetic [data-busy] grey-out for this window stays a
         // deferred parity item (#890 PR ruling) — the handler-side
         // ``busy || historyStale`` gate carries the correctness.
+        clearUiEpoch++;
         historyStale = true;
         refetchHistory()
           .then(() => {
@@ -5832,6 +5853,7 @@ function createCoordinatorPane(root, wsId, opts) {
     // mid-render.  The seq stamp makes overlapping dispatches resolve
     // last-dispatch-wins at the render-time gate.
     const seq = ++refetchSeq;
+    const epoch = clearUiEpoch;
     refetchesInFlight++;
     // Bound the await (r7): the counter and both heals gate on this
     // fetch settling.  A /history that is accepted and never answered
@@ -5843,6 +5865,7 @@ function createCoordinatorPane(root, wsId, opts) {
     // retry on later organic edges against a fresh attempt.
     const histCtrl =
       typeof AbortController === "function" ? new AbortController() : null;
+    activeHistCtrl = histCtrl;
     const histTimer = histCtrl
       ? setTimeout(() => histCtrl.abort(), 15000)
       : null;
@@ -5856,6 +5879,7 @@ function createCoordinatorPane(root, wsId, opts) {
       hist = null;
     } finally {
       if (histTimer) clearTimeout(histTimer);
+      if (activeHistCtrl === histCtrl) activeHistCtrl = null;
       refetchesInFlight--;
     }
     // A FAILED fetch keeps the pane intact: the wipe + tracking resets
@@ -5904,10 +5928,10 @@ function createCoordinatorPane(root, wsId, opts) {
     //     paints orphan batches (committed tool_calls, no persisted
     //     result) with that same class and nothing ever strips a dead
     //     orphan's — one orphan paint would poison every seedless heal
-    //     for the life of the page (the r6 find; unreachable today
-    //     because recovery synthesizes results for interrupted calls —
-    //     G6 pins that server invariant — but the encoding stands as
-    //     the client-side backstop).  NOT activeBatch either — that is
+    //     for the life of the page (the r6 find, REACHABLE per r7: a
+    //     hard crash leaves the orphan persisted — only graceful close
+    //     synthesizes a cancel result — and G6 proves the rewind
+    //     renders through the residue).  NOT activeBatch either — that is
     //     the pending-APPROVAL tracker (the r5 re-derivation's first
     //     mistake).  Liveness comes from the stream, never from DOM a
     //     render can forge.  The SEEDED resync bypasses the term: after
@@ -5976,11 +6000,18 @@ function createCoordinatorPane(root, wsId, opts) {
     // latch set (which is what arms the retry/backstop), while a mid-render
     // throw doesn't re-close a pane whose replaceChildren already
     // committed (a partially painted FRESH transcript at worst
-    // UNDER-counts, the safe direction).  The ONLY latch-clear site.
-    historyStale = false;
-    if (staleRetryTimer) {
-      clearTimeout(staleRetryTimer);
-      staleRetryTimer = null;
+    // UNDER-counts, the safe direction).  The ONLY latch-clear site —
+    // and epoch-conditional (r8): a dispatch that PREDATES the latest
+    // clear_ui may have joined a pre-rewind #884 server flight; its
+    // payload may paint (stale-but-real) but must not clear the latch
+    // (see clearUiEpoch's decl) — the surviving latch arms the retry,
+    // whose fresh dispatch heals with post-rewind truth.
+    if (epoch === clearUiEpoch) {
+      historyStale = false;
+      if (staleRetryTimer) {
+        clearTimeout(staleRetryTimer);
+        staleRetryTimer = null;
+      }
     }
     toolRows.clear();
     activeBatch = null;
@@ -6309,6 +6340,17 @@ function createCoordinatorPane(root, wsId, opts) {
     if (staleRetryTimer) {
       clearTimeout(staleRetryTimer);
       staleRetryTimer = null;
+    }
+    // Abort any in-flight /history for the same reason: the 15s bound
+    // alone would keep the detached pane's closure alive until it fired
+    // (the settled fetch's render then discards via the !hist path).
+    if (activeHistCtrl) {
+      try {
+        activeHistCtrl.abort();
+      } catch (_) {
+        /* noop */
+      }
+      activeHistCtrl = null;
     }
     [
       cancelTimeoutId,

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -3683,7 +3683,16 @@ function createCoordinatorPane(root, wsId, opts) {
             // so a wipe would strand a dangling ref), or torn down
             // (visHandler — destroy() also cancels this timer outright,
             // but coordCloseSession only nulls visHandler).
-            if (historyStale) {
+            //
+            // The ARM is visHandler-gated too: this .then can settle AFTER
+            // a teardown (destroy/close-session during the in-flight
+            // refetch), and destroy's clearTimeout already ran — an arm
+            // here would recreate the orphan timer destroy exists to kill
+            // (a no-op fire, but it pins the dead closure for 2s).  The
+            // edit-resend below stays UNgated on teardown by design: the
+            // rewind committed server-side and the workstream outlives the
+            // pane UI, so the user's committed edit still delivers.
+            if (historyStale && visHandler) {
               if (staleRetryTimer) clearTimeout(staleRetryTimer);
               staleRetryTimer = setTimeout(() => {
                 staleRetryTimer = null;

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -3702,8 +3702,18 @@ function createCoordinatorPane(root, wsId, opts) {
                   !busy &&
                   !currentAssistantEl &&
                   !currentReasoningEl &&
-                  visHandler
+                  visHandler &&
+                  evtSource
                 ) {
+                  // evtSource: a seedless heal must not render past a
+                  // frozen cursor (close-on-hide keeps this timer armed by
+                  // design, so the fire can land with the transport down)
+                  // — skip; the latch survives and the show-edge
+                  // reconnect's synthetic idle hands the heal to the
+                  // backstop.  The backstop itself needs no such term: it
+                  // runs inside SSE dispatch, so its stream is live by
+                  // construction.  refetchHistory's render-time gate
+                  // re-checks both invariants across the await window.
                   // Fire-and-forget, seedless (live stream — lastEventId
                   // must not rewind); a render throw stays loud, as on the
                   // backstop.
@@ -5765,6 +5775,41 @@ function createCoordinatorPane(root, wsId, opts) {
     // refetch.)  Success ordering is unchanged: the wipe always ran
     // after the await, never as immediate feedback.
     if (!hist) return;
+    // RENDER-TIME gate (#894 r4): the await above is a real window — pane
+    // state can change between a caller's fire-time checks and this
+    // render, and only THIS site can see across it (chokepoint, not
+    // per-caller guards).  Two invariants must hold at the wipe itself:
+    //
+    // 1. No live turn mid-stream.  A turn can START during the fetch (the
+    //    server drains queued sends at exactly the idle edges the
+    //    backstop rides; another operator on a shared coordinator can
+    //    send any time; coordSend paints an optimistic user row).  This
+    //    render does not reset the streaming refs, so replaceChildren
+    //    would detach the live bubble — every remaining token renders
+    //    into the dangling ref (invisible), and the optimistic user row
+    //    is destroyed with nothing to repaint it.  Skip instead: if the
+    //    staleness latch is set it stays set (clear is below), the gate
+    //    stays closed, and the turn's own settle re-fires the backstop.
+    // 2. Seedless renders need an IDLE pane on a LIVE stream.  busy: the
+    //    ref check above only sees the CONTENT phase — a turn in its tool
+    //    phase has null content refs but live tool rows, and the wipe +
+    //    toolRows.clear() below would orphan them mid-stream identically.
+    //    evtSource: a seedless render must not advance the DOM past a
+    //    frozen lastEventId (hide/suspend can land mid-fetch) — the
+    //    show-edge reconnect replays from the frozen cursor and every
+    //    turn this render already painted would render twice.  Seeded
+    //    callers (init, loadHistoryThenReconnect) own their reconnect
+    //    flow — they adopt hist.cursor below, and the truncated resync
+    //    legitimately rebuilds MID-turn — so both requirements key on the
+    //    seedCursor ARG, not caller identity.  On skip the latch
+    //    survives; the next organic settle (or the show-edge reconnect's
+    //    synthetic idle) re-fires the backstop.
+    //
+    // The callers' fire-time ref/stream guards remain as the efficiency
+    // layer (skip the pointless fetch); THIS gate is the correctness
+    // carrier.
+    if (currentAssistantEl || currentReasoningEl) return;
+    if (!seedCursor && (busy || !evtSource)) return;
     messagesEl.replaceChildren();
     // A full committed-history render repairs any recorded truncation gap —
     // whether this render came from the truncated resync itself or from an

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1661,6 +1661,9 @@ class ChatSession:
         self._persona_memory: bool
         self._apply_persona_snapshot(persona_snapshot)
         self._title_generated = False
+        # Monotonic truncation counter — folded into the /history
+        # single-flight key (see _persist_truncation).
+        self._history_generation = 0
         self._read_files: set[str] = set()
         # Session-monotonic run counter for sub-agent id minting (see
         # ``_run_agent``): the parent call id alone can repeat across runs (a
@@ -6962,6 +6965,16 @@ class ChatSession:
         does; a later resume rehydrates ``[summary] + [surviving tail]`` and the
         two reconcile.
         """
+        # History generation (#894/#884 seam): every truncation bumps the
+        # counter the /history single-flight folds into its flight key, so
+        # a request dispatched AFTER a rewind/retry can never join a flight
+        # whose load_messages ran BEFORE it (a joined pre-rewind payload
+        # rendered as fresh truth on the coordinator and reopened the
+        # over-rewind window the #894 client latch closes).  Bumped before
+        # the storage write on purpose: the in-memory tail is already
+        # trimmed by both callers, and a spuriously fresh flight is
+        # harmless while a wrongly-joined one is not.
+        self._history_generation += 1
         if removed_count <= 0:
             return
         # The caller already truncated self.messages (rewind/retry both trim

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -6965,16 +6965,6 @@ class ChatSession:
         does; a later resume rehydrates ``[summary] + [surviving tail]`` and the
         two reconcile.
         """
-        # History generation (#894/#884 seam): every truncation bumps the
-        # counter the /history single-flight folds into its flight key, so
-        # a request dispatched AFTER a rewind/retry can never join a flight
-        # whose load_messages ran BEFORE it (a joined pre-rewind payload
-        # rendered as fresh truth on the coordinator and reopened the
-        # over-rewind window the #894 client latch closes).  Bumped before
-        # the storage write on purpose: the in-memory tail is already
-        # trimmed by both callers, and a spuriously fresh flight is
-        # harmless while a wrongly-joined one is not.
-        self._history_generation += 1
         if removed_count <= 0:
             return
         # The caller already truncated self.messages (rewind/retry both trim
@@ -7000,6 +6990,19 @@ class ChatSession:
             # summarized prefix — skip rather than risk it; resume reconciles.
             return
         delete_messages_after(self._ws_id, max(floor, total - removed_count))
+        # History generation (#894/#884 seam): every truncation bumps the
+        # counter the /history single-flight folds into its flight key, so
+        # a request dispatched AFTER a rewind/retry can never join a flight
+        # whose load_messages ran BEFORE it (a joined pre-rewind payload
+        # rendered as fresh truth on the coordinator and reopened the
+        # over-rewind window the #894 client latch closes).  Bumped AFTER
+        # the storage delete: flights rebuild from storage, so a flight
+        # keyed with the OLD generation that reads post-delete rows is the
+        # harmless spuriously-fresh direction, while a NEW-generation
+        # flight reading pre-delete rows would be the wrongly-joined one —
+        # and the early-return error paths above (count/floor unavailable,
+        # delete skipped) correctly leave the generation unbumped.
+        self._history_generation += 1
 
     def rewind(self, n: int) -> int:
         """Drop the last *n* complete turns from the conversation.

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3554,8 +3554,11 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         # current) and reopened the over-rewind window.  Cold workstream:
         # generation 0; the first post-load truncation bumps to 1, so a
         # cold flight can never be joined across a rewind either.
+        # mgr.get returns the Workstream WRAPPER — the counter lives on
+        # its ChatSession (the G7 harness caught a direct getattr
+        # silently defaulting to 0 forever, which re-enabled joining).
         live_gen = (
-            getattr(live_session, "_history_generation", 0)
+            getattr(getattr(live_session, "session", None), "_history_generation", 0)
             if live_session is not None
             else 0
         )

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3466,7 +3466,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
     # isolation of every other lifted verb.  Touched only from the event
     # loop thread — no lock needed; the ``limit`` component is required
     # (a limit=10 caller must not receive a limit=500 payload).
-    flights: dict[tuple[str, int], asyncio.Task[_HistoryFlightResult]] = {}
+    flights: dict[tuple[str, int, int], asyncio.Task[_HistoryFlightResult]] = {}
 
     async def history(request: Request) -> Response:
         if cfg.permission_gate is not None:
@@ -3547,7 +3547,19 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         # existence, limit) and must stay above it: a request may only
         # join a flight after its own gates passed.  Everything below is
         # the caller-independent reconstruction, shared via ``flights``.
-        key = (ws_id, limit)
+        # The ws's truncation generation joins the key (#894): a request
+        # dispatched after a rewind/retry must never join a flight whose
+        # load_messages ran before it — the joined pre-rewind payload
+        # reads as fresh truth client-side (the dispatch stamp is
+        # current) and reopened the over-rewind window.  Cold workstream:
+        # generation 0; the first post-load truncation bumps to 1, so a
+        # cold flight can never be joined across a rewind either.
+        live_gen = (
+            getattr(live_session, "_history_generation", 0)
+            if live_session is not None
+            else 0
+        )
+        key = (ws_id, limit, live_gen)
         task = flights.get(key)
         joined = task is not None
         if task is None:
@@ -3595,7 +3607,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         return JSONResponse({"ws_id": ws_id, "messages": messages, "cursor": cursor})
 
     async def _run_flight(
-        key: tuple[str, int],
+        key: tuple[str, int, int],
         mgr: SessionManager,
         storage: Any,
         app_state: Any,

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3471,7 +3471,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
     # isolation of every other lifted verb.  Touched only from the event
     # loop thread — no lock needed; the ``limit`` component is required
     # (a limit=10 caller must not receive a limit=500 payload).
-    flights: dict[tuple[str, int, int], asyncio.Task[_HistoryFlightResult]] = {}
+    flights: dict[tuple[str, int, int | None], asyncio.Task[_HistoryFlightResult]] = {}
 
     async def history(request: Request) -> Response:
         if cfg.permission_gate is not None:
@@ -3562,10 +3562,17 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         # mgr.get returns the Workstream WRAPPER — the counter lives on
         # its ChatSession (the G7 harness caught a direct getattr
         # silently defaulting to 0 forever, which re-enabled joining).
-        live_gen = (
-            getattr(getattr(live_session, "session", None), "_history_generation", 0)
-            if live_session is not None
-            else 0
+        # Typed access, not getattr chains, so mypy carries the shape.
+        # A cold/detached workstream keys on None, NEVER 0: an eviction
+        # or close landing inside a held flight's window would otherwise
+        # let a post-truncation request join a generation-0 live flight
+        # (rewinds need a live session, so two COLD flights are always
+        # mutually safe — and a rehydrated session restarting at 0 can
+        # never share the manager slot with its evicted predecessor).
+        live_gen: int | None = (
+            live_session.session._history_generation
+            if live_session is not None and live_session.session is not None
+            else None
         )
         key = (ws_id, limit, live_gen)
         task = flights.get(key)
@@ -3615,7 +3622,7 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         return JSONResponse({"ws_id": ws_id, "messages": messages, "cursor": cursor})
 
     async def _run_flight(
-        key: tuple[str, int, int],
+        key: tuple[str, int, int | None],
         mgr: SessionManager,
         storage: Any,
         app_state: Any,

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3438,7 +3438,8 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
     inline on the event loop).
 
     Restart-herd coalescing (issue #884): concurrent requests for the
-    same ``(ws_id, limit)`` share ONE reconstruction (single-flight) —
+    same ``(ws_id, limit, history_generation)`` share ONE reconstruction
+    (single-flight) —
     after a node restart every open pane resyncs via REST ``/history``
     inside the same jitter window, and each un-coalesced request repeats
     the full ``load_messages`` → decoration → projection pipeline
@@ -3457,7 +3458,11 @@ def make_history_handler(cfg: SessionEndpointConfig) -> Handler:
         cfg: per-kind policy bundle.
     """
 
-    # In-flight reconstructions, keyed ``(ws_id, limit)``.  Holds ONLY
+    # In-flight reconstructions, keyed ``(ws_id, limit,
+    # history_generation)`` — the third component isolates flights across
+    # rewind/retry truncations (see ChatSession._persist_truncation), so
+    # a post-truncation request can never join a pre-truncation
+    # reconstruction.  Holds ONLY
     # live flights — each task pops its own key in a ``finally`` before
     # completing, so a later request can never read a completed (stale)
     # result: this map is a single-flight, not a cache.  Scoped to this


### PR DESCRIPTION
Closes #894.

## The bug

From clear_ui arrival until the next successful `refetchHistory` render, the coordinator pane shows the stale pre-rewind transcript with `busy === false` — so a second rewind/edit click counted the stale DOM and POSTed an over-large turn count against the already-restructured server conversation (the #890 sibling, pre-existing since #888 accepted the stale-interactive window).

## The fix — client (coordinator.js)

Port of interactive.js's converged #890 latch design, adapted to coord's structure (no load token, no replay quiesce, no ref-resetting render — each divergence ruled at-site):

- **`historyStale` latch**: set at clear_ui arrival, cleared in exactly one place — `refetchHistory`'s success path, below the failure guard. A refetch-in-flight flag would reopen on the failed exit, which is exactly the over-rewind window.
- **Gates**: `_rewindToMessage` / `_editAndResend` / `_startEdit` require `busy || historyStale`; `_rewindToTurns` / `_retryLast` stay deliberately busy-only (explicit-arg / no-DOM-count — rulings at-site; the former has exactly one caller, which is gated).
- **Heal A**: one bounded 2s retry armed in clear_ui's `.then`; arm and fire both teardown-gated (`visHandler`), fire additionally requires no in-flight fetch, idle pane, null streaming refs, and an OPEN stream (CONNECTING carries a frozen cursor and a pending replay).
- **Heal B**: idle-edge backstop as the `else if` behind the truncated-resync consumer — **transport-free by ruling**: a heal that reconnects draws the server's synthetic `state_change` back into its own trigger (the #890 round-5 storm). Fresh/truncated replays do carry a synthetic state edge (replay_ok does not) — the arm's cost is bounded by reconnect backoff and #884's server single-flight; ruled at-site.
- **Render-time gate** in `refetchHistory`, post-await, pre-wipe — the chokepoint that can see across the await window. Universal terms: dispatch currency (`refetchSeq`, last-dispatch-wins) and the content refs. Seedless-only terms: the **event-driven live-tool-call set** (`liveToolCalls` — fed only by live `tool_pending`/`tool_info`, retired by results, settle edges, or pane death; never by transport death, and never touched by any render — a DOM-probed marker is forgeable by the render's own orphan repaint), the optimistic-send `busySource` flavor, and stream-OPENness. Seeded callers bypass the seedless terms: the truncated resync's render *is* the recovery and legitimately rebuilds mid-turn.
- **Bounded fetch**: the `/history` await is bounded (AbortController + 15s, the coordSend shape) so a wedged node can't pin the in-flight counter and permanently disable the heals; `destroy()` aborts every in-flight controller (a Set — overlapping dispatches settle in any order).

## The fix — server (the joined-flight window)

The #884 `/history` single-flight could hand a joiner a payload whose `load_messages` ran **before** a rewind committed — the joined pre-rewind payload reads as fresh truth client-side (the dispatch stamp is current; the staleness is the flight's transaction point, visible only server-side) and reopened the over-rewind window through the server seam. Reachable single-user (rewind clicked during a truncated-resync fetch) and multi-viewer.

`ChatSession._history_generation` is bumped in `_persist_truncation` (the shared rewind/retry chokepoint), **after** `delete_messages_after` (flights rebuild from storage: old-generation-reads-post-delete is spuriously fresh and harmless; new-generation-reads-pre-delete would be wrongly joinable; the storage-error early-returns stay unbumped). The flight key becomes `(ws_id, limit, generation)`; cold/detached workstreams key on `None`, which can never collide with a live generation. The read is typed so mypy carries the shape.

## Hard-crash finding (tracked separately)

Building the orphan detector empirically established: only a *graceful* close synthesizes results for interrupted tool calls (`session.cancel()`); boot-time rehydration synthesizes nothing, so a hard crash (SIGKILL/OOM) leaves a persisted unresulted `tool_calls` turn — and a hard-crashed reborn node answers stale-high cursors with a silent fresh stream (no `replay_truncated`). The client is hardened against the resulting orphan render (the live-set gate); the server-side recovery-signal hole is pre-existing and filed as a follow-up.

## Validation

- **250 static/unit pins** across `test_coordinator_page.py` (the nine-section latch-contract test), `test_app_js.py`, `test_rewind_retry.py` (the generation producer pin, two-armed), and `test_workstream_endpoints.py` (the flight-generation join/miss test mirroring the #884 coalescing determinism scheme). 18+ mutants validated across the campaign — every load-bearing line has a pin that fails without it.
- **E2E harness**: seven new coordinator scenarios (G1–G7) beside the existing family — the E2/E3/E4 ports with coord observables (fault-layer counters + POST non-occurrence; the latch is closure-private), the mid-turn render-gate detector (G4), the hidden-retry liveness detector (G5), the hard-kill poisoned-pane detector (G6), and the two-actor joined-flight detector (G7, held open inside `load_messages` via the new `delay_load` knob; `stop(hard=True)` models a real crash). Every scenario negative-controlled: pre-fix or variant code stamps the predicted FAILED shape (`posts2-rows0` / `closed2-heal0` / `sse1` / `hist1` / `hidden1` / `orphan1` / `loads1-rows3`).
- **Full suite** (9725) and the **full 17-scenario harness** green on the final tree.

Ten review rounds (four-finder pipeline, unprimed full-surface, adversarial verify); every finding fixed or ruled at-site with the ruling in a code comment.
