### PR TITLE
fix(helm): render the chart Secret for every inline credential

### DIFF
--- a/deploy/helm/turnstone/templates/_helpers.tpl
+++ b/deploy/helm/turnstone/templates/_helpers.tpl
@@ -113,8 +113,9 @@ Determine the PostgreSQL username.
 {{/*
 The PostgreSQL password when the chart stores it itself, empty when it
 does not. Doubles as the predicate for "does <fullname>-secrets need to
-carry POSTGRES_PASSWORD", so templates/secret.yaml and
-turnstone.db.secretName cannot disagree about where the password lives.
+carry POSTGRES_PASSWORD", so an inline password is never written
+anywhere but <fullname>-secrets, and an operator-supplied Secret is
+never duplicated into it.
 
 An operator-supplied existingSecret wins outright: writing the value
 into a second Secret nothing reads would only duplicate a credential.

--- a/deploy/helm/turnstone/templates/_helpers.tpl
+++ b/deploy/helm/turnstone/templates/_helpers.tpl
@@ -111,6 +111,23 @@ Determine the PostgreSQL username.
 {{- end }}
 
 {{/*
+The PostgreSQL password when the chart stores it itself, empty when it
+does not. Doubles as the predicate for "does <fullname>-secrets need to
+carry POSTGRES_PASSWORD", so templates/secret.yaml and
+turnstone.db.secretName cannot disagree about where the password lives.
+
+An operator-supplied existingSecret wins outright: writing the value
+into a second Secret nothing reads would only duplicate a credential.
+*/}}
+{{- define "turnstone.db.inlinePassword" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.password }}
+{{- else if not .Values.database.external.existingSecret }}
+{{- .Values.database.external.password }}
+{{- end }}
+{{- end }}
+
+{{/*
 Determine the secret holding the PostgreSQL password.
 
 An external database may point at a secret the chart does not own (a
@@ -118,17 +135,18 @@ CloudNativePG-generated secret, an External Secrets target, ...), in
 which case the key name is rarely "POSTGRES_PASSWORD" — hence the
 companion existingSecretPasswordKey.
 
-Otherwise fall back to the chart's application secret, which is
-llm.existingSecret when the operator supplies one. That fallback must
-not be hardcoded to "<fullname>-secrets": templates/secret.yaml is
-skipped entirely when llm.existingSecret is set, so hardcoding it would
-point every workload at a Secret that is never created.
+Otherwise the password is inline in values, and the chart writes it to
+its own <fullname>-secrets. Note this is deliberately not
+turnstone.llm.secretName: that resolves to llm.existingSecret when the
+operator supplies one, which holds LLM API keys and has no reason to
+carry a database password. templates/secret.yaml renders on exactly the
+condition above, so the two stay in agreement.
 */}}
 {{- define "turnstone.db.secretName" -}}
 {{- if and (not .Values.postgresql.enabled) .Values.database.external.existingSecret }}
 {{- .Values.database.external.existingSecret }}
 {{- else }}
-{{- include "turnstone.llm.secretName" . }}
+{{- printf "%s-secrets" (include "turnstone.fullname" .) }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/turnstone/templates/_helpers.tpl
+++ b/deploy/helm/turnstone/templates/_helpers.tpl
@@ -118,12 +118,19 @@ turnstone.db.secretName cannot disagree about where the password lives.
 
 An operator-supplied existingSecret wins outright: writing the value
 into a second Secret nothing reads would only duplicate a credential.
+
+Both branches need "default" because this is reached through include,
+which captures rendered text rather than a value: a key that is unset
+rather than empty — "password:" with nothing after it — renders as the
+literal "<no value>", and a ten-character string is truthy. Without the
+default that lands base64-encoded in POSTGRES_PASSWORD and the workloads
+authenticate with it.
 */}}
 {{- define "turnstone.db.inlinePassword" -}}
 {{- if .Values.postgresql.enabled }}
-{{- .Values.postgresql.auth.password }}
+{{- .Values.postgresql.auth.password | default "" }}
 {{- else if not .Values.database.external.existingSecret }}
-{{- .Values.database.external.password }}
+{{- .Values.database.external.password | default "" }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/turnstone/templates/secret.yaml
+++ b/deploy/helm/turnstone/templates/secret.yaml
@@ -1,4 +1,19 @@
-{{- if not .Values.llm.existingSecret }}
+{{/*
+This Secret backs every credential supplied inline in values, so it is
+rendered whenever any one of them is set — not, as it once was, only
+when llm.existingSecret is empty. Under that older gate an operator who
+supplied an LLM Secret lost the unrelated inline values with it: both
+POSTGRES_PASSWORD and TURNSTONE_JWT_SECRET silently went unrendered
+while the workloads went on referencing them, so every pod stalled in
+CreateContainerConfigError.
+
+Each key keeps its own condition, so an operator-supplied Secret still
+suppresses the value it replaces and nothing else.
+*/}}
+{{- $apiKey := and .Values.llm.apiKey (not .Values.llm.existingSecret) }}
+{{- $dbPassword := include "turnstone.db.inlinePassword" . }}
+{{- $jwtSecret := and .Values.auth.jwtSecret (not .Values.auth.existingSecret) }}
+{{- if or $apiKey $dbPassword $jwtSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,15 +31,13 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
-  {{- if .Values.llm.apiKey }}
+  {{- if $apiKey }}
   OPENAI_API_KEY: {{ .Values.llm.apiKey | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
-  POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | b64enc | quote }}
-  {{- else if and (not .Values.postgresql.enabled) .Values.database.external.password }}
-  POSTGRES_PASSWORD: {{ .Values.database.external.password | b64enc | quote }}
+  {{- if $dbPassword }}
+  POSTGRES_PASSWORD: {{ $dbPassword | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.auth.jwtSecret (not .Values.auth.existingSecret) }}
+  {{- if $jwtSecret }}
   TURNSTONE_JWT_SECRET: {{ .Values.auth.jwtSecret | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Follow-up to #932, closing the gap its review raised but its final push did
not reach.

## The bug

`templates/secret.yaml` was gated on `{{- if not .Values.llm.existingSecret }}`,
so supplying an LLM Secret suppressed the chart's **whole** Secret rather than
just the API key it replaces. `POSTGRES_PASSWORD` and `TURNSTONE_JWT_SECRET`
went unrendered with it, while server, console and the migrate Job went on
referencing them — every pod stalls in `CreateContainerConfigError`.

`turnstone.db.secretName` compounded it by falling back to
`turnstone.llm.secretName`, aiming the password lookup at the operator's LLM
Secret, which has no reason to carry a database password.

`llm.existingSecret` is a documented value, so this took the install down on
both the bundled and external database paths. The `TURNSTONE_JWT_SECRET` half
predates #932; the `POSTGRES_PASSWORD` half arrived with it, when the fallback
changed in response to review.

## The fix

Both sides now derive from one predicate. `turnstone.db.inlinePassword` returns
the password when the chart stores it itself and empty when an operator supplies
it, so `secret.yaml` renders on exactly the condition under which
`turnstone.db.secretName` resolves to `<fullname>-secrets`. The two cannot
disagree about where the password lives — which is what the `llm.secretName`
fallback was working around.

Each key keeps its own condition, so an `existingSecret` still suppresses the
value it replaces and nothing else.

## Verification

Rendered nine values permutations against both this and the previous templates,
diffing every `secretKeyRef` against the Secrets each tree actually creates:

| Permutation | Before | After |
| --- | --- | --- |
| bundled, inline password | ok | ok |
| **bundled, inline password + `llm.existingSecret`** | **5 dangling refs** | **ok** |
| external, inline password | ok | ok |
| **external, inline password + `llm.existingSecret`** | **5 dangling refs** | **ok** |
| external, `existingSecret` | ok | ok |
| **external, `existingSecret` + `llm.existingSecret`** | **2 dangling refs** | **ok** |
| all credentials external | ok (no Secret) | ok (no Secret) |
| bundled defaults | 3 dangling refs | 3 dangling refs (see below) |
| everything inline | ok | ok |

Three fixed, six byte-identical, none regressed. `helm lint` passes on all nine.
The inline password was decoded back out of the rendered Secret and is
byte-identical to the previous templates' — it now flows through an `include`,
and a stray newline there would have silently corrupted every password.

## Left alone deliberately

**The bundled-PostgreSQL default is unchanged and still broken.** The subchart
generates its password into `<fullname>-postgresql` (keys `password`,
`postgres-password`), which the chart never reads, so `POSTGRES_PASSWORD`
dangles with or without this change. Pointing at it would not make that path
install anyway — it is separately blocked by the migrate hook running before the
database exists, which #932 flagged as needing a design decision (`post-install`,
an init container, or migrating on server boot). Worth folding into that
decision rather than guessing here.

One other thing #932 left, noted rather than changed: `secret.yaml` now carries
hook annotations, which makes it a hook resource and therefore untracked by the
release — it survives `helm uninstall` and is skipped by `helm rollback`, and
`before-hook-creation` deletes and recreates it on every upgrade. It works, but
the credentials outlive the release.