### PR TITLE
fix(console): restore back-to-console from a proxied node view

### DIFF
--- a/scripts/livepass.py
+++ b/scripts/livepass.py
@@ -45,6 +45,22 @@ Shell harness (?split=): right (default) · down · three · none — boots the
   document.title stamps SPLIT-READY-<visible cells> on success and
   SPLIT-FAILED-<reason> when a driven split was denied — judge the focused
   cell's top accent bar, the separators, and the .shown tab marker.
+Proxy-brand harness (/proxybrand/livepass.html): back-to-console from a
+  PROXIED node view, driven end to end.  An iframe hosts a node page built
+  from the REAL shell.js rail plus the REAL _JS_PROXY_SHIM (read out of
+  turnstone/console/server.py by text, never imported -- scripts/ has no
+  sys.path guard, so an import would silently pick up site-packages).  The
+  host clicks the brand's child span and, because the shim navigates the
+  FRAME away, reads the frame's post-navigation location from the surviving
+  top page.  document.title stamps PROXYBRAND-READY, or
+  PROXYBRAND-FAILED-<reason>: sub-not-repointed-server (nothing wired),
+  showhome-also-ran (shell.js won the click), nav-<path> (went somewhere
+  other than the console root), sub-not-console-<text>, aria-not-repointed,
+  no-navigation, no-brand, no-sub.  Needs --virtual-time-budget=9000;
+  there is nothing to screenshot.  Read the verdict from <title> --
+  both literals also appear in the host page's inline script, so a bare
+  grep over --dump-dom output false-positives.
+
 Attachments harness (/attachments/livepass.html): the composer attachment
   chips + the sent-message attachment pills, both driven through the REAL
   code paths — createAttachmentController.rehydrate() builds the chips and
@@ -141,6 +157,24 @@ def extract_admin_fragment() -> str:
     start = html.index('<div id="admin-layout"')
     end = html.index("<!-- /admin-layout -->") + len("<!-- /admin-layout -->")
     return html[start:end]
+
+
+def extract_proxy_shim(prefix: str = "/node/livepass-node") -> str:
+    """Pull ``_JS_PROXY_SHIM`` out of console/server.py BY TEXT, not import.
+
+    ``scripts/`` has no ``sys.path`` guard, so ``import turnstone`` from here
+    resolves to whatever is installed in site-packages rather than this
+    checkout -- silently building the page from a DIFFERENT version of the
+    shim than the one you are trying to verify.  Read the source instead.
+    """
+    src = (ROOT / "turnstone/console/server.py").read_text(encoding="utf-8")
+    m = re.search(r'^_JS_PROXY_SHIM = """\\\n(.*?)^"""', src, re.S | re.M)
+    if not m:
+        raise SystemExit(
+            "livepass: could not find _JS_PROXY_SHIM in turnstone/console/server.py "
+            "-- the constant was renamed or reshaped; update extract_proxy_shim()."
+        )
+    return m.group(1).replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix))
 
 
 def inject(template: str, marker: str, payload: str) -> str:
@@ -658,6 +692,108 @@ SHELL_TEMPLATE = """<!doctype html>
 # call the same window.buildAttachmentPreview).  The page frame is harness-only
 # chrome and not under review; the chips row and the pill row are.
 # --------------------------------------------------------------------------
+
+# The PROXIED NODE page: the real L-shell (so the rail brand is the real
+# element, with the real shell.js click listener on it) plus the real proxy
+# shim injected exactly where proxy_index puts it -- first thing inside
+# <body>, ahead of the deferred shell.js module.  caps mirror a NODE, not
+# the console: brandSub "server" is what the shim has to overwrite, and
+# leaving it "console" would make the host's /console/i check vacuous.
+PROXYBRAND_FRAME_TEMPLATE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>proxied node</title>
+    <link rel="stylesheet" href="shared/base.css" />
+    <link rel="stylesheet" href="shared/ui-base.css" />
+    <link rel="stylesheet" href="static/style.css" />
+    <link rel="stylesheet" href="shared/shell.css" />
+  </head>
+  <body>
+    <!-- SHIM:BEGIN -->
+    <!-- SHIM:END -->
+    <div id="header" style="display: none"><div id="status-bar"></div></div>
+    <div id="main" style="padding: 18px">
+      <h2 style="margin: 0 0 8px">Node dashboard</h2>
+    </div>
+    <div id="view-admin" style="display: none"></div>
+    <script>
+      window.TURNSTONE_SHELL_CAPS = { cluster: false, brandSub: "server" };
+      window.TS_APP = {
+        boot() {},
+        getClusterState() { return { nodes: {} }; },
+        onRender() {},
+      };
+      window.TS_ADMIN = {};
+      // Record on the PARENT, which survives the frame's navigation.
+      // A flag on the frame's own window dies with the document, so the
+      // host would read undefined and pass -- a check that cannot fail.
+      window.showHome = function () {
+        try { window.parent.__showHomeRan = true; } catch (e) {}
+      };
+    </script>
+    <script type="module" src="shared/shell.js"></script>
+  </body>
+</html>
+"""
+
+# The HOST page.  The shim navigates the FRAME to "/", which would destroy
+# any verdict stamped inside it -- so the surviving top page reads the
+# frame's post-navigation location and stamps its own title instead.  No
+# landing page at "/" is needed (the harness root serves a directory
+# listing) and no CDP client either.
+PROXYBRAND_HOST_TEMPLATE = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>proxybrand livepass</title>
+    <style>
+      html, body { margin: 0; height: 100%; }
+      iframe { width: 100%; height: 100%; border: 0; }
+    </style>
+  </head>
+  <body>
+    <iframe id="frame" src="frame.html"></iframe>
+    <script>
+      const frame = document.getElementById("frame");
+      let phase = 0;
+      const fail = (r) => { phase = 9; document.title = "PROXYBRAND-FAILED-" + r; };
+
+      frame.addEventListener("load", () => {
+        if (phase === 9) return;
+        if (phase === 0) {
+          const doc = frame.contentDocument;
+          const brand = doc.querySelector(".rail-brand .brand-home");
+          if (!brand) return fail("no-brand");
+          const sub = brand.querySelector(".brand-sub");
+          if (!sub) return fail("no-sub");
+          const text = sub.textContent.trim();
+          if (text === "server") return fail("sub-not-repointed-server");
+          if (!/console/i.test(text)) return fail("sub-not-console-" + text);
+          if (brand.getAttribute("aria-label") !== "Back to console")
+            return fail("aria-not-repointed");
+          phase = 1;
+          // Click the CHILD span, as a real user does: the shim must match
+          // via contains(), not target identity.
+          sub.click();
+          setTimeout(() => { if (phase === 1) fail("no-navigation"); }, 2000);
+          return;
+        }
+        const path = frame.contentWindow.location.pathname;
+        const ranShowHome = !!window.__showHomeRan;
+        phase = 2;
+        if (path !== "/") return fail("nav-" + path);
+        if (ranShowHome) return fail("showhome-also-ran");
+        // Sticky, mirroring fail(): a third load must not re-stamp.
+        phase = 9;
+        document.title = "PROXYBRAND-READY";
+      });
+    </script>
+  </body>
+</html>
+"""
+
+
 ATTACH_TEMPLATE = """<!doctype html>
 <html lang="en">
   <head>
@@ -1482,6 +1618,17 @@ def build(out: Path) -> None:
     symlink(pf / "static", ROOT / "turnstone/ui/static")
     (pf / "livepass.html").write_text(PERF_TEMPLATE, encoding="utf-8")
     print(f"{pf}/livepass.html — long-session perf baseline (real InteractivePane)")
+
+    pb = out / "proxybrand"
+    pb.mkdir(parents=True, exist_ok=True)
+    symlink(pb / "shared", ROOT / "turnstone/shared_static")
+    symlink(pb / "static", ROOT / "turnstone/ui/static")
+    shim = "<script>" + extract_proxy_shim() + "</script>"
+    (pb / "frame.html").write_text(
+        inject(PROXYBRAND_FRAME_TEMPLATE, "SHIM", shim), encoding="utf-8"
+    )
+    (pb / "livepass.html").write_text(PROXYBRAND_HOST_TEMPLATE, encoding="utf-8")
+    print(f"{pb}/livepass.html — back-to-console brand (real shell.js + real shim)")
 
 
 class _PerfStore:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1843,6 +1843,169 @@ class TestConsoleProxy:
 # ---------------------------------------------------------------------------
 
 
+_BRAND_HARNESS = r"""
+// Faithful two-walk DOM click dispatch.  The capture flag is RECORDED: an
+// earlier version of this harness dropped it, which silently encoded the
+// false premise that at target both phases fire in registration order, and
+// so wrongly rejected a same-element capture listener that Chrome accepts.
+// `document` is a real path member, so its non-capture listeners are
+// modelled too.  stopPropagation gates the walk BETWEEN nodes without
+// suppressing the rest of the current node's listeners.
+const order = [];
+const navigations = [];
+
+function fail(msg) { throw new Error(msg); }
+
+function makeEl(cls, tag) {
+  return {
+    className: cls || "", tagName: tag || "DIV", attrs: {},
+    children: [], parent: null, textContent: "", listeners: [],
+    setAttribute(k, v) { this.attrs[k] = v; },
+    getAttribute(k) { return k in this.attrs ? this.attrs[k] : null; },
+    appendChild(c) { c.parent = this; this.children.push(c); return c; },
+    addEventListener(type, fn, capture) {
+      this.listeners.push([type, fn, capture === true]);
+    },
+    removeEventListener() {},
+    contains(n) { while (n) { if (n === this) return true; n = n.parent; } return false; },
+    querySelector(sel) { return find(this, sel); },
+  };
+}
+
+function hasClass(el, c) {
+  return (" " + el.className + " ").includes(" " + c + " ");
+}
+
+// Descendant combinator: the last token must match, and for a two-token
+// selector some ancestor must match the first.
+function find(root, sel) {
+  const parts = sel.trim().split(/\s+/).map((t) => t.replace(/^\./, ""));
+  const want = parts[parts.length - 1];
+  const anc = parts.length > 1 ? parts[0] : null;
+  const walk = (el) => {
+    for (const c of el.children) {
+      if (hasClass(c, want)) {
+        if (!anc) return c;
+        for (let p = c.parent; p; p = p.parent) if (hasClass(p, anc)) return c;
+      }
+      const hit = walk(c);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  return walk(root);
+}
+
+// The rail as shell.js builds it: .rail-brand > .brand-home > .brand-sub,
+// with .rail-collapse a SIBLING of .brand-home inside .rail-brand.
+const root = makeEl("root");
+const railBrand = makeEl("rail-brand");
+const brand = makeEl("brand-home", "BUTTON");
+const sub = makeEl("brand-sub");
+sub.textContent = "server";
+root.appendChild(railBrand);
+railBrand.appendChild(brand);
+brand.appendChild(makeEl("brand-mark"));
+brand.appendChild(sub);
+const collapse = makeEl("rail-collapse", "BUTTON");
+railBrand.appendChild(collapse);
+
+// shell.js's own bubble-phase handler on the same element.
+brand.addEventListener("click", () => order.push("showHome"));
+
+const documentNode = makeEl("document-node");
+const document = {
+  readyState: "loading",
+  querySelector: (sel) => find(root, sel),
+  getElementById: () => null,
+  createElement: (tag) => makeEl("", tag.toUpperCase()),
+  addEventListener(type, fn, capture) {
+    documentNode.listeners.push([type, fn, capture === true]);
+  },
+  removeEventListener() {},
+};
+
+class FakeES { close() {} }
+const window = {
+  fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+  EventSource: FakeES,
+};
+// Recording href setter.  A plain string initialised to the node root made
+// "never navigated" and "navigated to the node root" produce identical
+// failures; these are different bugs and must read differently.
+let _href = "/node/n1/current";
+Object.defineProperty(window, "location", {
+  value: Object.defineProperty({}, "href", {
+    get: () => _href,
+    set: (v) => { _href = v; navigations.push(v); order.push("nav"); },
+  }),
+});
+
+function dispatchClick(target) {
+  const path = [];
+  for (let n = target; n; n = n.parent) path.push(n);
+  path.push(documentNode);
+  let stopped = false;
+  const ev = {
+    target, defaultPrevented: false,
+    preventDefault() { this.defaultPrevented = true; },
+    stopPropagation() { stopped = true; },
+  };
+  const invoke = (node, phase) => {
+    for (const [type, fn, capture] of node.listeners.slice()) {
+      if (type !== "click") continue;
+      if (phase === "capturing" && !capture) continue;
+      if (phase === "bubbling" && capture) continue;
+      fn.call(node, ev);
+    }
+  };
+  for (let i = path.length - 1; i >= 0; i--) {
+    invoke(path[i], "capturing");
+    if (stopped) return ev;
+  }
+  for (let i = 0; i < path.length; i++) {
+    invoke(path[i], "bubbling");
+    if (stopped) return ev;
+  }
+  return ev;
+}
+
+new Function("window", "document", SHIM)(window, document);
+
+const ready = documentNode.listeners.filter(([t]) => t === "DOMContentLoaded");
+if (!ready.length) fail("shim never registered a DOMContentLoaded hook");
+for (const [, fn] of ready) fn();
+
+// Post-wire, pre-click: the affordance must be visible and labelled.
+// aria-label first: it separates "nothing ran at all" from "only the
+// sub-label repoint was lost", which otherwise trip the same assertion.
+if (brand.getAttribute("aria-label") !== "Back to console")
+  fail("aria-label not repointed: " + brand.getAttribute("aria-label"));
+if (sub.textContent === "server")
+  fail("brand-sub still reads 'server' - no visible way back");
+if (!/console/i.test(sub.textContent))
+  fail("brand-sub does not name the console: " + sub.textContent);
+
+// Click a CHILD span, as a real user does: the handler must match via
+// contains(), not target identity.
+const ev = dispatchClick(sub);
+
+if (!ev.defaultPrevented)
+  fail("shim did not preventDefault on the brand click");
+if (!navigations.length)
+  fail("brand click did not navigate at all (order=[" + order.join(",") + "])");
+if (navigations[navigations.length - 1] !== "/")
+  fail("brand navigated to " + navigations[navigations.length - 1] + ", expected /");
+if (order.join(",") !== "nav")
+  fail("expected order [nav], got [" + order.join(",") + "]");
+
+// A sibling control inside .rail-brand must not be hijacked.
+const before = navigations.length;
+dispatchClick(collapse);
+if (navigations.length !== before) fail("sibling .rail-collapse click was hijacked");
+"""
+
+
 class TestProxyRewriting:
     """Test the JS shim and HTML rewriting logic."""
 
@@ -1860,96 +2023,110 @@ class TestProxyRewriting:
         assert "window.fetch" in _JS_PROXY_SHIM
         assert "window.EventSource" in _JS_PROXY_SHIM
 
-    def test_js_shim_carries_node_id_placeholder(self):
-        """The picker reads the current node_id from the shim's _nodeId
-        closure variable; the placeholder must be present and substitutable."""
+    def test_js_shim_repoints_rail_brand_at_console(self, tmp_path):
+        """Runtime guard: clicking the rail brand on a proxied page must
+        navigate to the console root, not run shell.js's showHome().
+
+        Executed under node against a stub DOM rather than asserted as
+        substrings: the previous back-to-console affordance (the picker's
+        menu item) was lost precisely because its ``#ui-header`` anchor
+        stopped existing while every string-presence assertion kept passing.
+        A string assertion cannot see a selector that stopped matching, so
+        ``tests/test_shell_js.py`` guards the selector literals themselves.
+
+        Expected click orders were MEASURED in Chrome, not reasoned: a
+        correct wiring gives ``[nav]``, a document bubble listener gives
+        ``[showHome, nav]``, and dropping stopPropagation gives
+        ``[nav, showHome]``.
+
+        ``new Function(...)`` in the harness doubles as the shim's only
+        syntax check in the default CI lane -- ``node --check`` never sees
+        this string, since it lives in a Python constant.
+        """
+        import subprocess
+
         from turnstone.console.server import _JS_PROXY_SHIM
 
-        assert "NODE_ID_PLACEHOLDER" in _JS_PROXY_SHIM
-        replaced = _JS_PROXY_SHIM.replace("NODE_ID_PLACEHOLDER", "node-a")
-        assert "node-a" in replaced
-        assert "NODE_ID_PLACEHOLDER" not in replaced
-
-    def test_js_shim_includes_picker_pieces(self):
-        """Picker logic ships in the same IIFE as the prefix shim — verify
-        the moving parts are present so a future refactor doesn't silently
-        drop them.  /v1/api/cluster/nodes is the lazy-fetch target;
-        #ui-header is the DOM anchor; console-node-pill is the trigger
-        class; ws-tab-dropdown is the menu shell we share with the
-        workstream chevron menu (style + behaviour parity); ArrowDown is
-        the keyboard-nav primitive that disambiguates this from a plain
-        click-only menu."""
-        from turnstone.console.server import _JS_PROXY_SHIM
-
-        # limit=1000 matches the collector's hard cap; without it the
-        # picker would silently drop nodes past the 100-default in
-        # clusters with >100 nodes.
-        assert "/v1/api/cluster/nodes?limit=1000" in _JS_PROXY_SHIM
-        assert "ui-header" in _JS_PROXY_SHIM
-        assert "console-node-pill" in _JS_PROXY_SHIM
-        assert "ws-tab-dropdown" in _JS_PROXY_SHIM
-        assert "ArrowDown" in _JS_PROXY_SHIM
-        assert "DOMContentLoaded" in _JS_PROXY_SHIM
-
-    def test_proxy_style_drops_banner_styles(self):
-        """The legacy banner CSS classes (.console-banner, .ts-header-back-link
-        offsets, .dashboard-overlay top:32px hack) should be gone — the new
-        picker lives inside #ui-header and doesn't need overlay offsets."""
-        from turnstone.console.server import _CONSOLE_PROXY_STYLE
-
-        assert ".console-banner" not in _CONSOLE_PROXY_STYLE
-        assert "dashboard-overlay" not in _CONSOLE_PROXY_STYLE
-        assert ".console-node-pill" in _CONSOLE_PROXY_STYLE
-        assert ".console-node-menu" in _CONSOLE_PROXY_STYLE
-
-    def test_proxy_style_uses_canonical_degraded_color(self):
-        """Degraded health dot must use --accent (the canonical "needs
-        attention" token used by the cluster-overview node table at
-        console/static/style.css:548) and not --yellow.  Yellow is reserved
-        for the dash-state attention dot, a stronger signal."""
-        from turnstone.console.server import _CONSOLE_PROXY_STYLE
-
-        assert "console-node-menu-item-dot--degraded" in _CONSOLE_PROXY_STYLE
-        # The degraded rule sits on its own line; assert it uses --accent
-        # by checking the CSS substring has --accent and not --yellow.
-        idx = _CONSOLE_PROXY_STYLE.find("console-node-menu-item-dot--degraded")
-        rule = _CONSOLE_PROXY_STYLE[idx : idx + 200]
-        assert "var(--accent)" in rule
-        assert "var(--yellow)" not in rule
-
-    def test_html_rewriting_changes_static_paths(self):
-        """Simulate the proxy_index rewriting logic."""
-        sample_html = (
-            '<link rel="stylesheet" href="/static/style.css">\n'
-            '<script src="/static/app.js"></script>'
+        shim = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps("/node/n1"))
+        script = tmp_path / "brand_harness.mjs"
+        script.write_text(
+            "const SHIM = " + json.dumps(shim) + ";\n" + _BRAND_HARNESS,
+            encoding="utf-8",
         )
-        prefix = "/node/test-node"
-        rewritten = sample_html.replace('href="/static/', f'href="{prefix}/static/')
-        rewritten = rewritten.replace('src="/static/', f'src="{prefix}/static/')
-        assert "/node/test-node/static/style.css" in rewritten
-        assert "/node/test-node/static/app.js" in rewritten
-        # Originals should be gone
-        assert 'href="/static/' not in rewritten
-        assert 'src="/static/' not in rewritten
-
-    def test_shim_injection_after_body(self):
-        """Simulate the proxy shim injection — the shim ships the node-id
-        and prefix as JS literals and renders the picker at runtime, so
-        we assert the substituted JS literals land in the page."""
-        from turnstone.console.server import _CONSOLE_PROXY_STYLE, _JS_PROXY_SHIM
-
-        sample_html = "<html><body><div>content</div></body></html>"
-        prefix = "/node/node-a"
-        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix)).replace(
-            '"NODE_ID_PLACEHOLDER"', json.dumps("node-a")
+        try:
+            proc = subprocess.run(["node", str(script)], capture_output=True, text=True, timeout=15)
+        except FileNotFoundError:
+            pytest.skip("node binary not available on PATH")
+        assert proc.returncode == 0, (
+            f"rail-brand back-to-console runtime check failed.\n"
+            f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
         )
-        injection = _CONSOLE_PROXY_STYLE + "<script>" + shim_js + "</script>"
-        result = sample_html.replace("<body>", "<body>" + injection, 1)
-        assert '"node-a"' in result
-        assert '"/node/node-a"' in result
-        assert "PREFIX_PLACEHOLDER" not in result
-        assert "NODE_ID_PLACEHOLDER" not in result
-        assert result.startswith("<html><body><style>")
+
+    def test_shim_injection_after_body(self, monkeypatch):
+        """Drive the REAL ``proxy_index`` against the REAL node index page.
+
+        The previous version asserted ``startswith("<html><body><script>")``
+        on a string the test itself had concatenated three lines earlier --
+        unconditionally true, and green even if proxy_index stopped
+        injecting entirely.
+
+        Feeding the real ``turnstone/ui/static/index.html`` also pins
+        something nothing else does: the injection is a literal
+        ``page.replace("<body>", ...)``, so the day that file grows a
+        ``<body class="...">`` attribute the ENTIRE shim silently vanishes --
+        prefix rewriting included, not just back-to-console.
+        """
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import httpx
+
+        from turnstone.console import server as csrv
+
+        index = (
+            Path(__file__).resolve().parent.parent / "turnstone/ui/static/index.html"
+        ).read_text(encoding="utf-8")
+        assert "<body>" in index, (
+            "the node index no longer has a bare <body>; proxy_index's "
+            "literal replace() would silently inject nothing at all."
+        )
+
+        upstream = httpx.Response(
+            200,
+            content=index.encode(),
+            headers={"content-type": "text/html; charset=utf-8"},
+            request=httpx.Request("GET", "http://n:1/"),
+        )
+
+        async def _mock_get(*a, **kw):
+            return upstream
+
+        proxy_client = MagicMock(spec=httpx.AsyncClient)
+        proxy_client.get = MagicMock(side_effect=_mock_get)
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(proxy_client=proxy_client)),
+            path_params={"node_id": "node-a"},
+            url=SimpleNamespace(query=""),
+        )
+        monkeypatch.setattr(csrv, "_proxy_auth_headers", lambda r: {})
+        monkeypatch.setattr(csrv, "_get_server_url", lambda r, n: "http://n:1")
+
+        resp = asyncio.run(csrv.proxy_index(request))
+        assert resp.status_code == 200
+        body = resp.body.decode()
+
+        # The shim is injected, and injected at <body> rather than appended.
+        assert "<body><script>" in body, "shim not injected immediately after <body>"
+        assert '"/node/node-a"' in body, "prefix literal missing from the shim"
+        assert "PREFIX_PLACEHOLDER" not in body
+        assert "wireBrandHome" in body, "back-to-console wiring absent from the page"
+        # Static + shared rewriting still happen on the same pass.
+        assert 'href="/static/' not in body
+        assert 'src="/static/' not in body
+        assert "/node/node-a/static/" in body
+        assert 'href="/shared/' not in body
+        assert "/node/node-a/shared/" in body
 
 
 # ---------------------------------------------------------------------------
@@ -2180,23 +2357,6 @@ class TestProxySharedStatic:
         assert "/node/test-node/static/app.js" in rewritten
         assert 'href="/shared/' not in rewritten
         assert 'src="/shared/' not in rewritten
-
-    def test_proxy_shim_injected_in_html(self):
-        """Verify shim is injected as inline script in proxied HTML."""
-
-        from turnstone.console.server import _JS_PROXY_SHIM
-
-        sample_html = "<html><body><div>content</div></body></html>"
-        prefix = "/node/test-node"
-        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix)).replace(
-            '"NODE_ID_PLACEHOLDER"', json.dumps("test-node")
-        )
-        shim = "<script>" + shim_js + "</script>"
-        result = sample_html.replace("<body>", "<body>" + shim, 1)
-        assert "<script>" in result
-        assert "/node/test-node" in result
-        assert "window.fetch" in result
-        assert "window.EventSource" in result
 
     def test_proxy_shared_static_unknown_node_returns_404(self):
         from starlette.testclient import TestClient

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -1132,3 +1132,130 @@ def test_popup_menu_shared_helper() -> None:
     assert 'prefer: "up"' in shell, (
         "the footer chip sits at the viewport bottom — the menu pops upward"
     )
+
+
+def _strip_js_comments_local(src: str) -> str:
+    """Copy-local of ``tests/test_app_js.py``'s helper (house convention:
+    these guard files stay import-independent of each other).
+
+    Needed because a bare ``"brand-home" in body`` substring test is a FALSE
+    guard -- that string also appears in prose comments, so it would stay
+    green after the class it names was renamed away.
+    """
+    out: list[str] = []
+    n = len(src)
+    i = 0
+    in_str: str | None = None
+    while i < n:
+        ch = src[i]
+        if in_str:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+            i += 1
+            continue
+        # Line comment: replace with spaces up to newline (preserve
+        # length so downstream offset math still works).
+        if ch == "/" and i + 1 < n and src[i + 1] == "/":
+            j = src.find("\n", i)
+            if j == -1:
+                j = n
+            out.append(" " * (j - i))
+            i = j
+            continue
+        # Block comment: replace with spaces up to closing */.
+        if ch == "/" and i + 1 < n and src[i + 1] == "*":
+            j = src.find("*/", i + 2)
+            if j == -1:
+                out.append(" " * (n - i))
+                i = n
+                continue
+            out.append(" " * (j + 2 - i))
+            i = j + 2
+            continue
+        if ch in ('"', "'", "`"):
+            in_str = ch
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def test_proxy_shim_selectors_still_exist_in_shell_js() -> None:
+    """The console's proxy shim reaches across a process boundary into this
+    file's DOM: ``turnstone/console/server.py::_JS_PROXY_SHIM`` is injected
+    into a PROXIED node page and selects ``.rail-brand .brand-home`` and
+    ``.brand-sub`` -- classes only shell.js emits.  Nothing links the two,
+    and the shim fails SOFT (``if (!brand) return;``), so renaming a class
+    here silently removes the only way back to the console from a node view.
+
+    That is precisely how the PREVIOUS affordance died: the node picker
+    anchored to ``#ui-header``, the L-shell renovation deleted that element,
+    and every string-presence assertion stayed green for two minor releases.
+    This guard exists so the replacement cannot die the same way.
+
+    The class names are DERIVED from the shim's own querySelector calls, not
+    hardcoded here, so adding a selector there without emitting it here fails.
+    """
+    from turnstone.console.server import _JS_PROXY_SHIM
+
+    selectors = re.findall(r'querySelector\("([^"]+)"\)', _JS_PROXY_SHIM)
+    classes = {c for sel in selectors for c in re.findall(r"\.([A-Za-z0-9_-]+)", sel)}
+
+    # Vacuity floor.  Without this, deleting wireBrandHome entirely would
+    # yield an empty set and make the loop below pass trivially -- a guard
+    # that goes green when the thing it guards is removed is not a guard.
+    assert classes >= {"rail-brand", "brand-home", "brand-sub"}, (
+        "the proxy shim no longer selects the rail-brand trio; derived "
+        f"{sorted(classes)}.  If back-to-console moved to a different anchor, "
+        "update this guard to match the new one -- do not delete it."
+    )
+
+    body = _strip_js_comments_local(_SHELL_JS.read_text(encoding="utf-8"))
+
+    # Names alone are NOT enough.  The shim's selector is a DESCENDANT
+    # selector, so shell.js emitting all three classes while re-parenting
+    # .brand-home out of .rail-brand would leave this guard green and
+    # querySelector returning null -- the picker's death, one refactor later.
+    # Pin the two containment edges, deriving the local variable names from
+    # source so renaming them stays green and re-parenting does not.
+    holder = {}
+    for cls in ("rail-brand", "brand-home"):
+        m = re.search(
+            r"(?:const|let|var)\s+(\w+)\s*=\s*make\(\s*\"[^\"]+\"\s*,\s*\""
+            + re.escape(cls)
+            + r"\"",
+            body,
+        )
+        assert m, (
+            f'shell.js no longer builds "{cls}" via a make(...) assignment; '
+            "re-derive this structural guard against the new shape rather "
+            "than deleting it -- the shim selects .rail-brand .brand-home."
+        )
+        holder[cls] = m.group(1)
+
+    assert f"{holder['rail-brand']}.append({holder['brand-home']})" in body, (
+        'shell.js no longer appends "brand-home" into "rail-brand"; the '
+        "shim's descendant selector .rail-brand .brand-home would return "
+        "null and back-to-console would silently stop working."
+    )
+    assert re.search(
+        re.escape(holder["brand-home"]) + r"\.append\(\s*make\(\s*\"span\"\s*,\s*\"brand-sub\"",
+        body,
+    ), (
+        'shell.js no longer appends "brand-sub" into "brand-home"; the shim '
+        "reads the sub-label via brand.querySelector('.brand-sub') and would "
+        "silently skip the visible 'back to console' cue."
+    )
+
+    for cls in sorted(classes):
+        assert f'"{cls}"' in body, (
+            f'shell.js no longer emits the class "{cls}", which '
+            "turnstone/console/server.py::_JS_PROXY_SHIM selects on when the "
+            "console proxies a node.  The shim fails soft, so this rename "
+            "would silently disable back-to-console.  Update the shim's "
+            "querySelector calls in the same change."
+        )

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -155,24 +155,17 @@ def _parse_int(
 # Proxy helpers
 # ---------------------------------------------------------------------------
 
-# Inline JS injected into proxied server-UI pages.  Two responsibilities,
-# kept in one IIFE so the original window.fetch closure variable is
-# available to the picker (which has to bypass the prefix shim):
+# Inline JS injected into proxied server-UI pages.  Two responsibilities:
 #
-#   1. Prefix shim \u2014 rewrites root-relative fetch() and EventSource()
+#   1. Prefix shim — rewrites root-relative fetch() and EventSource()
 #      URLs to /node/{id}/... so the proxied page's API calls land
 #      at the console (which forwards them to the right server node).
 #
-#   2. Node picker \u2014 on DOMContentLoaded, prepends a node-id pill into
-#      the server UI's #ui-header (.appbar).  Click \u2192 dropdown with
-#      \u2190 Console + the other healthy nodes.  Replaces the earlier
-#      32px back-to-console banner that used to live above the appbar.
-#      Lazy-fetches /api/cluster/nodes the first time the menu opens
-#      (cheap when the user never clicks; fresh when they do).
+#   2. Back to console — repoints the proxied page's rail brand at "/",
+#      so the console stays reachable from inside a node view.
 _JS_PROXY_SHIM = """\
 (function(){
   var _pfx = "PREFIX_PLACEHOLDER";
-  var _nodeId = "NODE_ID_PLACEHOLDER";
   var _oF = window.fetch;
   window.fetch = function(u, o){
     if (typeof u === "string" && u.startsWith("/")) u = _pfx + u;
@@ -188,402 +181,37 @@ _JS_PROXY_SHIM = """\
   window.EventSource.OPEN = _oE.OPEN;
   window.EventSource.CLOSED = _oE.CLOSED;
 
-  function el(tag, cls, text){
-    var n = document.createElement(tag);
-    if (cls) n.className = cls;
-    if (text != null) n.textContent = text;
-    return n;
-  }
-
-  function buildPicker(){
-    var header = document.getElementById("ui-header");
-    if (!header) return;
-
-    // Trigger pill \u2014 prepended into #ui-header (the server UI's appbar).
-    var pill = document.createElement("button");
-    pill.type = "button";
-    pill.className = "console-node-pill";
-    pill.setAttribute("aria-haspopup", "menu");
-    pill.setAttribute("aria-expanded", "false");
-    pill.setAttribute("aria-label", "Switch node, currently " + _nodeId);
-    // title gives sighted users the full id when it ellipsizes
-    // \u2014 see the max-width + text-overflow rules in _CONSOLE_PROXY_STYLE.
-    pill.setAttribute("title", _nodeId);
-    pill.appendChild(el("span", "console-node-pill-dot"));
-    pill.appendChild(el("span", "console-node-pill-id", _nodeId));
-    pill.appendChild(el("span", "console-node-pill-caret", "\u25be"));
-    header.insertBefore(pill, header.firstChild);
-
-    // Menu state lives at the picker level, not on the menu DOM, so a
-    // close-then-reopen reuses the cached node list (no stale spinner).
-    var menu = null;
-    var loaded = false;
-    var loading = false;
-    var lastNodes = [];
-    var closeHandler = null;
-
-    function closeMenu(){
-      if (menu){ menu.remove(); menu = null; }
-      if (closeHandler){
-        document.removeEventListener("mousedown", closeHandler);
-        document.removeEventListener("keydown", closeHandler);
-        closeHandler = null;
-      }
-      pill.setAttribute("aria-expanded", "false");
-    }
-
-    function openMenu(){
-      if (menu) return;
-      // Reuse the workstream-tab dropdown shell for visual + behavioural
-      // consistency with the chevron menu next to it in the same toolbar.
-      menu = document.createElement("div");
-      menu.className = "ws-tab-dropdown console-node-menu";
-      menu.setAttribute("role", "menu");
-      menu.setAttribute("aria-label", "Switch node");
-      menu.addEventListener("contextmenu", function(e){ e.preventDefault(); });
-      document.body.appendChild(menu);
-      pill.setAttribute("aria-expanded", "true");
-
-      if (loaded){
-        renderMenu(lastNodes);
-      } else if (loading){
-        menu.appendChild(skeleton());
-        positionMenu();
-      } else {
-        menu.appendChild(skeleton());
-        positionMenu();
-        loadNodes();
-      }
-
-      // Keyboard handler kept in lockstep with the workstream-tab dropdown
-      // in turnstone/ui/static/app.js (search for _tabDropdownCloseHandler).
-      // If you change the keys here, change them there.  The only intentional
-      // divergence is the :not([aria-disabled='true']) filter — the picker
-      // skips disabled rows (current + unreachable) during arrow-key cycling.
-      closeHandler = function(e){
-        if (e.type === "keydown"){
-          if (e.key === "Escape"){
-            e.preventDefault();
-            closeMenu();
-            pill.focus();
-          } else if (e.key === "Tab"){
-            // Per ARIA APG menu pattern: Tab closes the menu AND moves
-            // focus to the next focusable element.  Don't preventDefault —
-            // let the browser do its native Tab traversal.
-            closeMenu();
-          } else if (e.key === "ArrowDown" || e.key === "ArrowUp"
-                  || e.key === "Home" || e.key === "End"){
-            e.preventDefault();
-            if (!menu) return;
-            var btns = Array.from(
-              menu.querySelectorAll(".ws-tab-dropdown-item:not([aria-disabled='true'])")
-            );
-            if (!btns.length) return;
-            var idx = btns.indexOf(document.activeElement);
-            if (e.key === "ArrowDown") btns[(idx + 1) % btns.length].focus();
-            // idx <= 0 covers both "first item" (wrap to last) and "no
-            // current focus" (idx === -1, which would otherwise yield N-2
-            // via the modulo).  Same shape worth backporting to app.js.
-            else if (e.key === "ArrowUp") btns[idx <= 0 ? btns.length - 1 : idx - 1].focus();
-            else if (e.key === "Home") btns[0].focus();
-            else if (e.key === "End") btns[btns.length - 1].focus();
-          }
-        } else if (e.type === "mousedown"
-                && menu && !menu.contains(e.target)
-                && e.target !== pill && !pill.contains(e.target)){
-          closeMenu();
-        }
-      };
-
-      // Defer listener wiring + initial focus so the click that opened
-      // the menu doesn't immediately trigger the mousedown-close path.
-      var activeMenu = menu;
-      var activeHandler = closeHandler;
-      setTimeout(function(){
-        if (menu !== activeMenu || !activeHandler) return;
-        document.addEventListener("mousedown", activeHandler);
-        document.addEventListener("keydown", activeHandler);
-        var first = activeMenu.querySelector(
-          ".ws-tab-dropdown-item:not([aria-disabled='true'])"
-        );
-        if (first) first.focus();
-      }, 0);
-    }
-
-    function positionMenu(){
-      if (!menu) return;
-      var pr = pill.getBoundingClientRect();
-      var mr = menu.getBoundingClientRect();
-      var mx = pr.left;
-      var my = pr.bottom + 4;
-      if (my + mr.height > window.innerHeight) my = pr.top - mr.height - 4;
-      if (mx + mr.width > window.innerWidth) mx = window.innerWidth - mr.width - 4;
-      if (mx < 4) mx = 4;
-      menu.style.left = mx + "px";
-      menu.style.top = my + "px";
-    }
-
-    function skeleton(){
-      var box = el("div", "console-node-skeleton");
-      box.setAttribute("role", "status");
-      box.setAttribute("aria-label", "Loading nodes");
-      // Three rows: roughly the typical small-cluster size.  CSS fades
-      // opacity per :nth-child (1.0 / 0.7 / 0.5) — adding a fourth would
-      // need a fourth opacity stop to avoid visual repetition.
-      for (var i = 0; i < 3; i++) box.appendChild(el("div", "console-node-skeleton-row"));
-      return box;
-    }
-
-    function loadNodes(){
-      loading = true;
-      // Saved original fetch \u2014 the prefix shim above would otherwise
-      // rewrite this to /node/{id}/v1/api/cluster/nodes, which the node
-      // doesn't serve (it's a console-only endpoint mounted at /v1).
-      // limit=1000 requests the collector's hard maximum in one round-trip;
-      // beyond 1000 nodes the picker UI is no longer the right shape (it'd
-      // need a search box) so we don't try to paginate.
-      _oF.call(window, "/v1/api/cluster/nodes?limit=1000", { credentials: "same-origin" })
-        .then(function(r){ if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
-        .then(function(data){
-          loaded = true; loading = false;
-          lastNodes = Array.isArray(data && data.nodes) ? data.nodes : [];
-          if (menu) renderMenu(lastNodes);
-        })
-        .catch(function(){
-          loading = false;
-          if (menu) renderError();
-        });
-    }
-
-    function renderError(){
-      var status = el("div", "console-node-menu-status", "Failed to load nodes");
-      var retry = document.createElement("button");
-      retry.type = "button";
-      retry.className = "ws-tab-dropdown-item console-node-menu-item";
-      retry.setAttribute("role", "menuitem");
-      retry.setAttribute("tabindex", "-1");
-      retry.appendChild(el("span", "ws-tab-dropdown-label", "Retry"));
-      retry.addEventListener("click", function(e){
-        e.stopPropagation();
-        loaded = false;
-        if (menu){ menu.replaceChildren(skeleton()); positionMenu(); }
-        loadNodes();
-      });
-      menu.replaceChildren(status, retry);
-      positionMenu();
-      setTimeout(function(){ retry.focus(); }, 0);
-    }
-
-    function buildBackItem(){
-      var back = document.createElement("a");
-      back.href = "/";
-      back.className = "ws-tab-dropdown-item console-node-menu-item console-node-menu-back";
-      back.setAttribute("role", "menuitem");
-      back.setAttribute("tabindex", "-1");
-      back.setAttribute("aria-label", "Back to console");
-      back.appendChild(el("span", "console-node-menu-arrow", "\u2190"));
-      back.appendChild(el("span", "ws-tab-dropdown-label", "Console"));
-      return back;
-    }
-
-    function buildNodeItem(n){
-      var nid = n.node_id || "";
-      if (!nid) return null;
-      var isCurrent = nid === _nodeId;
-      var reachable = n.reachable !== false;
-      var hStatus = (n.health && n.health.status) || "";
-      var status = !reachable ? "unreachable"
-                  : (hStatus && hStatus !== "ok" ? "degraded" : "healthy");
-      var dotMod = status === "healthy" ? "" : status;
-      var wsTotal = n.ws_total != null ? n.ws_total : 0;
-      // Current + unreachable rows are non-interactive: rendered as <div>
-      // with aria-disabled so the keyboard-nav filter skips them and
-      // mouse clicks land on dead text.  A clickable <a> for an
-      // unreachable node would route the user to a 502 page.
-      var nonInteractive = isCurrent || !reachable;
-
-      var item;
-      if (nonInteractive){
-        item = document.createElement("div");
-      } else {
-        item = document.createElement("a");
-        item.href = "/node/" + encodeURIComponent(nid) + "/";
-      }
-      item.className = "ws-tab-dropdown-item console-node-menu-item"
-                      + (isCurrent ? " is-current" : "")
-                      + (!reachable && !isCurrent ? " is-unreachable" : "");
-      item.setAttribute("role", "menuitem");
-      item.setAttribute("tabindex", "-1");
-      if (isCurrent) item.setAttribute("aria-current", "true");
-      if (nonInteractive) item.setAttribute("aria-disabled", "true");
-      item.setAttribute(
-        "aria-label",
-        nid + ", " + wsTotal + " workstream" + (wsTotal === 1 ? "" : "s")
-            + ", " + status + (isCurrent ? ", current node" : "")
-      );
-
-      var dot = el("span",
-        "console-node-menu-item-dot"
-        + (dotMod ? " console-node-menu-item-dot--" + dotMod : ""));
-      dot.setAttribute("aria-hidden", "true");
-      item.appendChild(dot);
-
-      item.appendChild(el("span", "ws-tab-dropdown-label console-node-menu-item-id", nid));
-
-      // Meta carries ws-count + status text \u2014 the text suffix doubles as
-      // a colorblind-safe encoding of the dot color.  aria-hidden because
-      // the menuitem aria-label already says it.
-      var metaText = wsTotal + " ws" + (status !== "healthy" ? " \u00b7 " + status : "");
-      var meta = el("span", "ws-tab-dropdown-key", metaText);
-      meta.setAttribute("aria-hidden", "true");
-      item.appendChild(meta);
-
-      if (isCurrent){
-        var check = el("span", "console-node-menu-item-check", "\u2713");
-        check.setAttribute("aria-hidden", "true");
-        item.appendChild(check);
-      }
-      return item;
-    }
-
-    function renderMenu(nodes){
-      var children = [buildBackItem()];
-
-      var nodeItems = [];
-      nodes.forEach(function(n){
-        var it = buildNodeItem(n);
-        if (it) nodeItems.push(it);
-      });
-
-      if (nodeItems.length){
-        var sep = el("div", "ws-tab-dropdown-sep");
-        sep.setAttribute("role", "separator");
-        children.push(sep);
-        children = children.concat(nodeItems);
-      }
-
-      menu.replaceChildren(...children);
-      positionMenu();
-
-      // First-open path: openMenu()'s deferred focus hook ran before the
-      // async fetch resolved, so it found only the skeleton and left
-      // focus on the pill.  If focus is still on the pill (i.e. the user
-      // didn't navigate away while the skeleton was up), grab it now.
-      if (document.activeElement === pill){
-        var first = menu.querySelector(
-          ".ws-tab-dropdown-item:not([aria-disabled='true'])"
-        );
-        if (first) first.focus();
-      }
-    }
-
-    pill.addEventListener("click", function(e){
+  // Repoint the rail brand at the console.  Only proxied pages get this shim,
+  // so a standalone server keeps shell.js's showHome().  The node's own
+  // dashboard stays reachable as the non-closable first tab.
+  function wireBrandHome(){
+    var brand = document.querySelector(".rail-brand .brand-home");
+    if (!brand) return;
+    brand.setAttribute("aria-label", "Back to console");
+    brand.setAttribute("title", "Back to console");
+    var sub = brand.querySelector(".brand-sub");
+    if (sub) sub.textContent = "← console";
+    // Capture at the document so this runs during the capture walk, before
+    // any listener on the button itself; stopPropagation() then keeps
+    // shell.js's showHome() bubble listener from ever being reached.
+    document.addEventListener("click", function(e){
+      if (!brand.contains(e.target)) return;
+      e.preventDefault();
       e.stopPropagation();
-      if (menu) closeMenu(); else openMenu();
-    });
+      window.location.href = "/";
+    }, true);
   }
 
+  // shell.js builds the rail synchronously in mountShell (before its first
+  // await), and deferred modules run before DOMContentLoaded — so
+  // .brand-home exists by the time this fires.
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", buildPicker);
+    document.addEventListener("DOMContentLoaded", wireBrandHome);
   } else {
-    buildPicker();
+    wireBrandHome();
   }
 })();
 """
-
-# Inline <style> injected into proxied server-UI pages.  The dropdown
-# panel itself reuses .ws-tab-dropdown* (defined in ui/static/style.css,
-# which the proxied page already loads) for animation, shadow, theme
-# override, and item layout.  This sheet adds:
-#   - the trigger pill (no analogue exists in the server UI),
-#   - the inline health-dot in menu items (mirrors --green / --accent /
-#     --red from the cluster-overview node table \u2014 see
-#     console/static/style.css:535-549),
-#   - the "you are here" tint + cursor:default for the current node row,
-#   - a 3-row pulse skeleton for the loading state.
-_CONSOLE_PROXY_STYLE = (
-    "<style>"
-    # --- Trigger pill \u2014 sits at the start of #ui-header (.appbar).
-    # Height 24px passes WCAG 2.5.8 (24px min target) and harmonises
-    # with .btn (28px) and .appbar-back (~20px) without looking stunted.
-    # max-width caps the pill against pathologically long node ids
-    # (validated up to 256 chars upstream); the id span ellipsizes
-    # inside.  min-width:0 lets it shrink under appbar pressure.
-    ".console-node-pill{display:inline-flex;align-items:center;gap:6px;"
-    "height:24px;padding:0 10px;max-width:240px;min-width:0;"
-    "font-family:var(--font-mono);font-size:12px;color:var(--fg-dim);"
-    "background:transparent;border:1px solid var(--border-strong);"
-    "border-radius:var(--radius-sm);cursor:pointer;line-height:1;"
-    "transition:background .12s,color .12s}"
-    ".console-node-pill:hover{background:var(--bg-highlight);color:var(--fg)}"
-    '.console-node-pill[aria-expanded="true"]{background:var(--bg-highlight);'
-    "color:var(--fg);border-color:var(--accent-dim)}"
-    ".console-node-pill:focus-visible{outline:2px solid var(--accent);"
-    "outline-offset:2px}"
-    ".console-node-pill-dot{width:6px;height:6px;border-radius:50%;"
-    "background:var(--green);box-shadow:0 0 4px var(--green-glow);"
-    "flex-shrink:0}"
-    ".console-node-pill-id{font-weight:500;overflow:hidden;"
-    "text-overflow:ellipsis;white-space:nowrap;min-width:0}"
-    ".console-node-pill-caret{font-size:10px;color:var(--fg-dim);opacity:.7;"
-    "display:inline-block;transition:transform .12s}"
-    '.console-node-pill[aria-expanded="true"] .console-node-pill-caret'
-    "{transform:rotate(180deg)}"
-    # --- Menu shell uses .ws-tab-dropdown directly; no CSS needed here.
-    # Constrain the picker's width so node ids + meta have room.
-    ".console-node-menu{min-width:240px;max-width:360px}"
-    # --- Menu items reuse .ws-tab-dropdown-item \u2014 we only override
-    # font (mono, for hostname-like ids) and add the dot column.
-    ".console-node-menu-item{font-family:var(--font-mono);font-size:12px;"
-    "padding:6px 12px;gap:8px;color:var(--fg-dim);text-decoration:none}"
-    # Current row: keep the accent-tint visible.  The shared
-    # .ws-tab-dropdown-item[aria-disabled="true"] rule applies opacity:.55
-    # which would otherwise wash out the "you are here" tint \u2014 restore
-    # full opacity here.  Same restore for the unreachable row's red dot
-    # so its color signal stays legible against the dim row background.
-    ".console-node-menu-item.is-current{background:var(--accent-dim);"
-    "color:var(--fg);cursor:default;opacity:1}"
-    ".console-node-menu-item.is-current:hover{background:var(--accent-dim);"
-    "color:var(--fg)}"
-    # Unreachable row: dim the text but leave the dot at full saturation
-    # so the red signal reads against the dim row.  cursor:not-allowed
-    # comes from the shared aria-disabled rule.
-    ".console-node-menu-item.is-unreachable{color:var(--fg-dim)}"
-    ".console-node-menu-item.is-unreachable .console-node-menu-item-dot{opacity:1}"
-    ".console-node-menu-back{color:var(--accent)}"
-    ".console-node-menu-back:hover{color:var(--accent)}"
-    ".console-node-menu-arrow{font-family:var(--font-mono);font-size:13px}"
-    # Health dots in menu items \u2014 match cluster-overview canonical colors:
-    #   reachable + ok      \u2192 --green  (style.css:539)
-    #   reachable + !ok     \u2192 --accent (style.css:548  \u2014 was --yellow)
-    #   unreachable         \u2192 --red    (style.css:544)
-    ".console-node-menu-item-dot{width:6px;height:6px;border-radius:50%;"
-    "flex-shrink:0;background:var(--green);box-shadow:0 0 4px var(--green-glow)}"
-    ".console-node-menu-item-dot--unreachable{background:var(--red);"
-    "box-shadow:0 0 4px var(--red-glow)}"
-    ".console-node-menu-item-dot--degraded{background:var(--accent);"
-    "box-shadow:0 0 4px var(--accent-glow-strong)}"
-    ".console-node-menu-item-id{flex:1}"
-    ".console-node-menu-item-check{color:var(--accent);font-size:11px}"
-    # --- Loading state: 3-row pulsing skeleton.  Reuses --border-strong
-    # for the row tint and a dedicated keyframe so we can guard it under
-    # prefers-reduced-motion in step.
-    ".console-node-skeleton{padding:6px 0}"
-    ".console-node-skeleton-row{height:14px;margin:6px 12px;"
-    "background:var(--border-strong);border-radius:var(--radius-sm);"
-    "animation:console-node-skel-pulse 1.4s ease-in-out infinite}"
-    ".console-node-skeleton-row:nth-child(2){opacity:.7;animation-delay:.15s}"
-    ".console-node-skeleton-row:nth-child(3){opacity:.5;animation-delay:.3s}"
-    "@keyframes console-node-skel-pulse{"
-    "0%,100%{opacity:.4}50%{opacity:.8}}"
-    "@media (prefers-reduced-motion:reduce){"
-    ".console-node-skeleton-row{animation:none}}"
-    # --- Status text fallback (only used by the error path now).
-    ".console-node-menu-status{padding:8px 12px;font-family:var(--font-mono);"
-    "font-size:11px;color:var(--fg-dim);text-align:center}"
-    "</style>"
-)
-
 
 _VALID_NODE_ID = re.compile(r"^[a-zA-Z0-9._-]+$")
 _VALID_WS_ID_RE = re.compile(r"^[a-f0-9]{1,64}$")
@@ -3043,16 +2671,12 @@ async def proxy_index(request: Request) -> Response:
         page = page.replace('src="/static/', f'src="{prefix}/static/')
         page = page.replace('href="/shared/', f'href="{prefix}/shared/')
         page = page.replace('src="/shared/', f'src="{prefix}/shared/')
-        # Inject the proxy shim (prefix rewriting + node-picker) after <body>.
-        # The picker self-attaches to #ui-header on DOMContentLoaded; the
-        # banner that used to live above the appbar is gone.  node_id is
-        # validated against _VALID_NODE_ID upstream, so json.dumps is the
-        # only escaping the JS literal needs.
-        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix)).replace(
-            '"NODE_ID_PLACEHOLDER"', json.dumps(node_id)
-        )
-        shim = "<script>" + shim_js + "</script>"
-        page = page.replace("<body>", "<body>" + _CONSOLE_PROXY_STYLE + shim, 1)
+        # Inject the proxy shim (prefix rewriting + back-to-console) after
+        # <body>.  prefix is built from a node_id already validated against
+        # _VALID_NODE_ID, so json.dumps is the only escaping the JS literal
+        # needs.
+        shim_js = _JS_PROXY_SHIM.replace('"PREFIX_PLACEHOLDER"', json.dumps(prefix))
+        page = page.replace("<body>", "<body><script>" + shim_js + "</script>", 1)
         html_resp = HTMLResponse(page)
         html_resp.headers["Cache-Control"] = "no-cache"
         return html_resp

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -180,7 +180,7 @@ const INTERACTIVE_DEFAULT_HOST = {
   // EventSource (re)opened — the dual of onStreamError.  The console pane host
   // uses it to reset its terminal-failure counter (see createInteractivePane).
   onStreamOpen() {},
-  // Where the ``--skip-permissions`` banner lands (standalone: #ui-header).
+  // Where the ``--skip-permissions`` banner lands.
   warningTarget(pane) {
     return pane.messagesEl;
   },


### PR DESCRIPTION
The console proxies a node's web UI at /node/{id}/ and injects a shim into
the page it fetches upstream. The only way back was a node-picker menu the
shim built into #ui-header — an element the L-shell renovation (cc508cf4,
shipped v1.6.0) removed from the server UI. buildPicker() has returned on
its first line ever since, so every supported node version has served a
proxied page with no in-UI way back; the browser back button or a
hand-edited URL were the only exits.

The shim now repoints the rail brand (.rail-brand .brand-home) at "/" and
relabels it, so the element users already read as "go home" goes home. It
captures at the document rather than on the button: shell.js binds a bubble
listener to that same element, and stopPropagation() keeps showHome() from
firing as well. The node's own dashboard stays reachable as the
non-closable first tab.

The dead picker goes with it — its JS, the CSS constant that styled only
its elements, the el() helper, and the NODE_ID_PLACEHOLDER substitution
whose only reader it was. It could only ever have run for nodes at or below
v1.5.x, which are not a supported configuration.

The failure mode here is silent by construction: the shim reaches across a
process boundary to select classes another file emits, and fails soft when
they stop matching. Nothing failed when #ui-header disappeared. So the
coupling is now pinned from both ends.

- tests/test_shell_js.py asserts both halves. The class names are derived
  from the shim's own querySelector calls, so a newly selected class is
  covered without editing the guard, and a vacuity floor keeps it from
  going green if the selectors are removed entirely. The containment edges
  are pinned separately, deriving shell.js's local variable names from
  source: renaming a local stays green, re-parenting .brand-home out of
  .rail-brand does not.

- tests/test_console.py executes the shim under node against a two-walk DOM
  dispatcher — capture walk, then bubble walk, phase-filtered at every node
  including the target. Modelling the real rule means the test accepts any
  correct wiring rather than only the one that shipped.

- The injection test drives the real proxy_index against the real node
  index. That also pins the bare <body> the literal replace() depends on;
  an attribute there would silently drop the entire shim, prefix rewriting
  included.

- scripts/livepass.py gains a proxybrand harness for manual verification:
  an iframe host over the real shell.js and the real shim, reading the
  frame's post-navigation location from the surviving top page. The shim is
  read out of the source by text rather than imported, since scripts/ has
  no sys.path guard and an import resolves to site-packages.

