### PR TITLE
fix(mcp): dont trip per-server breaker on sync dispatch timeout

### DIFF
--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -6777,8 +6777,18 @@ class MCPClientManager:
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
+            # Slow-but-alive, not dead. The static session is still connected
+            # and the in-flight op keeps running server-side; ``future.cancel()``
+            # only drops our waiter, it does not tear down the transport. Tripping
+            # the per-server breaker here opens the circuit against healthy-but-slow
+            # servers (e.g. agent gateways that legitimately take minutes) and, once
+            # open, converts every subsequent call into a fast "circuit open"
+            # failure - a self-inflicted outage on a live server. Genuinely dead
+            # transports are handled by the health loop's liveness ping and
+            # ``_record_and_evict_on_dead_transport``; ``in_flight > 0`` also pins
+            # this session against eviction while the call is running.
             future.cancel()
-            self._cb_record_failure(server_name)
+            log.warning("mcp.slow_call", extra={"server": server_name, "timeout_s": timeout})
             raise TimeoutError(f"MCP tool call timed out after {timeout}s") from None
         except Exception as exc:
             self._record_and_evict_on_dead_transport(server_name, exc)
@@ -8431,8 +8441,11 @@ class MCPClientManager:
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
+            # Same policy as call_tool_sync: a client-side wait timeout against an
+            # already-connected static session means the server is slow, not dead.
+            # Do not trip the per-server breaker (see call_tool_sync comment).
             future.cancel()
-            self._cb_record_failure(server_name)
+            log.warning("mcp.slow_resource_read", extra={"server": server_name, "timeout_s": timeout})
             raise TimeoutError(f"MCP resource read timed out after {timeout}s") from None
         except Exception as exc:
             self._record_and_evict_on_dead_transport(server_name, exc)


### PR DESCRIPTION
## Problem

A client-side wait timeout against an **already-connected** static MCP session trips the per-server circuit breaker (`call_tool_sync`/`read_resource_sync` → `_cb_record_failure`). For long-running agent gateways (Hermes, OpenClaw) whose tasks legitimately take minutes, every timeout opens the circuit; once open, every subsequent call fails fast with "circuit open" (30s→300s capped exponential cooldown), and retrying during cooldown extends it. Self-inflicted outage on a live server.

## Why this is safe

- A wait timeout means the transport is still connected and the in-flight op keeps running server-side; `future.cancel()` only drops our waiter.
- Genuinely dead transports are already handled by the health loop liveness ping and `_record_and_evict_on_dead_transport` (`_is_dead_transport`).
- `in_flight > 0` pins the session against eviction while the call runs, so a slow call cannot be torn down mid-flight.

## Change

- `call_tool_sync`: on `concurrent.futures.TimeoutError`, log `mcp.slow_call` and stop calling `_cb_record_failure`.
- `read_resource_sync`: same policy.

## Tests

`tests/test_session_mcp_dispatch_error.py` + `tests/test_mcp_integration.py`: 24 passed.

## Related

- #951 (cancel propagation / lost results - the other half)
- Per-server timeout override PR (agent gateways declare 300-600s instead of inheriting a 120s default)
