### PR TITLE
test(authz): stop the retract test racing the drain's claim window

### DIFF
--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -1987,6 +1987,20 @@ class TestCompactCommandDispatch:
         # re-attempted) and nothing was dispatched behind the user's back.
         wait_until(lambda: calls["n"] >= 2, timeout=8.0)
         assert ws.session.sends == []
+        # ``calls["n"]`` increments as the FIRST statement of the attempt, so
+        # the counter crosses 2 while the drain still holds the entry CLAIMED
+        # (popped, dispatch in flight).  Retract only scans ``_pending_sends``
+        # and correctly answers not_found for a claimed entry, so firing the
+        # DELETE off the counter alone races the crash path's re-insert and
+        # loses whenever the re-insert is slower than the request -- which it
+        # is under pytest, where the log handlers make the intervening
+        # ``log.exception`` roughly as expensive as wait_until's poll interval.
+        # Wait for the state this test is actually about: the entry BACK on
+        # the list, mid-crash-loop, retractable.
+        wait_until(
+            lambda: any(e.msg_id == msg_id for e in list(ws._pending_sends)),
+            timeout=8.0,
+        )
         d = client.request(
             "DELETE",
             f"/v1/api/workstreams/{ws_id}/send",


### PR DESCRIPTION
test_persistently_crashing_entry_is_never_dropped_and_retract_frees_drain
fired its DELETE off the attempt counter, which increments as the FIRST
statement of the attempt. The counter therefore crossed 2 while the drain
still held the entry CLAIMED — popped off _pending_sends, dispatch in
flight. Retract only scans that list, and correctly answers not_found for a
claimed entry, so the request was racing the crash path's re-insert and the
assertion saw not_found instead of removed.

Both sides of that race are the same order of magnitude, which is why it
read as machine-specific rather than simply broken: the re-insert lands
after an intervening log.exception, roughly 5ms under pytest's capture
handlers against 0.05ms with none installed, and wait_until polls at 5ms.
A fast idle machine loses the race; a slower or busier one wins it.

Wait for the state the test is actually about — the entry back on the list,
mid-crash-loop and retractable — rather than for the counter. That is also
what the docstring already claims is under test.

The contract still bites: dropping the entry on the crash path fails the
new wait, and removing both retracted-purge sites leaves the drain spinning
and fails teardown.

