### PR TITLE
fix(helm): make the Kubernetes chart installable and multi-node capable

### DIFF
--- a/deploy/helm/turnstone/templates/_helpers.tpl
+++ b/deploy/helm/turnstone/templates/_helpers.tpl
@@ -111,6 +111,62 @@ Determine the PostgreSQL username.
 {{- end }}
 
 {{/*
+Determine the secret holding the PostgreSQL password.
+
+An external database may point at a secret the chart does not own (a
+CloudNativePG-generated secret, an External Secrets target, ...), in
+which case the key name is rarely "POSTGRES_PASSWORD" — hence the
+companion existingSecretPasswordKey.
+
+Otherwise fall back to the chart's application secret, which is
+llm.existingSecret when the operator supplies one. That fallback must
+not be hardcoded to "<fullname>-secrets": templates/secret.yaml is
+skipped entirely when llm.existingSecret is set, so hardcoding it would
+point every workload at a Secret that is never created.
+*/}}
+{{- define "turnstone.db.secretName" -}}
+{{- if and (not .Values.postgresql.enabled) .Values.database.external.existingSecret }}
+{{- .Values.database.external.existingSecret }}
+{{- else }}
+{{- include "turnstone.llm.secretName" . }}
+{{- end }}
+{{- end }}
+
+{{- define "turnstone.db.passwordKey" -}}
+{{- if and (not .Values.postgresql.enabled) .Values.database.external.existingSecret }}
+{{- .Values.database.external.existingSecretPasswordKey | default "password" }}
+{{- else }}
+{{- printf "POSTGRES_PASSWORD" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database environment shared by the server, console and migrate Job.
+
+Every value except the password is rendered inline rather than pulled
+from the ConfigMap via envFrom. The migrate Job is a pre-install hook,
+and Helm creates ordinary resources only after hooks finish, so any
+envFrom dependency would leave the hook stuck in
+CreateContainerConfigError on a ConfigMap that does not exist yet.
+
+POSTGRES_PASSWORD must still precede TURNSTONE_DB_URL: the kubelet
+expands $(VAR) only against env entries declared earlier in the list, so
+a later definition would leave a literal "$(POSTGRES_PASSWORD)" in the
+URL.
+*/}}
+{{- define "turnstone.db.env" -}}
+- name: TURNSTONE_DB_BACKEND
+  value: {{ .Values.database.backend | quote }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "turnstone.db.secretName" . }}
+      key: {{ include "turnstone.db.passwordKey" . }}
+- name: TURNSTONE_DB_URL
+  value: "postgresql+psycopg://{{ include "turnstone.postgresql.username" . }}:$(POSTGRES_PASSWORD)@{{ include "turnstone.postgresql.host" . }}:{{ include "turnstone.postgresql.port" . }}/{{ include "turnstone.postgresql.database" . }}{{ if and (not .Values.postgresql.enabled) .Values.database.external.sslmode }}?sslmode={{ .Values.database.external.sslmode }}{{ end }}"
+{{- end }}
+
+{{/*
 Determine the secret name for LLM API keys.
 */}}
 {{- define "turnstone.llm.secretName" -}}

--- a/deploy/helm/turnstone/templates/deployment-console.yaml
+++ b/deploy/helm/turnstone/templates/deployment-console.yaml
@@ -7,6 +7,17 @@ metadata:
     app.kubernetes.io/component: console
 spec:
   replicas: {{ .Values.console.replicas }}
+  {{- if eq (int .Values.console.replicas) 1 }}
+  # The console registers itself under the fixed service_id "console" and
+  # deregisters on shutdown. Under RollingUpdate the outgoing pod's
+  # deregister runs *after* the incoming pod registers and deletes its
+  # row -- and the heartbeat only touches last_heartbeat, so the row is
+  # never recreated and the console stays invisible in the registry until
+  # the next clean start. Recreate orders shutdown strictly before
+  # startup. Only valid at one replica; see console.replicas.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "turnstone.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/turnstone/templates/deployment-console.yaml
+++ b/deploy/helm/turnstone/templates/deployment-console.yaml
@@ -38,6 +38,15 @@ spec:
                 optional: true
           env:
             {{- include "turnstone.db.env" . | nindent 12 }}
+            # Self-registration URL for the service registry. Unlike a
+            # server node the console is one logical endpoint behind its
+            # Service, so the Service DNS name is correct here. Without
+            # it the console registers gethostname() (its pod name),
+            # which no server node can resolve. Stops at ".svc" rather
+            # than assuming a "cluster.local" DNS domain, which is
+            # configurable per cluster.
+            - name: TURNSTONE_CONSOLE_URL
+              value: "http://{{ include "turnstone.fullname" . }}-console.{{ .Release.Namespace }}.svc:{{ .Values.console.service.port }}"
           {{- if or .Values.auth.existingSecret .Values.auth.jwtSecret }}
             - name: TURNSTONE_JWT_SECRET
               valueFrom:

--- a/deploy/helm/turnstone/templates/deployment-console.yaml
+++ b/deploy/helm/turnstone/templates/deployment-console.yaml
@@ -36,8 +36,9 @@ spec:
             - secretRef:
                 name: {{ include "turnstone.llm.secretName" . }}
                 optional: true
-          {{- if or .Values.auth.existingSecret .Values.auth.jwtSecret }}
           env:
+            {{- include "turnstone.db.env" . | nindent 12 }}
+          {{- if or .Values.auth.existingSecret .Values.auth.jwtSecret }}
             - name: TURNSTONE_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/turnstone/templates/deployment-server.yaml
+++ b/deploy/helm/turnstone/templates/deployment-server.yaml
@@ -40,6 +40,19 @@ spec:
                 optional: true
           env:
             {{- include "turnstone.db.env" . | nindent 12 }}
+            # Each replica is a distinct node in the rendezvous ring, so it
+            # must advertise an address that reaches *itself*. The Service
+            # DNS name would load-balance across every replica, sending
+            # console traffic routed for node A to an arbitrary pod; the
+            # default (gethostname(), i.e. the pod name) is not resolvable
+            # at all. The pod IP is unique, routable in-cluster, and
+            # re-registered on every start, so churn is self-healing.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TURNSTONE_ADVERTISE_URL
+              value: "http://$(POD_IP):{{ .Values.server.service.port }}"
           {{- if or .Values.auth.existingSecret .Values.auth.jwtSecret }}
             - name: TURNSTONE_JWT_SECRET
               valueFrom:

--- a/deploy/helm/turnstone/templates/deployment-server.yaml
+++ b/deploy/helm/turnstone/templates/deployment-server.yaml
@@ -39,8 +39,7 @@ spec:
                 name: {{ include "turnstone.llm.secretName" . }}
                 optional: true
           env:
-            - name: TURNSTONE_DB_URL
-              value: "postgresql+psycopg://$(TURNSTONE_DB_USER):$(POSTGRES_PASSWORD)@$(TURNSTONE_DB_HOST):$(TURNSTONE_DB_PORT)/$(TURNSTONE_DB_NAME)"
+            {{- include "turnstone.db.env" . | nindent 12 }}
           {{- if or .Values.auth.existingSecret .Values.auth.jwtSecret }}
             - name: TURNSTONE_JWT_SECRET
               valueFrom:

--- a/deploy/helm/turnstone/templates/job-migrate.yaml
+++ b/deploy/helm/turnstone/templates/job-migrate.yaml
@@ -17,7 +17,12 @@ spec:
         {{- include "turnstone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: migrate
     spec:
-      serviceAccountName: {{ include "turnstone.serviceAccountName" . }}
+      # Deliberately not turnstone.serviceAccountName: this Job is a
+      # pre-install hook, and Helm creates the chart's ServiceAccount only
+      # after hooks complete, so referencing it deadlocks the install with
+      # "error looking up service account". The migration talks to
+      # PostgreSQL and never to the Kubernetes API, so the namespace
+      # default ServiceAccount is sufficient.
       restartPolicy: OnFailure
       containers:
         - name: migrate
@@ -27,12 +32,9 @@ spec:
             - python
             - -m
             - turnstone.core.storage._migrate
-          envFrom:
-            - configMapRef:
-                name: {{ include "turnstone.fullname" . }}-config
-            - secretRef:
-                name: {{ include "turnstone.llm.secretName" . }}
-                optional: true
+          # No envFrom: see turnstone.db.env. As a pre-install hook this
+          # Job runs before the ConfigMap exists. The chart's Secret is
+          # reachable — it carries matching hook annotations at a lower
+          # weight — but only for the password, by secretKeyRef.
           env:
-            - name: TURNSTONE_DB_URL
-              value: "postgresql+psycopg://$(TURNSTONE_DB_USER):$(POSTGRES_PASSWORD)@$(TURNSTONE_DB_HOST):$(TURNSTONE_DB_PORT)/$(TURNSTONE_DB_NAME)"
+            {{- include "turnstone.db.env" . | nindent 12 }}

--- a/deploy/helm/turnstone/templates/secret.yaml
+++ b/deploy/helm/turnstone/templates/secret.yaml
@@ -5,6 +5,15 @@ metadata:
   name: {{ include "turnstone.fullname" . }}-secrets
   labels:
     {{- include "turnstone.labels" . | nindent 4 }}
+  annotations:
+    # The migrate Job is a pre-install/pre-upgrade hook that sources
+    # POSTGRES_PASSWORD from this Secret. Ordinary resources are created
+    # only after hooks finish, so without matching hook annotations the
+    # Job fails with CreateContainerConfigError on a Secret that does not
+    # exist yet. A lower weight than the Job (-1) orders it first.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
   {{- if .Values.llm.apiKey }}

--- a/deploy/helm/turnstone/values.yaml
+++ b/deploy/helm/turnstone/values.yaml
@@ -14,7 +14,13 @@ database:
     port: 5432
     database: turnstone
     username: turnstone
+    # Secret holding the password for `username`. Leave empty to supply
+    # `password` inline below instead.
     existingSecret: ""
+    # Key within existingSecret holding the password. CloudNativePG
+    # generates "password"; other operators differ.
+    existingSecretPasswordKey: password
+    password: ""
     sslmode: prefer
 
 # -- Bitnami PostgreSQL subchart


### PR DESCRIPTION
Deploying the Helm chart to a Kubernetes cluster turned up three faults that prevent `helm install` from ever completing, plus an addressing problem that makes `server.replicas > 1` unusable. This fixes them.

Happy to split this up or reshape it however you prefer — the three commits are independent and the third is explicitly droppable.

## 1. Install blockers (`fix(helm): repair install-blocking template bugs`)

Hit in sequence on a clean namespace. Each one is unconditional — none depends on the values used:

**The console never receives `TURNSTONE_DB_URL`.** Only `deployment-server.yaml` defined it. `turnstone/console/server.py` treats it as fatal (`Storage backend is required for the console (service discovery)`) and exits, so the console pod cannot start under any configuration.

**The migrate Job is a `pre-install` hook that references the chart's ServiceAccount.** Helm creates ordinary resources only after hooks complete, so the Job can never be scheduled:

```
Error creating: pods "turnstone-migrate-" is forbidden: error looking up
service account vllm/turnstone: serviceaccount "turnstone" not found
```

The migration only talks to PostgreSQL, never to the Kubernetes API, so it now runs under the namespace default ServiceAccount.

**The same Job takes its config via `envFrom` on the chart's ConfigMap and Secret** — also ordinary resources. With the ServiceAccount fixed, it then failed with:

```
Error: configmap "turnstone-config" not found
```

The Job is now self-contained and references no chart-managed resource.

This commit also wires up two values that are documented in `values.yaml` but referenced by no template: `database.external.existingSecret` and `database.external.sslmode`. External databases commonly keep credentials in a secret the chart does not own (CloudNativePG, External Secrets, ...) where the key is rarely `POSTGRES_PASSWORD`, so `existingSecretPasswordKey` is added alongside it. `sslmode` is appended only on the external path, so the bundled subchart URL is unchanged.

## 2. Multi-node addressing (`fix(helm): advertise per-pod URLs`)

The chart set no advertise URL, so a server node fell back to `gethostname()` — the pod name — which nothing in the cluster can resolve, and the console's SSE collector could never attach.

The fix can't be the Service DNS name. `ConsoleRouter` uses rendezvous (HRW) hashing: `route(ws_id)` selects exactly one node and proxies to that node's advertised URL. A Service name load-balances across every replica, so traffic computed for node A lands on an arbitrary pod — a steady stream of 404s through the router's retry path once there's more than one replica. Each pod now advertises its own pod IP via the downward API: unique, routable in-cluster on any CNI, re-registered on every start.

The console is the opposite case — one logical endpoint behind its Service — so it advertises the Service DNS name via `TURNSTONE_CONSOLE_URL`.

## 3. Console rollout race (`fix(helm): use Recreate for the single-replica console`) — droppable

Separate commit because **the better fix is probably in the application, not the chart.**

The console registers under the fixed `service_id` `"console"` and deregisters on shutdown. Under RollingUpdate the incoming pod registers first, then the outgoing pod's deregister deletes that row. `heartbeat_service()` only updates `last_heartbeat` — it returns `False` when the row is missing and the caller discards that — so the registration is never recreated and the console stays absent from the registry for the life of the process.

`Recreate` orders shutdown before startup, gated on `console.replicas == 1`. But having `heartbeat_service()` re-register when its row has gone would fix the root cause and make this commit unnecessary. Say the word and I'll drop it.

One upgrade note if you do take it: switching strategy on a live Deployment fails with `spec.strategy.rollingUpdate: Forbidden` because the stored object still carries the defaulted `rollingUpdate` block; it needs a one-off `kubectl patch`. Fresh installs are unaffected.

## Verification

Deployed to a 3-node k3s/Rancher cluster against an external CloudNativePG PostgreSQL 16 cluster, with an OpenAI-compatible vLLM backend:

- `helm install` completes; the migration creates all 45 tables; both workloads connect over TLS (`sslmode=require`).
- End-to-end inference works — workstream create, send, and a persisted assistant reply.
- At `server.replicas=3`, all three nodes register distinct addresses and six workstreams created via `/v1/api/route/workstreams/new` distribute across the ring and complete real inference turns.
- `helm lint` passes on both the bundled and external database paths.

Templates only — no Python touched, and nothing under `tests/` exercises the chart.

## Deliberately not fixed here

Happy to follow up on any of these, separately or in this PR:

- **The bundled-PostgreSQL default still can't work.** The migrate Job is a `pre-install` hook, but the Bitnami subchart providing the database is an ordinary resource, so the hook always runs before PostgreSQL exists. The fix is a design call (`post-install`, an init container, or migrating on server boot), so I left it alone. This PR makes the external-database path work and leaves that default as it was.
- **`Chart.yaml` `appVersion` is `0.3.0`** while the project is at `1.8.0a4`. `image.tag` defaults to `appVersion`, so an install with default values pulls a tag that doesn't exist on GHCR.
- **`llm.baseUrl` and `llm.provider` render env vars no code reads.** The server takes these only as CLI flags or from `[api]` in config.toml, and models are registered in the DB registry anyway — so these two values look functional but silently do nothing.
- **No `extraEnv`/`extraArgs`, `nodeSelector`, `tolerations`, `affinity`, `imagePullSecrets`, PDB or HPA** in any template.
- I did not bump the chart `version` (still `0.1.0`) since I don't know your release process for it — let me know if you'd like that in here.
