### PR TITLE
fix(#900): invalidate in-flight loads at teardown; gate the seedless render on a live cursor

### DIFF
--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -26,6 +26,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario hidden-retry      # E5 (#900)
     python3 scripts/recovery_e2e.py --scenario await-window-gate # E6 (#900)
     python3 scripts/recovery_e2e.py --scenario destroy-invalidation # E7 (#900)
+    python3 scripts/recovery_e2e.py --scenario reconnect-in-await # E8 (#900 r2)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-window        # G1 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-failed-window # G2 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
@@ -133,6 +134,21 @@ the latch still SET (``replayHistory`` is the latch's only clear site, so a
 held latch proves no render ran); without the gate it stamps rows1-latch0.
 The repair still arrives on the organic settle the transport-free backstop
 owns.  Stamps ``RECOVERY-READY-AWAITGATE-rows3-latch1``.
+
+Scenario E8 (reconnect-in-await): the stream-generation term (#900 r2), and
+the FIRST detector here that can observe a double render at all.  Every other
+scenario counts ``.msg.user`` rows, and user rows never travel on the SSE
+stream, so none of them can see the artefact this campaign prevents — E8
+counts a sentinel's OCCURRENCES in the transcript text instead.  The retry
+fires with the transport OPEN, its /history is held, and inside that await the
+transport DROPS and RE-ESTABLISHES: ``readyState`` reads OPEN afterwards
+exactly as before, so neither the presence nor the readyState term can tell
+the two apart, but the redial re-presented the frozen cursor, the server
+answered replay_ok, and the quiesce BUFFERED that slice — rendering commits
+the turn and the flush repaints it.  The connection generation is the only
+term that sees it (object identity cannot: a native reconnect reuses the same
+EventSource).  Verified by control: stripping the term stamps ``dupes2``.
+Stamps ``RECOVERY-READY-RECONNECTAWAIT-dupes1-healed1``.
 
 The #894 coordinator ports (G family — the coord pane's ``historyStale``
 latch; coord state is closure-private, so where E2-E4 read pane fields the
@@ -386,6 +402,20 @@ SECOND_SENTINEL = "SECOND-a7f3"
 # proves the sent turn reached the healed /history render, distinct from
 # everything else on screen.
 BACKSTOP_SENTINEL = "BACKSTOP-b2e4"
+# Scenario E8's duplicate-detector sentinel.  Its whole job is to be COUNTED,
+# not merely found: the artefact #900's stream-generation term prevents is a
+# turn rendered twice, and every other detector in this file counts
+# ``.msg.user`` rows — which never travel on the SSE stream, so none of them
+# can see it.
+DUPLICATE_SENTINEL = "DUPE-c9a7"
+
+# Row-count selectors, hoisted above every runner that uses them (#900 r2):
+# eight inline copies had accumulated ABOVE the old definition site, so the
+# duplication was invisible to anyone reading top-down.  Python resolves
+# module names at CALL time, so the old placement worked — it just could
+# not be adopted by the runners that needed it most.
+_ROWS_JS = "window.__pane.messagesEl.querySelectorAll('.msg.user').length"
+_COORD_ROWS_JS = "document.getElementById('coord-messages').querySelectorAll('.msg.user').length"
 
 # Scenario G4 (coord-heal-midturn) sentinels: turn 4's final text (the
 # settle that fires the held backstop fetch) and turn 5's final text (the
@@ -577,6 +607,32 @@ PAGE_HTML = r"""<!doctype html>
 
       // Shared by the rewind scenarios (E2/E3): click the REAL rewind
       // button on the idx-th user row.  Depends only on `pane`.
+      // Count a sentinel's OCCURRENCES in the transcript text.  Every other
+      // detector in this harness counts `.msg.user` rows, and user rows are
+      // never emitted on the SSE stream — so none of them can observe a turn
+      // rendered twice.  Counting text is structure-agnostic: it catches a
+      // duplicate assistant bubble, a duplicate tool block, or both.
+      window.__countSentinel = function (s) {
+        const text = pane.messagesEl.textContent || "";
+        let n = 0;
+        let i = text.indexOf(s);
+        while (i !== -1) {
+          n += 1;
+          i = text.indexOf(s, i + s.length);
+        }
+        return n;
+      };
+      // Drop and re-establish the transport in place — scenario E8's
+      // reconnect-inside-the-await.  Deliberately NOT __hide()/__show():
+      // a hide leaves evtSource null, which the gate's presence term
+      // already decides, so the negative control would pass for the wrong
+      // reason.  This lands OPEN with a bumped generation, which only the
+      // generation term can see.
+      window.__redial = function () {
+        pane.disconnectSSE();
+        pane.connectSSE(pane.wsId);
+      };
+
       window.__clickRewind = function (idx) {
         const rows = pane.messagesEl.querySelectorAll(".msg.user");
         const row = rows[idx];
@@ -930,6 +986,41 @@ PAGE_HTML = r"""<!doctype html>
               "-latch" +
               (latchHeld ? 1 : 0) +
               "-heal" +
+              (healed ? 1 : 0);
+        };
+      } else if (scenario === "reconnect-in-await") {
+        // Scenario E8 — the stream-generation term (#900 r2).  A transport
+        // that DROPS and finishes RE-ESTABLISHING inside a seedless
+        // /history await reads back readyState OPEN, indistinguishable from
+        // one that never moved.  It is not: the redial re-presented the
+        // frozen _lastEventId, the server answered replay_ok, and the
+        // quiesce BUFFERED that slice — so a render here commits turns the
+        // flush is about to repaint on top.  Only a connection counter can
+        // see it; object identity cannot, because a NATIVE reconnect reuses
+        // the same EventSource object.
+        //
+        // THE DETECTOR IS A COUNT, not a presence check.  Both the fixed and
+        // the broken build end up SHOWING the turn — the difference is
+        // whether it appears once (render declined, the flushed replay
+        // paints it) or twice (render committed, then the flush repeats it).
+        window.__verifyReconnectInAwait = function (dupes, healed) {
+          // dupes is THE discriminator: the turn committed during the
+          //   transport gap must appear EXACTLY once.  2 is the double
+          //   render this scenario exists for.
+          // healed is the CONVERGENCE leg, not a discriminator — it holds in
+          //   both builds, and is asserted so a "no duplicates" verdict can
+          //   never be earned by rendering nothing at all.  Unlike E6 (tab
+          //   stays hidden, so the declined render's flushed settle edge
+          //   finds a dead transport and the latch stays set), here the
+          //   stream is LIVE at flush time: the queued settle fires the
+          //   transport-free backstop, whose own fetch has a stable
+          //   generation and lands.  A declined render still converges.
+          const ok = dupes === 1 && healed;
+          document.title = ok
+            ? "RECOVERY-READY-RECONNECTAWAIT-dupes1-healed1"
+            : "RECOVERY-FAILED-RECONNECTAWAIT-dupes" +
+              dupes +
+              "-healed" +
               (healed ? 1 : 0);
         };
       } else if (scenario === "destroy-invalidation") {
@@ -2379,9 +2470,7 @@ def run_rewind_window(chrome: str) -> str:
         _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
         # Wait for the initial /history to paint all three user rows.
         if not _poll_until(
-            lambda: (
-                cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length") == 3
-            ),
+            lambda: cdp.evaluate(_ROWS_JS) == 3,
             20,
             0.2,
         ):
@@ -2411,8 +2500,7 @@ def run_rewind_window(chrome: str) -> str:
         _poll_until(
             lambda: (
                 (not cdp.evaluate("window.__pane._replayQueue != null"))
-                and cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length")
-                == 1
+                and cdp.evaluate(_ROWS_JS) == 1
             ),
             8,
         )
@@ -2449,9 +2537,7 @@ def run_rewind_failed_window(chrome: str) -> str:
         # Wait for the initial /history to paint all three user rows.  This
         # load MUST succeed, so arm the forced failure only AFTERWARDS.
         if not _poll_until(
-            lambda: (
-                cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length") == 3
-            ),
+            lambda: cdp.evaluate(_ROWS_JS) == 3,
             20,
             0.2,
         ):
@@ -2500,7 +2586,7 @@ def run_rewind_failed_window(chrome: str) -> str:
                 "rewind-failed-window: failed fetch did not settle to latch-held/quiesce-released"
             )
         # The stale transcript is intact — the failed fetch wiped nothing.
-        stale_rows = cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length")
+        stale_rows = cdp.evaluate(_ROWS_JS)
         if stale_rows != 3:
             raise AssertionError(
                 f"rewind-failed-window: failed fetch did not preserve the transcript "
@@ -2522,9 +2608,7 @@ def run_rewind_failed_window(chrome: str) -> str:
         # (same arithmetic as run_rewind_window).  Poll to a deadline rather
         # than sleeping the 2s timer + 3s hold.
         healed = _poll_until(
-            lambda: (
-                cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length") == 1
-            ),
+            lambda: cdp.evaluate(_ROWS_JS) == 1,
             10,
             0.2,
         )
@@ -2603,9 +2687,7 @@ def run_stale_backstop(chrome: str) -> str:
         # Wait for the initial /history to paint all three user rows.  This
         # load MUST succeed, so arm the forced failures only AFTERWARDS.
         if not _poll_until(
-            lambda: (
-                cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length") == 3
-            ),
+            lambda: cdp.evaluate(_ROWS_JS) == 3,
             20,
             0.2,
         ):
@@ -2646,7 +2728,7 @@ def run_stale_backstop(chrome: str) -> str:
                 "stale-backstop: aftermath did not settle to latch-held/quiesce-released"
             )
         # The stale transcript is intact — the failed fetches wiped nothing.
-        stale_rows = cdp.evaluate("window.__pane.messagesEl.querySelectorAll('.msg.user').length")
+        stale_rows = cdp.evaluate(_ROWS_JS)
         if stale_rows != 3:
             raise AssertionError(
                 f"stale-backstop: failed fetches did not preserve the transcript "
@@ -2678,7 +2760,7 @@ def run_stale_backstop(chrome: str) -> str:
         # regressed looping backstop times out to a clean FAILED, never a hang.
         healed = _poll_until(
             lambda: cdp.evaluate(
-                "window.__pane.messagesEl.querySelectorAll('.msg.user').length === 2 "
+                _ROWS_JS + " === 2 "
                 "&& window.__pane._historyStale === false "
                 "&& (window.__pane.messagesEl.textContent||'').includes("
                 + json.dumps(BACKSTOP_SENTINEL)
@@ -2722,9 +2804,6 @@ def run_stale_backstop(chrome: str) -> str:
             cdp.close()
         _kill(proc)
         node.stop()
-
-
-_ROWS_JS = "window.__pane.messagesEl.querySelectorAll('.msg.user').length"
 
 
 def run_hidden_retry(chrome: str) -> str:
@@ -2789,7 +2868,13 @@ def run_hidden_retry(chrome: str) -> str:
         # NON-occurrence window: the retry fires at ~2s post-failure, so give
         # it 3.5s.  Without the guard this poll returns True (the hidden fetch
         # lands) and hidden_delta stamps 1.
-        _poll_until(lambda: node.history_requests != hidden_baseline, 3.5, 0.1)
+        # Window = the 2000 ms floor + the jitter ceiling + slack.  The
+        # retry's delay is `2000 + rand*STALE_RETRY_JITTER_MS` (#900), so a
+        # window sized on the floor alone would close BEFORE a
+        # top-of-range firing and report hidden0 for the wrong reason —
+        # the detector would go vacuous and its negative control would
+        # silently stop working.  Raise this with the constant.
+        _poll_until(lambda: node.history_requests != hidden_baseline, 4.5, 0.1)
         hidden_delta = node.history_requests - hidden_baseline
         # The latch must still be SET — a skipped retry heals nothing, which
         # is exactly why the backstop still owns the repair below.
@@ -2853,10 +2938,18 @@ def run_await_window_gate(chrome: str) -> str:
     released, latch intact for the backstop.
 
     DETECTOR: the stale transcript must survive the resolved fetch — THREE
-    user rows still standing (the pre-rewind truth) with the latch still SET,
-    after ``history_requests`` proves the held fetch both arrived AND
-    returned.  Without the gate the render lands and stamps rows1-latch0,
-    because a successful replayHistory is the latch's only clear site."""
+    user rows still standing (the pre-rewind truth) with the latch still SET.
+    Without the gate the render lands and stamps rows1-latch0, because a
+    successful replayHistory is the latch's only clear site.
+
+    NON-VACUITY is the load-bearing part here, and ``history_requests`` cannot
+    carry it: that counter bumps on ARRIVAL, before the hold and before any
+    status is chosen, so "the gate declined a good payload" and "there was no
+    good payload" would stamp identical observables (no wipe either way, latch
+    held either way).  ``history_ok`` — incremented only when the PRODUCTION
+    route answers 200 — is what proves a renderable payload actually existed,
+    and it closes the production-side-failure hole an injected-fail budget
+    cannot see."""
     from tests._sse_recovery_server import final_text_script
 
     # The heal-driving send needs its OWN scripted turn: an exhausted script
@@ -2890,6 +2983,7 @@ def run_await_window_gate(chrome: str) -> str:
         # Hold the RETRY's fetch open.  history_requests counts on ARRIVAL,
         # before the hold sleeps, so the bump below is the in-flight edge.
         retry_baseline = node.history_requests
+        ok_baseline = node.history_ok
         node.delay_history(3000)
         # The tab stays VISIBLE here — the retry must pass its fire guard,
         # or this scenario degenerates into E5 and proves nothing.
@@ -2900,10 +2994,20 @@ def run_await_window_gate(chrome: str) -> str:
         cdp.evaluate("window.__hide && window.__hide()")
         if not _poll_until(lambda: cdp.evaluate("window.__pane.evtSource === null"), 5, 0.05):
             raise AssertionError("await-window-gate: close-on-hide never dropped the transport")
-        # Let the held fetch resolve, then let the render decision settle.
+        # Clear the knob for any LATER arrival; the already-held fetch is
+        # sleeping on the duration it captured at arrival and serves that
+        # out regardless — which is why the poll below must outlast it.
         node.delay_history(0)
         if not _poll_until(lambda: cdp.evaluate("window.__pane._replayQueue === null"), 12, 0.1):
             raise AssertionError("await-window-gate: the quiesce never released")
+        # The payload must have been GOOD — otherwise a declined render and a
+        # failed fetch are indistinguishable (see the docstring).
+        if not _poll_until(lambda: node.history_ok >= ok_baseline + 1, 12, 0.1):
+            raise AssertionError(
+                "await-window-gate: the held /history never answered 200 "
+                f"(history_ok={node.history_ok}, baseline={ok_baseline}) — "
+                "a declined render cannot be distinguished from a failed fetch"
+            )
         rows = cdp.evaluate(_ROWS_JS)
         latch_held = cdp.evaluate("window.__pane._historyStale === true")
         # The heal still belongs to the backstop: show, then drive an organic
@@ -2929,6 +3033,119 @@ def run_await_window_gate(chrome: str) -> str:
             f"window.__verifyAwaitWindowGate({rows}, "
             f"{'true' if latch_held else 'false'}, {'true' if healed else 'false'})"
         )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
+def run_reconnect_in_await(chrome: str) -> str:
+    """Scenario E8 — the stream-generation term (#900 r2), and the first
+    detector in this harness that can observe a DOUBLE RENDER at all.
+
+    Every other scenario counts ``.msg.user`` rows, and user rows never travel
+    on the SSE stream (a /send emits none — only /history replay paints them),
+    so none of them can see the artefact this whole campaign prevents: a turn
+    rendered twice.  E8 counts a sentinel's OCCURRENCES in the transcript text
+    instead, which is structure-agnostic across duplicate assistant bubbles and
+    duplicate tool blocks.
+
+    The window: the clear_ui retry fires with the transport OPEN, its /history
+    is held at the fault layer, and inside that await the transport DROPS and
+    RE-ESTABLISHES.  ``readyState`` reads OPEN afterwards exactly as it did
+    before, so neither the presence term nor the readyState term can tell the
+    two apart — but the redial re-presented the frozen ``_lastEventId``, the
+    server answered ``replay_ok`` with the turn committed during the gap, and
+    the replay quiesce BUFFERED that slice.  Rendering then commits the turn,
+    and ``_endReplayQuiesce`` repaints it on top: two copies.
+
+    With the generation term the render is declined, the stale-but-real
+    transcript survives, and the flushed replay paints the new turn exactly
+    ONCE.  Strip the term and the same run stamps ``dupes2``.
+
+    The redial is a REAL disconnect+connect, deliberately not ``__hide()``:
+    a hide leaves ``evtSource`` null, which the presence term already decides,
+    so a hide-based control would pass for the wrong reason."""
+    from tests._sse_recovery_server import final_text_script
+
+    node, ws_id = _seed_three_completed_turns(
+        "browser-reconnect-in-await",
+        extra_scripts=(final_text_script(DUPLICATE_SENTINEL),),
+    )
+    profile = Path(_scratch()) / "chrome-reconnect-in-await"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=reconnect-in-await"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        if not _poll_until(lambda: cdp.evaluate(_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("reconnect-in-await: three user rows never rendered")
+        if not _poll_until(lambda: node.events_requests >= 1, 10, 0.05):
+            raise AssertionError("reconnect-in-await: SSE stream never opened")
+        # Arm the latch: the rewind's own clear_ui refetch fails, leaving the
+        # stale transcript up and the bounded retry armed.
+        node.fail_history(1)
+        if not cdp.evaluate("window.__clickRewind(1)"):
+            raise AssertionError("reconnect-in-await: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("reconnect-in-await: rewind never POSTed")
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 15):
+            raise AssertionError("reconnect-in-await: forced /history failure never fired")
+        # Hold the RETRY's fetch wide open — everything below happens inside
+        # its await.  history_requests counts on ARRIVAL, so the bump is the
+        # in-flight edge.
+        retry_baseline = node.history_requests
+        ok_baseline = node.history_ok
+        node.delay_history(6000)
+        if not _poll_until(lambda: node.history_requests == retry_baseline + 1, 8, 0.05):
+            raise AssertionError("reconnect-in-await: the retry never fetched on the live stream")
+        # (1) Drop the transport.  The cursor freezes here.
+        cdp.evaluate("window.__pane.disconnectSSE()")
+        if not _poll_until(lambda: cdp.evaluate("window.__pane.evtSource === null"), 5, 0.05):
+            raise AssertionError("reconnect-in-await: the transport never dropped")
+        # (2) Commit a turn while the stream is DOWN, so the server holds
+        #     events past the frozen cursor with no way to have delivered them.
+        # Runner-side send + the real turn-complete barrier: the page's
+        # stream is down, so driving this from the browser would prove
+        # nothing extra and only add a timing race.
+        node.send(ws_id, "gap turn")
+        node.wait_turn(ws_id)
+        # (3) Re-establish, still inside the await.  This is the whole point:
+        #     readyState goes back to OPEN, so only the generation moved.
+        cdp.evaluate("window.__redial()")
+        if not _poll_until(
+            lambda: cdp.evaluate(
+                "!!window.__pane.evtSource && "
+                "window.__pane.evtSource.readyState === EventSource.OPEN"
+            ),
+            10,
+            0.05,
+        ):
+            raise AssertionError("reconnect-in-await: the redial never reached OPEN")
+        # Release the knob for later arrivals; the held fetch serves out its
+        # own 6000 ms regardless, which is what the polls below outlast.
+        node.delay_history(0)
+        if not _poll_until(lambda: node.history_ok >= ok_baseline + 1, 15, 0.1):
+            raise AssertionError(
+                "reconnect-in-await: the held /history never answered 200 — "
+                "a declined render cannot be distinguished from a failed fetch"
+            )
+        # Settle to the CONVERGED end state before counting.  The declined
+        # render leaves the latch set, its flushed settle edge fires the
+        # backstop, and the backstop's own fetch — stable generation, live
+        # stream — lands the rewound-plus-gap transcript (2 user rows, latch
+        # cleared).  Counting before that would race the heal.
+        healed = _poll_until(
+            lambda: cdp.evaluate(_ROWS_JS + " === 2 && window.__pane._historyStale === false"),
+            25,
+            0.2,
+        )
+        dupes = cdp.evaluate(f"window.__countSentinel({json.dumps(DUPLICATE_SENTINEL)})")
+        print(f"  reconnect-in-await dupes={dupes} healed={healed}")
+        cdp.evaluate(f"window.__verifyReconnectInAwait({dupes}, {'true' if healed else 'false'})")
         return _poll_title(cdp, 15)
     finally:
         if cdp is not None:
@@ -2986,8 +3203,11 @@ def run_destroy_invalidation(chrome: str) -> str:
         cdp.evaluate("window.__ctl.destroy()")
         if not _poll_until(lambda: cdp.evaluate("!window.__pane.el.parentNode"), 5, 0.05):
             raise AssertionError("destroy-invalidation: destroy() never detached the pane")
-        # Let the held fetch resolve and its .finally run.  The wait must
-        # outlast the hold, or a 0 here would only mean "not yet".
+        # Hygiene only: this cannot release the in-flight hold (the fault
+        # layer captured the duration at arrival), and no further /history
+        # is expected here.  The non-occurrence poll below therefore has to
+        # outlast the REMAINING hold — raising delay_history above without
+        # raising that deadline would make this detector vacuous.
         node.delay_history(0)
         _poll_until(lambda: node.events_requests != 0, 8, 0.1)
         sse_opens = node.events_requests
@@ -3000,9 +3220,6 @@ def run_destroy_invalidation(chrome: str) -> str:
             cdp.close()
         _kill(proc)
         node.stop()
-
-
-_COORD_ROWS_JS = "document.getElementById('coord-messages').querySelectorAll('.msg.user').length"
 
 
 def run_coord_rewind_window(chrome: str) -> str:
@@ -3511,7 +3728,13 @@ def run_coord_hidden_retry(chrome: str) -> str:
         # NON-occurrence window: the retry fires at ~2s post-failure; give
         # it 3.5s.  Without the evtSource guard this poll returns True
         # (the hidden fetch lands) and hiddenDelta stamps 1.
-        _poll_until(lambda: node.history_requests != hidden_baseline, 3.5, 0.1)
+        # Window = the 2000 ms floor + the jitter ceiling + slack.  The
+        # retry's delay is `2000 + rand*STALE_RETRY_JITTER_MS` (#900), so a
+        # window sized on the floor alone would close BEFORE a
+        # top-of-range firing and report hidden0 for the wrong reason —
+        # the detector would go vacuous and its negative control would
+        # silently stop working.  Raise this with the constant.
+        _poll_until(lambda: node.history_requests != hidden_baseline, 4.5, 0.1)
         hidden_delta = node.history_requests - hidden_baseline
         # Show: the reconnect presents the frozen cursor and replays
         # replay_ok (nothing lost), which carries NO synthetic
@@ -3822,6 +4045,7 @@ def main() -> None:
             "hidden-retry",
             "await-window-gate",
             "destroy-invalidation",
+            "reconnect-in-await",
             "coord-rewind-window",
             "coord-rewind-failed-window",
             "coord-stale-backstop",
@@ -3893,6 +4117,10 @@ def main() -> None:
     if args.scenario in ("destroy-invalidation", "all"):
         verdict = run_destroy_invalidation(chrome)
         print(f"scenario E7 (destroyinval): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("reconnect-in-await", "all"):
+        verdict = run_reconnect_in_await(chrome)
+        print(f"scenario E8 (reconnectawait): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("coord-rewind-window", "all"):
         verdict = run_coord_rewind_window(chrome)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -23,6 +23,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario rewind-window     # E2 (#890)
     python3 scripts/recovery_e2e.py --scenario rewind-failed-window  # E3 (#890)
     python3 scripts/recovery_e2e.py --scenario stale-backstop    # E4 (#890)
+    python3 scripts/recovery_e2e.py --scenario hidden-retry      # E5 (#900)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-window        # G1 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-failed-window # G2 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
@@ -96,6 +97,25 @@ by exactly ONE (the backstop's single fetch — the plain fourth turn emits no
 clear_ui).  All polls are deadline-bounded so a regressed looping backstop
 stamps a clean FAILED, never a hang.  Stamps
 ``RECOVERY-READY-STALEBACKSTOP-heal1-sse0``.
+
+Scenario E5 (hidden-retry): the clear_ui retry's stream-liveness fire guard
+(#900 — the interactive mirror of G5, filed from the #894 campaign's
+backport set).  ``disconnectSSE`` deliberately leaves the 2s retry ARMED
+(transport-only redials keep the pending heal intent), so a close-on-hide
+inside the arm window lets it fire with the transport DOWN.  A seedless
+``_refetchHistory`` then renders /history's as-of-now truth while
+``_lastEventId`` stays frozen at the last delivered id — and the show-edge
+reconnect presents that frozen cursor, so the server's replay_ok slice
+repaints every turn the hidden render just committed (only ``system_turn``
+and compaction markers carry id dedup; content and tool rows do not).  The
+detector is a NON-OCCURRENCE counted at the fault layer: ``history_requests``
+UNCHANGED across the hidden window (``hidden0``), which regresses to
+``hidden1`` the moment the ``evtSource.readyState === OPEN`` term is
+removed.  A replay_ok reconnect carries no synthetic ``state_change``, so
+the latch survives ``__show`` — the accepted liveness lag — and the heal
+rides a plain send's ORGANIC settle into the transport-free backstop, hence
+exactly ONE new SSE open across show + heal.  Stamps
+``RECOVERY-READY-HIDDENRETRY-hidden0-heal1``.
 
 The #894 coordinator ports (G family — the coord pane's ``historyStale``
 latch; coord state is closure-private, so where E2-E4 read pane fields the
@@ -787,6 +807,58 @@ PAGE_HTML = r"""<!doctype html>
               histDelta +
               "-gated" +
               gatedPosts +
+              "-posts" +
+              posts +
+              "-rows" +
+              userRows;
+        };
+      } else if (scenario === "hidden-retry") {
+        // Scenario E5 — the retry's stream-liveness fire guard (#900, the
+        // E-family mirror of coord's G5).  disconnectSSE deliberately
+        // LEAVES the 2s retry armed (transport-only redials keep the heal
+        // intent), so a close-on-hide inside the arm window lets it fire
+        // with the transport down.  A seedless _refetchHistory then paints
+        // /history's as-of-now truth while _lastEventId stays frozen where
+        // the stream stopped delivering — and the show-edge reconnect
+        // presents that frozen cursor, so the server's replay_ok slice
+        // repaints every turn the hidden render already committed (content
+        // and tool rows carry no id dedup).  The fire guard's
+        // ``evtSource.readyState === OPEN`` term skips the hidden firing
+        // instead: hiddenDelta 0 is the NON-OCCURRENCE detector, and it
+        // regresses to 1 the moment the term is removed.
+        //
+        // A replay_ok reconnect carries no synthetic state_change (only
+        // fresh/truncated replays do), so the latch stays closed across
+        // __show — the accepted liveness-lag residual, not a defect.  The
+        // heal rides the runner's plain send, whose ORGANIC turn-settle
+        // idle edge fires the transport-free backstop on the live stream.
+        window.__verifyHiddenRetry = function (
+          hiddenDelta,
+          healed,
+          showSse,
+          posts,
+        ) {
+          const userRows =
+            pane.messagesEl.querySelectorAll(".msg.user").length;
+          // hidden0 = the retry did NOT fetch while the transport was down
+          //   (the guard held — the whole point of the scenario).
+          // heal1 = after __show + a plain send, the backstop's refetch
+          //   rebuilt the rewound (ONE user turn) + sent (a second)
+          //   transcript => TWO user rows with the sentinel.
+          // showSse 1 = exactly ONE new EventSource across show + heal (the
+          //   show edge's own reconnect; the transport-free heal adds none).
+          // posts 2 = the healed render reopened the gate and a fresh
+          //   rewind landed.
+          const ok =
+            hiddenDelta === 0 && healed && showSse === 1 && posts === 2;
+          document.title = ok
+            ? "RECOVERY-READY-HIDDENRETRY-hidden0-heal1"
+            : "RECOVERY-FAILED-HIDDENRETRY-hidden" +
+              hiddenDelta +
+              "-heal" +
+              (healed ? 1 : 0) +
+              "-sse" +
+              showSse +
               "-posts" +
               posts +
               "-rows" +
@@ -2557,6 +2629,119 @@ def run_stale_backstop(chrome: str) -> str:
         node.stop()
 
 
+_ROWS_JS = "window.__pane.messagesEl.querySelectorAll('.msg.user').length"
+
+
+def run_hidden_retry(chrome: str) -> str:
+    """Scenario E5 — the clear_ui retry's stream-liveness fire guard (#900,
+    the interactive mirror of coord's G5).  ``disconnectSSE`` deliberately
+    leaves the 2s retry ARMED — transport-only redials keep the pending heal
+    intent — so a close-on-hide landing inside the arm window lets the retry
+    fire with the transport down.  A seedless ``_refetchHistory`` then
+    renders /history's as-of-now truth while ``_lastEventId`` stays frozen at
+    the last delivered id, and the show-edge reconnect presents that frozen
+    cursor: the server answers replay_ok and the slice repaints every turn
+    the hidden render just committed (only ``system_turn`` and compaction
+    markers carry id dedup — content and tool rows do not, and the render has
+    just reset the streaming refs and the announce map).
+
+    THE DETECTOR is a NON-OCCURRENCE, counted at the fault layer:
+    ``history_requests`` must be UNCHANGED across the whole hidden window.
+    Remove the ``evtSource.readyState === OPEN`` term and the hidden fetch
+    lands, stamping hidden1 — the scenario's negative control.
+
+    A replay_ok reconnect carries NO synthetic ``state_change`` (only
+    fresh/truncated replays do), so the latch stays closed across ``__show``:
+    that is the accepted liveness-lag residual, and no timer may shortcut it.
+    The heal therefore rides the runner's plain send (sends are never
+    latch-gated), whose ORGANIC turn-settle idle edge fires the
+    TRANSPORT-FREE backstop on the now-live stream — hence exactly ONE new
+    SSE open across show + heal (the show edge's own; the heal adds zero)."""
+    from tests._sse_recovery_server import final_text_script
+
+    node, ws_id = _seed_three_completed_turns(
+        "browser-hidden-retry",
+        extra_scripts=(final_text_script(BACKSTOP_SENTINEL),),
+    )
+    profile = Path(_scratch()) / "chrome-hidden-retry"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=hidden-retry"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # First paint MUST succeed — arm the forced failure only afterwards.
+        if not _poll_until(lambda: cdp.evaluate(_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("hidden-retry: three user rows never rendered")
+        # The stream must be OPEN before the hide, or close-on-hide has
+        # nothing to tear down and the scenario proves nothing.
+        if not _poll_until(lambda: node.events_requests >= 1, 10, 0.05):
+            raise AssertionError("hidden-retry: SSE stream never opened")
+        node.fail_history(1)
+        if not cdp.evaluate("window.__clickRewind(1)"):
+            raise AssertionError("hidden-retry: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("hidden-retry: rewind never POSTed")
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 15):
+            raise AssertionError("hidden-retry: forced /history failure never fired")
+        # Hide IMMEDIATELY — well inside the 2s arm window (the poll above
+        # settles ~0.3s after the failure).  close-on-hide tears the
+        # transport down and deliberately leaves the retry armed.
+        cdp.evaluate("window.__hide && window.__hide()")
+        if not _poll_until(lambda: cdp.evaluate("window.__pane.evtSource === null"), 5, 0.05):
+            raise AssertionError("hidden-retry: close-on-hide never dropped the transport")
+        hidden_baseline = node.history_requests
+        # NON-occurrence window: the retry fires at ~2s post-failure, so give
+        # it 3.5s.  Without the guard this poll returns True (the hidden fetch
+        # lands) and hidden_delta stamps 1.
+        _poll_until(lambda: node.history_requests != hidden_baseline, 3.5, 0.1)
+        hidden_delta = node.history_requests - hidden_baseline
+        # The latch must still be SET — a skipped retry heals nothing, which
+        # is exactly why the backstop still owns the repair below.
+        latch_held = cdp.evaluate("window.__pane._historyStale === true")
+        # Show: the reconnect presents the frozen cursor (replay_ok, nothing
+        # lost) and carries no synthetic state_change, so the latch survives
+        # it.  A plain send then drives the ORGANIC settle the backstop needs.
+        events_before_show = node.events_requests
+        cdp.evaluate("window.__show && window.__show()")
+        if not _poll_until(lambda: node.events_requests == events_before_show + 1, 10, 0.05):
+            raise AssertionError("hidden-retry: show-edge reconnect never arrived")
+        _send_in_page(cdp, "fourth turn")
+        healed = _poll_until(
+            lambda: cdp.evaluate(
+                _ROWS_JS
+                + " === 2 && window.__pane._historyStale === false"
+                + " && (window.__pane.messagesEl.textContent||'').includes("
+                + json.dumps(BACKSTOP_SENTINEL)
+                + ")"
+            ),
+            20,
+            0.2,
+        )
+        show_sse = node.events_requests - events_before_show
+        if healed:
+            if not cdp.evaluate("window.__clickRewind(0)"):
+                raise AssertionError("hidden-retry: healed-row rewind button missing")
+            _poll_until(lambda: node.rewind_requests == 2, 8, 0.05)
+        posts = node.rewind_requests
+        print(
+            f"  hidden-retry hidden_delta={hidden_delta} latch_held={latch_held} "
+            f"healed={healed} show_sse={show_sse} posts={posts}"
+        )
+        if not latch_held:
+            raise AssertionError("hidden-retry: latch cleared without a render")
+        cdp.evaluate(
+            f"window.__verifyHiddenRetry({hidden_delta}, "
+            f"{'true' if healed else 'false'}, {show_sse}, {posts})"
+        )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 _COORD_ROWS_JS = "document.getElementById('coord-messages').querySelectorAll('.msg.user').length"
 
 
@@ -3374,6 +3559,7 @@ def main() -> None:
             "rewind-window",
             "rewind-failed-window",
             "stale-backstop",
+            "hidden-retry",
             "coord-rewind-window",
             "coord-rewind-failed-window",
             "coord-stale-backstop",
@@ -3433,6 +3619,10 @@ def main() -> None:
     if args.scenario in ("stale-backstop", "all"):
         verdict = run_stale_backstop(chrome)
         print(f"scenario E4 (stalebackstop): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("hidden-retry", "all"):
+        verdict = run_hidden_retry(chrome)
+        print(f"scenario E5 (hiddenretry): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("coord-rewind-window", "all"):
         verdict = run_coord_rewind_window(chrome)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -2804,7 +2804,16 @@ def run_await_window_gate(chrome: str) -> str:
     after ``history_requests`` proves the held fetch both arrived AND
     returned.  Without the gate the render lands and stamps rows1-latch0,
     because a successful replayHistory is the latch's only clear site."""
-    node, ws_id = _seed_three_completed_turns("browser-await-window-gate")
+    from tests._sse_recovery_server import final_text_script
+
+    # The heal-driving send needs its OWN scripted turn: an exhausted script
+    # queue still settles (into the error arm, which the backstop also
+    # consumes), so relying on it would let this scenario pass for a reason
+    # it does not name.
+    node, ws_id = _seed_three_completed_turns(
+        "browser-await-window-gate",
+        extra_scripts=(final_text_script(BACKSTOP_SENTINEL),),
+    )
     profile = Path(_scratch()) / "chrome-await-window-gate"
     proc, cdp_port = _launch_chrome(chrome, profile)
     cdp: CDP | None = None
@@ -2852,7 +2861,13 @@ def run_await_window_gate(chrome: str) -> str:
             raise AssertionError("await-window-gate: show-edge reconnect never arrived")
         _send_in_page(cdp, "fourth turn")
         healed = _poll_until(
-            lambda: cdp.evaluate(_ROWS_JS + " === 2 && window.__pane._historyStale === false"),
+            lambda: cdp.evaluate(
+                _ROWS_JS
+                + " === 2 && window.__pane._historyStale === false"
+                + " && (window.__pane.messagesEl.textContent||'').includes("
+                + json.dumps(BACKSTOP_SENTINEL)
+                + ")"
+            ),
             20,
             0.2,
         )

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -113,8 +113,10 @@ repaints every turn the hidden render just committed (only ``system_turn``
 and compaction markers carry id dedup; content and tool rows do not).  The
 detector is a NON-OCCURRENCE counted at the fault layer: ``history_requests``
 UNCHANGED across the hidden window (``hidden0``), which regresses to
-``hidden1`` the moment the ``evtSource.readyState === OPEN`` term is
-removed.  A replay_ok reconnect carries no synthetic ``state_change``, so
+``hidden1`` the moment the guard's transport clause is removed.  Note the
+scope: a hide nulls ``evtSource``, so this exercises the PRESENCE term only —
+the ``readyState`` half needs a redial in progress, which no fault primitive
+produces deterministically (see the runner's docstring).  A replay_ok reconnect carries no synthetic ``state_change``, so
 the latch survives ``__show`` — the accepted liveness lag — and the heal
 rides a plain send's ORGANIC settle into the transport-free backstop, hence
 exactly ONE new SSE open across show + heal.  Stamps
@@ -605,8 +607,6 @@ PAGE_HTML = r"""<!doctype html>
       if (ctl) ctl.connect();
       else pane._loadHistoryThenConnect(wsId);
 
-      // Shared by the rewind scenarios (E2/E3): click the REAL rewind
-      // button on the idx-th user row.  Depends only on `pane`.
       // Count a sentinel's OCCURRENCES in the transcript text.  Every other
       // detector in this harness counts `.msg.user` rows, and user rows are
       // never emitted on the SSE stream — so none of them can observe a turn
@@ -633,6 +633,8 @@ PAGE_HTML = r"""<!doctype html>
         pane.connectSSE(pane.wsId);
       };
 
+      // Shared by the rewind scenarios (E2/E3): click the REAL rewind
+      // button on the idx-th user row.  Depends only on `pane`.
       window.__clickRewind = function (idx) {
         const rows = pane.messagesEl.querySelectorAll(".msg.user");
         const row = rows[idx];
@@ -923,7 +925,9 @@ PAGE_HTML = r"""<!doctype html>
         // and tool rows carry no id dedup).  The fire guard's
         // ``evtSource.readyState === OPEN`` term skips the hidden firing
         // instead: hiddenDelta 0 is the NON-OCCURRENCE detector, and it
-        // regresses to 1 the moment the term is removed.
+        // regresses to 1 the moment the transport clause is removed.  Scope:
+        // a hide nulls evtSource, so this reaches the PRESENCE term only —
+        // not the readyState half, which needs a redial in progress.
         //
         // A replay_ok reconnect carries no synthetic state_change (only
         // fresh/truncated replays do), so the latch stays closed across
@@ -2821,8 +2825,19 @@ def run_hidden_retry(chrome: str) -> str:
 
     THE DETECTOR is a NON-OCCURRENCE, counted at the fault layer:
     ``history_requests`` must be UNCHANGED across the whole hidden window.
-    Remove the ``evtSource.readyState === OPEN`` term and the hidden fetch
-    lands, stamping hidden1 — the scenario's negative control.
+    Remove the transport clause from the fire guard and the hidden fetch lands,
+    stamping hidden1 — the scenario's negative control.
+
+    SCOPE, stated precisely (do not overclaim it): a hide nulls ``evtSource``
+    outright, and ``connectSSE`` early-returns while ``document.hidden``, so
+    this scenario can only ever exercise the guard's PRESENCE term
+    (``this.evtSource &&``).  It structurally cannot produce the non-null,
+    not-OPEN source the ``readyState === OPEN`` term exists for — that state
+    needs a native redial in progress, which no fault primitive here produces
+    deterministically.  The readyState half is therefore covered by REASONING
+    plus coord parity, not by this scenario; its correctness twin IS covered,
+    by E6/E8 through ``_refetchHistory``'s render-time gate.  Same true of
+    coord's G5.
 
     A replay_ok reconnect carries NO synthetic ``state_change`` (only
     fresh/truncated replays do), so the latch stays closed across ``__show``:
@@ -2865,9 +2880,10 @@ def run_hidden_retry(chrome: str) -> str:
         if not _poll_until(lambda: cdp.evaluate("window.__pane.evtSource === null"), 5, 0.05):
             raise AssertionError("hidden-retry: close-on-hide never dropped the transport")
         hidden_baseline = node.history_requests
-        # NON-occurrence window: the retry fires at ~2s post-failure, so give
-        # it 3.5s.  Without the guard this poll returns True (the hidden fetch
-        # lands) and hidden_delta stamps 1.
+        # NON-occurrence window: the retry fires at STALE_RETRY_BASE_MS plus up
+        # to STALE_RETRY_JITTER_MS, so the window must outlast floor+ceiling.
+        # Without the guard this poll returns True (the hidden fetch lands) and
+        # hidden_delta stamps 1.
         # Window = the 2000 ms floor + the jitter ceiling + slack.  The
         # retry's delay is `2000 + rand*STALE_RETRY_JITTER_MS` (#900), so a
         # window sized on the floor alone would close BEFORE a
@@ -3125,6 +3141,18 @@ def run_reconnect_in_await(chrome: str) -> str:
             0.05,
         ):
             raise AssertionError("reconnect-in-await: the redial never reached OPEN")
+        # NON-VACUITY, the leg this scenario turns on: the held fetch must
+        # still be OUTSTANDING right now.  If it already resolved — a slow box
+        # can push the disconnect/send/wait_turn/redial sequence past the hold
+        # — the payload landed while evtSource was still null, the PRESENCE
+        # term declined it, and a green verdict would never have touched the
+        # generation term at all.
+        if node.history_ok != ok_baseline:
+            raise AssertionError(
+                "reconnect-in-await: the held /history resolved BEFORE the "
+                f"redial (history_ok={node.history_ok}, baseline={ok_baseline}) "
+                "— the generation term was never exercised; raise the hold"
+            )
         # Release the knob for later arrivals; the held fetch serves out its
         # own 6000 ms regardless, which is what the polls below outlast.
         node.delay_history(0)
@@ -3186,6 +3214,7 @@ def run_destroy_invalidation(chrome: str) -> str:
         # Hold the FIRST /history — the one connect() dispatches — so the
         # teardown lands with the load genuinely outstanding.
         node.delay_history(4000)
+        ok_baseline = node.history_ok
         url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=destroy-invalidation"
         _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
         # history_requests counts on ARRIVAL, before the hold sleeps.
@@ -3210,6 +3239,15 @@ def run_destroy_invalidation(chrome: str) -> str:
         # raising that deadline would make this detector vacuous.
         node.delay_history(0)
         _poll_until(lambda: node.events_requests != 0, 8, 0.1)
+        # sse_opens == 0 only means "nothing connected in 8s".  Prove the held
+        # load actually SETTLED inside that window, or the .finally under test
+        # never ran and the non-occurrence is measuring nothing.
+        if node.history_ok < ok_baseline + 1:
+            raise AssertionError(
+                "destroy-invalidation: the held /history never resolved inside "
+                f"the observation window (history_ok={node.history_ok}) — the "
+                ".finally under test never ran"
+            )
         sse_opens = node.events_requests
         vis_null = cdp.evaluate("window.__pane._visHandler === null")
         print(f"  destroy-invalidation sse_opens={sse_opens} vis_null={vis_null}")
@@ -3725,8 +3763,9 @@ def run_coord_hidden_retry(chrome: str) -> str:
         # transport down but deliberately leaves the retry timer armed.
         cdp.evaluate("window.__hide && window.__hide()")
         hidden_baseline = node.history_requests
-        # NON-occurrence window: the retry fires at ~2s post-failure; give
-        # it 3.5s.  Without the evtSource guard this poll returns True
+        # NON-occurrence window: the retry fires at STALE_RETRY_BASE_MS plus up
+        # to STALE_RETRY_JITTER_MS, so the window must outlast floor+ceiling.
+        # Without the evtSource guard this poll returns True
         # (the hidden fetch lands) and hiddenDelta stamps 1.
         # Window = the 2000 ms floor + the jitter ceiling + slack.  The
         # retry's delay is `2000 + rand*STALE_RETRY_JITTER_MS` (#900), so a

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -24,6 +24,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario rewind-failed-window  # E3 (#890)
     python3 scripts/recovery_e2e.py --scenario stale-backstop    # E4 (#890)
     python3 scripts/recovery_e2e.py --scenario hidden-retry      # E5 (#900)
+    python3 scripts/recovery_e2e.py --scenario await-window-gate # E6 (#900)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-window        # G1 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-failed-window # G2 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
@@ -116,6 +117,21 @@ the latch survives ``__show`` — the accepted liveness lag — and the heal
 rides a plain send's ORGANIC settle into the transport-free backstop, hence
 exactly ONE new SSE open across show + heal.  Stamps
 ``RECOVERY-READY-HIDDENRETRY-hidden0-heal1``.
+
+Scenario E6 (await-window-gate): the seedless render's cursor-safety gate
+(#900) — the AWAIT-window half E5 cannot reach, since E5's retry never
+fetches at all.  Here the retry fires with the transport OPEN (its fire
+guard passes) and its /history is HELD at the fault layer while a
+close-on-hide drops the stream underneath it, so the payload resolves onto a
+dead transport: rendering it would commit as-of-now truth with
+``_lastEventId`` frozen BELOW the rows painted — E5's double-render, reached
+through a window no fire-time check can see.  The render-time gate declines
+and takes the failed-fetch path instead.  DETECTOR: the stale-but-real
+PRE-rewind transcript must survive the RESOLVED fetch — THREE user rows and
+the latch still SET (``replayHistory`` is the latch's only clear site, so a
+held latch proves no render ran); without the gate it stamps rows1-latch0.
+The repair still arrives on the organic settle the transport-free backstop
+owns.  Stamps ``RECOVERY-READY-AWAITGATE-rows3-latch1``.
 
 The #894 coordinator ports (G family — the coord pane's ``historyStale``
 latch; coord state is closure-private, so where E2-E4 read pane fields the
@@ -863,6 +879,32 @@ PAGE_HTML = r"""<!doctype html>
               posts +
               "-rows" +
               userRows;
+        };
+      } else if (scenario === "await-window-gate") {
+        // Scenario E6 — the seedless render's cursor-safety gate (#900).
+        // The retry fires on a LIVE stream (its fire guard passes) and its
+        // /history is held open while a close-on-hide drops the transport
+        // underneath it.  Rendering that payload would commit as-of-now
+        // truth with _lastEventId frozen BELOW the rows painted — E5's
+        // double-render, reached through a window no fire-time check can
+        // see.  The render-time gate declines and takes the failed-fetch
+        // path: no wipe, quiesce released, latch intact.
+        window.__verifyAwaitWindowGate = function (rows, latchHeld, healed) {
+          // rows3 = the stale-but-real PRE-rewind transcript survived a
+          //   resolved fetch (without the gate the post-rewind render lands
+          //   and this reads 1).  latch1 = nothing cleared it — replayHistory
+          //   is its only clear site, so a held latch proves no render ran.
+          //   heal1 = the repair still arrives, on the organic settle the
+          //   transport-free backstop owns.
+          const ok = rows === 3 && latchHeld && healed;
+          document.title = ok
+            ? "RECOVERY-READY-AWAITGATE-rows3-latch1"
+            : "RECOVERY-FAILED-AWAITGATE-rows" +
+              rows +
+              "-latch" +
+              (latchHeld ? 1 : 0) +
+              "-heal" +
+              (healed ? 1 : 0);
         };
       }
     </script>
@@ -2742,6 +2784,91 @@ def run_hidden_retry(chrome: str) -> str:
         node.stop()
 
 
+def run_await_window_gate(chrome: str) -> str:
+    """Scenario E6 — the seedless render's cursor-safety gate (#900), the
+    AWAIT-window half E5 cannot reach: E5's retry never fetches, so only a
+    fetch that STARTS on a live stream and resolves onto a dead one exercises
+    the render-time check.
+
+    The retry fires with the transport OPEN (its fire guard passes), and its
+    /history is held at the fault layer while a close-on-hide tears the
+    stream down underneath it.  Rendering that payload would commit
+    /history's as-of-now truth with ``_lastEventId`` frozen BELOW the rows
+    painted — the same frozen-cursor double-render E5 guards at fire time,
+    reached through a window no fire-time check can see.  The gate declines
+    the render and takes the failed-fetch path instead: no wipe, quiesce
+    released, latch intact for the backstop.
+
+    DETECTOR: the stale transcript must survive the resolved fetch — THREE
+    user rows still standing (the pre-rewind truth) with the latch still SET,
+    after ``history_requests`` proves the held fetch both arrived AND
+    returned.  Without the gate the render lands and stamps rows1-latch0,
+    because a successful replayHistory is the latch's only clear site."""
+    node, ws_id = _seed_three_completed_turns("browser-await-window-gate")
+    profile = Path(_scratch()) / "chrome-await-window-gate"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=await-window-gate"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        if not _poll_until(lambda: cdp.evaluate(_ROWS_JS) == 3, 20, 0.2):
+            raise AssertionError("await-window-gate: three user rows never rendered")
+        if not _poll_until(lambda: node.events_requests >= 1, 10, 0.05):
+            raise AssertionError("await-window-gate: SSE stream never opened")
+        # The rewind's own clear_ui refetch fails, arming the 2s retry with
+        # the latch set and the transcript stale-but-real.
+        node.fail_history(1)
+        if not cdp.evaluate("window.__clickRewind(1)"):
+            raise AssertionError("await-window-gate: second-row rewind button missing")
+        if not _poll_until(lambda: node.rewind_requests == 1, 5, 0.05):
+            raise AssertionError("await-window-gate: rewind never POSTed")
+        if not _poll_until(lambda: node.history_fail_remaining == 0, 15):
+            raise AssertionError("await-window-gate: forced /history failure never fired")
+        # Hold the RETRY's fetch open.  history_requests counts on ARRIVAL,
+        # before the hold sleeps, so the bump below is the in-flight edge.
+        retry_baseline = node.history_requests
+        node.delay_history(3000)
+        # The tab stays VISIBLE here — the retry must pass its fire guard,
+        # or this scenario degenerates into E5 and proves nothing.
+        if not _poll_until(lambda: node.history_requests == retry_baseline + 1, 6, 0.05):
+            raise AssertionError("await-window-gate: the retry never fetched on the live stream")
+        # Kill the transport mid-await.  The payload is already committed
+        # server-side; only the RENDER decision is still open.
+        cdp.evaluate("window.__hide && window.__hide()")
+        if not _poll_until(lambda: cdp.evaluate("window.__pane.evtSource === null"), 5, 0.05):
+            raise AssertionError("await-window-gate: close-on-hide never dropped the transport")
+        # Let the held fetch resolve, then let the render decision settle.
+        node.delay_history(0)
+        if not _poll_until(lambda: cdp.evaluate("window.__pane._replayQueue === null"), 12, 0.1):
+            raise AssertionError("await-window-gate: the quiesce never released")
+        rows = cdp.evaluate(_ROWS_JS)
+        latch_held = cdp.evaluate("window.__pane._historyStale === true")
+        # The heal still belongs to the backstop: show, then drive an organic
+        # settle with a plain send and watch the rewound truth land.
+        events_before_show = node.events_requests
+        cdp.evaluate("window.__show && window.__show()")
+        if not _poll_until(lambda: node.events_requests == events_before_show + 1, 10, 0.05):
+            raise AssertionError("await-window-gate: show-edge reconnect never arrived")
+        _send_in_page(cdp, "fourth turn")
+        healed = _poll_until(
+            lambda: cdp.evaluate(_ROWS_JS + " === 2 && window.__pane._historyStale === false"),
+            20,
+            0.2,
+        )
+        print(f"  await-window-gate rows={rows} latch_held={latch_held} healed={healed}")
+        cdp.evaluate(
+            f"window.__verifyAwaitWindowGate({rows}, "
+            f"{'true' if latch_held else 'false'}, {'true' if healed else 'false'})"
+        )
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 _COORD_ROWS_JS = "document.getElementById('coord-messages').querySelectorAll('.msg.user').length"
 
 
@@ -3560,6 +3687,7 @@ def main() -> None:
             "rewind-failed-window",
             "stale-backstop",
             "hidden-retry",
+            "await-window-gate",
             "coord-rewind-window",
             "coord-rewind-failed-window",
             "coord-stale-backstop",
@@ -3623,6 +3751,10 @@ def main() -> None:
     if args.scenario in ("hidden-retry", "all"):
         verdict = run_hidden_retry(chrome)
         print(f"scenario E5 (hiddenretry): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("await-window-gate", "all"):
+        verdict = run_await_window_gate(chrome)
+        print(f"scenario E6 (awaitgate): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("coord-rewind-window", "all"):
         verdict = run_coord_rewind_window(chrome)

--- a/scripts/recovery_e2e.py
+++ b/scripts/recovery_e2e.py
@@ -25,6 +25,7 @@ Usage::
     python3 scripts/recovery_e2e.py --scenario stale-backstop    # E4 (#890)
     python3 scripts/recovery_e2e.py --scenario hidden-retry      # E5 (#900)
     python3 scripts/recovery_e2e.py --scenario await-window-gate # E6 (#900)
+    python3 scripts/recovery_e2e.py --scenario destroy-invalidation # E7 (#900)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-window        # G1 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-rewind-failed-window # G2 (#894)
     python3 scripts/recovery_e2e.py --scenario coord-stale-backstop       # G3 (#894)
@@ -424,7 +425,10 @@ PAGE_HTML = r"""<!doctype html>
       window.showLogin = function () {};
     </script>
     <script type="module">
-      import { InteractivePane } from "/shared/interactive.js";
+      import {
+        InteractivePane,
+        createInteractivePane,
+      } from "/shared/interactive.js";
 
       const q = new URLSearchParams(location.search);
       const wsId = q.get("ws_id");
@@ -439,8 +443,25 @@ PAGE_HTML = r"""<!doctype html>
 
       // REAL pane against THIS origin (base=""): real authFetch (cookie) and
       // real EventSource. The default host provides all SSE seams.
-      const pane = new InteractivePane(wsId, { base: "" });
-      document.getElementById("mount").appendChild(pane.el);
+      //
+      // E7 mounts through the FACTORY instead, because the factory closure is
+      // the only thing that owns destroy() — every other interactive scenario
+      // drives the Pane class directly, so the controller's TERMINAL seam had
+      // no browser coverage at all.  Scenario-scoped on purpose: the factory
+      // owns its own connect()/recover-beat lifecycle, and switching the
+      // other scenarios onto it would change what they are testing.
+      let ctl = null;
+      let pane;
+      if (scenario === "destroy-invalidation") {
+        ctl = createInteractivePane(document.getElementById("mount"), wsId, {
+          base: "",
+        });
+        pane = ctl.pane;
+        window.__ctl = ctl;
+      } else {
+        pane = new InteractivePane(wsId, { base: "" });
+        document.getElementById("mount").appendChild(pane.el);
+      }
       pane.wsId = wsId;
       window.__pane = pane;
 
@@ -546,8 +567,13 @@ PAGE_HTML = r"""<!doctype html>
         };
       }
 
-      // First paint the REAL way: /history then connect SSE.
-      pane._loadHistoryThenConnect(wsId);
+      // First paint the REAL way: /history then connect SSE.  Under the
+      // factory that load is owned by connect() (which also seeds the
+      // empty state), and going through it is the point of E7 — the
+      // in-flight load destroy() must invalidate is the one connect()
+      // starts.
+      if (ctl) ctl.connect();
+      else pane._loadHistoryThenConnect(wsId);
 
       // Shared by the rewind scenarios (E2/E3): click the REAL rewind
       // button on the idx-th user row.  Depends only on `pane`.
@@ -905,6 +931,33 @@ PAGE_HTML = r"""<!doctype html>
               (latchHeld ? 1 : 0) +
               "-heal" +
               (healed ? 1 : 0);
+        };
+      } else if (scenario === "destroy-invalidation") {
+        // Scenario E7 — destroy()'s load-token bump (#900).  destroy() used
+        // to bump nothing, so a /history still in flight at teardown kept
+        // passing every post-await gate: its .finally reopened an
+        // EventSource on the DETACHED pane and re-registered the
+        // document-level visibilitychange listener destroy had just
+        // removed, and that stream's onerror re-armed the host recover beat
+        // forever (it gives up only on `dead`, which destroy never sets).
+        // A closed tab therefore held a node connection and a 5s reconnect
+        // beat for the life of the page.
+        window.__verifyDestroyInvalidation = function (sseOpens) {
+          // detached = destroy() removed the pane element; visNull = no
+          // handler was re-registered behind it; sseOpens 0 = the held load
+          // resolved WITHOUT reconnecting (the fault-layer non-occurrence
+          // detector — it stamps 1 the moment the bump is removed).
+          const detached = !pane.el.parentNode;
+          const visNull = pane._visHandler === null;
+          const ok = sseOpens === 0 && detached && visNull;
+          document.title = ok
+            ? "RECOVERY-READY-DESTROYINVAL-sse0-vis0"
+            : "RECOVERY-FAILED-DESTROYINVAL-sse" +
+              sseOpens +
+              "-detached" +
+              (detached ? 1 : 0) +
+              "-vis" +
+              (visNull ? 1 : 0);
         };
       }
     </script>
@@ -2884,6 +2937,71 @@ def run_await_window_gate(chrome: str) -> str:
         node.stop()
 
 
+def run_destroy_invalidation(chrome: str) -> str:
+    """Scenario E7 — destroy()'s load-token bump (#900).  The ONLY interactive
+    scenario that mounts through ``createInteractivePane``: every other one
+    drives the ``Pane`` class directly, so the factory closure that owns
+    ``destroy()`` had no browser coverage at all — and destroy() is where the
+    #900 backport's largest hole lived.
+
+    ``destroy()`` bumped no load token, so a ``/history`` still in flight at
+    teardown kept passing every post-await gate.  The worst leg is
+    ``_loadHistoryThenConnect``'s ``.finally``: it reopened an ``EventSource``
+    on the DETACHED pane and re-registered the document-level
+    ``visibilitychange`` listener ``_removeVisibilityHandler`` had just
+    dropped — and that stream's ``onerror`` re-armed the host recover beat
+    indefinitely, because it gives up only on ``dead``, which ``destroy()``
+    never sets.  A closed tab kept a node connection and a 5s reconnect beat
+    for the life of the page.
+
+    The runner holds the FIRST ``/history`` open at the fault layer, destroys
+    the controller mid-flight, and lets the load resolve into the void.
+    DETECTOR: ``events_requests`` must still be 0 — the load resolved without
+    reconnecting — with the pane detached and ``_visHandler`` null behind it.
+    Remove the bump and the ``.finally`` fires: sse1, and a non-null handler
+    still bound to the document."""
+    node, ws_id = _seed_three_completed_turns("browser-destroy-invalidation")
+    profile = Path(_scratch()) / "chrome-destroy-invalidation"
+    proc, cdp_port = _launch_chrome(chrome, profile)
+    cdp: CDP | None = None
+    try:
+        cdp = CDP(_page_ws_url(cdp_port))
+        # Hold the FIRST /history — the one connect() dispatches — so the
+        # teardown lands with the load genuinely outstanding.
+        node.delay_history(4000)
+        url = f"{node.base_url}/recovery?ws_id={ws_id}&scenario=destroy-invalidation"
+        _set_cookie_and_navigate(cdp, node.base_url, node.token, url)
+        # history_requests counts on ARRIVAL, before the hold sleeps.
+        if not _poll_until(lambda: node.history_requests >= 1, 20, 0.05):
+            raise AssertionError("destroy-invalidation: the first /history never arrived")
+        # Non-vacuity: nothing may have connected yet, or the .finally under
+        # test has already run and the scenario proves nothing.
+        if node.events_requests != 0:
+            raise AssertionError(
+                f"destroy-invalidation: stream opened before teardown "
+                f"(events_requests={node.events_requests})"
+            )
+        if not cdp.evaluate("!!window.__ctl"):
+            raise AssertionError("destroy-invalidation: page did not mount through the factory")
+        cdp.evaluate("window.__ctl.destroy()")
+        if not _poll_until(lambda: cdp.evaluate("!window.__pane.el.parentNode"), 5, 0.05):
+            raise AssertionError("destroy-invalidation: destroy() never detached the pane")
+        # Let the held fetch resolve and its .finally run.  The wait must
+        # outlast the hold, or a 0 here would only mean "not yet".
+        node.delay_history(0)
+        _poll_until(lambda: node.events_requests != 0, 8, 0.1)
+        sse_opens = node.events_requests
+        vis_null = cdp.evaluate("window.__pane._visHandler === null")
+        print(f"  destroy-invalidation sse_opens={sse_opens} vis_null={vis_null}")
+        cdp.evaluate(f"window.__verifyDestroyInvalidation({sse_opens})")
+        return _poll_title(cdp, 15)
+    finally:
+        if cdp is not None:
+            cdp.close()
+        _kill(proc)
+        node.stop()
+
+
 _COORD_ROWS_JS = "document.getElementById('coord-messages').querySelectorAll('.msg.user').length"
 
 
@@ -3703,6 +3821,7 @@ def main() -> None:
             "stale-backstop",
             "hidden-retry",
             "await-window-gate",
+            "destroy-invalidation",
             "coord-rewind-window",
             "coord-rewind-failed-window",
             "coord-stale-backstop",
@@ -3770,6 +3889,10 @@ def main() -> None:
     if args.scenario in ("await-window-gate", "all"):
         verdict = run_await_window_gate(chrome)
         print(f"scenario E6 (awaitgate): {verdict}")
+        failures += 0 if verdict.startswith("RECOVERY-READY") else 1
+    if args.scenario in ("destroy-invalidation", "all"):
+        verdict = run_destroy_invalidation(chrome)
+        print(f"scenario E7 (destroyinval): {verdict}")
         failures += 0 if verdict.startswith("RECOVERY-READY") else 1
     if args.scenario in ("coord-rewind-window", "all"):
         verdict = run_coord_rewind_window(chrome)

--- a/tests/_sse_recovery_server.py
+++ b/tests/_sse_recovery_server.py
@@ -62,6 +62,8 @@ from turnstone.prompts import ClientType
 from turnstone.server import WebUI, create_app
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     from turnstone.core.workstream import Workstream
 
 _JWT_SECRET = "sse-recovery-e2e-jwt-secret-minimum-32-chars!"
@@ -230,6 +232,10 @@ class RecoveryServer:
         # write atomic, so these need no lock even though the uvicorn loop
         # thread increments/decrements them while the runner thread reads.
         self.history_requests = 0
+        # /history responses the PRODUCTION route answered 200 (not the
+        # fault layer's injected 500s).  See _fault_app for why arrival
+        # counting cannot substitute.
+        self.history_ok = 0
         self.rewind_requests = 0
         # Per-ws SSE connection opens (``GET …/events`` — the EventSource the
         # pane's connectSSE builds).  A TRANSPORT-FREE heal (the #890 idle-edge
@@ -256,6 +262,11 @@ class RecoveryServer:
                 path = scope.get("path", "")
                 method = scope.get("method", "")
                 if path.endswith("/history") and method == "GET":
+                    # ARRIVAL, never move.  Scenarios that hold a request open
+                    # use this bump as the IN-FLIGHT edge (E6/E7/G1/G7 say so
+                    # at their poll sites); counting on forward instead would
+                    # delay it past the hold and silently stop those scenarios
+                    # testing anything.
                     self.history_requests += 1
                     if self._history_delay_ms > 0:
                         await asyncio.sleep(self._history_delay_ms / 1000.0)
@@ -270,6 +281,26 @@ class RecoveryServer:
                         )
                         await send({"type": "http.response.body", "body": b'{"error": "injected"}'})
                         return
+
+                    # Successful-RESPONSE counter, distinct from the arrival
+                    # bump above.  A scenario asserting that a render was
+                    # DECLINED needs to know a good payload actually existed —
+                    # otherwise "the client refused to render" and "there was
+                    # nothing to render" produce identical observables (no
+                    # wipe, latch held).  Arrival cannot prove that, and
+                    # neither can an injected-fail budget: a PRODUCTION-side
+                    # 500/404 would slip through both.  Reading the real
+                    # status off the response start is the only honest signal.
+                    async def _counting_send(message: MutableMapping[str, Any]) -> None:
+                        if (
+                            message.get("type") == "http.response.start"
+                            and message.get("status") == 200
+                        ):
+                            self.history_ok += 1
+                        await send(message)
+
+                    await production_app(scope, receive, _counting_send)
+                    return
                 elif path.endswith("/rewind") and method == "POST":
                     self.rewind_requests += 1
                 elif path.endswith("/events") and method == "GET":

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -716,10 +716,20 @@ def test_coordinator_history_stale_latch_contract():
         "exists to kill."
     )
     retry_arm = body.index("staleRetryTimer = setTimeout")
-    # Anchor on the delay EXPRESSION's opening, not on a literal `}, 2000);`
-    # — #900 made the delay `2000 + Math.random() * STALE_RETRY_JITTER_MS`,
-    # and a literal anchor raises ValueError (the suite ERRORS instead of
-    # failing) the moment the spread changes.
+    # #900 made the delay an expression over two SHARED constants, so the old
+    # literal `}, 2000);` anchor is gone.  Assert the new anchor EXISTS before
+    # slicing on it: `.index` would raise ValueError and the suite would ERROR
+    # with an anonymous traceback rather than fail on a named assertion, which
+    # is the exact failure mode this re-anchor exists to remove.  Coord and
+    # interactive must carry the identical expression or the herd-spread
+    # invariant silently forks.
+    # Unwindowed on purpose: the expression occurs exactly once in coord, so a
+    # fixed slice buys nothing and can truncate mid-expression (it did).
+    # Locality is established by the retry_fire slice below, which starts at
+    # the arm — this assertion only has to prove the anchor exists at all.
+    assert "STALE_RETRY_BASE_MS + Math.random() * STALE_RETRY_JITTER_MS" in body, (
+        "the coord retry must keep the shared floor + jitter (#900)"
+    )
     retry_fire = _strip_comments(body[retry_arm : body.index("STALE_RETRY_JITTER_MS", retry_arm)])
     assert "!refetchesInFlight" in retry_fire, (
         "the retry's fire guard must yield to an in-flight refetch "

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -716,7 +716,11 @@ def test_coordinator_history_stale_latch_contract():
         "exists to kill."
     )
     retry_arm = body.index("staleRetryTimer = setTimeout")
-    retry_fire = _strip_comments(body[retry_arm : body.index("}, 2000);", retry_arm)])
+    # Anchor on the delay EXPRESSION's opening, not on a literal `}, 2000);`
+    # — #900 made the delay `2000 + Math.random() * STALE_RETRY_JITTER_MS`,
+    # and a literal anchor raises ValueError (the suite ERRORS instead of
+    # failing) the moment the spread changes.
+    retry_fire = _strip_comments(body[retry_arm : body.index("STALE_RETRY_JITTER_MS", retry_arm)])
     assert "!refetchesInFlight" in retry_fire, (
         "the retry's fire guard must yield to an in-flight refetch "
         "(mirrors interactive's !_replayQueue pin)."
@@ -732,11 +736,13 @@ def test_coordinator_history_stale_latch_contract():
         "render-time gate would discard (the chokepoint carries the "
         "correctness; these are the efficiency layer — keep them)."
     )
-    assert (
-        "visHandler &&\n                  evtSource &&\n"
-        "                  evtSource.readyState === EventSource.OPEN\n"
-        "                ) {" in body
-    ), (
+    # Whitespace-normalised, not indentation-exact: #900 made the delay an
+    # expression, which reflowed setTimeout to prettier's multi-line call form
+    # and re-indented this whole callback body.  Still an ORDERED-tail pin, so
+    # a mere comment mention cannot satisfy it.
+    cond_start = body.index("if (", retry_arm)
+    guard = " ".join(body[cond_start : body.index(") {", cond_start)].split())
+    assert guard.endswith("visHandler && evtSource && evtSource.readyState === EventSource.OPEN"), (
         "the retry's fire guard must require an OPEN stream — not handle "
         "existence: CONNECTING keeps the handle with a frozen cursor and "
         "a pending replay, and a seedless heal then double-renders when "

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -387,12 +387,71 @@ def test_interactive_refetch_failure_preserves_the_pane() -> None:
     ref = body.index("async _refetchHistory(wsId, token, seedCursor = false) {")
     ref_seg = body[ref : body.index("\n  _beginReplayQuiesce(token) {", ref)]
     gate = ref_seg.index("const cursorSafe =")
-    assert "seedCursor ||" in ref_seg[gate : gate + 200], (
+    gate_seg = ref_seg[gate : ref_seg.index(";", gate)]
+    assert "seedCursor ||" in gate_seg, (
         "the render-time gate must exempt seeded (disconnect-first) loads (#900)"
     )
-    assert "this.evtSource.readyState === EventSource.OPEN" in ref_seg[gate : gate + 200]
+    assert "this.evtSource.readyState === EventSource.OPEN" in gate_seg
+    # Connection-generation term (#900 r2): readyState alone cannot see a
+    # transport that DROPPED and finished RE-ESTABLISHING inside the await —
+    # it reads OPEN either way, while the redial re-presented the frozen
+    # cursor and the quiesce buffered the replay the render would duplicate.
+    # Object identity is not a substitute: a NATIVE reconnect reuses the same
+    # EventSource, so only a counter can see it.
+    assert "this._connectEpoch === epoch" in gate_seg, (
+        "the seedless render must require an unchanged stream generation (#900)"
+    )
     assert "if (data && cursorSafe) {" in ref_seg, (
         "the seedless render must be gated on a live cursor (#900)"
+    )
+    # Captured at DISPATCH, not read live at render time — a live read would
+    # compare the epoch against itself and the term would be vacuous.
+    assert "const epoch = this._connectEpoch;" in ref_seg, (
+        "the gate must compare against the generation captured at dispatch (#900)"
+    )
+    assert ref_seg.index("const epoch = this._connectEpoch;") < ref_seg.index("await authFetch("), (
+        "the generation must be captured BEFORE the fetch await (#900)"
+    )
+
+    # The bump belongs to onopen and NOWHERE else.  A native auto-reconnect
+    # calls neither connectSSE nor disconnectSSE, so those two are blind to
+    # the very case the term exists for; connectSSE would additionally
+    # FALSE-bump on its document.hidden early return, which establishes no
+    # stream.  Absence from both is therefore load-bearing, not incidental.
+    assert "this._connectEpoch = 0;" in body, (
+        "the generation must be initialised — undefined makes every compare "
+        "NaN-false and silently declines every seedless render (#900)"
+    )
+    onopen = body.index("this.evtSource.onopen = () => {")
+    onopen_seg = body[onopen : body.index("\n    };", onopen)]
+    assert "this._connectEpoch += 1;" in onopen_seg, (
+        "the stream generation must be bumped in onopen — the only site that "
+        "fires for a NATIVE auto-reconnect (#900)"
+    )
+    conn = body.index("connectSSE(wsId) {")
+    assert "_connectEpoch" not in _strip_comments(body[conn:onopen]), (
+        "connectSSE must NOT bump the generation — it would false-bump on the "
+        "document.hidden early return, which establishes no stream (#900)"
+    )
+    dis = re.search(r"\n  disconnectSSE\(\) \{(.*?)\n  \}\n", body, re.S)
+    assert dis is not None, "disconnectSSE not found"
+    # Comment-stripped: the method's inventory comment NAMES both fields as
+    # deliberately-not-cleared, which is the ruling — assert on code only.
+    dis_code = _strip_comments(dis.group(1))
+    assert "_connectEpoch" not in dis_code, (
+        "disconnectSSE must NOT bump the generation — a teardown is decided "
+        "by the presence term, and a re-establish by the next onopen (#900)"
+    )
+    # THE load-bearing negative: disconnectSSE deliberately does NOT cancel
+    # the clear_ui retry (transport-only redials keep the pending heal
+    # intent).  That is exactly why the retry can fire against a dead
+    # transport, which is what its OPEN fire-guard term exists to handle —
+    # so a "symmetry" cleanup adding the cancel here would silently make
+    # that guard unreachable and E5's detector vacuous, with nothing else
+    # failing.  Coord pins the same invariant (test_coordinator_page.py).
+    assert "_staleRetryTimer" not in dis_code, (
+        "disconnectSSE must NOT cancel the clear_ui failure retry — "
+        "transport-only reconnects keep the pending heal intent (#890/#900)"
     )
 
     # Failure branch: quiesce release only.

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -555,6 +555,14 @@ def test_interactive_refetch_failure_preserves_the_pane() -> None:
     assert "this.evtSource.readyState === EventSource.OPEN" in cl_seg[retry:], (
         "the clear_ui retry must require a live stream at fire time (#900)"
     )
+    # The delay is floor + spread, both from the SHARED module: one clear_ui
+    # reaches every listener on the ws, so an un-spread retry re-fetches in
+    # lockstep across tabs, and the floor is what the e2e non-occurrence
+    # windows size themselves on.  Coord carries the identical expression —
+    # this pin is what keeps the two from drifting.
+    assert "STALE_RETRY_BASE_MS + Math.random() * STALE_RETRY_JITTER_MS" in cl_seg[retry:], (
+        "the clear_ui retry must keep the shared floor + jitter (#900)"
+    )
 
     # Terminal teardown must invalidate in-flight loads AND cancel the
     # failure retry.  The token bump (#900) is the chokepoint: without it

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -377,6 +377,24 @@ def test_interactive_refetch_failure_preserves_the_pane() -> None:
         "this._refetchHistory("
     ), "clear_ui must arm the quiesce BEFORE the fetch"
 
+    # Render-time cursor-safety gate (#900): a SEEDLESS render commits
+    # /history's as-of-now truth without advancing _lastEventId, so
+    # committing it while the transport is down strands the cursor below
+    # the rows just painted and the next connect's replay paints them
+    # again.  The gate must be seedless-SCOPED — _loadHistoryThenConnect
+    # disconnects first, so its evtSource is null for its whole fetch and
+    # gating it would break every first paint, ws switch and resync.
+    ref = body.index("async _refetchHistory(wsId, token, seedCursor = false) {")
+    ref_seg = body[ref : body.index("\n  _beginReplayQuiesce(token) {", ref)]
+    gate = ref_seg.index("const cursorSafe =")
+    assert "seedCursor ||" in ref_seg[gate : gate + 200], (
+        "the render-time gate must exempt seeded (disconnect-first) loads (#900)"
+    )
+    assert "this.evtSource.readyState === EventSource.OPEN" in ref_seg[gate : gate + 200]
+    assert "if (data && cursorSafe) {" in ref_seg, (
+        "the seedless render must be gated on a live cursor (#900)"
+    )
+
     # Failure branch: quiesce release only.
     fail = body.index("Failed fetch = DOM + ref + repair-intent no-op")
     fail_seg = body[fail : fail + 1100]
@@ -469,16 +487,42 @@ def test_interactive_refetch_failure_preserves_the_pane() -> None:
     assert "!this._replayQueue &&" in cl_seg[retry : retry + 700], (
         "the clear_ui retry must yield to an in-flight quiesced fetch"
     )
+    # ...and must not fire against a DOWN transport (#900): disconnectSSE
+    # deliberately keeps the timer armed, so a hidden tab / degraded
+    # cooldown / native redial can hold the fire.  A seedless refetch then
+    # paints rows the frozen _lastEventId still sits below, and the next
+    # connect replays that slice on top.  OPEN, not merely present — a
+    # CONNECTING source has a frozen cursor with a replay pending.
+    assert "this.evtSource.readyState === EventSource.OPEN" in cl_seg[retry:], (
+        "the clear_ui retry must require a live stream at fire time (#900)"
+    )
 
-    # Terminal teardown must cancel the failure retry: destroy() bumps
-    # no token and clears no latch, so an armed timer would otherwise
-    # pass its fire-time guards ~2s post-destroy and replayHistory into
-    # the detached pane.  (disconnectSSE deliberately does NOT cancel
-    # it — transport-only reconnects keep the pending heal intent.)
+    # Terminal teardown must invalidate in-flight loads AND cancel the
+    # failure retry.  The token bump (#900) is the chokepoint: without it
+    # destroy() left _loadHistoryThenConnect's .finally free to reopen an
+    # EventSource on the detached pane (re-registering the document-level
+    # visibilitychange listener destroy just removed), a settling
+    # _refetchHistory free to replayHistory into detached DOM, and the
+    # clear_ui .then free to RE-ARM the timer destroy had cancelled.  The
+    # clearTimeout stays because the timer may already be armed and a
+    # timer into a destroyed pane must be dead, not merely inert.
+    # (disconnectSSE deliberately does NOT cancel it — transport-only
+    # reconnects keep the pending heal intent.)
     dest = body.index("destroy() {")
-    dest_seg = body[dest : dest + 1600]
+    dest_seg = body[dest : body.index("\n    },", dest)]
     assert "clearTimeout(pane._staleRetryTimer);" in dest_seg, (
         "destroy() must cancel the clear_ui failure retry (#890)"
+    )
+    assert "pane._historyLoadToken = (pane._historyLoadToken || 0) + 1;" in dest_seg, (
+        "destroy() must bump the load token to invalidate in-flight loads (#900)"
+    )
+    # Same rule on the other terminal path: giveUp() already bumped the
+    # token, so the timer is inert there — but inert is not dead.
+    give = body.index("const giveUp = function () {")
+    give_seg = body[give : body.index("\n  };", give)]
+    assert "pane._historyLoadToken = (pane._historyLoadToken || 0) + 1;" in give_seg
+    assert "clearTimeout(pane._staleRetryTimer);" in give_seg, (
+        "giveUp() must cancel the clear_ui failure retry too (#900 symmetry)"
     )
 
 

--- a/tests/test_sse_overflow_js.py
+++ b/tests/test_sse_overflow_js.py
@@ -29,7 +29,7 @@ _SSE_OVERFLOW = _ROOT / "turnstone/shared_static/sse_overflow.js"
 
 
 def test_module_exports_constants_and_pure_helpers() -> None:
-    """The single source of truth exports the five tuning constants and the two
+    """The single source of truth exports the seven tuning constants and the two
     pure helpers.  Both panes import these by name (pinned in their own suites),
     so a rename here is a breaking change that must surface loudly."""
     body = _SSE_OVERFLOW.read_text(encoding="utf-8")
@@ -39,6 +39,13 @@ def test_module_exports_constants_and_pure_helpers() -> None:
         ("DEGRADED_COOLDOWN_BASE_MS", "15000"),
         ("DEGRADED_COOLDOWN_MAX_MS", "120000"),
         ("DEGRADED_COOLDOWN_RESET_MS", "300000"),
+        ("TRUNCATED_RESYNC_JITTER_MS", "10000"),
+        # ADDITIVE over the retry's 2000 floor, and deliberately NOT the
+        # truncated-resync spread: this one works against #884's /history
+        # single-flight, so it stays small enough to sit inside a typical
+        # flight.  Both e2e non-occurrence detectors size their windows on
+        # the floor plus this value.
+        ("STALE_RETRY_JITTER_MS", "500"),
     ):
         assert f"export const {const} = {value};" in body, f"missing export const {const}"
     assert "export function overflowWindowTripped(" in body

--- a/tests/test_sse_overflow_js.py
+++ b/tests/test_sse_overflow_js.py
@@ -29,7 +29,7 @@ _SSE_OVERFLOW = _ROOT / "turnstone/shared_static/sse_overflow.js"
 
 
 def test_module_exports_constants_and_pure_helpers() -> None:
-    """The single source of truth exports the seven tuning constants and the two
+    """The single source of truth exports the eight tuning constants and the two
     pure helpers.  Both panes import these by name (pinned in their own suites),
     so a rename here is a breaking change that must surface loudly."""
     body = _SSE_OVERFLOW.read_text(encoding="utf-8")
@@ -46,6 +46,7 @@ def test_module_exports_constants_and_pure_helpers() -> None:
         # flight.  Both e2e non-occurrence detectors size their windows on
         # the floor plus this value.
         ("STALE_RETRY_JITTER_MS", "500"),
+        ("STALE_RETRY_BASE_MS", "2000"),
     ):
         assert f"export const {const} = {value};" in body, f"missing export const {const}"
     assert "export function overflowWindowTripped(" in body

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -58,6 +58,7 @@ import {
   DEGRADED_COOLDOWN_RESET_MS,
   TRUNCATED_RESYNC_JITTER_MS,
   STALE_RETRY_JITTER_MS,
+  STALE_RETRY_BASE_MS,
   overflowWindowTripped,
   degradedCooldownStep,
 } from "/shared/sse_overflow.js";
@@ -3806,7 +3807,7 @@ function createCoordinatorPane(root, wsId, opts) {
                   // e2e non-occurrence windows size on it) — jitter up, never
                   // down.  Mirrored in interactive.js; the constant is shared.
                 },
-                2000 + Math.random() * STALE_RETRY_JITTER_MS,
+                STALE_RETRY_BASE_MS + Math.random() * STALE_RETRY_JITTER_MS,
               );
             }
             if (!_pendingEditSend) return;

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -57,6 +57,7 @@ import {
   DEGRADED_COOLDOWN_MAX_MS,
   DEGRADED_COOLDOWN_RESET_MS,
   TRUNCATED_RESYNC_JITTER_MS,
+  STALE_RETRY_JITTER_MS,
   overflowWindowTripped,
   degradedCooldownStep,
 } from "/shared/sse_overflow.js";
@@ -3770,35 +3771,43 @@ function createCoordinatorPane(root, wsId, opts) {
             // pane UI, so the user's committed edit still delivers.
             if (historyStale && visHandler) {
               if (staleRetryTimer) clearTimeout(staleRetryTimer);
-              staleRetryTimer = setTimeout(() => {
-                staleRetryTimer = null;
-                if (
-                  historyStale &&
-                  !refetchesInFlight &&
-                  !busy &&
-                  !currentAssistantEl &&
-                  !currentReasoningEl &&
-                  visHandler &&
-                  evtSource &&
-                  evtSource.readyState === EventSource.OPEN
-                ) {
-                  // Stream must be OPEN, not merely present: close-on-hide
-                  // keeps this timer armed by design (the fire can land
-                  // with the transport down), and a CONNECTING source has
-                  // a frozen cursor with a pending replay — a seedless
-                  // fetch then would render past it (double-render when
-                  // the replay lands).  Skip instead; the latch survives
-                  // and the next organic settle re-fires the backstop.
-                  // The backstop itself needs no such term: it runs
-                  // inside SSE dispatch, so its stream is live by
-                  // construction.  refetchHistory's render-time gate
-                  // re-checks every invariant across the await window.
-                  // Fire-and-forget, seedless (live stream — lastEventId
-                  // must not rewind); a render throw stays loud, as on the
-                  // backstop.
-                  refetchHistory();
-                }
-              }, 2000);
+              staleRetryTimer = setTimeout(
+                () => {
+                  staleRetryTimer = null;
+                  if (
+                    historyStale &&
+                    !refetchesInFlight &&
+                    !busy &&
+                    !currentAssistantEl &&
+                    !currentReasoningEl &&
+                    visHandler &&
+                    evtSource &&
+                    evtSource.readyState === EventSource.OPEN
+                  ) {
+                    // Stream must be OPEN, not merely present: close-on-hide
+                    // keeps this timer armed by design (the fire can land
+                    // with the transport down), and a CONNECTING source has
+                    // a frozen cursor with a pending replay — a seedless
+                    // fetch then would render past it (double-render when
+                    // the replay lands).  Skip instead; the latch survives
+                    // and the next organic settle re-fires the backstop.
+                    // The backstop itself needs no such term: it runs
+                    // inside SSE dispatch, so its stream is live by
+                    // construction.  refetchHistory's render-time gate
+                    // re-checks every invariant across the await window.
+                    // Fire-and-forget, seedless (live stream — lastEventId
+                    // must not rewind); a render throw stays loud, as on the
+                    // backstop.
+                    refetchHistory();
+                  }
+                  // ADDITIVE spread over the 2000 floor: one clear_ui reaches
+                  // every listener on the ws, so an un-spread retry re-fetches
+                  // in lockstep across tabs.  The floor is load-bearing (the
+                  // e2e non-occurrence windows size on it) — jitter up, never
+                  // down.  Mirrored in interactive.js; the constant is shared.
+                },
+                2000 + Math.random() * STALE_RETRY_JITTER_MS,
+              );
             }
             if (!_pendingEditSend) return;
             const editText = _pendingEditSend;
@@ -5998,7 +6007,6 @@ function createCoordinatorPane(root, wsId, opts) {
     if (staleRetryTimer) {
       clearTimeout(staleRetryTimer);
       staleRetryTimer = null;
-
     }
     toolRows.clear();
     activeBatch = null;

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -64,6 +64,7 @@ import {
   DEGRADED_COOLDOWN_RESET_MS,
   TRUNCATED_RESYNC_JITTER_MS,
   STALE_RETRY_JITTER_MS,
+  STALE_RETRY_BASE_MS,
   overflowWindowTripped,
   degradedCooldownStep,
 } from "./sse_overflow.js";
@@ -2579,7 +2580,7 @@ class Pane {
                   // e2e non-occurrence windows size on it) — jitter up, never
                   // down.  Mirrored in coordinator.js; the constant is shared.
                 },
-                2000 + Math.random() * STALE_RETRY_JITTER_MS,
+                STALE_RETRY_BASE_MS + Math.random() * STALE_RETRY_JITTER_MS,
               );
             }
             if (token !== this._historyLoadToken && this.wsId !== editWs) {

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -266,6 +266,23 @@ class Pane {
     // _beginReplayQuiesce.  {token, events[]} or null.  (The truncated
     // resync no longer quiesces: it tears the stream down first, so no
     // live events exist during its rebuild.)
+    //
+    // This is also why interactive needs no dispatch-seq stamp
+    // (coordinator.js's refetchSeq / refetchesInFlight — #894 r5, ruled
+    // NOT APPLICABLE here at #900): same-token /history fetches cannot
+    // overlap.  Every seedless refetch arms this queue synchronously
+    // before its await, handleEvent queues ALL events while it is armed —
+    // clear_ui included — and the backlog flushes from _endReplayQuiesce,
+    // which runs in _refetchHistory's finally AFTER the render.  So a
+    // clear_ui arriving under an in-flight heal is serialized behind it
+    // rather than racing it, and a fetch dispatched BEFORE a clear_ui
+    // cannot still be running when the latch is set (same ordering) —
+    // which is also what keeps replayHistory's latch clear honest.  The
+    // one unquiesced fetch, _loadHistoryThenConnect's, disconnects the
+    // transport first AND bumps the load token.  Coord needed the stamp
+    // precisely because it has no quiesce (see its refetchesInFlight
+    // declaration).  Ship a stamp here only if a seedless refetch ever
+    // starts without arming this queue.
     this._replayQueue = null;
     // Transcript-staleness latch (#890): TRUE = the visible transcript
     // no longer matches the server's conversation STRUCTURE.  Set at
@@ -1762,6 +1779,13 @@ class Pane {
     // with no reconnect — strand the omitted turn).
     const id = wsId || this.wsId;
     let data = null;
+    // Deliberately unbounded and unabortable, deferred not overlooked
+    // (#900): coordinator.js carries an AbortController set plus a 15s
+    // bound so destroy() can cut a slow /history loose.  Here the load
+    // token already makes a post-teardown settle render-inert, so the
+    // residual is a detached closure pinned for the request's life — a
+    // resource cost, not a correctness defect.  It belongs with the
+    // shared recovery core rather than a third hand-port.
     try {
       const r = await authFetch(
         this._base +
@@ -1780,7 +1804,43 @@ class Pane {
       this._endReplayQuiesce(token);
       return;
     }
-    if (data) {
+    // Render-time transport gate (#900) — the correctness half of the
+    // clear_ui retry's fire-time OPEN term, covering the AWAIT window the
+    // fire-time check cannot: a hide edge, an onerror redial, or degraded
+    // entry can tear the transport down while THIS fetch is outstanding.
+    // A SEEDLESS render commits /history's as-of-now truth while leaving
+    // _lastEventId where the stream stopped delivering, so any turn
+    // committed during the outage gets painted with the cursor still
+    // BELOW it — the next connect presents that cursor, the server
+    // answers replay_ok, and the slice paints a second time (only
+    // system_turn and compaction markers carry id dedup; content and tool
+    // rows do not, and replayHistory has just reset the streaming refs and
+    // the announce map).  Handled exactly like a failed fetch below: no
+    // wipe, the latch survives, the quiesce releases, and the retry /
+    // idle-edge backstop own the heal.
+    //
+    // seedCursor renders are EXEMPT by construction and must stay so: their
+    // only caller is _loadHistoryThenConnect, which disconnects FIRST
+    // (evtSource is null for its whole fetch) and reconnects from
+    // data.cursor in its .finally — that adoption is what makes its render
+    // cursor-safe.
+    //
+    // SCOPE, ruled (#900): this ports the stream-OPENness term of
+    // coordinator.js's render-time gate and deliberately NOT its liveness
+    // terms (liveToolCalls / optimistic busySource / content refs).
+    // Interactive's replay quiesce holds every LIVE SSE event across the
+    // await, so no stream-driven turn state can appear beneath a render
+    // that is already committed — coord needed those terms because it has
+    // no quiesce.  Known residual, accepted: the user's own send is not an
+    // SSE event, so a send landing inside the await has its optimistic row
+    // wiped by the render.  The message is already committed server-side
+    // and a DOM short one user row can only UNDER-count a later rewind —
+    // non-destructive, the same ruling the Route-L reload carries at
+    // _historyStale's declaration.
+    const cursorSafe =
+      seedCursor ||
+      (!!this.evtSource && this.evtSource.readyState === EventSource.OPEN);
+    if (data && cursorSafe) {
       // Fresh-connect fast-forward: when the trailing turn is an
       // executing in-flight tool batch the server can replay, /history
       // returns a non-null ``cursor`` (a Last-Event-ID) and OMITS that
@@ -1807,7 +1867,9 @@ class Pane {
       }
     } else {
       // Failed fetch = DOM + ref + repair-intent no-op (#890, the G3
-      // guard-before-wipe ported from coordinator.js refetchHistory).
+      // guard-before-wipe ported from coordinator.js refetchHistory) —
+      // and, since #900, the same no-op for a good payload the
+      // cursor-safety gate above declined to render.
       // The prior transcript stays on screen: no wipe ever ran (see
       // the clear_ui case), and appending an empty-state hint below
       // real content was the old resync-route wart.  The streaming
@@ -2393,7 +2455,9 @@ class Pane {
                   !this._replayQueue &&
                   !this.busy &&
                   !this.currentAssistantEl &&
-                  !this.currentReasoningEl
+                  !this.currentReasoningEl &&
+                  this.evtSource &&
+                  this.evtSource.readyState === EventSource.OPEN
                 ) {
                   // !_replayQueue: yield to an in-flight quiesced
                   // fetch (the idle-edge backstop shares this token)
@@ -2401,6 +2465,26 @@ class Pane {
                   // double-render.  Fire-and-forget like the backstop:
                   // no composer state to strand here, so a render throw is
                   // left loud/uncaught (see the backstop's note).
+                  //
+                  // The stream must be OPEN, not merely present (#900):
+                  // disconnectSSE deliberately keeps this timer armed, so
+                  // the fire can land with the transport down — hidden tab
+                  // (close-on-hide), degraded catch-up cooldown, or a
+                  // CLOSED source — and a CONNECTING one has a frozen
+                  // cursor with a replay pending.  A seedless refetch then
+                  // paints rows the frozen _lastEventId still sits BELOW,
+                  // and the next connect replays that slice on top (see
+                  // _refetchHistory's render-time gate for the full
+                  // trace).  Skipping keeps the latch, so the idle-edge
+                  // backstop heals at the next settle — the accepted
+                  // liveness lag already ruled there.  NOTE the polarity
+                  // is deliberately the OPPOSITE of the host recover
+                  // beat's `readyState !== CLOSED`: that one asks "is
+                  // native reconnect still working the problem" (don't
+                  // stomp it), this one asks "is the cursor live" (a
+                  // reconnecting stream's is not).  The backstop needs no
+                  // such term — it runs inside SSE dispatch, so its
+                  // stream is live by construction.
                   this._beginReplayQuiesce(token);
                   this._refetchHistory(this.wsId, token);
                 }
@@ -3184,6 +3268,16 @@ class Pane {
     // The render also restores structural truth — clear the staleness
     // latch (its ONLY clear site) and cancel any pending clear_ui
     // failure retry, which exists to produce exactly this render.
+    //
+    // The clear assumes every successful render is POST-rewind truth.
+    // Two seams could break that assumption and both are closed (#900):
+    // server-side, a post-rewind request joining a pre-rewind #884
+    // coalescing flight — the flight key carries the workstream's
+    // truncation generation (#894), and make_history_handler is the
+    // SHARED body behind both clients' /history mounts, so interactive
+    // inherits it; client-side, a pre-clear_ui fetch landing after the
+    // latch was set — the replay quiesce makes that ordering unreachable
+    // (see the _replayQueue declaration).
     this._historyStale = false;
     if (this._staleRetryTimer) {
       clearTimeout(this._staleRetryTimer);
@@ -4943,6 +5037,15 @@ function createInteractivePane(root, wsId, opts) {
     // Invalidate any in-flight history load: its .finally would otherwise
     // reopen a stream for a session we just declared dead.
     pane._historyLoadToken = (pane._historyLoadToken || 0) + 1;
+    // Same dead-not-inert rule destroy() applies (#900): the bump above
+    // already fails the retry's fire guard, but a pane whose session is
+    // gone must not hold a live timer — /history would 404 anyway, and a
+    // give-up is not always followed by a destroy (the shell can leave a
+    // dead-but-visible pane parked behind its reconnect banner).
+    if (pane._staleRetryTimer) {
+      clearTimeout(pane._staleRetryTimer);
+      pane._staleRetryTimer = null;
+    }
     pane.disconnectSSE();
     // Detach the visibility handler and clear the hide-close marker: a dead
     // controller must NOT be resurrected by a tab-visibility change.  Without
@@ -5093,12 +5196,28 @@ function createInteractivePane(root, wsId, opts) {
         clearTimeout(recoverTimer);
         recoverTimer = null;
       }
+      // Invalidate any in-flight history load — the SAME bump giveUp()
+      // makes, and for the same reason (#900): the load token is the one
+      // chokepoint every post-await consumer already reads, so one write
+      // here closes all four escapes at once.  Without it destroy() was
+      // the WEAKER terminal path: (1) _loadHistoryThenConnect's .finally
+      // (token gate) reopened an EventSource on the detached pane AND
+      // re-registered the document-level visibilitychange listener
+      // _removeVisibilityHandler drops below — whose onerror then re-armed
+      // the host recover beat forever, since it gives up only on `dead`,
+      // which destroy never sets; (2) a settling _refetchHistory passed
+      // its supersession check and replayHistory'd into the detached DOM;
+      // (3) the clear_ui .then re-armed _staleRetryTimer AFTER the cancel
+      // below (its arm guard is latch + token, and destroy touched
+      // neither).  Every future terminal path must bump this too.
+      pane._historyLoadToken = (pane._historyLoadToken || 0) + 1;
       // The clear_ui failure retry survives everything EXCEPT a token
-      // bump — and destroy() bumps nothing, so an armed retry would
-      // fire ~2s post-destroy, pass its guards (latch still set, refs
-      // null), and replayHistory into the detached pane.  Cancel it
-      // here, terminal-only: disconnectSSE must NOT cancel it —
-      // transport-only reconnects keep the pending heal intent.
+      // bump, so the bump above already renders a firing inert — but a
+      // timer into a destroyed pane must be DEAD, not merely inert (it
+      // pins the closure for its remaining delay), so cancel an
+      // already-armed one here.  Terminal-only: disconnectSSE must NOT
+      // cancel it — transport-only reconnects keep the pending heal
+      // intent.
       if (pane._staleRetryTimer) {
         clearTimeout(pane._staleRetryTimer);
         pane._staleRetryTimer = null;

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -63,6 +63,7 @@ import {
   DEGRADED_COOLDOWN_MAX_MS,
   DEGRADED_COOLDOWN_RESET_MS,
   TRUNCATED_RESYNC_JITTER_MS,
+  STALE_RETRY_JITTER_MS,
   overflowWindowTripped,
   degradedCooldownStep,
 } from "./sse_overflow.js";
@@ -262,6 +263,14 @@ class Pane {
     this.projectName = "";
     this._lastStatusEvt = null;
     this._historyLoadToken = 0;
+    // Monotonic STREAM-generation counter (#900), bumped only in
+    // evtSource.onopen.  _refetchHistory captures it at dispatch and its
+    // render-time gate requires it unchanged, so a transport that dropped
+    // and re-established across a seedless fetch's await cannot be mistaken
+    // for one that never moved — readyState reads OPEN in both cases.
+    // Must stay initialised: undefined would make every compare NaN-false
+    // and silently decline every seedless render for the life of the pane.
+    this._connectEpoch = 0;
     // Event backlog while a clear_ui rebuild is in flight — see
     // _beginReplayQuiesce.  {token, events[]} or null.  (The truncated
     // resync no longer quiesces: it tears the stream down first, so no
@@ -484,8 +493,16 @@ class Pane {
       this.evtSource.close();
       this.evtSource = null;
     }
-    // Deliberately NOT cleared here: _agentCards/_agentOrphans and any armed
-    // _replayQueue.  disconnectSSE also runs for transport-only reconnects
+    // Deliberately NOT cleared here: _agentCards/_agentOrphans, any armed
+    // _replayQueue, and _staleRetryTimer.  The retry's survival is
+    // load-bearing, not an oversight: it is a REST heal, not transport
+    // state, so a transport-only redial must keep the pending repair intent
+    // — and it is precisely why that timer can fire against a dead stream,
+    // which is what its OPEN fire-guard term exists to handle.  Cancelling
+    // it here would silently make that guard unreachable.  Terminal-only
+    // cancel (destroy/giveUp); pinned negatively in
+    // tests/test_interactive_pane_js.py.  disconnectSSE also runs for
+    // transport-only reconnects
     // (connectSSE's first line, the host's 5s recovery beat) where the DOM
     // survives — wiping the card map there made the next child event build a
     // DUPLICATE agent card beside the still-attached one, and cancelling
@@ -1426,6 +1443,20 @@ class Pane {
     this.evtSource = new EventSource(evtUrl);
 
     this.evtSource.onopen = () => {
+      // Connection generation (#900) — bumped HERE and nowhere else, because
+      // "a stream generation began" is the only thing a cursor can be
+      // anchored to.  onopen is the sole site that means that: per spec the
+      // announce-the-connection step fires `open` for EVERY established
+      // connection, including the ones the browser's own reestablish loop
+      // produces — and a NATIVE auto-reconnect calls neither connectSSE nor
+      // disconnectSSE (see onerror below), so those two are blind to the
+      // case this exists for.  connectSSE would also FALSE-bump on the
+      // document.hidden early return above, which establishes nothing.  And
+      // a close()d source can never fire a late open (the spec's queued task
+      // early-returns on readyState CLOSED), so a discarded stream cannot
+      // bump a generation the pane has moved past.  Read once, by
+      // _refetchHistory's render-time gate.
+      this._connectEpoch += 1;
       this.retryDelay = 1000;
       this.statusBarEl.classList.remove("ws-sb-disconnected");
       if (this._lastStatusEvt) this.updateStatus(this._lastStatusEvt);
@@ -1778,14 +1809,27 @@ class Pane {
     // transient reconnect, or — on a re-render that trims an orphan
     // with no reconnect — strand the omitted turn).
     const id = wsId || this.wsId;
+    // Stream generation at DISPATCH (#900), captured at entry rather than
+    // beside the await — it mirrors coordinator.js refetchHistory's
+    // `const seq = ++refetchSeq;`, and entry-capture can only ever decline
+    // MORE if a future edit inserts transport-touching work ahead of the
+    // fetch, which is the safe direction.
+    const epoch = this._connectEpoch;
     let data = null;
     // Deliberately unbounded and unabortable, deferred not overlooked
-    // (#900): coordinator.js carries an AbortController set plus a 15s
-    // bound so destroy() can cut a slow /history loose.  Here the load
-    // token already makes a post-teardown settle render-inert, so the
-    // residual is a detached closure pinned for the request's life — a
-    // resource cost, not a correctness defect.  It belongs with the
-    // shared recovery core rather than a third hand-port.
+    // (#900, tracked as #905): coordinator.js carries an AbortController
+    // set plus a 15s bound so destroy() can cut a slow /history loose.
+    // Here the load token already makes a post-teardown settle
+    // render-inert, so the residual is a resource cost, not a correctness
+    // defect.  The honest bound is wider than "one request": authFetch
+    // retries up to three attempts, sleeping Retry-After on 429 and doing
+    // a refresh round-trip on 401, so the detached pane's closure stays
+    // reachable for all of it — and that same unbounded await is what
+    // makes the slow transport-bounce cases (recover beat ~5s, degraded
+    // timer 15-120s) reachable by the epoch gate below.  REOPEN when a
+    // /history blocks long enough for the pin to matter (large-session
+    // resume), or with the shared recovery core, which should own one
+    // implementation rather than a third hand-port.
     try {
       const r = await authFetch(
         this._base +
@@ -1837,9 +1881,40 @@ class Pane {
     // and a DOM short one user row can only UNDER-count a later rewind —
     // non-destructive, the same ruling the Route-L reload carries at
     // _historyStale's declaration.
+    // The generation term is what makes this gate total rather than
+    // point-in-time (#900 r2).  A transport that DROPPED and finished
+    // RE-ESTABLISHING inside the await — natively, or via a hide/show, the
+    // recover beat, or the degraded timer — reads back `OPEN` and is
+    // indistinguishable from one that never moved.  It is not: the redial
+    // presented the frozen _lastEventId, the server answered replay_ok, and
+    // the quiesce BUFFERED that slice, so rendering here would commit the
+    // same turns the flush is about to repaint on top.  Only a counter can
+    // see it — object identity cannot, since a native reconnect reuses the
+    // same EventSource.  (Do NOT cite coordinator.js's REMOVED r8 epoch as
+    // precedent: that one was a clear_ui/truncation-generation stamp made
+    // redundant by its seq gate.  This is a connection generation — a
+    // different value with a different matrix.)
+    //
+    // KNOWN FALSE-DECLINE, accepted: if the reconnect answered fresh or
+    // truncated rather than replay_ok, its slice carries no ring content and
+    // the render would have been safe.  Cost is one wasted /history, and it
+    // self-heals — the flushed synthetic state_change lands in the idle-edge
+    // backstop, or the truncated handler schedules a seeded resync.
+    //
+    // (Coord's half of this gate is tracked as #904 — its exposure is a
+    // race rather than this determinism, so it is not ported blind.)
+    //
+    // KNOWN RESIDUAL, server-side-blocked (#903): a refetch DISPATCHED in
+    // the gap between onopen and the replay slice actually arriving captures
+    // an already-bumped generation and still renders past the frozen cursor.
+    // replay_ok emits no end-of-replay marker, so no client-side signal
+    // exists to gate on; closing it needs a server change.  Narrow (the
+    // replay almost always beats a fresh HTTP round-trip) but real.
     const cursorSafe =
       seedCursor ||
-      (!!this.evtSource && this.evtSource.readyState === EventSource.OPEN);
+      (!!this.evtSource &&
+        this.evtSource.readyState === EventSource.OPEN &&
+        this._connectEpoch === epoch);
     if (data && cursorSafe) {
       // Fresh-connect fast-forward: when the trailing turn is an
       // executing in-flight tool batch the server can replay, /history
@@ -2447,48 +2522,65 @@ class Pane {
             // case).
             if (this._historyStale && token === this._historyLoadToken) {
               if (this._staleRetryTimer) clearTimeout(this._staleRetryTimer);
-              this._staleRetryTimer = setTimeout(() => {
-                this._staleRetryTimer = null;
-                if (
-                  token === this._historyLoadToken &&
-                  this._historyStale &&
-                  !this._replayQueue &&
-                  !this.busy &&
-                  !this.currentAssistantEl &&
-                  !this.currentReasoningEl &&
-                  this.evtSource &&
-                  this.evtSource.readyState === EventSource.OPEN
-                ) {
-                  // !_replayQueue: yield to an in-flight quiesced
-                  // fetch (the idle-edge backstop shares this token)
-                  // instead of stomping its queue for a same-token
-                  // double-render.  Fire-and-forget like the backstop:
-                  // no composer state to strand here, so a render throw is
-                  // left loud/uncaught (see the backstop's note).
-                  //
-                  // The stream must be OPEN, not merely present (#900):
-                  // disconnectSSE deliberately keeps this timer armed, so
-                  // the fire can land with the transport down — hidden tab
-                  // (close-on-hide), degraded catch-up cooldown, or a
-                  // CLOSED source — and a CONNECTING one has a frozen
-                  // cursor with a replay pending.  A seedless refetch then
-                  // paints rows the frozen _lastEventId still sits BELOW,
-                  // and the next connect replays that slice on top (see
-                  // _refetchHistory's render-time gate for the full
-                  // trace).  Skipping keeps the latch, so the idle-edge
-                  // backstop heals at the next settle — the accepted
-                  // liveness lag already ruled there.  NOTE the polarity
-                  // is deliberately the OPPOSITE of the host recover
-                  // beat's `readyState !== CLOSED`: that one asks "is
-                  // native reconnect still working the problem" (don't
-                  // stomp it), this one asks "is the cursor live" (a
-                  // reconnecting stream's is not).  The backstop needs no
-                  // such term — it runs inside SSE dispatch, so its
-                  // stream is live by construction.
-                  this._beginReplayQuiesce(token);
-                  this._refetchHistory(this.wsId, token);
-                }
-              }, 2000);
+              this._staleRetryTimer = setTimeout(
+                () => {
+                  this._staleRetryTimer = null;
+                  if (
+                    token === this._historyLoadToken &&
+                    this._historyStale &&
+                    !this._replayQueue &&
+                    !this.busy &&
+                    !this.currentAssistantEl &&
+                    !this.currentReasoningEl &&
+                    this.evtSource &&
+                    this.evtSource.readyState === EventSource.OPEN
+                  ) {
+                    // !_replayQueue: yield to an in-flight quiesced
+                    // fetch (the idle-edge backstop shares this token)
+                    // instead of stomping its queue for a same-token
+                    // double-render.  Fire-and-forget like the backstop:
+                    // no composer state to strand here, so a render throw is
+                    // left loud/uncaught (see the backstop's note).
+                    //
+                    // The stream must be OPEN, not merely present (#900):
+                    // disconnectSSE deliberately keeps this timer armed, so
+                    // the fire can land with the transport down — hidden tab
+                    // (close-on-hide), degraded catch-up cooldown, or a
+                    // CLOSED source — and a CONNECTING one has a frozen
+                    // cursor with a replay pending.  A seedless refetch then
+                    // paints rows the frozen _lastEventId still sits BELOW,
+                    // and the next connect replays that slice on top (see
+                    // _refetchHistory's render-time gate for the full
+                    // trace).  Skipping keeps the latch, so the idle-edge
+                    // backstop heals at the next settle — the accepted
+                    // liveness lag already ruled there.  NOTE the polarity
+                    // is deliberately the OPPOSITE of the host recover
+                    // beat's `readyState !== CLOSED`: that one asks "is
+                    // native reconnect still working the problem" (don't
+                    // stomp it), this one asks "is the cursor live" (a
+                    // reconnecting stream's is not).  The idle-edge backstop
+                    // needs no such term, but NOT because its stream is live
+                    // by construction — it isn't.  handleEvent also runs from
+                    // _endReplayQuiesce's flush, which fires AFTER a seedless
+                    // fetch settles, so a state_change:idle queued during that
+                    // fetch reaches the backstop with the transport already
+                    // down.  What covers it is _refetchHistory's render-time
+                    // gate: the backstop's refetch is seedless, so the gate
+                    // declines it and the cost is one wasted /history, never a
+                    // double-render.  Add a fire-time term there only if a
+                    // backstop refetch is ever dispatched somewhere the
+                    // render-time gate does not cover.
+                    this._beginReplayQuiesce(token);
+                    this._refetchHistory(this.wsId, token);
+                  }
+                  // ADDITIVE spread over the 2000 floor: one clear_ui reaches
+                  // every listener on the ws, so an un-spread retry re-fetches
+                  // in lockstep across tabs.  The floor is load-bearing (the
+                  // e2e non-occurrence windows size on it) — jitter up, never
+                  // down.  Mirrored in coordinator.js; the constant is shared.
+                },
+                2000 + Math.random() * STALE_RETRY_JITTER_MS,
+              );
             }
             if (token !== this._historyLoadToken && this.wsId !== editWs) {
               // Cross-ws supersession: drop the pending edit + release

--- a/turnstone/shared_static/sse_overflow.js
+++ b/turnstone/shared_static/sse_overflow.js
@@ -45,6 +45,22 @@ export const DEGRADED_COOLDOWN_RESET_MS = 300000;
 // total per-restart fetch count.
 export const TRUNCATED_RESYNC_JITTER_MS = 10000;
 
+// Spread for the clear_ui staleness retry, ADDITIVE over a 2000 ms floor
+// (`2000 + Math.random() * this`).  One clear_ui fans out to every listener
+// on the workstream, so an un-spread retry makes N tabs re-fetch /history in
+// near-lockstep — and #900 widened that arm: a render the cursor-safety gate
+// declines now leaves the latch set, so a SUCCESSFUL fetch can arm the retry
+// too, and the decline trigger (transport down) is itself herd-shaped.
+//
+// Deliberately small, and deliberately NOT TRUNCATED_RESYNC_JITTER_MS: this
+// spread works AGAINST #884's `(ws_id, limit, generation)` single-flight,
+// which coalesces a lockstep herd into one reconstruction.  Spreading past a
+// typical flight duration de-coalesces it — lower peak, higher total. 500 ms
+// keeps the window comparable to a flight while still breaking lockstep.
+// The 2000 floor is load-bearing for the e2e non-occurrence detectors (they
+// size their windows on it); raising this constant requires widening those.
+export const STALE_RETRY_JITTER_MS = 500;
+
 // Rolling-window trip check.  Prunes `times` in place (entries older than
 // windowMs against nowMs) and reports whether count-or-more remain.  A
 // standalone pure function so the trip logic can be lifted verbatim into a

--- a/turnstone/shared_static/sse_overflow.js
+++ b/turnstone/shared_static/sse_overflow.js
@@ -45,8 +45,8 @@ export const DEGRADED_COOLDOWN_RESET_MS = 300000;
 // total per-restart fetch count.
 export const TRUNCATED_RESYNC_JITTER_MS = 10000;
 
-// Spread for the clear_ui staleness retry, ADDITIVE over a 2000 ms floor
-// (`2000 + Math.random() * this`).  One clear_ui fans out to every listener
+// Spread for the clear_ui staleness retry, ADDITIVE over STALE_RETRY_BASE_MS
+// (`STALE_RETRY_BASE_MS + Math.random() * this`).  One clear_ui fans out to every listener
 // on the workstream, so an un-spread retry makes N tabs re-fetch /history in
 // near-lockstep — and #900 widened that arm: a render the cursor-safety gate
 // declines now leaves the latch set, so a SUCCESSFUL fetch can arm the retry
@@ -57,9 +57,15 @@ export const TRUNCATED_RESYNC_JITTER_MS = 10000;
 // which coalesces a lockstep herd into one reconstruction.  Spreading past a
 // typical flight duration de-coalesces it — lower peak, higher total. 500 ms
 // keeps the window comparable to a flight while still breaking lockstep.
-// The 2000 floor is load-bearing for the e2e non-occurrence detectors (they
-// size their windows on it); raising this constant requires widening those.
+// The floor is load-bearing for the e2e non-occurrence detectors (they size
+// their windows on floor + this); raising either requires widening those.
 export const STALE_RETRY_JITTER_MS = 500;
+
+// The floor the jitter is additive OVER.  Exported rather than left as a
+// literal in each client because FOUR sites must move together: both panes'
+// retry arms and both e2e non-occurrence windows, which size themselves on
+// floor + jitter and go vacuous if the retry can fire before they open.
+export const STALE_RETRY_BASE_MS = 2000;
 
 // Rolling-window trip check.  Prunes `times` in place (entries older than
 // windowMs against nowMs) and reports whether count-or-more remain.  A


### PR DESCRIPTION
Closes #900.

Verifies the three findings #900 filed against `interactive.js` from the coordinator campaign, fixes the two that are real, and writes the rulings for the two that are not into the code at the site.

## What was wrong

**`destroy()` bumped no load token**, which made it the weaker of the two terminal paths — `giveUp()` already bumped. Three things escaped it, all reachable when a pane is closed with a `/history` in flight:

- `_loadHistoryThenConnect`'s `.finally` reopened an `EventSource` on the detached pane **and re-registered the document-level `visibilitychange` listener** teardown had just removed. That stream's `onerror` then re-armed the host recover beat indefinitely, because it gives up only on `dead`, which `destroy()` never sets — so a closed tab kept a node connection and a 5s reconnect beat for the life of the page.
- A settling `_refetchHistory` passed its supersession check and rendered into detached DOM.
- The clear_ui `.then` re-armed `_staleRetryTimer` after `destroy()`'s own cancel.

One bump at the terminal seam closes all three, since the token is already the chokepoint every post-await consumer reads. `giveUp()` gains the matching timer cancel — inert is not dead.

**The clear_ui retry could fire against a dead transport.** `disconnectSSE` deliberately keeps it armed, so a hidden tab, a degraded cooldown, or a native redial holds the fire while `_lastEventId` is frozen. A seedless refetch then paints rows the cursor still sits below, and the next connect's `replay_ok` paints them again — only `system_turn` and compaction markers carry id dedup, so content and tool rows duplicate.

That needed closing at both ends of the window. The fire guard requires an OPEN stream, and `_refetchHistory` gained a render-time gate for the await window a fire-time check cannot see. The render-time half is the correctness carrier: a transport that **dropped and finished re-establishing** inside the await reads back `OPEN` and is indistinguishable from one that never moved. Object identity cannot separate them either, since a native reconnect reuses the same `EventSource` — so the gate carries a connection generation (`_connectEpoch`), bumped in `onopen` and nowhere else. Native redials call neither `connectSSE` nor `disconnectSSE`; `connectSSE` would additionally false-bump on its `document.hidden` early return, which establishes no stream.

This is original-strata residual rather than a regression: before this change the seedless render was ungated entirely.

**Two findings were not reachable** and are declined with the ruling written in at the site, so a later pass re-derives rather than re-files them. Same-token `/history` fetches cannot overlap here — the replay quiesce serializes what the coordinator's dispatch stamp had to order, because the coordinator has no quiesce. The joined-flight window is closed for both clients by the shared `make_history_handler`'s generation-keyed flight.

## Behaviour worth knowing

A declined render leaves the staleness latch set, so rewind/edit stay closed until the idle-edge backstop heals at the next settle — the existing safe-closed-beats-destructive-open trade, now reachable on one more path. Because a declined render also arms the bounded retry, and its trigger (transport down) is herd-shaped, the retry gains additive jitter over a shared floor in **both** panes. Kept deliberately small: the spread works against the `/history` single-flight, which coalesces a lockstep herd.

## Tests

Static pins for each fix, including the negative one that had been asserted in prose at three sites and pinned nowhere: `disconnectSSE` must **not** cancel the retry, since that is precisely why the retry can fire on a dead transport.

Four browser scenarios in the recovery harness:

- **E5** `hidden-retry` — the retry does not fetch while the transport is down.
- **E6** `await-window-gate` — a payload arriving on a dead transport is declined, proven against a real 200 so a decline cannot be confused with a failed fetch.
- **E7** `destroy-invalidation` — the first coverage of the factory teardown at all; every other scenario drives the pane class directly.
- **E8** `reconnect-in-await` — the first detector here that can observe a double render. Every other scenario counts `.msg.user` rows, and user rows never travel on the SSE stream, so the artefact was invisible to all of them; E8 counts sentinel occurrences instead.

## Follow-ups

- #903 — `replay_ok` emits no end-of-replay marker, so a refetch dispatched between `onopen` and the replay arriving still renders past the frozen cursor. No client-side signal exists; closing it needs a server change. Named at the gate. Carries a traced (not measured) hypothesis linking the duplicate-render path to the occasional high-CPU reports, via row-cache misses degrading to whole-transcript scans.
- #904 — the coordinator's render-time gate has no connection-generation term. Same window, reached as a race rather than deterministically. Not ported blind: it needs its own scenario, or it is an unverified guard.
- #905 — `interactive`'s `/history` fetch is unbounded and unabortable, where the coordinator has an AbortController plus a 15s bound. Resource residual, not correctness.
