### PR TITLE
fix(streaming): survive mid-stream transport deaths in interactive turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,15 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Changed
 
+- **Log event rename: `drain_stream.post_finish_blip` is now
+  `stream.post_finish_blip`, without the `usage_captured` field.** The
+  single-shot drain normalizes mid-body transport deaths through the same
+  `transport_guarded` wrapper the interactive loop uses, so its
+  post-finish-blip tolerance logs under the wrapper's event name. Update
+  any external log filters pinned to the old name; the drained result's
+  possible `usage=None` on a post-finish blip is unchanged and documented
+  on `drain_stream`.
+
 - **Breaking (1.8): compaction feedback moved from `info` events to the
   typed `compaction` SSE event.** Pre-1.8 SSE/SDK clients that ignore
   unknown event types no longer see compaction lines (they are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,26 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Fixed
 
+- **A transport failure mid-generation no longer kills the interactive
+  turn (#937).** A wire death during body streaming (TLS record failure,
+  connection reset — `httpx.ReadError` and kin) surfaces after the
+  request has already returned its stream handle, so neither the SDK's
+  request retries nor the creation-time retry ladder ever saw it: the
+  turn died with a bare `ReadError: …`, the partial output was
+  discarded, and nothing was logged. The interactive loop now normalizes
+  mid-body transport deaths exactly like the single-shot lanes and
+  re-issues the turn (bounded, cancel-aware, exponential backoff),
+  finalizing the dead attempt across every UI surface first so retried
+  text never double-renders (web transcript, CLI markdown fences,
+  Slack/Discord streamed messages). Before re-creating the stream the
+  session re-resolves its registry binding, so a concurrent model-registry
+  reload that closed the old client cannot turn the retry into a
+  misleading closed-client error. On exhaustion the surfaced error names
+  the provider, endpoint, and model with a stream-death message instead
+  of a bare exception string, and every fatal turn now leaves a
+  `session.fatal.recorded` log line (INFO for a user Ctrl-C, ERROR
+  otherwise).
+
 - **A failed worker-thread spawn no longer wedges the workstream — at
   either spawn site — and never masquerades as success.** If
   `Thread.start()` itself raised (thread exhaustion, out-of-memory), the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 ### Changed
 
 - **Log event rename: `drain_stream.post_finish_blip` is now
-  `stream.post_finish_blip`, without the `usage_captured` field.** The
+  `stream.post_finish_blip`; its `usage_captured` field is retained.** The
   single-shot drain normalizes mid-body transport deaths through the same
   `transport_guarded` wrapper the interactive loop uses, so its
   post-finish-blip tolerance logs under the wrapper's event name. Update

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -348,6 +348,7 @@ def as_stream(result: Any) -> list[StreamChunk]:
         )
     ]
 
+
 class RecordingUI:
     """UI adapter recording the ordered event stream ``send()`` emits."""
 

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -347,3 +347,82 @@ def as_stream(result: Any) -> list[StreamChunk]:
             provider_blocks=list(result.provider_blocks or []),
         )
     ]
+
+class RecordingUI:
+    """UI adapter recording the ordered event stream ``send()`` emits."""
+
+    def __init__(self):
+        self.events = []
+
+    def _rec(self, kind, detail=""):
+        self.events.append((kind, detail))
+
+    def on_turn_start(self):
+        self._rec("turn_start")
+
+    def on_turn_committed(self):
+        self._rec("turn_committed")
+
+    def on_stream_discarded(self):
+        self._rec("stream_discarded")
+
+    def on_thinking_start(self):
+        self._rec("thinking_start")
+
+    def on_thinking_stop(self):
+        self._rec("thinking_stop")
+
+    def on_reasoning_token(self, text):
+        self._rec("reasoning", text)
+
+    def on_content_token(self, text):
+        self._rec("content", text)
+
+    def on_stream_end(self):
+        self._rec("stream_end")
+
+    def approve_tools(self, items):
+        return True, None
+
+    def on_tool_result(self, call_id, name, output, **kwargs):
+        pass
+
+    def on_tool_output_chunk(self, call_id, chunk):
+        pass
+
+    def on_status(self, usage, context_window, effort):
+        pass
+
+    def on_info(self, message):
+        self._rec("info", message)
+
+    def on_error(self, message):
+        self._rec("error", message)
+
+    def on_state_change(self, state):
+        self._rec("state", state)
+
+    def on_rename(self, name):
+        pass
+
+    def on_output_warning(self, call_id, assessment):
+        pass
+
+    def record_output_assessment(
+        self,
+        call_id,
+        assessment,
+        *,
+        tier="heuristic",
+        reasoning="",
+        judge_model="",
+        latency_ms=0,
+        confidence=0.0,
+    ):
+        pass
+
+    def kinds(self):
+        return [k for k, _ in self.events]
+
+    def of(self, kind):
+        return [d for k, d in self.events if k == kind]

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -164,7 +164,7 @@ class TestCancelEvent:
 
 
 class TestCancelDuringStreaming:
-    """Cancel while _stream_response is iterating chunks."""
+    """Cancel while _stream_attempt is iterating chunks."""
 
     def test_preserves_partial_content(self, tmp_db):
         """Partial content already streamed should be preserved in messages."""
@@ -706,7 +706,7 @@ class TestForceCancelGeneration:
 
         # We can't trivially test the full threading scenario in a unit test,
         # so directly verify that _check_cancelled raises when my_generation
-        # is stale, which is what guards _stream_response against orphaned
+        # is stale, which is what guards _stream_attempt against orphaned
         # (force-cancelled) threads continuing to mutate messages.
         session._generation = 5
         with pytest.raises(GenerationCancelled):

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -418,8 +418,9 @@ class TestStreamFlushBeforeToolCalls:
             arguments_delta: str = ""
 
         def stream_content_then_tool():
-            # Content long enough to leave chars in pending buffer
-            # (_MAX_TAG_LEN = 13, so _drain_pending retains last 13 chars)
+            # Content long enough to leave chars in the tag-scan carry
+            # buffer (ThinkTagSplitter retains the last MAX_TAG_LEN = 12
+            # chars until a flush)
             yield FakeChunk(content_delta="Hello world, this is a test message")
             yield FakeChunk(
                 tool_call_deltas=[FakeToolDelta(index=0, id="tc_1", name="bash")],

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -39,6 +39,9 @@ class NullUI:
     def on_turn_committed(self):
         pass
 
+    def on_stream_discarded(self):
+        pass
+
     def on_thinking_start(self):
         pass
 

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -1093,19 +1093,16 @@ class TestProactivePreSend:
                 forwarded["preserve_tail"] = kwargs.get("preserve_tail")
             return True
 
-        def fake_stream(*_args, **_kwargs):
+        def fake_stream_response(*_args, **_kwargs):
             order.append("stream")
-            return iter([])
+            return {"role": "assistant", "content": "done"}
 
         with (
             # 9999 > hard (9000) → compaction is owed at send time.
             patch.object(session, "_estimated_prompt_tokens", return_value=9_999),
             patch.object(session, "_check_metacognitive_nudge", return_value=None),
             patch.object(session, "_do_auto_compact", side_effect=fake_compact),
-            patch.object(session, "_create_stream_with_retry", side_effect=fake_stream),
-            patch.object(
-                session, "_stream_response", return_value={"role": "assistant", "content": "done"}
-            ),
+            patch.object(session, "_stream_response", side_effect=fake_stream_response),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),

--- a/tests/test_drain_stream.py
+++ b/tests/test_drain_stream.py
@@ -322,7 +322,11 @@ class TestTransportGuarded:
             out = list(transport_guarded(chunks()))
         assert [c.content_delta for c in out] == ["done", ""]
         assert out[-1].finish_reason == "stop"
-        assert any("stream.post_finish_blip" in r.message for r in caplog.records)
+        blips = [r.message for r in caplog.records if "stream.post_finish_blip" in r.message]
+        assert blips
+        # usage_captured is the missing-spend attribution signal: this
+        # stream never delivered a usage chunk, so the blip must say so.
+        assert any("usage_captured" in m and "False" in m for m in blips)
 
     def test_chunks_pass_through_untouched(self):
         src = [

--- a/tests/test_drain_stream.py
+++ b/tests/test_drain_stream.py
@@ -16,6 +16,7 @@ from turnstone.core.providers import (
     ToolCallDelta,
     UsageInfo,
     drain_stream,
+    transport_guarded,
 )
 from turnstone.core.providers._openai_common import RETRYABLE_ERROR_NAMES
 from turnstone.core.providers._protocol import IncompleteStreamError
@@ -268,6 +269,85 @@ class TestInfoDelta:
                     ]
                 )
             )
+
+
+class TestTransportGuarded:
+    """``transport_guarded`` — drain's conversion rule for consumers that
+    keep streaming semantics (the interactive loop)."""
+
+    @pytest.mark.parametrize("exc_name", ["ReadError", "RemoteProtocolError"])
+    def test_pre_finish_transport_error_becomes_retryable_incomplete(self, exc_name):
+        import httpx
+
+        exc_cls = getattr(httpx, exc_name)
+
+        def chunks():
+            yield StreamChunk(content_delta="partial")
+            raise exc_cls("wire died")
+
+        it = transport_guarded(chunks())
+        assert next(it).content_delta == "partial"
+        with pytest.raises(IncompleteStreamError, match=exc_name) as excinfo:
+            next(it)
+        assert isinstance(excinfo.value.__cause__, exc_cls)
+
+    def test_message_byte_matches_drains_shape(self):
+        # The wrapper and the drain are the SAME conversion rule; any test
+        # or log filter pinned to drain's message must match the wrapper's.
+        import httpx
+
+        def chunks():
+            yield StreamChunk(content_delta="partial")
+            raise httpx.ReadError("[SSL] record layer failure (_ssl.c:2590)")
+
+        with pytest.raises(IncompleteStreamError) as guarded:
+            list(transport_guarded(chunks()))
+        with pytest.raises(IncompleteStreamError) as drained:
+            drain_stream(chunks())
+        assert str(guarded.value) == str(drained.value)
+
+    def test_post_finish_blip_ends_stream_cleanly(self, caplog):
+        # The generation already completed — the blip only cost trailing
+        # metadata, so the stream ends instead of raising.
+        import logging
+
+        import httpx
+
+        def chunks():
+            yield StreamChunk(content_delta="done")
+            yield StreamChunk(finish_reason="stop")
+            raise httpx.ReadError("late blip")
+
+        with caplog.at_level(logging.WARNING, logger="turnstone.core.providers._protocol"):
+            out = list(transport_guarded(chunks()))
+        assert [c.content_delta for c in out] == ["done", ""]
+        assert out[-1].finish_reason == "stop"
+        assert any("stream.post_finish_blip" in r.message for r in caplog.records)
+
+    def test_chunks_pass_through_untouched(self):
+        src = [
+            StreamChunk(content_delta="a"),
+            StreamChunk(reasoning_delta="r"),
+            StreamChunk(finish_reason="stop"),
+        ]
+        out = list(transport_guarded(iter(src)))
+        assert all(a is b for a, b in zip(out, src, strict=True))
+
+    def test_exhaustion_without_finish_reason_passes_through(self):
+        # No complete-or-error gate here — that stays drain-only; the
+        # interactive consumer shows partial output live.
+        out = list(transport_guarded(iter([StreamChunk(content_delta="x")])))
+        assert len(out) == 1
+
+    def test_non_transport_exception_propagates_verbatim(self):
+        def chunks():
+            yield StreamChunk(content_delta="x")
+            raise ValueError("upstream broke")
+
+        it = transport_guarded(chunks())
+        assert next(it).content_delta == "x"
+        with pytest.raises(ValueError, match="upstream broke"):
+            next(it)
 
 
 class TestErrorPropagation:

--- a/tests/test_drain_stream.py
+++ b/tests/test_drain_stream.py
@@ -351,6 +351,22 @@ class TestTransportGuarded:
 
 
 class TestErrorPropagation:
+    def test_post_finish_blip_keeps_completed_result(self):
+        # The generation completed (finish reason in hand) — a trailing
+        # transport blip forfeits only trailing metadata (here: the usage
+        # chunk), never the completed result.
+        import httpx
+
+        def chunks():
+            yield StreamChunk(content_delta="whole answer")
+            yield StreamChunk(finish_reason="stop")
+            raise httpx.ReadError("late blip")
+
+        result = drain_stream(chunks())
+        assert result.content == "whole answer"
+        assert result.finish_reason == "stop"
+        assert result.usage is None
+
     def test_httpx_transport_error_becomes_retryable_incomplete(self):
         # Streaming moves the body read out of the SDK's wrapped request:
         # a mid-body wire failure surfaces as a raw httpx.TransportError

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -5,9 +5,11 @@ returned its stream handle, so neither the SDK's ``max_retries`` nor the
 creation-time ``_try_stream`` ladder ever sees it.  These tests drive
 ``ChatSession.send()`` with scripted provider streams and pin the retry
 loop's contract: bounded re-issue on the normalized retryable shape, the
-dead attempt finalized in every UI consumer (``stream_end`` +
-``turn_committed`` BEFORE the retry notice), cancel-during-backoff
-abort, exhaustion surfacing the stream-death wording, and the
+dead attempt finalized client-side before the retry notice
+(``stream_end``) and discarded from the server buffers once the backoff
+survives the Stop window (``stream_discarded`` — never
+``turn_committed``, whose semantics keep the turn buffer), cancel-in-
+retry-window abort, exhaustion surfacing the stream-death wording, and the
 ``_assistant_pending_tokens`` reset that keeps a post-finish blip from
 recycling the prior turn's token count.
 
@@ -22,92 +24,12 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from tests._session_helpers import NullUI, make_session
+from tests._session_helpers import NullUI, RecordingUI, make_session
 from turnstone.core.memory import load_last_error
 from turnstone.core.providers import IncompleteStreamError, StreamChunk, UsageInfo
 from turnstone.core.session import GenerationCancelled
 from turnstone.core.streaming_text import ThinkTagSplitter
 from turnstone.core.trajectory import dicts_from_turns
-
-
-class RecordingUI:
-    """UI adapter recording the ordered event stream ``send()`` emits."""
-
-    def __init__(self):
-        self.events = []
-
-    def _rec(self, kind, detail=""):
-        self.events.append((kind, detail))
-
-    def on_turn_start(self):
-        self._rec("turn_start")
-
-    def on_turn_committed(self):
-        self._rec("turn_committed")
-
-    def on_stream_discarded(self):
-        self._rec("stream_discarded")
-
-    def on_thinking_start(self):
-        self._rec("thinking_start")
-
-    def on_thinking_stop(self):
-        self._rec("thinking_stop")
-
-    def on_reasoning_token(self, text):
-        self._rec("reasoning", text)
-
-    def on_content_token(self, text):
-        self._rec("content", text)
-
-    def on_stream_end(self):
-        self._rec("stream_end")
-
-    def approve_tools(self, items):
-        return True, None
-
-    def on_tool_result(self, call_id, name, output, **kwargs):
-        pass
-
-    def on_tool_output_chunk(self, call_id, chunk):
-        pass
-
-    def on_status(self, usage, context_window, effort):
-        pass
-
-    def on_info(self, message):
-        self._rec("info", message)
-
-    def on_error(self, message):
-        self._rec("error", message)
-
-    def on_state_change(self, state):
-        self._rec("state", state)
-
-    def on_rename(self, name):
-        pass
-
-    def on_output_warning(self, call_id, assessment):
-        pass
-
-    def record_output_assessment(
-        self,
-        call_id,
-        assessment,
-        *,
-        tier="heuristic",
-        reasoning="",
-        judge_model="",
-        latency_ms=0,
-        confidence=0.0,
-    ):
-        pass
-
-    def kinds(self):
-        return [k for k, _ in self.events]
-
-    def of(self, kind):
-        return [d for k, d in self.events if k == kind]
 
 
 def _make_session(ui=None, **kwargs):
@@ -179,10 +101,12 @@ class TestMidStreamRetry:
         # is a fresh bubble, not an append onto the dead attempt's.
         flushed = first_text[: len(first_text) - ThinkTagSplitter.MAX_TAG_LEN]
         assert ui.of("content") == [flushed, "Hello world"]
-        # The dead attempt is finalized EVERYWHERE before re-streaming:
-        # stream_end (client finalize) -> stream_discarded (server buffer
-        # truncate) -> notice -> spinner, then the retried stream's own
-        # end-of-turn pair (a real commit).
+        # The dead attempt is finalized client-side before the notice, and
+        # DISCARDED only after the backoff survives the Stop window (a
+        # Stop during backoff must find the dead text still in the turn
+        # buffer, matching what the cancel handler persists): stream_end
+        # -> notice -> (backoff) -> stream_discarded -> spinner, then the
+        # retried stream's own end-of-turn pair (a real commit).
         seq = [
             (k, d)
             for k, d in ui.events
@@ -192,13 +116,13 @@ class TestMidStreamRetry:
         assert [k for k, _ in seq] == [
             "thinking_start",
             "stream_end",
-            "stream_discarded",
             "info",
+            "stream_discarded",
             "thinking_start",
             "stream_end",
             "turn_committed",
         ]
-        notice = seq[3][1]
+        notice = seq[2][1]
         assert "(ReadError)" in notice
         assert "(1/2)" in notice
         assert ("state", "idle") in ui.events
@@ -344,10 +268,11 @@ class TestMidStreamRetry:
         # A pre-first-token death leaves the spinner RUNNING; the CLI's
         # on_thinking_start is idempotent at the callee (it stops a live
         # spinner before replacing it), so the retry arm restarts with a
-        # single call.
+        # single call — after the backoff-gated discard.
         notice = [i for i, (k, d) in enumerate(ui.events) if k == "info" and "stream died" in d]
         assert notice
-        assert ui.events[notice[0] + 1][0] == "thinking_start"
+        after = [k for k, _ in ui.events[notice[0] + 1 : notice[0] + 3]]
+        assert after == ["stream_discarded", "thinking_start"]
 
     def test_pretoken_death_stop_persists_marker_row(self, tmp_db):
         ui = RecordingUI()
@@ -636,6 +561,41 @@ class TestMidStreamRetry:
         # The dead segment was truncated at the watermark; only the
         # retried attempt's text reaches the IDLE payload.
         assert "".join(ui._ws_turn_content) == "final answer"
+
+    def test_stop_in_backoff_keeps_dead_text_in_turn_buffer(self, tmp_db):
+        # The discard is gated on the backoff SURVIVING: a Stop during the
+        # window persists the promoted partial to history, and the idle
+        # payload (drained from the turn buffer) must carry the same text
+        # — discarding first rendered the cancelled turn empty on the
+        # dashboard while the transcript had it.
+        class _BufferUI(NullUI):
+            def on_state_change(self, state):
+                pass
+
+        ui = _BufferUI()
+        session = _make_session(ui)
+        session._RETRY_BASE_DELAY = 30.0
+        real_backoff = session._backoff_or_cancelled
+
+        def cancel_then_backoff(delay, my_generation=0):
+            session.cancel()
+            real_backoff(delay, my_generation)
+
+        dead_text = "a dead attempt long enough to flush past the carry window"
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[_dying_stream(dead_text, exc=httpx.ReadError("wire died"))],
+            ),
+            patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        assert "a dead attempt" in "".join(ui._ws_turn_content)
+        assistant = _assistant_msgs(session)
+        assert assistant and assistant[-1]["content"].startswith("a dead attempt")
 
     def test_overflow_recovery_discards_dead_text_from_turn_buffer(self, tmp_db):
         # A mid-consumption overflow is TERMINAL for the retry ladder but

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from tests._session_helpers import make_session
+from tests._session_helpers import NullUI, make_session
 from turnstone.core.memory import load_last_error
 from turnstone.core.providers import IncompleteStreamError, StreamChunk, UsageInfo
 from turnstone.core.session import GenerationCancelled
@@ -44,6 +44,9 @@ class RecordingUI:
 
     def on_turn_committed(self):
         self._rec("turn_committed")
+
+    def on_stream_discarded(self):
+        self._rec("stream_discarded")
 
     def on_thinking_start(self):
         self._rec("thinking_start")
@@ -177,19 +180,19 @@ class TestMidStreamRetry:
         flushed = first_text[: len(first_text) - ThinkTagSplitter.MAX_TAG_LEN]
         assert ui.of("content") == [flushed, "Hello world"]
         # The dead attempt is finalized EVERYWHERE before re-streaming:
-        # stream_end (client finalize) -> turn_committed (server buffer
-        # reset) -> notice -> spinner, then the retried stream's own
-        # end-of-turn pair.
+        # stream_end (client finalize) -> stream_discarded (server buffer
+        # truncate) -> notice -> spinner, then the retried stream's own
+        # end-of-turn pair (a real commit).
         seq = [
             (k, d)
             for k, d in ui.events
-            if k in ("stream_end", "turn_committed", "thinking_start")
+            if k in ("stream_end", "stream_discarded", "turn_committed", "thinking_start")
             or (k == "info" and "stream died mid-response" in d)
         ]
         assert [k for k, _ in seq] == [
             "thinking_start",
             "stream_end",
-            "turn_committed",
+            "stream_discarded",
             "info",
             "thinking_start",
             "stream_end",
@@ -228,11 +231,13 @@ class TestMidStreamRetry:
         assert fatal and any(r.levelno == logging.ERROR for r in fatal)
         # Every dead attempt is finalized client-side — two retry-path
         # stream_ends plus the terminal arm's (the CLI markdown fence reset
-        # rides on it).  turn_committed comes only from the RETRY arms: the
-        # terminal arm deliberately keeps the in-progress snapshot, the
-        # last partial's only surviving copy, for refresh-replay.
+        # rides on it).  The retry arms DISCARD their dead segments; no
+        # commit ever happens, and the terminal arm deliberately keeps the
+        # in-progress snapshot, the last partial's only surviving copy, for
+        # refresh-replay.
         assert ui.kinds().count("stream_end") == 3
-        assert ui.kinds().count("turn_committed") == 2
+        assert ui.kinds().count("stream_discarded") == 2
+        assert ui.kinds().count("turn_committed") == 0
 
     def test_cancel_during_backoff_stops_without_recreate(self, tmp_db):
         ui = RecordingUI()
@@ -605,6 +610,34 @@ class TestMidStreamRetry:
         assert session._cancelled_partial_msg is None
         assert not _assistant_msgs(session)
 
+    def test_dead_attempt_text_absent_from_turn_buffer(self, tmp_db):
+        # Real SessionUIBase buffers — a recording fake cannot see the
+        # multi-segment turn buffer the IDLE payload drains, which
+        # on_turn_committed deliberately does NOT clear.  on_state_change
+        # is a web-fanout concern narrowed off the shared base.
+        class _BufferUI(NullUI):
+            def on_state_change(self, state):
+                pass
+
+        ui = _BufferUI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream(
+                "dead attempt text that must not surface",
+                exc=httpx.ReadError("wire died"),
+            ),
+            _good_stream("final answer"),
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # The dead segment was truncated at the watermark; only the
+        # retried attempt's text reaches the IDLE payload.
+        assert "".join(ui._ws_turn_content) == "final answer"
+
     def test_non_retryable_error_is_immediately_fatal(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
@@ -625,6 +658,7 @@ class TestMidStreamRetry:
         # The terminal arm finalizes even a zero-retry death — client-side
         # only; the snapshot survives for refresh-replay of the partial.
         assert ui.kinds().count("stream_end") == 1
+        assert ui.kinds().count("stream_discarded") == 0
         assert ui.kinds().count("turn_committed") == 0
 
     def test_recreate_failure_surfaces_original_stream_death(self, tmp_db, caplog):

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -231,6 +231,11 @@ class TestMidStreamRetry:
         assert persisted and "Backend stream died mid-response" in persisted
         fatal = [r for r in caplog.records if "session.fatal.recorded" in r.message]
         assert fatal and any(r.levelno == logging.ERROR for r in fatal)
+        # Every dead attempt is finalized — two retry-path pairs plus the
+        # terminal arm's pair (the CLI markdown fence reset rides on
+        # stream_end; server workers add their own only after the fatal).
+        assert ui.kinds().count("stream_end") == 3
+        assert ui.kinds().count("turn_committed") == 3
 
     def test_cancel_during_backoff_stops_without_recreate(self, tmp_db):
         ui = RecordingUI()
@@ -259,6 +264,68 @@ class TestMidStreamRetry:
         assert ("state", "idle") in ui.events
         assert ("state", "error") not in ui.events
         assert any("cancelled" in d.lower() for d in ui.of("info"))
+        # The dead attempt's partial survives the Stop with the cancel
+        # marker — same disposition a cancel DURING the attempt gets.  "Hel"
+        # is shorter than the splitter's carry window, so this also pins the
+        # carry-tail inclusion in the stash.
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "Hel\n\n[generation cancelled before completion]"
+
+    def test_rebind_reprepares_wire_messages(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream("x", exc=httpx.ReadError("wire died")),
+            _good_stream("ok"),
+        ]
+
+        def swap_binding():
+            # A registry reload that rebinds mid-retry replaces the client
+            # object (the identity signal the wrapper keys on).
+            session.client = MagicMock()
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
+            patch.object(session, "_refresh_model_from_registry", side_effect=swap_binding),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(
+                session, "_prepare_wire_messages", wraps=session._prepare_wire_messages
+            ) as prep,
+        ):
+            session.send("test")
+
+        # send() prepares once; the rebind forces exactly one re-prepare
+        # (capability-sensitive wire fold) before the re-issue.
+        assert prep.call_count == 2
+        assert create.call_count == 2
+        assert _assistant_msgs(session)[-1]["content"] == "ok"
+
+    def test_refresh_fires_per_reissue(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream("x", exc=httpx.ReadError("wire died")),
+            _dying_stream("y", exc=httpx.ReadError("wire died again")),
+            _good_stream("ok"),
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(
+                session,
+                "_refresh_model_from_registry",
+                wraps=session._refresh_model_from_registry,
+            ) as refresh,
+        ):
+            session.send("test")
+
+        assert create.call_count == 3
+        # Once at the top of send() (the per-send driver) plus once per
+        # re-issue — a regression that drops the mid-retry refresh would
+        # show 1 here and stream a reload-closed client (#937 recreate
+        # hardening).
+        assert refresh.call_count == 3
 
     def test_non_retryable_error_is_immediately_fatal(self, tmp_db):
         ui = RecordingUI()
@@ -277,6 +344,9 @@ class TestMidStreamRetry:
         assert create.call_count == 1  # zero retries
         assert ("state", "error") in ui.events
         assert not any("stream died mid-response" in d for d in ui.of("info"))
+        # The terminal arm finalizes even a zero-retry death.
+        assert ui.kinds().count("stream_end") == 1
+        assert ui.kinds().count("turn_committed") == 1
 
     def test_recreate_failure_surfaces_original_stream_death(self, tmp_db, caplog):
         """A failing re-create (closed client, registry chaos) must not

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -16,15 +16,16 @@ retry pays real exponential backoff).
 """
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
+from tests._session_helpers import make_session
 from turnstone.core.memory import load_last_error
-from turnstone.core.providers import StreamChunk, UsageInfo
-from turnstone.core.providers._protocol import IncompleteStreamError
-from turnstone.core.session import ChatSession
+from turnstone.core.providers import IncompleteStreamError, StreamChunk, UsageInfo
+from turnstone.core.session import GenerationCancelled
 from turnstone.core.streaming_text import ThinkTagSplitter
 from turnstone.core.trajectory import dicts_from_turns
 
@@ -107,18 +108,12 @@ class RecordingUI:
 
 
 def _make_session(ui=None, **kwargs):
-    """Helper to construct a ChatSession with minimal setup."""
-    defaults = dict(
-        client=MagicMock(),
-        model="test-model",
-        ui=ui or RecordingUI(),
-        instructions=None,
-        temperature=0.5,
-        max_tokens=4096,
-        tool_timeout=30,
-    )
-    defaults.update(kwargs)
-    session = ChatSession(**defaults)
+    """Wrap the shared session factory with this suite's two retry knobs.
+
+    The defaults live in tests/_session_helpers.make_session — duplicating
+    them here is exactly the drift its docstring warns about.
+    """
+    session = make_session(ui=ui or RecordingUI(), **kwargs)
     session._RETRY_BASE_DELAY = 0
     # Latch the auto-title trigger: its background thread would drive a
     # second model call through the MagicMock client (drain retries, real
@@ -231,11 +226,13 @@ class TestMidStreamRetry:
         assert persisted and "Backend stream died mid-response" in persisted
         fatal = [r for r in caplog.records if "session.fatal.recorded" in r.message]
         assert fatal and any(r.levelno == logging.ERROR for r in fatal)
-        # Every dead attempt is finalized — two retry-path pairs plus the
-        # terminal arm's pair (the CLI markdown fence reset rides on
-        # stream_end; server workers add their own only after the fatal).
+        # Every dead attempt is finalized client-side — two retry-path
+        # stream_ends plus the terminal arm's (the CLI markdown fence reset
+        # rides on it).  turn_committed comes only from the RETRY arms: the
+        # terminal arm deliberately keeps the in-progress snapshot, the
+        # last partial's only surviving copy, for refresh-replay.
         assert ui.kinds().count("stream_end") == 3
-        assert ui.kinds().count("turn_committed") == 3
+        assert ui.kinds().count("turn_committed") == 2
 
     def test_cancel_during_backoff_stops_without_recreate(self, tmp_db):
         ui = RecordingUI()
@@ -327,6 +324,287 @@ class TestMidStreamRetry:
         # hardening).
         assert refresh.call_count == 3
 
+    def test_retry_window_stops_then_restarts_spinner(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream(exc=httpx.ReadError("pre-token wire death")),
+            _good_stream("ok"),
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # A pre-first-token death leaves the spinner RUNNING; the CLI's
+        # on_thinking_start replaces the spinner object without stopping
+        # the old one (thread leak), so the retry arm must stop-then-start.
+        notice = [i for i, (k, d) in enumerate(ui.events) if k == "info" and "stream died" in d]
+        assert notice
+        after = [k for k, _ in ui.events[notice[0] + 1 : notice[0] + 3]]
+        assert after == ["thinking_stop", "thinking_start"]
+
+    def test_pretoken_death_stop_persists_marker_row(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        session._RETRY_BASE_DELAY = 30.0
+        real_backoff = session._backoff_or_cancelled
+
+        def cancel_then_backoff(delay, my_generation=0):
+            session.cancel()
+            real_backoff(delay, my_generation)
+
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[_dying_stream(exc=httpx.ReadError("died before first token"))],
+            ),
+            patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # No content ever streamed, but a cancelled streaming turn must
+        # still persist the marker row — an absent assistant row is the
+        # ambiguous shape the marker branch exists to prevent.
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "[generation cancelled before completion]"
+        assert ("state", "idle") in ui.events
+
+    def test_ttft_window_stop_backfills_previous_partial(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+
+        def second_stream():
+            # A Stop lands after the re-create, before the first chunk:
+            # cancel() closes the fresh stream and the read dies.
+            session.cancel()
+            raise httpx.ReadError("closed by cancel")
+            yield  # pragma: no cover — generator marker
+
+        streams = [
+            _dying_stream("Hel", exc=httpx.ReadError("wire died")),
+            second_stream(),
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # The replacement attempt recorded an EMPTY partial; the wrapper
+        # backfills it with the previous attempt's text — the user saw it,
+        # and a Stop one second earlier (during backoff) preserves it too.
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "Hel\n\n[generation cancelled before completion]"
+
+    def test_trailing_window_stop_aborts_with_marker(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+
+        def gen():
+            yield StreamChunk(content_delta="done-ish")
+            yield StreamChunk(finish_reason="stop")
+            # Stop races the trailing-metadata window; the closed stream
+            # ends cleanly under transport_guarded's post-finish tolerance.
+            session.cancel()
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=[gen()]),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # The post-loop cancel re-check converts the Stop — the turn must
+        # NOT commit as complete (its tool calls would execute despite the
+        # Stop); it aborts with the marker like any observed cancel.
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "done-ish\n\n[generation cancelled before completion]"
+        assert ("state", "idle") in ui.events
+        assert ("state", "error") not in ui.events
+
+    def test_keyboard_interrupt_finalizes_dead_attempt(self, tmp_db, caplog):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[_dying_stream("Hel", exc=KeyboardInterrupt())],
+            ),
+            patch.object(session, "_full_messages", return_value=[]),
+            caplog.at_level(logging.INFO, logger="turnstone.core.session"),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            session.send("test")
+
+        # Ctrl-C is BaseException — the retry gate never sees it, but the
+        # dead attempt still needs its client-side finalize (the CLI's
+        # markdown fence resets only in on_stream_end).
+        assert ui.kinds().count("stream_end") == 1
+        assert ("state", "error") in ui.events
+
+    def test_gate_consults_live_stream_provider_not_primary(self, tmp_db):
+        class FlakyError(Exception):
+            pass
+
+        ui = RecordingUI()
+        session = _make_session(ui)
+        live = SimpleNamespace(retryable_error_names=frozenset({"FlakyError"}))
+        calls = {"n": 0}
+
+        def create(msgs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # What _try_stream records at creation: the provider that
+                # owns the live stream (a fallback here — its retryable
+                # set differs from the primary's).
+                session._active_stream_provider = live
+                return _dying_stream("x", exc=FlakyError("in-band transient"))
+            return _good_stream("ok")
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=create),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # FlakyError is NOT in the primary provider's retryable set — the
+        # re-issue proves the gate consulted the live stream's provider.
+        assert calls["n"] == 2
+        assert _assistant_msgs(session)[-1]["content"] == "ok"
+
+    def test_recreate_overflow_falls_through_to_compact_retry(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        calls = {"n": 0}
+
+        def create(msgs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _dying_stream("x", exc=httpx.ReadError("wire died"))
+            if calls["n"] == 2:
+                # A mid-retry rebind landed on a smaller-window model: the
+                # re-create overflows deterministically.
+                raise RuntimeError("maximum context length exceeded")
+            return _good_stream("recovered")
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=create),
+            patch.object(session, "_compact_messages") as compact,
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        # The overflow surfaced as ITSELF (not masked behind the stream
+        # death), so send()'s compact-and-retry arm recovered the turn.
+        assert calls["n"] == 3
+        compact.assert_called_once()
+        assert _assistant_msgs(session)[-1]["content"] == "recovered"
+
+    def test_postcompaction_failure_surfaces_as_itself(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        calls = {"n": 0}
+
+        def create(msgs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("maximum context length exceeded")
+            raise ValueError("backend exploded")
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=create),
+            patch.object(session, "_compact_messages"),
+            patch.object(session, "_full_messages", return_value=[]),
+            pytest.raises(ValueError, match="backend exploded"),
+        ):
+            session.send("test")
+
+        # Compaction already succeeded — the post-compaction failure must
+        # not be re-labeled as a context overflow.
+        persisted = load_last_error(session._ws_id)
+        assert persisted and "ValueError" in persisted
+        assert "Context window exceeded" not in persisted
+
+    def test_model_only_rebind_reprepares(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream("x", exc=httpx.ReadError("wire died")),
+            _good_stream("ok"),
+        ]
+
+        refreshes = {"n": 0}
+
+        def swap_model():
+            # reload() keeps the pooled client when only the alias's model
+            # id changed — the binding triple must still trigger the
+            # re-prepare.  The swap fires on the RETRY's refresh (call 2);
+            # call 1 is send()'s per-send driver at the top of the turn.
+            refreshes["n"] += 1
+            if refreshes["n"] == 2:
+                session.model = "swapped-model"
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams),
+            patch.object(session, "_refresh_model_from_registry", side_effect=swap_model),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(
+                session, "_prepare_wire_messages", wraps=session._prepare_wire_messages
+            ) as prep,
+        ):
+            session.send("test")
+
+        assert prep.call_count == 2
+
+    def test_orphan_attempt_touches_neither_ui_nor_partial_slot(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        session._generation = 7  # a successor generation owns the session
+
+        def chunks():
+            yield StreamChunk(content_delta="orphan text")
+            yield StreamChunk(content_delta="more")
+
+        with pytest.raises(GenerationCancelled):
+            session._stream_attempt(iter(chunks()), my_generation=3)
+
+        # The superseded thread's cancel arm must touch neither the UI
+        # (its stream_end would reset the successor's inflight buffers)
+        # nor the shared partial slot the successor's handler consumes.
+        assert "stream_end" not in ui.kinds()
+        assert session._cancelled_partial_msg is None
+
+    def test_superseded_backoff_cancel_does_not_write_partial_slot(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+
+        def supersede_then_cancel(delay, my_generation=0):
+            session._generation += 1  # force-cancel claimed a successor
+            raise GenerationCancelled()
+
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[_dying_stream("Hel", exc=httpx.ReadError("wire died"))],
+            ),
+            patch.object(session, "_backoff_or_cancelled", side_effect=supersede_then_cancel),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")  # the orphaned turn returns silently
+
+        # An orphan waking in the backoff window must not write the
+        # successor's partial slot or persist anything.
+        assert session._cancelled_partial_msg is None
+        assert not _assistant_msgs(session)
+
     def test_non_retryable_error_is_immediately_fatal(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
@@ -344,9 +622,10 @@ class TestMidStreamRetry:
         assert create.call_count == 1  # zero retries
         assert ("state", "error") in ui.events
         assert not any("stream died mid-response" in d for d in ui.of("info"))
-        # The terminal arm finalizes even a zero-retry death.
+        # The terminal arm finalizes even a zero-retry death — client-side
+        # only; the snapshot survives for refresh-replay of the partial.
         assert ui.kinds().count("stream_end") == 1
-        assert ui.kinds().count("turn_committed") == 1
+        assert ui.kinds().count("turn_committed") == 0
 
     def test_recreate_failure_surfaces_original_stream_death(self, tmp_db, caplog):
         """A failing re-create (closed client, registry chaos) must not

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -597,6 +597,30 @@ class TestMidStreamRetry:
         assistant = _assistant_msgs(session)
         assert assistant and assistant[-1]["content"].startswith("a dead attempt")
 
+    def test_pre937_ui_without_discard_hook_survives_retry(self, tmp_db):
+        # A duck-typed UI predating on_stream_discarded must degrade to
+        # "no server-buffer truncate", not crash the retry arm with an
+        # AttributeError that replaces the stream death being handled.
+        class _Pre937UI(RecordingUI):
+            # property() with no getter raises AttributeError on access —
+            # simulating the hook's absence on an inheriting fake.
+            on_stream_discarded = property()
+
+        ui = _Pre937UI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream("x", exc=httpx.ReadError("wire died")),
+            _good_stream("ok"),
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        assert _assistant_msgs(session)[-1]["content"] == "ok"
+        assert ("state", "idle") in ui.events
+
     def test_overflow_recovery_discards_dead_text_from_turn_buffer(self, tmp_db):
         # A mid-consumption overflow is TERMINAL for the retry ladder but
         # RECOVERED by send()'s compact-and-retry — the dead attempt's text

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -229,14 +229,13 @@ class TestMidStreamRetry:
         assert persisted and "Backend stream died mid-response" in persisted
         fatal = [r for r in caplog.records if "session.fatal.recorded" in r.message]
         assert fatal and any(r.levelno == logging.ERROR for r in fatal)
-        # Every dead attempt is finalized client-side — two retry-path
-        # stream_ends plus the terminal arm's (the CLI markdown fence reset
-        # rides on it).  The retry arms DISCARD their dead segments; no
-        # commit ever happens, and the terminal arm deliberately keeps the
-        # in-progress snapshot, the last partial's only surviving copy, for
-        # refresh-replay.
+        # Every dead attempt is finalized AND discarded — the terminal arm
+        # included (keeping its buffers bought nothing: the fatal path's
+        # error-state drain wipes them anyway, and an overflow recovered by
+        # compact-and-retry would otherwise concatenate dead text into the
+        # idle payload).  No commit ever happens.
         assert ui.kinds().count("stream_end") == 3
-        assert ui.kinds().count("stream_discarded") == 2
+        assert ui.kinds().count("stream_discarded") == 3
         assert ui.kinds().count("turn_committed") == 0
 
     def test_cancel_during_backoff_stops_without_recreate(self, tmp_db):
@@ -329,7 +328,7 @@ class TestMidStreamRetry:
         # hardening).
         assert refresh.call_count == 3
 
-    def test_retry_window_stops_then_restarts_spinner(self, tmp_db):
+    def test_retry_window_restarts_spinner(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
         streams = [
@@ -343,12 +342,12 @@ class TestMidStreamRetry:
             session.send("test")
 
         # A pre-first-token death leaves the spinner RUNNING; the CLI's
-        # on_thinking_start replaces the spinner object without stopping
-        # the old one (thread leak), so the retry arm must stop-then-start.
+        # on_thinking_start is idempotent at the callee (it stops a live
+        # spinner before replacing it), so the retry arm restarts with a
+        # single call.
         notice = [i for i, (k, d) in enumerate(ui.events) if k == "info" and "stream died" in d]
         assert notice
-        after = [k for k, _ in ui.events[notice[0] + 1 : notice[0] + 3]]
-        assert after == ["thinking_stop", "thinking_start"]
+        assert ui.events[notice[0] + 1][0] == "thinking_start"
 
     def test_pretoken_death_stop_persists_marker_row(self, tmp_db):
         ui = RecordingUI()
@@ -638,6 +637,63 @@ class TestMidStreamRetry:
         # retried attempt's text reaches the IDLE payload.
         assert "".join(ui._ws_turn_content) == "final answer"
 
+    def test_overflow_recovery_discards_dead_text_from_turn_buffer(self, tmp_db):
+        # A mid-consumption overflow is TERMINAL for the retry ladder but
+        # RECOVERED by send()'s compact-and-retry — the dead attempt's text
+        # must not concatenate with the recovered answer in the idle
+        # payload (the terminal arm discards, same as the retry arm).
+        class _BufferUI(NullUI):
+            def on_state_change(self, state):
+                pass
+
+        ui = _BufferUI()
+        session = _make_session(ui)
+        calls = {"n": 0}
+
+        def create(msgs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _dying_stream(
+                    "dead overflow text",
+                    exc=RuntimeError("maximum context length exceeded"),
+                )
+            return _good_stream("recovered")
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=create),
+            patch.object(session, "_compact_messages"),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        assert calls["n"] == 2
+        assert "".join(ui._ws_turn_content) == "recovered"
+
+    def test_orphan_death_records_no_fatal_over_successor(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+
+        def dying_superseded():
+            yield StreamChunk(content_delta="Hel")
+            # A force-cancel claims a successor generation before the
+            # orphan's death propagates (its cancel event was replaced, so
+            # cancel conversion cannot fire).
+            session._generation += 1
+            raise ValueError("orphan death")
+
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=[dying_superseded()]),
+            patch.object(session, "_full_messages", return_value=[]),
+            pytest.raises(ValueError, match="orphan death"),
+        ):
+            session.send("test")
+
+        # The orphan must not flash an error banner over the live
+        # successor turn or persist a wrong last_error for the coord.
+        assert ("state", "error") not in ui.events
+        assert not ui.of("error")
+        assert not load_last_error(session._ws_id)
+
     def test_non_retryable_error_is_immediately_fatal(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
@@ -655,10 +711,9 @@ class TestMidStreamRetry:
         assert create.call_count == 1  # zero retries
         assert ("state", "error") in ui.events
         assert not any("stream died mid-response" in d for d in ui.of("info"))
-        # The terminal arm finalizes even a zero-retry death — client-side
-        # only; the snapshot survives for refresh-replay of the partial.
+        # The terminal arm finalizes and discards even a zero-retry death.
         assert ui.kinds().count("stream_end") == 1
-        assert ui.kinds().count("stream_discarded") == 0
+        assert ui.kinds().count("stream_discarded") == 1
         assert ui.kinds().count("turn_committed") == 0
 
     def test_recreate_failure_surfaces_original_stream_death(self, tmp_db, caplog):

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -1,0 +1,333 @@
+"""Session-level tests for the mid-stream transport-retry loop (#937).
+
+A wire death DURING body iteration surfaces after the request already
+returned its stream handle, so neither the SDK's ``max_retries`` nor the
+creation-time ``_try_stream`` ladder ever sees it.  These tests drive
+``ChatSession.send()`` with scripted provider streams and pin the retry
+loop's contract: bounded re-issue on the normalized retryable shape, the
+dead attempt finalized in every UI consumer (``stream_end`` +
+``turn_committed`` BEFORE the retry notice), cancel-during-backoff
+abort, exhaustion surfacing the stream-death wording, and the
+``_assistant_pending_tokens`` reset that keeps a post-finish blip from
+recycling the prior turn's token count.
+
+Fixture note: tests zero ``_RETRY_BASE_DELAY`` per instance (else each
+retry pays real exponential backoff).
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from turnstone.core.memory import load_last_error
+from turnstone.core.providers import StreamChunk, UsageInfo
+from turnstone.core.providers._protocol import IncompleteStreamError
+from turnstone.core.session import ChatSession
+from turnstone.core.trajectory import dicts_from_turns
+
+
+class RecordingUI:
+    """UI adapter recording the ordered event stream ``send()`` emits."""
+
+    def __init__(self):
+        self.events = []
+
+    def _rec(self, kind, detail=""):
+        self.events.append((kind, detail))
+
+    def on_turn_start(self):
+        self._rec("turn_start")
+
+    def on_turn_committed(self):
+        self._rec("turn_committed")
+
+    def on_thinking_start(self):
+        self._rec("thinking_start")
+
+    def on_thinking_stop(self):
+        self._rec("thinking_stop")
+
+    def on_reasoning_token(self, text):
+        self._rec("reasoning", text)
+
+    def on_content_token(self, text):
+        self._rec("content", text)
+
+    def on_stream_end(self):
+        self._rec("stream_end")
+
+    def approve_tools(self, items):
+        return True, None
+
+    def on_tool_result(self, call_id, name, output, **kwargs):
+        pass
+
+    def on_tool_output_chunk(self, call_id, chunk):
+        pass
+
+    def on_status(self, usage, context_window, effort):
+        pass
+
+    def on_info(self, message):
+        self._rec("info", message)
+
+    def on_error(self, message):
+        self._rec("error", message)
+
+    def on_state_change(self, state):
+        self._rec("state", state)
+
+    def on_rename(self, name):
+        pass
+
+    def on_output_warning(self, call_id, assessment):
+        pass
+
+    def record_output_assessment(
+        self,
+        call_id,
+        assessment,
+        *,
+        tier="heuristic",
+        reasoning="",
+        judge_model="",
+        latency_ms=0,
+        confidence=0.0,
+    ):
+        pass
+
+    def kinds(self):
+        return [k for k, _ in self.events]
+
+    def of(self, kind):
+        return [d for k, d in self.events if k == kind]
+
+
+def _make_session(ui=None, **kwargs):
+    """Helper to construct a ChatSession with minimal setup."""
+    defaults = dict(
+        client=MagicMock(),
+        model="test-model",
+        ui=ui or RecordingUI(),
+        instructions=None,
+        temperature=0.5,
+        max_tokens=4096,
+        tool_timeout=30,
+    )
+    defaults.update(kwargs)
+    session = ChatSession(**defaults)
+    session._RETRY_BASE_DELAY = 0
+    # Latch the auto-title trigger: its background thread would drive a
+    # second model call through the MagicMock client (drain retries, real
+    # backoff) alongside the send under test.
+    session._title_generated = True
+    return session
+
+
+def _dying_stream(*texts, exc):
+    """Content chunks, then a mid-body death — no finish reason seen."""
+
+    def gen():
+        for t in texts:
+            yield StreamChunk(content_delta=t)
+        raise exc
+
+    return gen()
+
+
+def _good_stream(text):
+    return iter(
+        [
+            StreamChunk(content_delta=text),
+            StreamChunk(
+                finish_reason="stop",
+                usage=UsageInfo(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            ),
+        ]
+    )
+
+
+def _assistant_msgs(session):
+    return [m for m in dicts_from_turns(session.messages) if m["role"] == "assistant"]
+
+
+class TestMidStreamRetry:
+    def test_death_retries_and_commits_one_clean_turn(self, tmp_db, caplog):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        first_text = "streaming from the dead attempt"
+        streams = [
+            _dying_stream(first_text, exc=httpx.ReadError("[SSL] record layer failure")),
+            _good_stream("Hello world"),
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
+            patch.object(session, "_full_messages", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
+        ):
+            session.send("test")
+
+        assert create.call_count == 2
+        # ONE committed turn, carrying only the successful attempt's text.
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "Hello world"
+        # The dead attempt's tokens streamed live (minus the trailing
+        # _MAX_TAG_LEN chars the tag-scan buffer held back — never
+        # displayed, so nothing needs to finalize them); the retried text
+        # is a fresh bubble, not an append onto the dead attempt's.
+        flushed = first_text[: len(first_text) - ChatSession._MAX_TAG_LEN]
+        assert ui.of("content") == [flushed, "Hello world"]
+        # The dead attempt is finalized EVERYWHERE before re-streaming:
+        # stream_end (client finalize) -> turn_committed (server buffer
+        # reset) -> notice -> spinner, then the retried stream's own
+        # end-of-turn pair.
+        seq = [
+            (k, d)
+            for k, d in ui.events
+            if k in ("stream_end", "turn_committed", "thinking_start")
+            or (k == "info" and "stream died mid-response" in d)
+        ]
+        assert [k for k, _ in seq] == [
+            "thinking_start",
+            "stream_end",
+            "turn_committed",
+            "info",
+            "thinking_start",
+            "stream_end",
+            "turn_committed",
+        ]
+        notice = seq[3][1]
+        assert "(ReadError)" in notice
+        assert "(1/2)" in notice
+        assert ("state", "idle") in ui.events
+        assert not ui.of("error")
+        assert any("stream.retry" in r.message for r in caplog.records)
+
+    def test_exhaustion_surfaces_stream_death_wording(self, tmp_db, caplog):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        streams = [
+            _dying_stream("a", exc=httpx.ReadError("[SSL] record layer failure")) for _ in range(3)
+        ]
+        with (
+            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
+            patch.object(session, "_full_messages", return_value=[]),
+            caplog.at_level(logging.INFO, logger="turnstone.core.session"),
+            pytest.raises(IncompleteStreamError, match="ReadError"),
+        ):
+            session.send("test")
+
+        # Initial attempt + _MID_STREAM_RETRIES re-creates, then fatal.
+        assert create.call_count == 1 + session._MID_STREAM_RETRIES
+        assert ("state", "error") in ui.events
+        errors = ui.of("error")
+        assert errors and "Backend stream died mid-response" in errors[-1]
+        assert "retries did not recover it" in errors[-1]
+        persisted = load_last_error(session._ws_id)
+        assert persisted and "Backend stream died mid-response" in persisted
+        fatal = [r for r in caplog.records if "session.fatal.recorded" in r.message]
+        assert fatal and any(r.levelno == logging.ERROR for r in fatal)
+
+    def test_cancel_during_backoff_stops_without_recreate(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        session._RETRY_BASE_DELAY = 30.0
+        real_backoff = session._backoff_or_cancelled
+
+        def cancel_then_backoff(delay, my_generation=0):
+            # A Stop landing during the backoff window: the event-wait
+            # returns immediately instead of burning the 30s delay.
+            session.cancel()
+            real_backoff(delay, my_generation)
+
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[_dying_stream("Hel", exc=httpx.ReadError("wire died"))],
+            ) as create,
+            patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        assert create.call_count == 1  # no further API call after the Stop
+        assert ("state", "idle") in ui.events
+        assert ("state", "error") not in ui.events
+        assert any("cancelled" in d.lower() for d in ui.of("info"))
+
+    def test_non_retryable_error_is_immediately_fatal(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[_dying_stream("Hel", exc=ValueError("model exploded"))],
+            ) as create,
+            patch.object(session, "_full_messages", return_value=[]),
+            pytest.raises(ValueError, match="model exploded"),
+        ):
+            session.send("test")
+
+        assert create.call_count == 1  # zero retries
+        assert ("state", "error") in ui.events
+        assert not any("stream died mid-response" in d for d in ui.of("info"))
+
+    def test_recreate_failure_surfaces_original_stream_death(self, tmp_db, caplog):
+        """A failing re-create (closed client, registry chaos) must not
+        replace the operator-actionable stream-death error with its own."""
+        ui = RecordingUI()
+        session = _make_session(ui)
+        with (
+            patch.object(
+                session,
+                "_create_stream_with_retry",
+                side_effect=[
+                    _dying_stream("He", exc=httpx.ReadError("[SSL] record layer failure")),
+                    RuntimeError("Cannot send a request, as the client has been closed."),
+                ],
+            ) as create,
+            patch.object(session, "_full_messages", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
+            pytest.raises(IncompleteStreamError, match="ReadError"),
+        ):
+            session.send("test")
+
+        assert create.call_count == 2
+        assert any("stream.retry.recreate_failed" in r.message for r in caplog.records)
+        errors = ui.of("error")
+        assert errors and "Backend stream died mid-response" in errors[-1]
+        assert "client has been closed" not in errors[-1]
+
+    def test_post_finish_blip_appends_fresh_token_estimate(self, tmp_db):
+        """The post-finish tolerance can end a turn with the trailing usage
+        chunk lost; the estimate appended for that turn must be a fresh
+        char-based one, never the PREVIOUS turn's completion count."""
+        ui = RecordingUI()
+        session = _make_session(ui)
+        session._assistant_pending_tokens = 777  # stale prior-turn count
+
+        def blipping():
+            yield StreamChunk(content_delta="Hello world")
+            yield StreamChunk(finish_reason="stop")
+            raise httpx.ReadError("late blip")  # the usage chunk is lost
+
+        with (
+            patch.object(session, "_create_stream_with_retry", return_value=blipping()),
+            patch.object(session, "_full_messages", return_value=[]),
+        ):
+            session.send("test")
+
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "Hello world"
+        # Clean end, no retry — the finish reason had already passed.
+        assert not any("stream died mid-response" in d for d in ui.of("info"))
+        assert ("state", "idle") in ui.events
+        expected = max(1, int(session._msg_char_count(assistant[0]) / session._chars_per_token))
+        assert session._msg_tokens[-1] == expected
+        assert session._msg_tokens[-1] != 777

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -25,6 +25,7 @@ from turnstone.core.memory import load_last_error
 from turnstone.core.providers import StreamChunk, UsageInfo
 from turnstone.core.providers._protocol import IncompleteStreamError
 from turnstone.core.session import ChatSession
+from turnstone.core.streaming_text import ThinkTagSplitter
 from turnstone.core.trajectory import dicts_from_turns
 
 
@@ -175,10 +176,10 @@ class TestMidStreamRetry:
         assert len(assistant) == 1
         assert assistant[0]["content"] == "Hello world"
         # The dead attempt's tokens streamed live (minus the trailing
-        # _MAX_TAG_LEN chars the tag-scan buffer held back — never
+        # MAX_TAG_LEN chars the tag-scan buffer held back — never
         # displayed, so nothing needs to finalize them); the retried text
         # is a fresh bubble, not an append onto the dead attempt's.
-        flushed = first_text[: len(first_text) - ChatSession._MAX_TAG_LEN]
+        flushed = first_text[: len(first_text) - ThinkTagSplitter.MAX_TAG_LEN]
         assert ui.of("content") == [flushed, "Hello world"]
         # The dead attempt is finalized EVERYWHERE before re-streaming:
         # stream_end (client finalize) -> turn_committed (server buffer

--- a/tests/test_reasoning_audit_log_discipline.py
+++ b/tests/test_reasoning_audit_log_discipline.py
@@ -226,10 +226,10 @@ class TestReasoningAuditLogDiscipline:
             f"reasoning text into INFO+ logs: {offending}"
         )
 
-    def test_synth_reasoning_block_via_stream_response_does_not_log_reasoning(
+    def test_synth_reasoning_block_via_stream_attempt_does_not_log_reasoning(
         self,
     ) -> None:
-        """Drives ChatSession._stream_response (which invokes
+        """Drives ChatSession._stream_attempt (which invokes
         model_turn.synth_reasoning_block at end-of-stream via
         _finalize_provider_blocks) with a fake
         ``reasoning_delta=_MARKER`` chunk; asserts no log call carried
@@ -247,7 +247,7 @@ class TestReasoningAuditLogDiscipline:
         for p in patchers:
             p.start()
         try:
-            msg = session._stream_response(iter(chunks))
+            msg = session._stream_attempt(iter(chunks))
             # Synth block stamped onto _provider_content with the marker.
             assert msg["_provider_content"][0]["text"] == _MARKER
         finally:
@@ -259,7 +259,7 @@ class TestReasoningAuditLogDiscipline:
             if _payload_contains_marker(args, kwargs)
         ]
         assert offending == [], (
-            f"_stream_response + synth_reasoning_block leaked reasoning "
+            f"_stream_attempt + synth_reasoning_block leaked reasoning "
             f"text into INFO+ logs: {offending}"
         )
 

--- a/tests/test_sdk_stream_boundary.py
+++ b/tests/test_sdk_stream_boundary.py
@@ -1,0 +1,203 @@
+"""Offline pins of the SDK boundary behaviors the #937 retry design rests on.
+
+Three facts, each probed against the REAL SDKs over mock/loopback
+transports (no network, no live backend):
+
+1. The OpenAI SDK's ``max_retries`` covers request time only — a
+   mid-BODY death produces no re-request, and the raw ``httpx.ReadError``
+   escapes the chunk iterator unwrapped.
+2. The Anthropic ``messages.stream()`` helper propagates the same shape.
+3. Closing an httpx-backed SDK client from another thread while a read is
+   blocked (the ``ModelRegistry.reload()`` shape) surfaces as an
+   ``httpx.TransportError`` on the blocked ``next()`` — which is why the
+   resilient ``_stream_response`` re-resolves the registry binding before
+   re-creating.
+
+If an SDK/httpx upgrade changes any of these, the ``transport_guarded``
+conversion (and the retry gate consuming it) must be re-verified — these
+tests are the tripwire.  Wire framing bytes (CRLF, the SSE double-LF) are
+built via ``chr`` rather than escape literals so the payloads are
+byte-exact regardless of source-encoding handling.
+"""
+
+import contextlib
+import socket
+import threading
+import time
+
+import anthropic
+import httpx
+import openai
+import pytest
+
+LF = chr(10)
+CRLF = chr(13) + chr(10)
+
+CHAT_CHUNK = (
+    'data: {"id":"x","object":"chat.completion.chunk","created":0,'
+    '"model":"m","choices":[{"index":0,"delta":{"content":"hello"},'
+    '"finish_reason":null}]}' + LF + LF
+)
+
+ANTHROPIC_EVENTS = (
+    "event: message_start"
+    + LF
+    + 'data: {"type":"message_start","message":{"id":"msg_01X","type":"message",'
+    '"role":"assistant","model":"m","content":[],"stop_reason":null,'
+    '"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}'
+    + LF
+    + LF
+    + "event: content_block_start"
+    + LF
+    + 'data: {"type":"content_block_start","index":0,'
+    '"content_block":{"type":"text","text":""}}'
+    + LF
+    + LF
+    + "event: content_block_delta"
+    + LF
+    + 'data: {"type":"content_block_delta","index":0,'
+    '"delta":{"type":"text_delta","text":"hello"}}' + LF + LF
+)
+
+
+class _DyingStream(httpx.SyncByteStream):
+    """Response body: one valid SSE payload, then a mid-read wire death."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def __iter__(self):
+        yield self._payload
+        raise httpx.ReadError("[SSL] record layer failure (_ssl.c:2590)")
+
+
+def _dying_transport(payload: str, requests: list) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=_DyingStream(payload.encode()),
+            request=request,
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def test_openai_midbody_death_is_unwrapped_readerror_and_no_rerequest():
+    requests: list = []
+    client = openai.OpenAI(
+        api_key="probe",
+        base_url="http://probe.invalid/v1",
+        http_client=httpx.Client(transport=_dying_transport(CHAT_CHUNK, requests)),
+        max_retries=2,
+    )
+    stream = client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "hi"}], stream=True
+    )
+    texts = []
+    with pytest.raises(httpx.ReadError) as excinfo:
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                texts.append(chunk.choices[0].delta.content)
+    # The retry gate matches on the class NAME; pin the exact identity the
+    # SDK lets escape, and that it is the httpx transport family.
+    assert type(excinfo.value).__name__ == "ReadError"
+    assert isinstance(excinfo.value, httpx.TransportError)
+    assert texts == ["hello"]  # the request succeeded; the BODY died
+    assert len(requests) == 1  # max_retries never re-requested mid-body
+
+
+def test_anthropic_midbody_death_is_unwrapped_readerror_and_no_rerequest():
+    requests: list = []
+    client = anthropic.Anthropic(
+        api_key="probe",
+        base_url="http://probe.invalid",
+        http_client=httpx.Client(transport=_dying_transport(ANTHROPIC_EVENTS, requests)),
+        max_retries=2,
+    )
+    texts = []
+    # The provider adapter consumes the stream() helper's iterator — same
+    # shape as _anthropic.py's create_streaming.
+    with (
+        client.messages.stream(
+            model="m", max_tokens=64, messages=[{"role": "user", "content": "hi"}]
+        ) as stream,
+        pytest.raises(httpx.ReadError) as excinfo,
+    ):
+        for event in stream:
+            if getattr(event, "type", "") == "content_block_delta":
+                delta = getattr(event, "delta", None)
+                if getattr(delta, "type", "") == "text_delta":
+                    texts.append(delta.text)
+    assert type(excinfo.value).__name__ == "ReadError"
+    assert isinstance(excinfo.value, httpx.TransportError)
+    assert texts == ["hello"]
+    assert len(requests) == 1
+
+
+def test_cross_thread_client_close_surfaces_transport_error_to_blocked_read():
+    """The ``ModelRegistry.reload()`` shape: an admin-thread ``client.close()``
+    under a worker blocked in ``next()`` must surface as an
+    ``httpx.TransportError`` (so ``transport_guarded`` converts it and the
+    retry gate passes) — not as a plain ``RuntimeError`` the gate would
+    treat as fatal."""
+    body = f"{len(CHAT_CHUNK):x}" + CRLF + CHAT_CHUNK + CRLF
+    response_head = (
+        "HTTP/1.1 200 OK"
+        + CRLF
+        + "Content-Type: text/event-stream"
+        + CRLF
+        + "Transfer-Encoding: chunked"
+        + CRLF
+        + CRLF
+    )
+    listener = socket.create_server(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    client_closed = threading.Event()
+    reader_blocked = threading.Event()
+
+    def serve() -> None:
+        conn, _ = listener.accept()
+        conn.recv(65536)
+        conn.sendall((response_head + body).encode())
+        # Hold the connection (no second chunk) so the reader blocks, and
+        # release only once the client has been closed under it.
+        client_closed.wait(timeout=10.0)
+        conn.close()
+
+    client = openai.OpenAI(api_key="probe", base_url=f"http://127.0.0.1:{port}/v1", max_retries=0)
+
+    def closer() -> None:
+        reader_blocked.wait(timeout=10.0)
+        time.sleep(0.5)  # let the reader enter the blocking socket read
+        client.close()
+        client_closed.set()
+
+    server_thread = threading.Thread(target=serve)
+    closer_thread = threading.Thread(target=closer)
+    server_thread.start()
+    closer_thread.start()
+    try:
+        stream = client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "hi"}], stream=True
+        )
+        it = iter(stream)
+        first = next(it)  # the one sent chunk arrives; the wire then idles
+        assert first.choices[0].delta.content == "hello"
+        reader_blocked.set()
+        with pytest.raises(httpx.TransportError) as excinfo:
+            next(it)  # blocked read, killed by the cross-thread close()
+        assert type(excinfo.value).__name__ == "ReadError"
+    finally:
+        # Unblock and join both threads on every exit path so nothing
+        # outlives the test (leaked-thread guard).
+        reader_blocked.set()
+        client_closed.set()
+        closer_thread.join(timeout=10.0)
+        server_thread.join(timeout=10.0)
+        listener.close()
+        with contextlib.suppress(Exception):
+            client.close()
+    assert not closer_thread.is_alive()
+    assert not server_thread.is_alive()

--- a/tests/test_sdk_stream_boundary.py
+++ b/tests/test_sdk_stream_boundary.py
@@ -188,7 +188,13 @@ def test_cross_thread_client_close_surfaces_transport_error_to_blocked_read():
         reader_blocked.set()
         with pytest.raises(httpx.TransportError) as excinfo:
             next(it)  # blocked read, killed by the cross-thread close()
-        assert type(excinfo.value).__name__ == "ReadError"
+        # Platform/timing-dependent: the killed read surfaces as ReadError
+        # (EBADF from the blocked recv) or, where the reader observes EOF
+        # first, RemoteProtocolError (chunked body never terminated).  Both
+        # are TransportError members of _BACKEND_STREAM_EXC_NAMES, so
+        # transport_guarded converts either and the retry gate passes — the
+        # property this pin exists for.
+        assert type(excinfo.value).__name__ in {"ReadError", "RemoteProtocolError"}
     finally:
         # Unblock and join both threads on every exit path so nothing
         # outlives the test (leaked-thread guard).

--- a/tests/test_server_live.py
+++ b/tests/test_server_live.py
@@ -76,6 +76,10 @@ class RecordingUI:
     def on_turn_committed(self):
         self.events.append(("turn_committed",))
 
+    def on_stream_discarded(self):
+        # A live-wire blip entering the retry arm must not crash the fake.
+        self.events.append(("stream_discarded",))
+
     def on_thinking_start(self):
         self.events.append(("thinking_start",))
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -135,16 +135,10 @@ def _send_with_mocks(session, responses, mock_execute, **extra_patches):
     """
     from unittest.mock import patch as _patch
 
-    def mock_stream(_msgs):
-        return iter([])
-
-    def mock_response(_stream, _gen):
+    def mock_response(_msgs, _gen):
         return responses.pop(0)
 
     with contextlib.ExitStack() as stack:
-        stack.enter_context(
-            _patch.object(session, "_create_stream_with_retry", side_effect=mock_stream)
-        )
         stack.enter_context(_patch.object(session, "_stream_response", side_effect=mock_response))
         stack.enter_context(_patch.object(session, "_execute_tools", side_effect=mock_execute))
         for attr, side_effect in extra_patches.items():
@@ -6447,7 +6441,7 @@ class TestUserAdvisoryCancelClear:
         session._title_generated = True
         stream_calls = 0
 
-        def mock_create_stream(msgs):
+        def mock_stream_response(msgs, my_generation=0):
             nonlocal stream_calls
             stream_calls += 1
             if stream_calls == 1:
@@ -6455,15 +6449,10 @@ class TestUserAdvisoryCancelClear:
                 # time the no-tool branch runs ``_flush_queued_messages``,
                 # this item is in the queue waiting to be drained.
                 session.queue_message("late arrival", queue_msg_id="q-late")
-            return iter([])
+            return {"role": "assistant", "content": "ok"}
 
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=mock_create_stream),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", side_effect=mock_stream_response),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),

--- a/tests/test_session_backend_error_format.py
+++ b/tests/test_session_backend_error_format.py
@@ -106,6 +106,14 @@ class RateLimitError(Exception):
     pass
 
 
+class ReadError(Exception):  # noqa: N818
+    pass
+
+
+class RemoteProtocolError(Exception):  # noqa: N818
+    pass
+
+
 class SomeUnrelatedError(Exception):
     """Outside the recognised set — should fall through to ``None``."""
 
@@ -197,6 +205,87 @@ def test_rate_limit_with_overflow_phrasing_is_not_mislabeled_overflow():
     )
     assert msg is not None
     assert "Backend rate-limited" in msg
+    assert "Context window exceeded" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Stream-death branch — the mid-response wire-failure wording (#937)
+# ---------------------------------------------------------------------------
+
+
+def _stream_death_exemplars() -> list[BaseException]:
+    """One realistic instance per name in ``_BACKEND_STREAM_EXC_NAMES``:
+    the normalized shape the guarded iterators raise, plus the raw httpx
+    names for any future unguarded path."""
+    from turnstone.core.providers import IncompleteStreamError
+
+    return [
+        IncompleteStreamError(
+            "stream transport failed mid-response "
+            "(ReadError: [SSL] record layer failure (_ssl.c:2590))"
+        ),
+        ReadError("[SSL] record layer failure (_ssl.c:2590)"),
+        RemoteProtocolError("peer closed connection without sending complete message body"),
+    ]
+
+
+@pytest.mark.parametrize("exc", _stream_death_exemplars(), ids=lambda e: type(e).__name__)
+def test_stream_death_names_backend_and_model(exc):
+    msg = _format(_stub(), exc)
+    assert msg is not None
+    assert "Backend stream died mid-response" in msg
+    assert type(exc).__name__ in msg
+    assert "openai-compatible" in msg
+    assert "http://192.168.0.5:8000/v1" in msg
+    assert "model=flatspark" in msg
+    assert "retries did not recover it" in msg
+    # Raw exception text is preserved as a tail for grep-correlation.
+    assert str(exc) in msg
+
+
+def test_stream_death_first_sentence_survives_discord_cut():
+    """Discord truncates ``on_error`` text to 500 chars — the identity-bearing
+    first sentence must fit even with realistic-length alias/URL inputs."""
+    msg = _format(
+        _stub(
+            base_url="https://inference-gateway.internal.example-corp.net:8443/serving/v1",
+            provider_name="openai-compatible",
+            model="deepseek-r2-awq-128k-instruct-20260115",
+            model_alias="prod-reasoning-primary",
+        ),
+        ReadError("[SSL] record layer failure (_ssl.c:2590)"),
+    )
+    assert msg is not None
+    first_sentence = msg[: msg.index(". ") + 1]
+    assert "Backend stream died mid-response" in first_sentence
+    assert len(first_sentence) < 500
+
+
+def test_registry_diagnosed_binding_outranks_stream_death():
+    """An alias the per-send refresh diagnosed dead outranks the raw stream
+    symptom: the rebind wording points at the admin action, the transport
+    wording at network health — the former is the actionable one."""
+    from turnstone.core.providers import IncompleteStreamError
+
+    stub = _stub()
+    stub._registry_alias_removed = "flatspark"
+    stub._registry = None
+    stub._kind = None
+    msg = _format(stub, IncompleteStreamError("stream transport failed mid-response"))
+    assert msg is not None
+    assert "has been removed from the registry" in msg
+    assert "Backend stream died" not in msg
+
+
+def test_stream_death_with_overflow_phrasing_stays_stream_death():
+    """Joining the stream names into ``_BACKEND_KNOWN_EXC_NAMES`` removes them
+    from ``_is_ctx_overflow``'s text-detection eligibility (its class
+    self-gate) — deliberate: transport/SSL texts never carry real overflow
+    phrases, and a stream death must never be misfiled as a deterministic
+    overflow (which callers route to a non-retryable compaction path)."""
+    msg = _format(_stub(), ReadError("proxy said: maximum context length hint in banner"))
+    assert msg is not None
+    assert "Backend stream died mid-response" in msg
     assert "Context window exceeded" not in msg
 
 
@@ -372,6 +461,55 @@ def test_record_fatal_falls_back_for_unknown(monkeypatch):
 
     assert ui.errors == ["ValueError: plain old error"]
     assert captured["persist"] == "ValueError: plain old error"
+
+
+def test_record_fatal_logs_session_fatal_recorded_at_error(monkeypatch, caplog):
+    """The one journal trace of a fatal turn — the UI/persist sinks are
+    invisible to log scrapers, so the chokepoint must emit
+    ``session.fatal.recorded`` with the sanitized text."""
+    import logging
+
+    import turnstone.core.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "persist_last_error", lambda ws_id, msg: None)
+    monkeypatch.setattr(memory_mod, "sanitize_error_text", lambda text, **kw: text)
+
+    class _UI:
+        def on_error(self, msg: str) -> None:
+            pass
+
+    stub = _record_fatal_stub(_UI(), {})
+    with caplog.at_level(logging.INFO, logger="turnstone.core.session"):
+        ChatSession._record_fatal_error(stub, ReadTimeout("timed out"))  # type: ignore[arg-type]
+
+    recorded = [r for r in caplog.records if "session.fatal.recorded" in r.message]
+    assert recorded
+    assert any(r.levelno == logging.ERROR for r in recorded)
+    assert any("ReadTimeout" in r.message for r in recorded)
+
+
+def test_record_fatal_logs_keyboard_interrupt_at_info(monkeypatch, caplog):
+    """Ctrl-C routes through the same chokepoint but is a user action, not a
+    fault — it must not add an ERROR-level line per CLI interrupt."""
+    import logging
+
+    import turnstone.core.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "persist_last_error", lambda ws_id, msg: None)
+    monkeypatch.setattr(memory_mod, "sanitize_error_text", lambda text, **kw: text)
+
+    class _UI:
+        def on_error(self, msg: str) -> None:
+            pass
+
+    stub = _record_fatal_stub(_UI(), {})
+    with caplog.at_level(logging.INFO, logger="turnstone.core.session"):
+        ChatSession._record_fatal_error(stub, KeyboardInterrupt())  # type: ignore[arg-type]
+
+    recorded = [r for r in caplog.records if "session.fatal.recorded" in r.message]
+    assert recorded
+    assert all(r.levelno < logging.ERROR for r in recorded)
+    assert any(r.levelno == logging.INFO for r in recorded)
 
 
 def test_backend_auth_unavailable_names_the_mint_not_the_key():

--- a/tests/test_session_backend_error_format.py
+++ b/tests/test_session_backend_error_format.py
@@ -463,10 +463,20 @@ def test_record_fatal_falls_back_for_unknown(monkeypatch):
     assert captured["persist"] == "ValueError: plain old error"
 
 
-def test_record_fatal_logs_session_fatal_recorded_at_error(monkeypatch, caplog):
-    """The one journal trace of a fatal turn — the UI/persist sinks are
-    invisible to log scrapers, so the chokepoint must emit
-    ``session.fatal.recorded`` with the sanitized text."""
+@pytest.mark.parametrize(
+    ("exc", "expect_error_level", "message_substring"),
+    [
+        pytest.param(ReadTimeout("timed out"), True, "ReadTimeout", id="fault-at-error"),
+        pytest.param(KeyboardInterrupt(), False, None, id="ctrl-c-at-info"),
+    ],
+)
+def test_record_fatal_log_level_contract(
+    monkeypatch, caplog, exc, expect_error_level, message_substring
+):
+    """The one journal trace of a fatal turn emits ``session.fatal.recorded``
+    with the sanitized text — at ERROR for genuine faults; a Ctrl-C routes
+    through the same chokepoint but is a user action, not a fault, and must
+    not add an ERROR-level line per CLI interrupt."""
     import logging
 
     import turnstone.core.memory as memory_mod
@@ -480,36 +490,17 @@ def test_record_fatal_logs_session_fatal_recorded_at_error(monkeypatch, caplog):
 
     stub = _record_fatal_stub(_UI(), {})
     with caplog.at_level(logging.INFO, logger="turnstone.core.session"):
-        ChatSession._record_fatal_error(stub, ReadTimeout("timed out"))  # type: ignore[arg-type]
+        ChatSession._record_fatal_error(stub, exc)  # type: ignore[arg-type]
 
     recorded = [r for r in caplog.records if "session.fatal.recorded" in r.message]
     assert recorded
-    assert any(r.levelno == logging.ERROR for r in recorded)
-    assert any("ReadTimeout" in r.message for r in recorded)
-
-
-def test_record_fatal_logs_keyboard_interrupt_at_info(monkeypatch, caplog):
-    """Ctrl-C routes through the same chokepoint but is a user action, not a
-    fault — it must not add an ERROR-level line per CLI interrupt."""
-    import logging
-
-    import turnstone.core.memory as memory_mod
-
-    monkeypatch.setattr(memory_mod, "persist_last_error", lambda ws_id, msg: None)
-    monkeypatch.setattr(memory_mod, "sanitize_error_text", lambda text, **kw: text)
-
-    class _UI:
-        def on_error(self, msg: str) -> None:
-            pass
-
-    stub = _record_fatal_stub(_UI(), {})
-    with caplog.at_level(logging.INFO, logger="turnstone.core.session"):
-        ChatSession._record_fatal_error(stub, KeyboardInterrupt())  # type: ignore[arg-type]
-
-    recorded = [r for r in caplog.records if "session.fatal.recorded" in r.message]
-    assert recorded
-    assert all(r.levelno < logging.ERROR for r in recorded)
-    assert any(r.levelno == logging.INFO for r in recorded)
+    if expect_error_level:
+        assert any(r.levelno == logging.ERROR for r in recorded)
+    else:
+        assert all(r.levelno < logging.ERROR for r in recorded)
+        assert any(r.levelno == logging.INFO for r in recorded)
+    if message_substring:
+        assert any(message_substring in r.message for r in recorded)
 
 
 def test_backend_auth_unavailable_names_the_mint_not_the_key():

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -8,7 +8,7 @@ provider_blocks shape on the wire, so the captured reasoning text is
 stamped onto ``_provider_content`` as a synthetic
 ``{type: "reasoning_text"}`` block at the end of the turn by
 ``model_turn.synth_reasoning_block`` — the one synthesizer every lane
-runs (the main loop reaches it through ``ChatSession._stream_response``
+runs (the main loop reaches it through ``ChatSession._stream_attempt``
 → ``_finalize_provider_blocks``; agents and judges through
 ``model_turn``).
 
@@ -210,9 +210,9 @@ class TestOpenAIChatExtractReasoningText:
         assert provider.extract_reasoning_text(blocks) == ""
 
 
-class TestStreamResponseSynthBlockIntegration:
+class TestStreamAttemptSynthBlockIntegration:
     """Integration test: drives a fake reasoning-emitting stream
-    through ``ChatSession._stream_response`` and asserts the
+    through ``ChatSession._stream_attempt`` and asserts the
     synthesizer wires up correctly.  Pins the call site at
     ``session.py`` (where ``model_turn.synth_reasoning_block`` is
     invoked — via ``_finalize_provider_blocks`` — on the assembled
@@ -250,17 +250,17 @@ class TestStreamResponseSynthBlockIntegration:
         )
         return iter(chunks)
 
-    def test_stream_response_stamps_synth_block_when_path3_reasoning_captured(
+    def test_stream_attempt_stamps_synth_block_when_path3_reasoning_captured(
         self,
     ) -> None:
         """Drive a fake stream emitting reasoning_delta chunks (no
-        native provider_blocks) through ``_stream_response``; assert
+        native provider_blocks) through ``_stream_attempt``; assert
         the resulting assistant_msg carries a synthetic reasoning_text
         block stamped onto ``_provider_content``."""
         session = _make_session()
         # No registry → source field omitted from synth block.
         stream = self._make_stream(content="Final answer.", reasoning="path-3 reasoning")
-        msg = session._stream_response(stream)
+        msg = session._stream_attempt(stream)
         assert msg["role"] == "assistant"
         assert msg["content"] == "Final answer."
         # Synthetic block should be stamped onto _provider_content.
@@ -270,17 +270,17 @@ class TestStreamResponseSynthBlockIntegration:
         assert provider_content[0]["type"] == "reasoning_text"
         assert provider_content[0]["text"] == "path-3 reasoning"
 
-    def test_stream_response_no_synth_when_no_reasoning_captured(self) -> None:
+    def test_stream_attempt_no_synth_when_no_reasoning_captured(self) -> None:
         """Stream emits only content (no reasoning_delta).  No synth
         block stamped — _provider_content key absent on assistant_msg."""
         session = _make_session()
         stream = self._make_stream(content="just content", reasoning="")
-        msg = session._stream_response(stream)
+        msg = session._stream_attempt(stream)
         assert msg["content"] == "just content"
         # No synth block (and no native blocks either) → key absent.
         assert "_provider_content" not in msg
 
-    def test_stream_response_synth_block_carries_source_when_server_type_resolvable(
+    def test_stream_attempt_synth_block_carries_source_when_server_type_resolvable(
         self,
     ) -> None:
         """When the active model has server_compat.server_type set,
@@ -294,7 +294,7 @@ class TestStreamResponseSynthBlockIntegration:
         )
         session._model_alias = "qwen3-32b"
         stream = self._make_stream(content="answer", reasoning="reasoning text")
-        msg = session._stream_response(stream)
+        msg = session._stream_attempt(stream)
         provider_content = msg.get("_provider_content")
         assert isinstance(provider_content, list)
         assert provider_content[0]["source"] == "vllm"

--- a/tests/test_think_tag_split.py
+++ b/tests/test_think_tag_split.py
@@ -1,0 +1,196 @@
+"""Behavior pins for the interactive think-tag splitting layer.
+
+``ChatSession._stream_attempt`` splits streamed content into content vs
+reasoning around ``<think>``/``<reasoning>`` tags, buffering potential
+partial tags across chunk boundaries.  These tables pin the CURRENT
+emission behavior — exact UI token sequence and final message content —
+so the logic can move into a standalone ``ThinkTagSplitter`` class with
+byte-identical output.  Every case drives the real chunk consumer end to
+end; none reaches into the implementation, so the same rows must stay
+green across the extraction.
+
+Pinned rules:
+
+- partial-tag buffering: a chunk ending in a possible tag prefix emits
+  nothing until the tag resolves or the safe-flush margin clears it;
+- safe-flush: with no tag in sight, everything but the trailing
+  MAX-tag-length chars flushes immediately (live streaming), the tail
+  only at stream end;
+- open/close tag selection by EARLIEST index among the tag variants;
+- ``in_think`` transitions, including the ``reasoning_delta`` (path-1)
+  interplay and the raw pending flush when tool calls begin (pending
+  text can no longer be a partial tag).
+"""
+
+import pytest
+
+from tests._session_helpers import make_session
+from turnstone.core.providers import StreamChunk, ToolCallDelta
+from turnstone.core.streaming_text import ThinkTagSplitter
+
+
+class _TokenRecorderUI:
+    """Records dispatched token events; stubs the rest of the surface
+    ``_stream_attempt`` touches."""
+
+    def __init__(self):
+        self.tokens = []
+
+    def on_content_token(self, text):
+        self.tokens.append(("content", text))
+
+    def on_reasoning_token(self, text):
+        self.tokens.append(("reasoning", text))
+
+    def on_thinking_stop(self):
+        pass
+
+    def on_stream_end(self):
+        pass
+
+    def on_info(self, message):
+        pass
+
+    def on_error(self, message):
+        pass
+
+
+def _drive(chunks, *, show_reasoning=True):
+    session = make_session()
+    session.show_reasoning = show_reasoning
+    ui = _TokenRecorderUI()
+    session.ui = ui
+    msg = session._stream_attempt(iter(chunks))
+    return msg, ui.tokens
+
+
+def _c(text):
+    return StreamChunk(content_delta=text)
+
+
+_FINISH = StreamChunk(finish_reason="stop")
+
+# (case id, chunks, expected ordered token events, expected final content)
+CASES = [
+    (
+        "plain_short_held_until_end",
+        [_c("hello"), _FINISH],
+        [("content", "hello")],
+        "hello",
+    ),
+    (
+        "think_block_single_chunk",
+        [_c("<think>deep</think>answer"), _FINISH],
+        [("reasoning", "deep"), ("content", "answer")],
+        "answer",
+    ),
+    (
+        "tag_split_across_chunk_boundary",
+        [_c("before<thi"), _c("nk>r</think>after"), _FINISH],
+        [("content", "before"), ("reasoning", "r"), ("content", "after")],
+        "beforeafter",
+    ),
+    (
+        "reasoning_tag_variant",
+        [_c("<reasoning>x</reasoning>done"), _FINISH],
+        [("reasoning", "x"), ("content", "done")],
+        "done",
+    ),
+    (
+        "earliest_tag_index_wins",
+        [_c("a<reasoning>b</reasoning>c<think>d</think>e"), _FINISH],
+        [
+            ("content", "a"),
+            ("reasoning", "b"),
+            ("content", "c"),
+            ("reasoning", "d"),
+            ("content", "e"),
+        ],
+        "ace",
+    ),
+    (
+        "safe_flush_streams_all_but_max_tag_len",
+        [_c("x" * 30), _FINISH],
+        [("content", "x" * 18), ("content", "x" * 12)],
+        "x" * 30,
+    ),
+    (
+        "path1_reasoning_then_content",
+        [StreamChunk(reasoning_delta="rr"), _c("cc"), _FINISH],
+        [("reasoning", "rr"), ("content", "cc")],
+        "cc",
+    ),
+    (
+        "unterminated_think_tail_flushes_as_reasoning",
+        [_c("<think>abc"), _FINISH],
+        [("reasoning", "abc")],
+        "",
+    ),
+    (
+        "content_surrounds_think_block",
+        [_c("before<think>mid</think>after"), _FINISH],
+        [("content", "before"), ("reasoning", "mid"), ("content", "after")],
+        "beforeafter",
+    ),
+    (
+        "safe_flush_inside_think_block",
+        [_c("<think>" + "y" * 20), _c("</think>ok"), _FINISH],
+        [("reasoning", "y" * 8), ("reasoning", "y" * 12), ("content", "ok")],
+        "ok",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("chunks", "expected_events", "expected_content"),
+    [c[1:] for c in CASES],
+    ids=[c[0] for c in CASES],
+)
+def test_tag_splitting_emissions(chunks, expected_events, expected_content):
+    msg, tokens = _drive(chunks)
+    assert tokens == expected_events
+    assert msg["content"] == expected_content
+
+
+def test_show_reasoning_off_suppresses_reasoning_dispatch_only():
+    msg, tokens = _drive([_c("<think>deep</think>answer"), _FINISH], show_reasoning=False)
+    assert tokens == [("content", "answer")]
+    assert msg["content"] == "answer"
+
+
+def test_splitter_standalone_contract():
+    """The extracted class is consumable without a session: feed() emits
+    tag-resolved spans through the callback, flush_pending() drains the
+    carry buffer raw, and in_think is externally writable for
+    out-of-band transitions."""
+    events = []
+    splitter = ThinkTagSplitter(lambda text, is_reasoning: events.append((text, is_reasoning)))
+    splitter.feed("a<think>b</think>c")
+    assert events == [("a", False), ("b", True)]
+    assert splitter.pending == "c"
+    splitter.flush_pending()
+    assert events == [("a", False), ("b", True), ("c", False)]
+    assert splitter.pending == ""
+    splitter.in_think = True
+    splitter.feed("tail")
+    splitter.flush_pending()
+    assert events[-1] == ("tail", True)
+
+
+def test_tool_calls_flush_pending_raw_at_current_state():
+    # Once tool calls begin, buffered text cannot be a partial tag: it
+    # flushes RAW (no tag scan) at the current in_think state.
+    chunks = [
+        _c("part<thi"),
+        StreamChunk(tool_call_deltas=[ToolCallDelta(index=0, id="tc1", name="bash")]),
+        StreamChunk(
+            tool_call_deltas=[ToolCallDelta(index=0, arguments_delta="{}")],
+            finish_reason="tool_calls",
+        ),
+    ]
+    msg, tokens = _drive(chunks)
+    assert tokens == [("content", "part<thi")]
+    assert msg["content"] == "part<thi"
+    assert msg["tool_calls"] == [
+        {"id": "tc1", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
+    ]

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -205,20 +205,17 @@ class TestContextOverflowRecovery:
 
         call_count = 0
 
-        def mock_create_stream(msgs):
+        def mock_stream_response(msgs, my_generation=0):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise Exception("maximum context length exceeded")
-            return iter([])
+            return {"role": "assistant", "content": "ok"}
 
         compact_mock = MagicMock()
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=mock_create_stream),
+            patch.object(session, "_stream_response", side_effect=mock_stream_response),
             patch.object(session, "_compact_messages", compact_mock),
-            patch.object(
-                session, "_stream_response", return_value={"role": "assistant", "content": "ok"}
-            ),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -238,20 +235,17 @@ class TestContextOverflowRecovery:
 
         call_count = 0
 
-        def mock_create_stream(msgs):
+        def mock_stream_response(msgs, my_generation=0):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise Exception("prompt is too long: 250000 tokens > 200000 maximum")
-            return iter([])
+            return {"role": "assistant", "content": "ok"}
 
         compact_mock = MagicMock()
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=mock_create_stream),
+            patch.object(session, "_stream_response", side_effect=mock_stream_response),
             patch.object(session, "_compact_messages", compact_mock),
-            patch.object(
-                session, "_stream_response", return_value={"role": "assistant", "content": "ok"}
-            ),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -328,16 +322,10 @@ def _send_with_tool_batches(session, batches, **extra_patches):
     ] + [{"role": "assistant", "content": "done"}]
     exec_results = [(results, []) for _, results in batches]
 
-    def mock_stream(_msgs):
-        return iter([])
-
-    def mock_response(_stream, _gen):
+    def mock_response(_msgs, _gen):
         return responses.pop(0)
 
     with contextlib.ExitStack() as stack:
-        stack.enter_context(
-            patch.object(session, "_create_stream_with_retry", side_effect=mock_stream)
-        )
         stack.enter_context(patch.object(session, "_stream_response", side_effect=mock_response))
         stack.enter_context(patch.object(session, "_execute_tools", side_effect=exec_results))
         for attr, value in extra_patches.items():

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -121,6 +121,11 @@ class TerminalUI(SessionUI):
         # Terminal UI has no inflight buffer to reset.
         pass
 
+    def on_stream_discarded(self) -> None:
+        # Printed text cannot be unprinted; the renderer reset rides the
+        # stream_end that precedes this call.
+        pass
+
     def on_thinking_start(self) -> None:
         self.spinner = Spinner("Thinking")
         self.spinner.start()

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -127,6 +127,11 @@ class TerminalUI(SessionUI):
         pass
 
     def on_thinking_start(self) -> None:
+        # Idempotent: replacing a RUNNING spinner would orphan its render
+        # thread (painting frames over all later output for the process
+        # lifetime) — callers must not need a stop-first protocol.
+        if self.spinner:
+            self.spinner.stop()
         self.spinner = Spinner("Thinking")
         self.spinner.start()
 

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -284,7 +284,7 @@ def sanitize_tool_call_arguments(messages: list[dict[str, Any]]) -> list[dict[st
 
     The stream accumulator commits ``arguments`` verbatim, and the only guard that
     drops a malformed tool call is ``finish_reason == "length"``
-    (``ChatSession._stream_response``); a model that emits invalid JSON with a
+    (``ChatSession._stream_attempt``); a model that emits invalid JSON with a
     ``stop`` / ``tool_calls`` finish reason slips through, and one such turn then
     poison-pills every later request that replays it on a strict renderer.  This
     legalizes each offending ``arguments`` to a JSON-object string.

--- a/turnstone/core/providers/__init__.py
+++ b/turnstone/core/providers/__init__.py
@@ -18,6 +18,7 @@ from turnstone.core.providers._protocol import (
     UsageInfo,
     accumulate_tool_call_delta,
     drain_stream,
+    merge_usage,
     transport_guarded,
 )
 from turnstone.core.providers._xai import XAI_DEFAULT_BASE_URL, XAIProvider
@@ -40,6 +41,7 @@ __all__ = [
     "drain_stream",
     "list_known_models",
     "lookup_model_capabilities",
+    "merge_usage",
     "transport_guarded",
 ]
 

--- a/turnstone/core/providers/__init__.py
+++ b/turnstone/core/providers/__init__.py
@@ -18,6 +18,7 @@ from turnstone.core.providers._protocol import (
     UsageInfo,
     accumulate_tool_call_delta,
     drain_stream,
+    transport_guarded,
 )
 from turnstone.core.providers._xai import XAI_DEFAULT_BASE_URL, XAIProvider
 
@@ -39,6 +40,7 @@ __all__ = [
     "drain_stream",
     "list_known_models",
     "lookup_model_capabilities",
+    "transport_guarded",
 ]
 
 # Singleton instances (stateless, safe to share).

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -1292,7 +1292,7 @@ def _normalize_finish_reason(reason: str) -> str:
         # drain gate only errors on an ABSENT finish reason.  "content_filter"
         # is the
         # OpenAI-vocabulary equivalent this function normalizes onto, and both
-        # consumers already handle it: ChatSession._stream_response warns the
+        # consumers already handle it: ChatSession._stream_attempt warns the
         # user, and the sub-agent loop stops early instead of flailing on an
         # empty turn.  Falling through to the raw "refusal" string instead
         # would land a truncated answer as a complete result.

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -92,9 +92,11 @@ def merge_usage(acc: UsageInfo | None, new: UsageInfo) -> UsageInfo:
     recomputed from the merged parts.  Returns a fresh ``UsageInfo`` and
     never mutates ``new`` (the provider's object).
 
-    ``ChatSession``'s inline chunk consumer implements the same rule over
-    its dict-shaped accumulator; it adopts this helper when the main loop
-    moves onto ``model_turn`` (#832).
+    Serves :func:`drain_stream` and ``ChatSession``'s inline chunk
+    consumer alike — the interactive loop re-projects the merged
+    accumulator into its ``_last_usage`` dict on every usage chunk (that
+    dict has mid-stream readers), so the two lanes cannot drift on the
+    merge rule.
     """
     if acc is None:
         return replace(new)
@@ -221,7 +223,9 @@ def drain_stream(chunks: Iterator[StreamChunk]) -> CompletionResult:
       never be handed to a caller that stores it as a complete result (a
       compaction summary, a title).  A transport blip AFTER the finish
       reason keeps the completed result and forfeits only trailing
-      metadata.
+      metadata — on the chat lane the usage chunk trails the finish
+      reason, so that result may report usage=None and the call's spend
+      goes missing from usage accounting.
     - ``usage`` merges via :func:`merge_usage` — Anthropic splits prompt
       and completion tokens across separate events.
     - Tool calls accumulate by ``ToolCallDelta.index`` via
@@ -241,15 +245,14 @@ def drain_stream(chunks: Iterator[StreamChunk]) -> CompletionResult:
 
     Raises whatever the underlying stream raises — retry/deadline/fallback
     policy stays with the caller, exactly as with the old non-streaming
-    transport — EXCEPT httpx transport failures: streaming moves the body
-    read out of the SDK's ``APIConnectionError``-wrapped request into raw
-    iteration, so a mid-body connection drop or read timeout surfaces as a
-    bare ``httpx.TransportError`` no retry predicate recognizes.  Those
-    are re-raised (chained) as :class:`IncompleteStreamError`, restoring
-    the wire-blip retryability the non-streaming transport had.
+    transport — EXCEPT httpx transport failures, normalized by
+    :func:`transport_guarded` (the one conversion rule, shared with the
+    interactive loop): a mid-body death before the finish reason is
+    re-raised (chained) as :class:`IncompleteStreamError`, restoring the
+    wire-blip retryability the non-streaming transport had, and a
+    post-finish blip ends the stream cleanly so the completed result is
+    kept.
     """
-    import httpx  # noqa: PLC0415 — heavyweight; deferred off the type-module import path
-
     content_parts: list[str] = []
     reasoning_parts: list[str] = []
     trailing_info_parts: list[str] = []
@@ -258,32 +261,7 @@ def drain_stream(chunks: Iterator[StreamChunk]) -> CompletionResult:
     finish_reason: str | None = None
     provider_blocks: list[dict[str, Any]] = []
 
-    iterator = iter(chunks)
-    while True:
-        try:
-            sc = next(iterator)
-        except StopIteration:
-            break
-        except httpx.TransportError as exc:
-            if finish_reason is not None:
-                # The generation already completed (finish reason in hand);
-                # the blip only cost trailing metadata — a usage-only chunk
-                # or the citation footer.  Keep the complete result rather
-                # than discarding it for a retry that re-pays the tokens —
-                # but say so: on the chat lane the usage chunk trails the
-                # finish reason, so this result may report usage=None and
-                # the call's spend goes missing from usage accounting.
-                import structlog  # noqa: PLC0415 — deferred with httpx off the type-module path
-
-                structlog.get_logger(__name__).warning(
-                    "drain_stream.post_finish_blip",
-                    error_type=type(exc).__name__,
-                    usage_captured=usage is not None,
-                )
-                break
-            raise IncompleteStreamError(
-                f"stream transport failed mid-response ({type(exc).__name__}: {exc})"
-            ) from exc
+    for sc in transport_guarded(chunks):
         if sc.content_delta:
             content_parts.append(sc.content_delta)
         if sc.reasoning_delta:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -156,6 +156,53 @@ def accumulate_tool_call_delta(
     return tc
 
 
+def transport_guarded(chunks: Iterator[StreamChunk]) -> Iterator[StreamChunk]:
+    """Normalize mid-body transport deaths on a ``create_streaming`` iterator.
+
+    Streaming moves the body read out of the SDK's
+    ``APIConnectionError``-wrapped request into raw iteration, so a
+    mid-body wire death (connection drop, TLS record failure, read
+    timeout) surfaces as a bare ``httpx.TransportError`` no retry
+    predicate recognizes.  This wrapper is that conversion rule made
+    reusable for consumers that keep streaming semantics (the
+    interactive loop); :func:`drain_stream` applies the same rule for
+    the single-shot lanes.
+
+    - A ``TransportError`` BEFORE any finish reason re-raises (chained)
+      as the retryable :class:`IncompleteStreamError`.
+    - A ``TransportError`` AFTER a finish reason passed through ends the
+      stream cleanly: the generation already completed, and the blip
+      only cost trailing metadata (a usage-only chunk or the citation
+      footer) — logged as ``stream.post_finish_blip``.
+    - Everything else — chunks, exhaustion, non-transport exceptions —
+      passes through untouched.
+    """
+    import httpx  # noqa: PLC0415 — heavyweight; deferred off the type-module import path
+
+    finish_seen = False
+    iterator = iter(chunks)
+    while True:
+        try:
+            sc = next(iterator)
+        except StopIteration:
+            return
+        except httpx.TransportError as exc:
+            if finish_seen:
+                import structlog  # noqa: PLC0415 — deferred with httpx off the type-module path
+
+                structlog.get_logger(__name__).warning(
+                    "stream.post_finish_blip",
+                    error_type=type(exc).__name__,
+                )
+                return
+            raise IncompleteStreamError(
+                f"stream transport failed mid-response ({type(exc).__name__}: {exc})"
+            ) from exc
+        if sc.finish_reason:
+            finish_seen = True
+        yield sc
+
+
 def drain_stream(chunks: Iterator[StreamChunk]) -> CompletionResult:
     """Drain a ``create_streaming`` iterator into a ``CompletionResult``.
 

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -182,6 +182,7 @@ def transport_guarded(chunks: Iterator[StreamChunk]) -> Iterator[StreamChunk]:
     import httpx  # noqa: PLC0415 — heavyweight; deferred off the type-module import path
 
     finish_seen = False
+    usage_seen = False
     iterator = iter(chunks)
     while True:
         try:
@@ -192,9 +193,15 @@ def transport_guarded(chunks: Iterator[StreamChunk]) -> Iterator[StreamChunk]:
             if finish_seen:
                 import structlog  # noqa: PLC0415 — deferred with httpx off the type-module path
 
+                # usage_captured distinguishes "completed result kept but
+                # its spend went missing from usage accounting" (the chat
+                # lane's usage chunk trails the finish) from a harmless
+                # citation-footer loss — the one log signal that lets a
+                # missing-spend incident be attributed afterward.
                 structlog.get_logger(__name__).warning(
                     "stream.post_finish_blip",
                     error_type=type(exc).__name__,
+                    usage_captured=usage_seen,
                 )
                 return
             raise IncompleteStreamError(
@@ -202,6 +209,8 @@ def transport_guarded(chunks: Iterator[StreamChunk]) -> Iterator[StreamChunk]:
             ) from exc
         if sc.finish_reason:
             finish_seen = True
+        if sc.usage is not None:
+            usage_seen = True
         yield sc
 
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5304,10 +5304,14 @@ class ChatSession:
         # Frames only — ``exc_info=True`` would render the raw exception
         # message, which can carry credentials verbatim (the sanitize floor
         # the lines above exist to hold); format_tb renders the stack
-        # without the message.
+        # without the message.  ws + error_type mirror the ERROR line so a
+        # trace correlates to its session.fatal.recorded event under
+        # concurrent sessions.
         if exc.__traceback__ is not None:
             log.debug(
                 "session.fatal.recorded.trace",
+                ws=self._ws_id,
+                error_type=type(exc).__name__,
                 trace="".join(traceback.format_tb(exc.__traceback__)),
             )
         try:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1255,6 +1255,8 @@ def _coerce_event_id(value: Any) -> int | None:
 class SessionUI(Protocol):
     def on_turn_start(self) -> None: ...
     def on_turn_committed(self) -> None: ...
+
+    def on_stream_discarded(self) -> None: ...
     def on_thinking_start(self) -> None: ...
     def on_thinking_stop(self) -> None: ...
     def on_reasoning_token(self, text: str) -> None: ...
@@ -7423,6 +7425,15 @@ class ChatSession:
             # an idle session until the next send.  Restores the "None outside a
             # send" invariant on every exit (success, cancel, or error).
             self._wire_part_cache = None
+            # Send-scoped stream bookkeeping: the live-stream provider label
+            # must not leak into a LATER lane's fatal formatting (title/
+            # summary/task_agent fatals would otherwise wear a stale
+            # interactive binding), and the wire fold is a full-context-
+            # sized copy that must not outlive its calibration use above.
+            # Cleared HERE (after the except arms' _record_fatal_error ran,
+            # which is what reads the provider on the fatal path).
+            self._active_stream_provider = None
+            self._active_wire_msgs = None
             # Consume this generation's cancel signal on exit so a cancel that
             # targeted THIS send can't later abort an unrelated idle operation
             # (e.g. a manual /compact between sends would otherwise inherit the
@@ -7841,17 +7852,28 @@ class ChatSession:
                     attempt=attempt,
                     model=self.model,
                     retry_in=delay,
+                    # Spend trace for the abandoned generation: the wire
+                    # reports usage only at stream end, so a dead attempt's
+                    # billed tokens are otherwise invisible — dead_usage
+                    # carries what the wire DID deliver (Anthropic's early
+                    # prompt tokens; None on the OpenAI chat lane, whose
+                    # usage chunk trails the finish), and the char count
+                    # lets an operator estimate the discarded completion.
+                    dead_usage=self._last_usage,
+                    dead_content_chars=len(dead_partial),
                 )
                 # Finalize the dead attempt EVERYWHERE before re-streaming.
                 # Order matters: stream_end (client-side finalize — browser
                 # bubble, CLI markdown flush/fence reset, Slack/Discord
-                # StreamingMessage) -> turn_committed (server buffer reset —
-                # in_progress_snapshot, IDLE payload, turn-content cap) ->
-                # notice -> spinner for the backoff+recreate window.
-                # Without the pair every consumer appends the retried
-                # attempt's text onto the dead attempt's.
+                # StreamingMessage) -> stream_discarded (server buffers:
+                # the dead segment truncated from the multi-segment turn
+                # buffer the IDLE payload drains, pending batch dropped,
+                # inflight snapshot reset) -> notice -> spinner for the
+                # backoff+recreate window.  Without the pair every consumer
+                # appends the retried attempt's text onto the dead
+                # attempt's.
                 self.ui.on_stream_end()
-                self.ui.on_turn_committed()
+                self.ui.on_stream_discarded()
                 self.ui.on_info(
                     f"[stream died mid-response ({cause}) — retrying in "
                     f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -172,7 +172,11 @@ from turnstone.core.preview import (
     resolve_preview_kind,
     transcode_text,
 )
-from turnstone.core.providers import accumulate_tool_call_delta, create_provider
+from turnstone.core.providers import (
+    accumulate_tool_call_delta,
+    create_provider,
+    transport_guarded,
+)
 from turnstone.core.ratelimit import TokenBucket
 from turnstone.core.safety import is_command_blocked, sanitize_command
 from turnstone.core.settings_registry import DEFAULT_AUTO_COMPACT_PCT
@@ -1162,6 +1166,18 @@ _BACKEND_AUTH_EXC_NAMES: frozenset[str] = frozenset(
     {"AuthenticationError", "PermissionDeniedError"}
 )
 _BACKEND_RATE_LIMIT_EXC_NAMES: frozenset[str] = frozenset({"RateLimitError"})
+# Mid-response stream deaths: the normalized shape every guarded iterator
+# raises (``IncompleteStreamError`` from ``drain_stream`` /
+# ``transport_guarded``) plus the raw httpx names for any future unguarded
+# path (defense in depth).  Unioning them into ``_BACKEND_KNOWN_EXC_NAMES``
+# is required — ``_format_backend_error`` gates on that set before the
+# branch lookups — and makes these three names ineligible for
+# ``_is_ctx_overflow``'s text-based overflow detection (its class
+# self-gate): harmless, since their texts are fixed transport/SSL strings
+# that never carry overflow phrases.
+_BACKEND_STREAM_EXC_NAMES: frozenset[str] = frozenset(
+    {"IncompleteStreamError", "ReadError", "RemoteProtocolError"}
+)
 
 _BACKEND_KNOWN_EXC_NAMES: frozenset[str] = (
     _BACKEND_TIMEOUT_EXC_NAMES
@@ -1169,6 +1185,7 @@ _BACKEND_KNOWN_EXC_NAMES: frozenset[str] = (
     | _BACKEND_NOT_FOUND_EXC_NAMES
     | _BACKEND_AUTH_EXC_NAMES
     | _BACKEND_RATE_LIMIT_EXC_NAMES
+    | _BACKEND_STREAM_EXC_NAMES
 )
 
 
@@ -5246,6 +5263,19 @@ class ChatSession:
 
         raw = self._format_backend_error(exc) or f"{type(exc).__name__}: {exc}"
         safe = sanitize_error_text(raw)
+        # The one journal trace of a fatal turn — UI sinks and the config row
+        # are invisible to log scrapers.  Sanitized text only (same
+        # confidentiality floor as the sinks below).  KeyboardInterrupt routes
+        # through this chokepoint too; it is a user action, not a fault, so it
+        # logs at INFO instead of ERROR.
+        fatal_log = log.info if isinstance(exc, KeyboardInterrupt) else log.error
+        fatal_log(
+            "session.fatal.recorded",
+            ws=self._ws_id,
+            error_type=type(exc).__name__,
+            error=safe,
+        )
+        log.debug("session.fatal.recorded", exc_info=True)
         try:
             self.ui.on_error(safe)
         except Exception:
@@ -5448,6 +5478,15 @@ class ChatSession:
                 f"Backend rate-limited ({name}): {provider_label} "
                 f"at {base_url} (model={model_label})."
                 f"{raw_tail}"
+            )
+        if name in _BACKEND_STREAM_EXC_NAMES:
+            # First sentence kept short so Discord's message[:500] cut keeps
+            # the identity even when it loses the raw tail.
+            return (
+                f"Backend stream died mid-response ({name}): connection to "
+                f"{provider_label} at {base_url} dropped while model={model_label} "
+                f"was generating; retries did not recover it. Check "
+                f"network-path/TLS stability to the endpoint.{raw_tail}"
             )
         return None  # unreachable — `name` is in _BACKEND_KNOWN_EXC_NAMES by construction
 
@@ -5710,6 +5749,11 @@ class ChatSession:
 
     # Retryable error names are now provided by LLMProvider.retryable_error_names.
     _MAX_RETRIES = 3
+    # Mid-stream re-issues of the interactive turn after a wire death DURING
+    # body iteration (see _stream_response) — the consumer-side twin of
+    # model_turn's _DRAIN_RETRIES, distinct from the creation-time
+    # _MAX_RETRIES above.
+    _MID_STREAM_RETRIES = 2
     _RETRY_BASE_DELAY = 1.0  # seconds
 
     # Chunked-compaction tuning (see _summarize_blocks / _summary_input_budget_chars).
@@ -5821,15 +5865,24 @@ class ChatSession:
             self.ui.on_info(f"[Fallback {alias} also failed: {fb_err}]")
             return None
 
-    def _stop_retrying(self, exc: BaseException, attempt: int, provider: LLMProvider) -> bool:
-        """Terminal-retry predicate shared by every API retry loop (stream, summary,
-        task_agent): stop on a non-retryable error class, a deterministic
-        context-overflow (retrying an identical oversized payload is pointless), or
-        retry exhaustion."""
+    def _stop_retrying(
+        self,
+        exc: BaseException,
+        attempt: int,
+        provider: LLMProvider,
+        max_retries: int | None = None,
+    ) -> bool:
+        """Terminal-retry predicate shared by every API retry loop (stream
+        creation, summary, task_agent, mid-stream re-issue): stop on a
+        non-retryable error class, a deterministic context-overflow (retrying
+        an identical oversized payload is pointless), or ladder exhaustion.
+        *max_retries* overrides the creation ladder's ``_MAX_RETRIES`` for
+        loops with their own cap (``_MID_STREAM_RETRIES``)."""
+        cap = self._MAX_RETRIES if max_retries is None else max_retries
         return (
             type(exc).__name__ not in provider.retryable_error_names
             or _is_ctx_overflow(exc)
-            or attempt == self._MAX_RETRIES
+            or attempt == cap
         )
 
     def _try_stream(
@@ -6752,7 +6805,7 @@ class ChatSession:
                 self.ui.on_thinking_start()
                 try:
                     try:
-                        stream = self._create_stream_with_retry(msgs)
+                        assistant_msg = self._stream_response(msgs, my_generation)
                     except Exception as ctx_err:
                         # Context overflow recovery: if the API rejects the
                         # request due to exceeding the context window, compact
@@ -6776,14 +6829,13 @@ class ChatSession:
                             self._compact_messages(auto=True, my_generation=my_generation)
                             msgs = self._prepare_wire_messages(self._full_messages())
                             self.ui.on_thinking_start()
-                            stream = self._create_stream_with_retry(msgs)
+                            assistant_msg = self._stream_response(msgs, my_generation)
                         except Exception:
                             log.warning(
                                 "Compact-and-retry failed, raising original error",
                                 exc_info=True,
                             )
                             raise ctx_err from None
-                    assistant_msg = self._stream_response(stream, my_generation)
                 finally:
                     # Only clear if this generation is still active —
                     # an orphaned thread must not clobber a newer stream.
@@ -7255,7 +7307,7 @@ class ChatSession:
             # flagged ("…cannot simultaneously guarantee Consistency,"
             # surfaced as if it were a complete sentence).
             if self._cancelled_partial_msg:
-                # _stream_response was interrupted — save partial
+                # _stream_attempt was interrupted — save partial
                 # assistant msg.  Two shapes:
                 #
                 # - Some text streamed before cancel: append the
@@ -7601,16 +7653,110 @@ class ChatSession:
                 text = text[:start] + text[end + len(close_t) :] if end != -1 else text[:start]
         return text.strip()
 
+    def _stream_response(
+        self, msgs: list[dict[str, Any]], my_generation: int = 0
+    ) -> dict[str, Any]:
+        """Run one resilient streaming turn: acquire, consume, re-issue on death.
+
+        The single-pass consumer is :meth:`_stream_attempt`; this wrapper
+        owns ALL stream acquisition — first attempt included — so every
+        attempt's stream comes from the same seam and callers hand over
+        wire-ready *msgs*, never a stream.  A wire death DURING body
+        iteration surfaces after the request already returned its stream
+        handle, so neither the SDK's ``max_retries`` nor the creation-time
+        ``_try_stream`` ladder ever sees it.  ``transport_guarded``
+        normalizes those deaths to the retryable ``IncompleteStreamError``;
+        this loop finalizes the dead attempt in every UI consumer, then
+        re-issues the whole turn (the APIs cannot resume a generation) up
+        to ``_MID_STREAM_RETRIES`` times.
+
+        Ladder stacking: a 3-way stack — each re-issue runs the full
+        creation ladder, itself the ``_MAX_RETRIES`` loop times the
+        fallback-chain walk, so a persistently transient-shaped failure
+        burns (_MID_STREAM_RETRIES + 1) x ((_MAX_RETRIES + 1) + fallback
+        passes) calls before the terminal error surfaces.  Both inner
+        layers are the pre-existing creation path (task_agent's
+        ``_api_call`` documents the equivalent 2-way stack); only the
+        outer factor is new, and every layer stops immediately on a
+        non-retryable class.
+        """
+        attempt = 0
+        stream = self._create_stream_with_retry(msgs)
+        while True:
+            try:
+                return self._stream_attempt(transport_guarded(stream), my_generation)
+            # GenerationCancelled subclasses BaseException, so this arm
+            # structurally cannot swallow the cancel path.
+            except Exception as e:
+                # self._provider, not a creation-time local: after
+                # _try_fallback the live stream belongs to the fallback
+                # provider (the sets overlap on IncompleteStreamError, so
+                # the gate is correct either way — but read the session's
+                # current binding).  The terminal predicate is the SHARED
+                # _stop_retrying, capped at _MID_STREAM_RETRIES: its
+                # overflow arm applies here too — an overflow can surface
+                # mid-consumption (error-frame lanes), and it must fall
+                # through to send()'s compact-and-retry arm rather than
+                # burn re-issues on a deterministic failure.
+                if self._generation != my_generation or self._stop_retrying(
+                    e, attempt, self._provider, max_retries=self._MID_STREAM_RETRIES
+                ):
+                    raise  # fatal path unchanged
+                attempt += 1
+                cause = type(e.__cause__).__name__ if e.__cause__ else type(e).__name__
+                delay = self._RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                log.warning(
+                    "stream.retry",
+                    error_type=cause,
+                    attempt=attempt,
+                    model=self.model,
+                    retry_in=delay,
+                )
+                # Finalize the dead attempt EVERYWHERE before re-streaming.
+                # Order matters: stream_end (client-side finalize — browser
+                # bubble, CLI markdown flush/fence reset, Slack/Discord
+                # StreamingMessage) -> turn_committed (server buffer reset —
+                # in_progress_snapshot, IDLE payload, turn-content cap) ->
+                # notice -> spinner for the backoff+recreate window.
+                # Without the pair every consumer appends the retried
+                # attempt's text onto the dead attempt's.
+                self.ui.on_stream_end()
+                self.ui.on_turn_committed()
+                self.ui.on_info(
+                    f"[stream died mid-response ({cause}) — retrying in "
+                    f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"
+                )
+                self.ui.on_thinking_start()
+                self._backoff_or_cancelled(delay, my_generation)
+                self._cancel_stream = None  # drop the dead SDK handle
+                # A concurrent ModelRegistry.reload() closes cached clients
+                # whose connection config changed — the in-flight read then
+                # dies with a ReadError and self.client is CLOSED.  The
+                # refresh is generation-gated (two compares when nothing
+                # changed), so this is free in the common case and re-binds
+                # exactly when reload made the old client unusable.
+                self._refresh_model_from_registry()
+                try:
+                    stream = self._create_stream_with_retry(msgs)
+                except Exception:
+                    # The re-create's failure must not mask the true
+                    # stream-death error: a closed-client recreate surfaces
+                    # as a retryable APIConnectionError and would otherwise
+                    # replace the operator-actionable wording after burning
+                    # its own ladder.
+                    log.warning("stream.retry.recreate_failed", exc_info=True)
+                    raise e from None
+
     # Tags that delimit reasoning blocks in content stream.
     # Checked in order; first match wins.
     _THINK_OPEN_TAGS = ("<think>", "<reasoning>")
     _THINK_CLOSE_TAGS = ("</think>", "</reasoning>")
     _MAX_TAG_LEN = max(len(t) for t in _THINK_OPEN_TAGS + _THINK_CLOSE_TAGS)
 
-    def _stream_response(
+    def _stream_attempt(
         self, stream: Iterator[StreamChunk], my_generation: int = 0
     ) -> dict[str, Any]:
-        """Stream response, dispatching tokens to the UI as they arrive.
+        """Consume ONE streaming attempt, dispatching tokens to the UI live.
 
         Handles two reasoning delivery mechanisms:
         1. The `reasoning_delta` field (e.g. vLLM with --reasoning-parser)
@@ -7619,12 +7765,22 @@ class ChatSession:
         Calls self.ui.on_thinking_stop() on the first received delta.
 
         Returns the complete assistant message as a dict suitable for
-        appending to self.messages.
+        appending to self.messages.  Single-pass by contract: the
+        acquisition + mid-stream-retry wrapper is :meth:`_stream_response`,
+        which hands this method a ``transport_guarded`` iterator per
+        attempt.
         """
         # Reset so this API call captures fresh usage — prevents stale
         # completion_tokens from a prior tool-chain iteration leaking
-        # through the max() accumulator.
+        # through the max() accumulator.  _assistant_pending_tokens is the
+        # same staleness one hop later: a post-finish transport blip
+        # (transport_guarded's tolerance) can end this stream with the
+        # trailing usage chunk lost, and _update_token_table's falsy-usage
+        # early-return would then leave the PREVIOUS turn's completion
+        # count to be appended as this turn's estimate by send()'s
+        # `_assistant_pending_tokens or ...` fallback.
         self._last_usage = None
+        self._assistant_pending_tokens = 0
 
         content_parts: list[str] = []
         reasoning_parts: list[str] = []

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1897,15 +1897,14 @@ class ChatSession:
         # the model detached on purpose.  close() reaps everything.
         self._background_shells = BackgroundShellRegistry(on_exit=self._on_background_shell_exit)
         self._cancelled_partial_msg: dict[str, Any] | None = None
-        # The provider that created the LIVE stream (primary or fallback) —
-        # the mid-stream retry gate consults ITS retryable set, and the
-        # fatal formatter labels errors with it.  Best-effort under
-        # supersede races; None falls back to the primary binding.
+        # Creation-time HANDOFF REGISTER: _try_stream stamps the provider
+        # that owns the stream it is about to return (fallback walk
+        # included), and _stream_response copies it into a frame local
+        # immediately after each create returns.  Nothing else reads it —
+        # a late read would race a superseding generation's creation — and
+        # it is deliberately never cleared (stale values are unreachable
+        # by construction).
         self._active_stream_provider: LLMProvider | None = None
-        # The wire-message fold the live stream was actually created from —
-        # a mid-retry rebind re-prepares it, and send()'s token-table
-        # calibration must count the fold the provider counted.
-        self._active_wire_msgs: list[dict[str, Any]] | None = None
         self._pending_retry: str | None = None
         # True when a fatal exception's text has been persisted to
         # workstream_config["last_error"] for the coord's inspect/wait
@@ -3945,7 +3944,7 @@ class ChatSession:
             # tag from lanes that pre-inject the opening ``<think>`` into the
             # prompt (only ``</think>`` reaches ``content``). See ``_TITLE_*``.
             stripped = self._strip_reasoning(raw)
-            for _close in ("</think>", "</reasoning>"):
+            for _close in ThinkTagSplitter.CLOSE_TAGS:
                 _pos = stripped.rfind(_close)
                 if _pos != -1:
                     stripped = stripped[_pos + len(_close) :]
@@ -5461,12 +5460,12 @@ class ChatSession:
             log.debug("session.fatal.base_url_lookup_failed", exc_info=True)
         provider_label = "?"
         try:
-            # Prefer the provider that actually owned the live stream — a
-            # fallback-carried turn's failure must not be labeled with the
-            # primary binding it never touched.  getattr: this helper is
-            # bound to lightweight stubs in tests (see the module-scope
-            # note on the _BACKEND_* sets) that predate the field.
-            prov = getattr(self, "_active_stream_provider", None) or self._provider
+            # The PRIMARY binding, deliberately: base_url and model_label
+            # above come from the primary too, and a mixed identity (a
+            # fallback's provider name over the primary's URL and alias)
+            # sends the operator to debug the wrong backend.  Stamping the
+            # full producing identity onto turns/errors is #964.
+            prov = self._provider
             provider_label = (
                 getattr(prov, "provider_name", None) or type(prov).__name__ if prov else "?"
             )
@@ -6907,11 +6906,16 @@ class ChatSession:
                 # (perf-2); passing the already-prepared list keeps the
                 # calibration char count aligned with what the provider
                 # actually counted.
-                # The wire fold the provider ACTUALLY counted — a mid-retry
-                # rebind re-prepares it inside _stream_response, invisibly
-                # to this frame's msgs local (the calibration contract:
-                # char counts align with the counted fold).
-                self._update_token_table(assistant_msg, msgs=self._active_wire_msgs or msgs)
+                # The wire fold the provider ACTUALLY counted rides the
+                # returned message (a mid-retry rebind re-prepares it
+                # inside _stream_response, invisibly to this frame's msgs
+                # local) — popped BEFORE the message is committed so the
+                # carrier key never persists.  Frame-owned, so a
+                # superseding generation cannot alias it; plain-dict fakes
+                # without the key fall through to the frame-local fold.
+                self._update_token_table(
+                    assistant_msg, msgs=assistant_msg.pop("_wire_msgs", None) or msgs
+                )
                 self._print_status_line()  # Report usage for EVERY API call
                 self.messages.append(turn_from_dict(assistant_msg))
                 # Clear per-turn inflight buffers — the assistant
@@ -7409,12 +7413,23 @@ class ChatSession:
             # Do NOT re-raise — return normally so server worker thread
             # completes cleanly.
         except KeyboardInterrupt as exc:
+            if self._generation != my_generation:
+                raise  # orphaned: no history mutation or fatal over the live turn
             self._synthesize_cancelled_results("Interrupted by user.")
             self._flush_queued_messages()
             self._drain_pending_advisories()
             self._record_fatal_error(exc)
             raise
         except Exception as exc:
+            # Orphan gate: a superseded thread's stream death can escape
+            # cancel conversion (the successor replaced the cancel event
+            # before the blocked read died) and reach here — recording it
+            # would flash an error banner over the HEALTHY successor turn,
+            # wipe its buffers via the error-state drain, and persist a
+            # wrong last_error for the coord's inspect/wait.  The wrapper's
+            # orphan arm re-raises for exactly this gate to absorb.
+            if self._generation != my_generation:
+                raise
             self._flush_queued_messages()
             self._drain_pending_advisories()
             self._record_fatal_error(exc)
@@ -7425,15 +7440,6 @@ class ChatSession:
             # an idle session until the next send.  Restores the "None outside a
             # send" invariant on every exit (success, cancel, or error).
             self._wire_part_cache = None
-            # Send-scoped stream bookkeeping: the live-stream provider label
-            # must not leak into a LATER lane's fatal formatting (title/
-            # summary/task_agent fatals would otherwise wear a stale
-            # interactive binding), and the wire fold is a full-context-
-            # sized copy that must not outlive its calibration use above.
-            # Cleared HERE (after the except arms' _record_fatal_error ran,
-            # which is what reads the provider on the fatal path).
-            self._active_stream_provider = None
-            self._active_wire_msgs = None
             # Consume this generation's cancel signal on exit so a cancel that
             # targeted THIS send can't later abort an unrelated idle operation
             # (e.g. a manual /compact between sends would otherwise inherit the
@@ -7709,11 +7715,16 @@ class ChatSession:
 
     @staticmethod
     def _strip_reasoning(text: str) -> str:
-        """Remove <think>/<reasoning> tags and their content."""
-        for open_t, close_t in [
-            ("<think>", "</think>"),
-            ("<reasoning>", "</reasoning>"),
-        ]:
+        """Remove think-tag blocks and their content.
+
+        The tag vocabulary is ThinkTagSplitter's — deriving it keeps this
+        strip (and the title lane's) from going blind when a variant is
+        added to the splitter, which would leak raw chain-of-thought into
+        compaction summaries.
+        """
+        for open_t, close_t in zip(
+            ThinkTagSplitter.OPEN_TAGS, ThinkTagSplitter.CLOSE_TAGS, strict=True
+        ):
             while open_t in text:
                 start = text.find(open_t)
                 end = text.find(close_t, start)
@@ -7778,14 +7789,25 @@ class ChatSession:
                     "content": dead_partial,
                 }
 
-        # Exported for send()'s token-table calibration — the char count
-        # must match the fold the provider actually counted, and a
-        # mid-retry rebind can re-prepare it below.
-        self._active_wire_msgs = msgs
         stream = self._create_stream_with_retry(msgs)
+        # FRAME-LOCAL copy of the creation-time handoff register, taken
+        # immediately after the create returns: the retry gate must judge a
+        # death by the provider that owns THIS stream (a fallback's set can
+        # differ), and reading the shared register later would race a
+        # superseding generation's own creation.
+        live_provider = self._active_stream_provider or self._provider
         while True:
             try:
-                return self._stream_attempt(transport_guarded(stream), my_generation)
+                result = self._stream_attempt(transport_guarded(stream), my_generation)
+                # The fold this turn was ACTUALLY created from rides the
+                # returned message (popped by send() at calibration, before
+                # commit — the message-dict underscore lane, like
+                # _provider_content): a mid-retry rebind re-prepares msgs,
+                # and send()'s frame-local copy cannot see that.  Carried on
+                # the frame-owned dict rather than a session slot so a
+                # superseding generation can never alias it.
+                result["_wire_msgs"] = msgs
+                return result
             except GenerationCancelled:
                 # A Stop during an attempt (incl. the re-create/TTFT window
                 # after a death) — preserve the window's best partial.
@@ -7811,16 +7833,11 @@ class ChatSession:
                     # emitted here would clobber the NEW generation's
                     # in-flight stream state.
                     raise
-                # The provider whose stream actually died: after
-                # _try_fallback the live stream belongs to the FALLBACK
-                # provider, whose retryable set can differ (e.g.
-                # ResponsesStreamFailedError) — judging it by the primary
-                # binding's set would declare fallback transients terminal.
-                # Best-effort field (a racing creation could re-write it);
-                # at worst one gate decision consults a sibling set.
-                live_provider = self._active_stream_provider or self._provider
                 # The terminal predicate is the SHARED _stop_retrying,
-                # capped at _MID_STREAM_RETRIES: its overflow arm applies
+                # capped at _MID_STREAM_RETRIES, judged by the FRAME-LOCAL
+                # live_provider (the provider that owns this stream — a
+                # fallback's retryable set can differ, e.g.
+                # ResponsesStreamFailedError).  The overflow arm applies
                 # here too — an overflow can surface mid-consumption
                 # (error-frame lanes), and it must fall through to send()'s
                 # compact-and-retry arm rather than burn re-issues on a
@@ -7828,18 +7845,16 @@ class ChatSession:
                 if self._stop_retrying(
                     e, attempt, live_provider, max_retries=self._MID_STREAM_RETRIES
                 ):
-                    # Terminal: client-side finalize only (the CLI's
-                    # markdown fence resets in on_stream_end; the server
-                    # /send workers emit their own after a fatal, the
-                    # CLI's direct send() does not).  on_turn_committed is
-                    # DELIBERATELY absent here, unlike the retry arm
-                    # below: the dead partial is in neither history nor
-                    # storage, so the in-progress snapshot is its only
-                    # surviving copy — wiping it would silently lose
-                    # visible text on the most reconnect-prone path.  It
-                    # clears at the next send, the pre-#937 fatal
-                    # behavior.
+                    # Terminal: finalize AND discard, exactly like the
+                    # retry arm.  Keeping the buffers bought nothing — the
+                    # fatal path's _emit_state("error") drains and wipes
+                    # them anyway on every SessionUIBase lane — and an
+                    # overflow that send()'s compact-and-retry RECOVERS
+                    # re-streams into buffers that would otherwise still
+                    # hold the dead attempt's text, concatenating the two
+                    # in the idle payload.
                     self.ui.on_stream_end()
+                    self.ui.on_stream_discarded()
                     raise  # fatal path otherwise unchanged
                 # Delay from the PRE-increment attempt index — the same
                 # convention as the three sibling ladders' range loops.
@@ -7878,13 +7893,10 @@ class ChatSession:
                     f"[stream died mid-response ({cause}) — retrying in "
                     f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"
                 )
-                # Stop-then-start: a pre-first-token death leaves the
-                # spinner RUNNING (_stop_spinner_once never fired), and the
-                # CLI's on_thinking_start is not idempotent — it replaces
-                # the spinner object without stopping the old one, leaking
-                # its render thread (the compact-retry arm guards the same
-                # way).
-                self.ui.on_thinking_stop()
+                # A pre-first-token death leaves the spinner RUNNING
+                # (_stop_spinner_once never fired) — on_thinking_start is
+                # idempotent at the callee (TerminalUI stops a live spinner
+                # before replacing it), so no stop-first dance here.
                 self.ui.on_thinking_start()
                 try:
                     self._backoff_or_cancelled(delay, my_generation)
@@ -7909,9 +7921,12 @@ class ChatSession:
                         # client-identity check alone would re-issue the
                         # old model's fold against the new model.
                         msgs = self._prepare_wire_messages(self._full_messages())
-                        self._active_wire_msgs = msgs
                     try:
                         stream = self._create_stream_with_retry(msgs)
+                        # Refresh the frame-local gate identity: the
+                        # re-create may have walked to a different
+                        # provider (fallback, rebind).
+                        live_provider = self._active_stream_provider or self._provider
                     except Exception as recreate_exc:
                         if _is_ctx_overflow(recreate_exc):
                             # Deterministic — surface as ITSELF so send()'s

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -190,6 +190,7 @@ from turnstone.core.storage._utils import (
     attachment_to_content_part,
     normalize_search_terms,
 )
+from turnstone.core.streaming_text import ThinkTagSplitter
 from turnstone.core.tool_advisory import (
     make_system_turn,
     render_output_guard_text,
@@ -7748,12 +7749,6 @@ class ChatSession:
                     log.warning("stream.retry.recreate_failed", exc_info=True)
                     raise e from None
 
-    # Tags that delimit reasoning blocks in content stream.
-    # Checked in order; first match wins.
-    _THINK_OPEN_TAGS = ("<think>", "<reasoning>")
-    _THINK_CLOSE_TAGS = ("</think>", "</reasoning>")
-    _MAX_TAG_LEN = max(len(t) for t in _THINK_OPEN_TAGS + _THINK_CLOSE_TAGS)
-
     def _stream_attempt(
         self, stream: Iterator[StreamChunk], my_generation: int = 0
     ) -> dict[str, Any]:
@@ -7789,9 +7784,7 @@ class ChatSession:
         provider_blocks: list[dict[str, Any]] = []
         usage_acc: UsageInfo | None = None
         first_token = True
-        in_think = False  # inside a <think>...</think> block
         path1_reasoning = False  # last reasoning came via reasoning_delta field
-        pending = ""  # buffer for partial tag detection
 
         def _flush_text(text: str, is_reasoning: bool) -> None:
             """Dispatch text to the appropriate UI callback."""
@@ -7805,53 +7798,9 @@ class ChatSession:
                 content_parts.append(text)
                 self.ui.on_content_token(text)
 
-        def _drain_pending() -> None:
-            """Process the pending buffer, flushing content and detecting tags."""
-            nonlocal pending, in_think
-
-            while pending:
-                if in_think:
-                    # Look for any close tag
-                    best_idx, best_tag = None, None
-                    for tag in self._THINK_CLOSE_TAGS:
-                        idx = pending.find(tag)
-                        if idx != -1 and (best_idx is None or idx < best_idx):
-                            best_idx, best_tag = idx, tag
-
-                    if best_idx is not None:
-                        assert best_tag is not None
-                        _flush_text(pending[:best_idx], True)
-                        pending = pending[best_idx + len(best_tag) :]
-                        in_think = False
-                        continue
-
-                    # No close tag found — check if tail could be a partial tag
-                    safe = len(pending) - self._MAX_TAG_LEN
-                    if safe > 0:
-                        _flush_text(pending[:safe], True)
-                        pending = pending[safe:]
-                    break
-                else:
-                    # Look for any open tag
-                    best_idx, best_tag = None, None
-                    for tag in self._THINK_OPEN_TAGS:
-                        idx = pending.find(tag)
-                        if idx != -1 and (best_idx is None or idx < best_idx):
-                            best_idx, best_tag = idx, tag
-
-                    if best_idx is not None:
-                        assert best_tag is not None
-                        _flush_text(pending[:best_idx], False)
-                        pending = pending[best_idx + len(best_tag) :]
-                        in_think = True
-                        continue
-
-                    # No open tag found — flush all but potential partial tag
-                    safe = len(pending) - self._MAX_TAG_LEN
-                    if safe > 0:
-                        _flush_text(pending[:safe], False)
-                        pending = pending[safe:]
-                    break
+        # Owns the partial-tag carry buffer and the in-think state;
+        # dispatch stays here in _flush_text.
+        splitter = ThinkTagSplitter(_flush_text)
 
         def _stop_spinner_once() -> None:
             """Stop the spinner on first real content. Call is idempotent."""
@@ -7878,8 +7827,7 @@ class ChatSession:
               appends to ``content``, hiding the partial-output signal
               from the model.
             """
-            if pending:
-                _flush_text(pending, in_think)
+            splitter.flush_pending()
             self.ui.on_stream_end()
             partial: dict[str, Any] = {"role": "assistant"}
             partial["content"] = "".join(content_parts) or ""
@@ -7930,7 +7878,7 @@ class ChatSession:
                 if chunk.reasoning_delta:
                     _stop_spinner_once()
                     reasoning_parts.append(chunk.reasoning_delta)
-                    in_think = True
+                    splitter.in_think = True
                     path1_reasoning = True
                     if self.show_reasoning:
                         self.ui.on_reasoning_token(chunk.reasoning_delta)
@@ -7941,21 +7889,18 @@ class ChatSession:
                     # Close reasoning if transitioning from Path 1 reasoning
                     if path1_reasoning:
                         path1_reasoning = False
-                        in_think = False
-                    pending += chunk.content_delta
-                    _drain_pending()
+                        splitter.in_think = False
+                    splitter.feed(chunk.content_delta)
 
                 # Handle tool call deltas
                 if chunk.tool_call_deltas:
                     _stop_spinner_once()
                     # Flush any buffered content — model has moved to tool calls,
                     # so pending text cannot be a partial <think> tag.
-                    if pending:
-                        _flush_text(pending, in_think)
-                        pending = ""
+                    splitter.flush_pending()
                     # Close reasoning if transitioning from reasoning
-                    if in_think:
-                        in_think = False
+                    if splitter.in_think:
+                        splitter.in_think = False
                     for tcd in chunk.tool_call_deltas:
                         # THE tool-call merge rule, shared with drain_stream
                         # and the Google raw-fidelity capture — the chat
@@ -7985,8 +7930,7 @@ class ChatSession:
             raise
 
         # Flush any remaining buffered text
-        if pending:
-            _flush_text(pending, in_think)
+        splitter.flush_pending()
 
         # Warn on non-standard finish reasons
         if finish_reason == "length":

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -5463,8 +5463,7 @@ class ChatSession:
             # The PRIMARY binding, deliberately: base_url and model_label
             # above come from the primary too, and a mixed identity (a
             # fallback's provider name over the primary's URL and alias)
-            # sends the operator to debug the wrong backend.  Stamping the
-            # full producing identity onto turns/errors is #964.
+            # sends the operator to debug the wrong backend.
             prov = self._provider
             provider_label = (
                 getattr(prov, "provider_name", None) or type(prov).__name__ if prov else "?"
@@ -7826,7 +7825,8 @@ class ChatSession:
                 # _stream_attempt's death arm).  Keep the previous
                 # attempt's text when the new death had none — the user
                 # saw it, and a later Stop must preserve it.
-                dead_partial = getattr(e, "_dead_partial", "") or dead_partial
+                new_dead = getattr(e, "_dead_partial", "")
+                dead_partial = new_dead or dead_partial
                 if self._generation != my_generation:
                     # Superseded (force-cancel started a newer generation):
                     # an orphaned thread must not touch the UI — a finalize
@@ -7874,32 +7874,41 @@ class ChatSession:
                     # prompt tokens; None on the OpenAI chat lane, whose
                     # usage chunk trails the finish), and the char count
                     # lets an operator estimate the discarded completion.
+                    # THIS death's flushed text only — a pre-token re-death
+                    # logs 0, never the Stop-preservation carry from a
+                    # prior attempt (that would double-count spend).
                     dead_usage=self._last_usage,
-                    dead_content_chars=len(dead_partial),
+                    dead_content_chars=len(new_dead),
                 )
-                # Finalize the dead attempt EVERYWHERE before re-streaming.
-                # Order matters: stream_end (client-side finalize — browser
-                # bubble, CLI markdown flush/fence reset, Slack/Discord
-                # StreamingMessage) -> stream_discarded (server buffers:
-                # the dead segment truncated from the multi-segment turn
-                # buffer the IDLE payload drains, pending batch dropped,
-                # inflight snapshot reset) -> notice -> spinner for the
-                # backoff+recreate window.  Without the pair every consumer
-                # appends the retried attempt's text onto the dead
-                # attempt's.
+                # Finalize the dead attempt client-side, then WAIT before
+                # discarding: stream_end (browser bubble, CLI markdown
+                # flush/fence reset, Slack/Discord StreamingMessage) ->
+                # notice -> backoff.  The server-buffer discard runs only
+                # AFTER the backoff survives the Stop window — a Stop
+                # during backoff persists the promoted partial to history,
+                # and the idle payload (drained from the turn buffer)
+                # must carry the same text, or the dashboard renders the
+                # cancelled turn empty while the transcript has it.
                 self.ui.on_stream_end()
-                self.ui.on_stream_discarded()
                 self.ui.on_info(
                     f"[stream died mid-response ({cause}) — retrying in "
                     f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"
                 )
-                # A pre-first-token death leaves the spinner RUNNING
-                # (_stop_spinner_once never fired) — on_thinking_start is
-                # idempotent at the callee (TerminalUI stops a live spinner
-                # before replacing it), so no stop-first dance here.
-                self.ui.on_thinking_start()
                 try:
                     self._backoff_or_cancelled(delay, my_generation)
+                    # Retry is proceeding: truncate the dead segment from
+                    # the multi-segment turn buffer (the IDLE payload's
+                    # source) and reset the inflight snapshot BEFORE any
+                    # retried token lands, or every consumer appends the
+                    # retried text onto the dead attempt's.
+                    self.ui.on_stream_discarded()
+                    # Spinner for the recreate+TTFT window, and the fresh
+                    # segment watermark — AFTER the truncate, so a later
+                    # discard cannot resurrect this dead segment.  A
+                    # pre-first-token death leaves the spinner RUNNING
+                    # (_stop_spinner_once never fired) — on_thinking_start
+                    # is idempotent at the callee.
+                    self.ui.on_thinking_start()
                     self._cancel_stream = None  # drop the dead SDK handle
                     # A concurrent ModelRegistry.reload() closes cached
                     # clients whose connection config changed — the

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -30,6 +30,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import traceback
 import uuid
 from datetime import UTC, datetime
 from html import escape as _html_escape
@@ -1893,6 +1894,11 @@ class ChatSession:
         # the model detached on purpose.  close() reaps everything.
         self._background_shells = BackgroundShellRegistry(on_exit=self._on_background_shell_exit)
         self._cancelled_partial_msg: dict[str, Any] | None = None
+        # The most recent dead attempt's flushed content, stashed by
+        # _stream_attempt's non-cancel death arm so the resilient wrapper
+        # can preserve it when a cancel lands in the retry window (a Stop
+        # during backoff must not vaporize text the user already saw).
+        self._midstream_dead_partial: str = ""
         self._pending_retry: str | None = None
         # True when a fatal exception's text has been persisted to
         # workstream_config["last_error"] for the coord's inspect/wait
@@ -5277,7 +5283,15 @@ class ChatSession:
             error_type=type(exc).__name__,
             error=safe,
         )
-        log.debug("session.fatal.recorded", exc_info=True)
+        # Frames only — ``exc_info=True`` would render the raw exception
+        # message, which can carry credentials verbatim (the sanitize floor
+        # the lines above exist to hold); format_tb renders the stack
+        # without the message.
+        if exc.__traceback__ is not None:
+            log.debug(
+                "session.fatal.recorded.trace",
+                trace="".join(traceback.format_tb(exc.__traceback__)),
+            )
         try:
             self.ui.on_error(safe)
         except Exception:
@@ -7700,10 +7714,26 @@ class ChatSession:
                 # mid-consumption (error-frame lanes), and it must fall
                 # through to send()'s compact-and-retry arm rather than
                 # burn re-issues on a deterministic failure.
-                if self._generation != my_generation or self._stop_retrying(
+                if self._generation != my_generation:
+                    # Superseded (force-cancel started a newer generation):
+                    # an orphaned thread must not touch the UI — a finalize
+                    # emitted here would clobber the NEW generation's
+                    # in-flight stream state.
+                    raise
+                if self._stop_retrying(
                     e, attempt, self._provider, max_retries=self._MID_STREAM_RETRIES
                 ):
-                    raise  # fatal path unchanged
+                    # Terminal: finalize the dead attempt exactly as the
+                    # retry path below does, or the last attempt's partial
+                    # stays un-flushed in every consumer — the CLI is the
+                    # sharp case (its markdown fence state resets only in
+                    # on_stream_end; the server /send workers emit their own
+                    # stream_end after a fatal, the CLI's direct send() does
+                    # not).  An attempt that died before its first token
+                    # finalizes empty buffers, which no-ops everywhere.
+                    self.ui.on_stream_end()
+                    self.ui.on_turn_committed()
+                    raise  # fatal path otherwise unchanged
                 attempt += 1
                 cause = type(e.__cause__).__name__ if e.__cause__ else type(e).__name__
                 delay = self._RETRY_BASE_DELAY * (2 ** (attempt - 1))
@@ -7729,25 +7759,55 @@ class ChatSession:
                     f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"
                 )
                 self.ui.on_thinking_start()
-                self._backoff_or_cancelled(delay, my_generation)
-                self._cancel_stream = None  # drop the dead SDK handle
-                # A concurrent ModelRegistry.reload() closes cached clients
-                # whose connection config changed — the in-flight read then
-                # dies with a ReadError and self.client is CLOSED.  The
-                # refresh is generation-gated (two compares when nothing
-                # changed), so this is free in the common case and re-binds
-                # exactly when reload made the old client unusable.
-                self._refresh_model_from_registry()
                 try:
-                    stream = self._create_stream_with_retry(msgs)
-                except Exception:
-                    # The re-create's failure must not mask the true
-                    # stream-death error: a closed-client recreate surfaces
-                    # as a retryable APIConnectionError and would otherwise
-                    # replace the operator-actionable wording after burning
-                    # its own ladder.
-                    log.warning("stream.retry.recreate_failed", exc_info=True)
-                    raise e from None
+                    self._backoff_or_cancelled(delay, my_generation)
+                    self._cancel_stream = None  # drop the dead SDK handle
+                    # A concurrent ModelRegistry.reload() closes cached
+                    # clients whose connection config changed — the
+                    # in-flight read then dies with a ReadError and
+                    # self.client is CLOSED.  The refresh is
+                    # generation-gated (two compares when nothing changed),
+                    # so this is free in the common case and re-binds
+                    # exactly when reload made the old client unusable.
+                    client_before = self.client
+                    self._refresh_model_from_registry()
+                    if self.client is not client_before:
+                        # The rebind may have changed the model family, and
+                        # the wire fold is capability-sensitive
+                        # (fold_system_turns) — re-prepare against the new
+                        # binding, the same pass the overflow arm runs
+                        # mid-send.  Identity compare: _bind_model_from_
+                        # registry replaces the client object on any
+                        # connection-relevant change.
+                        msgs = self._prepare_wire_messages(self._full_messages())
+                    try:
+                        stream = self._create_stream_with_retry(msgs)
+                    except Exception as recreate_exc:
+                        # The re-create's failure must not mask the true
+                        # stream-death error: a closed-client recreate
+                        # surfaces as a retryable APIConnectionError and
+                        # would otherwise replace the operator-actionable
+                        # wording after burning its own ladder.  Class name
+                        # only — a ConnectError's text can carry a
+                        # credential-bearing base_url verbatim.
+                        log.warning(
+                            "stream.retry.recreate_failed",
+                            error_type=type(recreate_exc).__name__,
+                        )
+                        raise e from None
+                except GenerationCancelled:
+                    # A Stop landing in the backoff/re-create window aborts
+                    # the turn with the dead attempt's partial preserved —
+                    # the same disposition a cancel DURING the attempt gets
+                    # (send()'s cancel handler persists it with the
+                    # cancellation marker).  Without this, cancel-in-backoff
+                    # silently drops text the user already saw.
+                    if self._midstream_dead_partial:
+                        self._cancelled_partial_msg = {
+                            "role": "assistant",
+                            "content": self._midstream_dead_partial,
+                        }
+                    raise
 
     def _stream_attempt(
         self, stream: Iterator[StreamChunk], my_generation: int = 0
@@ -7777,6 +7837,7 @@ class ChatSession:
         # `_assistant_pending_tokens or ...` fallback.
         self._last_usage = None
         self._assistant_pending_tokens = 0
+        self._midstream_dead_partial = ""
 
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
@@ -7927,6 +7988,16 @@ class ChatSession:
             if self._cancel_event.is_set():
                 _record_cancelled_partial()
                 raise GenerationCancelled() from None
+            # A non-cancel death: stash the flushed partial so the resilient
+            # wrapper can preserve it if a cancel lands in the retry window
+            # (its backoff arm promotes the stash to _cancelled_partial_msg).
+            # The splitter's carry tail rides along when it is content-state
+            # — matching _record_cancelled_partial, which flushes it into
+            # content_parts — but without emitting mid-exception UI tokens;
+            # an in-think tail is reasoning and stays out, as there too.
+            self._midstream_dead_partial = "".join(content_parts) + (
+                splitter.pending if not splitter.in_think else ""
+            )
             raise
 
         # Flush any remaining buffered text

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -14,6 +14,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import copy
+import dataclasses
 import difflib
 import functools
 import hashlib
@@ -1894,11 +1895,15 @@ class ChatSession:
         # the model detached on purpose.  close() reaps everything.
         self._background_shells = BackgroundShellRegistry(on_exit=self._on_background_shell_exit)
         self._cancelled_partial_msg: dict[str, Any] | None = None
-        # The most recent dead attempt's flushed content, stashed by
-        # _stream_attempt's non-cancel death arm so the resilient wrapper
-        # can preserve it when a cancel lands in the retry window (a Stop
-        # during backoff must not vaporize text the user already saw).
-        self._midstream_dead_partial: str = ""
+        # The provider that created the LIVE stream (primary or fallback) —
+        # the mid-stream retry gate consults ITS retryable set, and the
+        # fatal formatter labels errors with it.  Best-effort under
+        # supersede races; None falls back to the primary binding.
+        self._active_stream_provider: LLMProvider | None = None
+        # The wire-message fold the live stream was actually created from —
+        # a mid-retry rebind re-prepares it, and send()'s token-table
+        # calibration must count the fold the provider counted.
+        self._active_wire_msgs: list[dict[str, Any]] | None = None
         self._pending_retry: str | None = None
         # True when a fatal exception's text has been persisted to
         # workstream_config["last_error"] for the coord's inspect/wait
@@ -5454,7 +5459,12 @@ class ChatSession:
             log.debug("session.fatal.base_url_lookup_failed", exc_info=True)
         provider_label = "?"
         try:
-            prov = self._provider
+            # Prefer the provider that actually owned the live stream — a
+            # fallback-carried turn's failure must not be labeled with the
+            # primary binding it never touched.  getattr: this helper is
+            # bound to lightweight stubs in tests (see the module-scope
+            # note on the _BACKEND_* sets) that predate the field.
+            prov = getattr(self, "_active_stream_provider", None) or self._provider
             provider_label = (
                 getattr(prov, "provider_name", None) or type(prov).__name__ if prov else "?"
             )
@@ -5944,6 +5954,12 @@ class ChatSession:
         for attempt in range(self._MAX_RETRIES + 1):
             self._check_cancelled()
             self._cancel_ref.clear()  # discard stale handle from prior attempt
+            # The provider about to own the live stream — read by the
+            # mid-stream retry gate (retryable-set membership) and the
+            # fatal formatter's label.  Written here so the fallback walk
+            # (which routes through this method with provider=fb_provider)
+            # is covered by construction.
+            self._active_stream_provider = prov
             try:
                 return prov.create_streaming(
                     client=client,
@@ -6844,11 +6860,31 @@ class ChatSession:
                             # site already guards.
                             self._compact_messages(auto=True, my_generation=my_generation)
                             msgs = self._prepare_wire_messages(self._full_messages())
-                            self.ui.on_thinking_start()
-                            assistant_msg = self._stream_response(msgs, my_generation)
                         except Exception:
+                            # RECOVERY-machinery failure: the overflow error
+                            # is still the actionable one, and its wording
+                            # already anticipates this case ("compaction
+                            # could not reduce it enough").
                             log.warning(
                                 "Compact-and-retry failed, raising original error",
+                                exc_info=True,
+                            )
+                            raise ctx_err from None
+                        self.ui.on_thinking_start()
+                        try:
+                            assistant_msg = self._stream_response(msgs, my_generation)
+                        except Exception as retry_err:
+                            if not _is_ctx_overflow(retry_err):
+                                # A post-compaction failure that is NOT a
+                                # recurring overflow surfaces as ITSELF
+                                # (implicitly chained to ctx_err): masking
+                                # a dead wire or bad credentials behind
+                                # "Context window exceeded" sends the
+                                # operator to shrink a conversation that
+                                # already compacted fine.
+                                raise
+                            log.warning(
+                                "Compact-and-retry re-overflowed, raising original error",
                                 exc_info=True,
                             )
                             raise ctx_err from None
@@ -6869,7 +6905,11 @@ class ChatSession:
                 # (perf-2); passing the already-prepared list keeps the
                 # calibration char count aligned with what the provider
                 # actually counted.
-                self._update_token_table(assistant_msg, msgs=msgs)
+                # The wire fold the provider ACTUALLY counted — a mid-retry
+                # rebind re-prepares it inside _stream_response, invisibly
+                # to this frame's msgs local (the calibration contract:
+                # char counts align with the counted fold).
+                self._update_token_table(assistant_msg, msgs=self._active_wire_msgs or msgs)
                 self._print_status_line()  # Report usage for EVERY API call
                 self.messages.append(turn_from_dict(assistant_msg))
                 # Clear per-turn inflight buffers — the assistant
@@ -7697,46 +7737,104 @@ class ChatSession:
         non-retryable class.
         """
         attempt = 0
+        # The latest non-empty dead attempt's flushed text.  Wrapper-LOCAL:
+        # each death carries its partial on the raised exception (thread-
+        # private), so an orphaned superseded generation cannot poison a
+        # live generation's preservation the way a shared session slot
+        # could.
+        dead_partial = ""
+
+        def _promote_dead_partial() -> None:
+            """Hand send()'s cancel handler the retry window's partial.
+
+            Runs on a same-generation Stop anywhere in the retry window.
+            Unconditional when no partial was recorded — empty content
+            still takes the cancel handler's marker-as-message branch,
+            preserving the invariant that a cancelled streaming turn
+            always persists the cancellation-marker row.  Backfills a
+            recorded-but-EMPTY partial (a Stop in the re-create/TTFT
+            window records the new attempt's empty content) with the
+            previous attempt's text: cancel-in-retry preserves the latest
+            text the user actually saw.  Never writes for a superseded
+            generation — an orphan must not touch the successor's slot.
+            """
+            if self._generation != my_generation:
+                return
+            cur = self._cancelled_partial_msg
+            if cur is None or (not cur.get("content") and dead_partial):
+                self._cancelled_partial_msg = {
+                    "role": "assistant",
+                    "content": dead_partial,
+                }
+
+        # Exported for send()'s token-table calibration — the char count
+        # must match the fold the provider actually counted, and a
+        # mid-retry rebind can re-prepare it below.
+        self._active_wire_msgs = msgs
         stream = self._create_stream_with_retry(msgs)
         while True:
             try:
                 return self._stream_attempt(transport_guarded(stream), my_generation)
-            # GenerationCancelled subclasses BaseException, so this arm
-            # structurally cannot swallow the cancel path.
+            except GenerationCancelled:
+                # A Stop during an attempt (incl. the re-create/TTFT window
+                # after a death) — preserve the window's best partial.
+                _promote_dead_partial()
+                raise
+            except KeyboardInterrupt:
+                # BaseException — the Exception arm below never sees it,
+                # but send() treats Ctrl-C as a survivable, recorded path,
+                # so the dead attempt still needs its client-side finalize
+                # (the CLI's markdown fence resets only in on_stream_end).
+                if self._generation == my_generation:
+                    self.ui.on_stream_end()
+                raise
             except Exception as e:
-                # self._provider, not a creation-time local: after
-                # _try_fallback the live stream belongs to the fallback
-                # provider (the sets overlap on IncompleteStreamError, so
-                # the gate is correct either way — but read the session's
-                # current binding).  The terminal predicate is the SHARED
-                # _stop_retrying, capped at _MID_STREAM_RETRIES: its
-                # overflow arm applies here too — an overflow can surface
-                # mid-consumption (error-frame lanes), and it must fall
-                # through to send()'s compact-and-retry arm rather than
-                # burn re-issues on a deterministic failure.
+                # The death carries the attempt's flushed text (attached by
+                # _stream_attempt's death arm).  Keep the previous
+                # attempt's text when the new death had none — the user
+                # saw it, and a later Stop must preserve it.
+                dead_partial = getattr(e, "_dead_partial", "") or dead_partial
                 if self._generation != my_generation:
                     # Superseded (force-cancel started a newer generation):
                     # an orphaned thread must not touch the UI — a finalize
                     # emitted here would clobber the NEW generation's
                     # in-flight stream state.
                     raise
+                # The provider whose stream actually died: after
+                # _try_fallback the live stream belongs to the FALLBACK
+                # provider, whose retryable set can differ (e.g.
+                # ResponsesStreamFailedError) — judging it by the primary
+                # binding's set would declare fallback transients terminal.
+                # Best-effort field (a racing creation could re-write it);
+                # at worst one gate decision consults a sibling set.
+                live_provider = self._active_stream_provider or self._provider
+                # The terminal predicate is the SHARED _stop_retrying,
+                # capped at _MID_STREAM_RETRIES: its overflow arm applies
+                # here too — an overflow can surface mid-consumption
+                # (error-frame lanes), and it must fall through to send()'s
+                # compact-and-retry arm rather than burn re-issues on a
+                # deterministic failure.
                 if self._stop_retrying(
-                    e, attempt, self._provider, max_retries=self._MID_STREAM_RETRIES
+                    e, attempt, live_provider, max_retries=self._MID_STREAM_RETRIES
                 ):
-                    # Terminal: finalize the dead attempt exactly as the
-                    # retry path below does, or the last attempt's partial
-                    # stays un-flushed in every consumer — the CLI is the
-                    # sharp case (its markdown fence state resets only in
-                    # on_stream_end; the server /send workers emit their own
-                    # stream_end after a fatal, the CLI's direct send() does
-                    # not).  An attempt that died before its first token
-                    # finalizes empty buffers, which no-ops everywhere.
+                    # Terminal: client-side finalize only (the CLI's
+                    # markdown fence resets in on_stream_end; the server
+                    # /send workers emit their own after a fatal, the
+                    # CLI's direct send() does not).  on_turn_committed is
+                    # DELIBERATELY absent here, unlike the retry arm
+                    # below: the dead partial is in neither history nor
+                    # storage, so the in-progress snapshot is its only
+                    # surviving copy — wiping it would silently lose
+                    # visible text on the most reconnect-prone path.  It
+                    # clears at the next send, the pre-#937 fatal
+                    # behavior.
                     self.ui.on_stream_end()
-                    self.ui.on_turn_committed()
                     raise  # fatal path otherwise unchanged
+                # Delay from the PRE-increment attempt index — the same
+                # convention as the three sibling ladders' range loops.
+                delay = self._RETRY_BASE_DELAY * (2**attempt)
                 attempt += 1
                 cause = type(e.__cause__).__name__ if e.__cause__ else type(e).__name__
-                delay = self._RETRY_BASE_DELAY * (2 ** (attempt - 1))
                 log.warning(
                     "stream.retry",
                     error_type=cause,
@@ -7758,6 +7856,13 @@ class ChatSession:
                     f"[stream died mid-response ({cause}) — retrying in "
                     f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"
                 )
+                # Stop-then-start: a pre-first-token death leaves the
+                # spinner RUNNING (_stop_spinner_once never fired), and the
+                # CLI's on_thinking_start is not idempotent — it replaces
+                # the spinner object without stopping the old one, leaking
+                # its render thread (the compact-retry arm guards the same
+                # way).
+                self.ui.on_thinking_stop()
                 self.ui.on_thinking_start()
                 try:
                     self._backoff_or_cancelled(delay, my_generation)
@@ -7769,27 +7874,36 @@ class ChatSession:
                     # generation-gated (two compares when nothing changed),
                     # so this is free in the common case and re-binds
                     # exactly when reload made the old client unusable.
-                    client_before = self.client
+                    binding_before = (self.client, self.model, self._provider)
                     self._refresh_model_from_registry()
-                    if self.client is not client_before:
+                    if (self.client, self.model, self._provider) != binding_before:
                         # The rebind may have changed the model family, and
                         # the wire fold is capability-sensitive
                         # (fold_system_turns) — re-prepare against the new
                         # binding, the same pass the overflow arm runs
-                        # mid-send.  Identity compare: _bind_model_from_
-                        # registry replaces the client object on any
-                        # connection-relevant change.
+                        # mid-send.  Compared as the full binding triple:
+                        # reload() deliberately KEEPS the pooled client
+                        # when only the alias's model id changed, so a
+                        # client-identity check alone would re-issue the
+                        # old model's fold against the new model.
                         msgs = self._prepare_wire_messages(self._full_messages())
+                        self._active_wire_msgs = msgs
                     try:
                         stream = self._create_stream_with_retry(msgs)
                     except Exception as recreate_exc:
-                        # The re-create's failure must not mask the true
-                        # stream-death error: a closed-client recreate
-                        # surfaces as a retryable APIConnectionError and
-                        # would otherwise replace the operator-actionable
-                        # wording after burning its own ladder.  Class name
-                        # only — a ConnectError's text can carry a
-                        # credential-bearing base_url verbatim.
+                        if _is_ctx_overflow(recreate_exc):
+                            # Deterministic — surface as ITSELF so send()'s
+                            # compact-and-retry arm can recover the turn; a
+                            # rebind can land on a smaller-window model
+                            # mid-retry.
+                            raise
+                        # Otherwise the re-create's failure must not mask
+                        # the true stream-death error: a closed-client
+                        # recreate surfaces as a retryable
+                        # APIConnectionError and would replace the
+                        # operator-actionable wording after burning its own
+                        # ladder.  Class name only — a ConnectError's text
+                        # can carry a credential-bearing base_url verbatim.
                         log.warning(
                             "stream.retry.recreate_failed",
                             error_type=type(recreate_exc).__name__,
@@ -7798,15 +7912,8 @@ class ChatSession:
                 except GenerationCancelled:
                     # A Stop landing in the backoff/re-create window aborts
                     # the turn with the dead attempt's partial preserved —
-                    # the same disposition a cancel DURING the attempt gets
-                    # (send()'s cancel handler persists it with the
-                    # cancellation marker).  Without this, cancel-in-backoff
-                    # silently drops text the user already saw.
-                    if self._midstream_dead_partial:
-                        self._cancelled_partial_msg = {
-                            "role": "assistant",
-                            "content": self._midstream_dead_partial,
-                        }
+                    # the same disposition a cancel DURING the attempt gets.
+                    _promote_dead_partial()
                     raise
 
     def _stream_attempt(
@@ -7837,7 +7944,6 @@ class ChatSession:
         # `_assistant_pending_tokens or ...` fallback.
         self._last_usage = None
         self._assistant_pending_tokens = 0
-        self._midstream_dead_partial = ""
 
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
@@ -7870,10 +7976,24 @@ class ChatSession:
                 self.ui.on_thinking_stop()
                 first_token = False
 
+        def _partial_content() -> str:
+            """THE partial-content rule, in one form: flushed content plus
+            the splitter's carry tail when it is content-state (an in-think
+            tail is reasoning and stays out).  Both preservation paths —
+            the cancel arms' record below and the death arm's exception
+            payload — derive from this single closure so a Stop landing in
+            the retry window persists the same text as a Stop during the
+            attempt."""
+            return "".join(content_parts) + (splitter.pending if not splitter.in_think else "")
+
         def _record_cancelled_partial() -> None:
             """Flush buffered text, finalize the stream in the UI, and stash
             the partial for send()'s cancel handler — the one sequence both
             cancel arms (cooperative and stream-close-converted) must run.
+            No-op for a SUPERSEDED generation: an orphaned thread must
+            touch neither the UI (its stream_end would reset the successor
+            generation's inflight buffers mid-stream) nor the shared
+            partial slot the successor's cancel handler consumes.
             ``tool_calls`` and ``_provider_content`` are DELIBERATELY
             OMITTED from the partial:
 
@@ -7888,11 +8008,12 @@ class ChatSession:
               appends to ``content``, hiding the partial-output signal
               from the model.
             """
+            if self._generation != my_generation:
+                return
+            content = _partial_content()
             splitter.flush_pending()
             self.ui.on_stream_end()
-            partial: dict[str, Any] = {"role": "assistant"}
-            partial["content"] = "".join(content_parts) or ""
-            self._cancelled_partial_msg = partial
+            self._cancelled_partial_msg = {"role": "assistant", "content": content}
 
         finish_reason = None
         try:
@@ -7916,13 +8037,7 @@ class ChatSession:
                 # so the dict write cannot defer to stream end.
                 if chunk.usage:
                     usage_acc = merge_usage(usage_acc, chunk.usage)
-                    self._last_usage = {
-                        "prompt_tokens": usage_acc.prompt_tokens,
-                        "completion_tokens": usage_acc.completion_tokens,
-                        "total_tokens": usage_acc.total_tokens,
-                        "cache_creation_tokens": usage_acc.cache_creation_tokens,
-                        "cache_read_tokens": usage_acc.cache_read_tokens,
-                    }
+                    self._last_usage = dataclasses.asdict(usage_acc)
 
                 if self.debug:
                     parts = []
@@ -7977,10 +8092,17 @@ class ChatSession:
                 # Raw provider content blocks (for multi-turn preservation)
                 if chunk.provider_blocks:
                     provider_blocks = chunk.provider_blocks
+            # A Stop that raced the trailing-metadata window: cancel()
+            # closed the stream, and transport_guarded's post-finish
+            # tolerance ended it CLEANLY instead of letting the closed-
+            # stream raise reach the conversion arm below — without this
+            # re-check the turn would commit as complete and its tool
+            # calls would execute despite the Stop.
+            self._check_cancelled(my_generation)
         except GenerationCancelled:
             _record_cancelled_partial()
             raise
-        except Exception:
+        except Exception as death_exc:
             # cancel() closed the underlying SDK stream, aborting the HTTP
             # connection.  The blocked next() call on the iterator raises a
             # transport-level error (httpx, httpcore, etc.).  Convert to
@@ -7988,16 +8110,12 @@ class ChatSession:
             if self._cancel_event.is_set():
                 _record_cancelled_partial()
                 raise GenerationCancelled() from None
-            # A non-cancel death: stash the flushed partial so the resilient
-            # wrapper can preserve it if a cancel lands in the retry window
-            # (its backoff arm promotes the stash to _cancelled_partial_msg).
-            # The splitter's carry tail rides along when it is content-state
-            # — matching _record_cancelled_partial, which flushes it into
-            # content_parts — but without emitting mid-exception UI tokens;
-            # an in-think tail is reasoning and stays out, as there too.
-            self._midstream_dead_partial = "".join(content_parts) + (
-                splitter.pending if not splitter.in_think else ""
-            )
+            # A non-cancel death: the attempt's flushed text rides the
+            # EXCEPTION (thread-private, so an orphaned generation's death
+            # can never poison a live generation's preservation) for the
+            # resilient wrapper's Stop-in-retry-window promotion.  No UI
+            # emission here — the wrapper finalizes the dead attempt.
+            death_exc._dead_partial = _partial_content()  # type: ignore[attr-defined]
             raise
 
         # Flush any remaining buffered text

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -175,6 +175,7 @@ from turnstone.core.preview import (
 from turnstone.core.providers import (
     accumulate_tool_call_delta,
     create_provider,
+    merge_usage,
     transport_guarded,
 )
 from turnstone.core.ratelimit import TokenBucket
@@ -7786,6 +7787,7 @@ class ChatSession:
         reasoning_parts: list[str] = []
         tool_calls_acc: dict[int, dict[str, Any]] = {}
         provider_blocks: list[dict[str, Any]] = []
+        usage_acc: UsageInfo | None = None
         first_token = True
         in_think = False  # inside a <think>...</think> block
         path1_reasoning = False  # last reasoning came via reasoning_delta field
@@ -7858,6 +7860,31 @@ class ChatSession:
                 self.ui.on_thinking_stop()
                 first_token = False
 
+        def _record_cancelled_partial() -> None:
+            """Flush buffered text, finalize the stream in the UI, and stash
+            the partial for send()'s cancel handler — the one sequence both
+            cancel arms (cooperative and stream-close-converted) must run.
+            ``tool_calls`` and ``_provider_content`` are DELIBERATELY
+            OMITTED from the partial:
+
+            * ``tool_calls`` — incomplete, no matching tool_result;
+              re-emitting on the next turn would orphan them.
+            * ``_provider_content`` — the Anthropic provider reads this
+              lane verbatim ahead of plain ``content`` (see
+              ``providers/_anthropic.py``), and a cancellation can leave
+              partial tool_use blocks here too.  Keeping it would also
+              cause the next-turn replay to bypass the ``[generation
+              cancelled before completion]`` marker the cancel handler
+              appends to ``content``, hiding the partial-output signal
+              from the model.
+            """
+            if pending:
+                _flush_text(pending, in_think)
+            self.ui.on_stream_end()
+            partial: dict[str, Any] = {"role": "assistant"}
+            partial["content"] = "".join(content_parts) or ""
+            self._cancelled_partial_msg = partial
+
         finish_reason = None
         try:
             for chunk in stream:
@@ -7873,35 +7900,20 @@ class ChatSession:
                     finish_reason = chunk.finish_reason
 
                 # Accumulate usage (Anthropic sends prompt tokens in message_start
-                # and completion tokens in message_delta as separate events)
+                # and completion tokens in message_delta as separate events) via
+                # THE shared max-merge rule (merge_usage, drain_stream's twin).
+                # self._last_usage is re-written on EVERY usage chunk: it is
+                # read mid-stream (_estimated_prompt_tokens, the status line),
+                # so the dict write cannot defer to stream end.
                 if chunk.usage:
-                    if self._last_usage is None:
-                        self._last_usage = {
-                            "prompt_tokens": chunk.usage.prompt_tokens,
-                            "completion_tokens": chunk.usage.completion_tokens,
-                            "total_tokens": chunk.usage.total_tokens,
-                            "cache_creation_tokens": chunk.usage.cache_creation_tokens,
-                            "cache_read_tokens": chunk.usage.cache_read_tokens,
-                        }
-                    else:
-                        self._last_usage["prompt_tokens"] = max(
-                            self._last_usage["prompt_tokens"], chunk.usage.prompt_tokens
-                        )
-                        self._last_usage["completion_tokens"] = max(
-                            self._last_usage["completion_tokens"], chunk.usage.completion_tokens
-                        )
-                        self._last_usage["total_tokens"] = (
-                            self._last_usage["prompt_tokens"]
-                            + self._last_usage["completion_tokens"]
-                        )
-                        self._last_usage["cache_creation_tokens"] = max(
-                            self._last_usage.get("cache_creation_tokens", 0),
-                            chunk.usage.cache_creation_tokens,
-                        )
-                        self._last_usage["cache_read_tokens"] = max(
-                            self._last_usage.get("cache_read_tokens", 0),
-                            chunk.usage.cache_read_tokens,
-                        )
+                    usage_acc = merge_usage(usage_acc, chunk.usage)
+                    self._last_usage = {
+                        "prompt_tokens": usage_acc.prompt_tokens,
+                        "completion_tokens": usage_acc.completion_tokens,
+                        "total_tokens": usage_acc.total_tokens,
+                        "cache_creation_tokens": usage_acc.cache_creation_tokens,
+                        "cache_read_tokens": usage_acc.cache_read_tokens,
+                    }
 
                 if self.debug:
                     parts = []
@@ -7960,26 +7972,7 @@ class ChatSession:
                 if chunk.provider_blocks:
                     provider_blocks = chunk.provider_blocks
         except GenerationCancelled:
-            # Flush whatever was buffered and build a partial message.
-            # Both ``tool_calls`` and ``_provider_content`` are
-            # DELIBERATELY OMITTED:
-            #   * ``tool_calls`` — incomplete, no matching tool_result;
-            #     re-emitting on the next turn would orphan them.
-            #   * ``_provider_content`` — the Anthropic provider reads
-            #     this lane verbatim ahead of plain ``content`` (see
-            #     ``providers/_anthropic.py``), and a cancellation can
-            #     leave partial tool_use blocks here too.  Keeping it
-            #     would also cause the next-turn replay to bypass the
-            #     ``[generation cancelled before completion]`` marker
-            #     the cancel handler appends to ``content``, hiding
-            #     the partial-output signal from the model.
-            if pending:
-                _flush_text(pending, in_think)
-            self.ui.on_stream_end()
-            partial: dict[str, Any] = {"role": "assistant"}
-            partial_content = "".join(content_parts)
-            partial["content"] = partial_content or ""
-            self._cancelled_partial_msg = partial
+            _record_cancelled_partial()
             raise
         except Exception:
             # cancel() closed the underlying SDK stream, aborting the HTTP
@@ -7987,17 +7980,7 @@ class ChatSession:
             # transport-level error (httpx, httpcore, etc.).  Convert to
             # GenerationCancelled if a cancel was requested.
             if self._cancel_event.is_set():
-                if pending:
-                    _flush_text(pending, in_think)
-                self.ui.on_stream_end()
-                partial = {"role": "assistant"}
-                partial["content"] = "".join(content_parts) or ""
-                # Same reasoning as the cooperative-cancel branch
-                # above: ``_provider_content`` is omitted so the
-                # next-turn replay reads from the marker-bearing
-                # plain content and any partial tool_use blocks
-                # inside provider_blocks don't leak through.
-                self._cancelled_partial_msg = partial
+                _record_cancelled_partial()
                 raise GenerationCancelled() from None
             raise
 

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -1256,7 +1256,19 @@ class SessionUI(Protocol):
     def on_turn_start(self) -> None: ...
     def on_turn_committed(self) -> None: ...
 
-    def on_stream_discarded(self) -> None: ...
+    def on_stream_discarded(self) -> None:
+        """Drop a dead stream attempt's text from any server-side buffers.
+
+        A REAL no-op default, not a bare ``...`` stub, for the same reason
+        ``on_compaction`` below carries one: an explicit pre-#937
+        ``SessionUI`` subclass inherits this as its implementation, and
+        for a discard the no-op IS correct — a UI without server-side
+        turn buffers has nothing to truncate.  ``SessionUIBase`` overrides
+        with the real truncation; duck-typed UIs that never subclass are
+        covered by the getattr probe in ``_ui_stream_discarded``.
+        """
+        return
+
     def on_thinking_start(self) -> None: ...
     def on_thinking_stop(self) -> None: ...
     def on_reasoning_token(self, text: str) -> None: ...
@@ -7730,6 +7742,21 @@ class ChatSession:
                 text = text[:start] + text[end + len(close_t) :] if end != -1 else text[:start]
         return text.strip()
 
+    def _ui_stream_discarded(self) -> None:
+        """Best-effort dead-segment discard across UI generations.
+
+        Probed, never called directly: a pre-#937 duck-typed UI may lack
+        the hook, and an AttributeError raised from the retry/terminal
+        arms would REPLACE the stream death being handled — the retry
+        gate would then judge the attribute error instead of the wire
+        failure.  Missing hook degrades to no server-buffer truncate,
+        which is correct for UIs without server-side buffers (the same
+        compat posture as ``_compaction_event``'s probe).
+        """
+        discard = getattr(self.ui, "on_stream_discarded", None)
+        if discard is not None:
+            discard()
+
     def _stream_response(
         self, msgs: list[dict[str, Any]], my_generation: int = 0
     ) -> dict[str, Any]:
@@ -7854,7 +7881,7 @@ class ChatSession:
                     # hold the dead attempt's text, concatenating the two
                     # in the idle payload.
                     self.ui.on_stream_end()
-                    self.ui.on_stream_discarded()
+                    self._ui_stream_discarded()
                     raise  # fatal path otherwise unchanged
                 # Delay from the PRE-increment attempt index — the same
                 # convention as the three sibling ladders' range loops.
@@ -7901,7 +7928,7 @@ class ChatSession:
                     # source) and reset the inflight snapshot BEFORE any
                     # retried token lands, or every consumer appends the
                     # retried text onto the dead attempt's.
-                    self.ui.on_stream_discarded()
+                    self._ui_stream_discarded()
                     # Spinner for the recreate+TTFT window, and the fresh
                     # segment watermark — AFTER the truncate, so a later
                     # discard cannot resurrect this dead segment.  A

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -635,6 +635,10 @@ class SessionUIBase:
         # turns within one user-facing send.
         self._ws_turn_content: list[str] = []
         self._ws_turn_content_size: int = 0
+        # Segment watermark for :meth:`on_stream_discarded` — (list length,
+        # size) of ``_ws_turn_content`` at the current stream segment's
+        # start, snapshotted in :meth:`on_thinking_start`.
+        self._turn_content_watermark: tuple[int, int] = (0, 0)
         # Per-turn inflight accumulators: the in-progress turn's content
         # + reasoning, exposed to a reconnecting SSE client via the
         # ``in_progress_snapshot`` event so a mid-stream page refresh
@@ -3181,6 +3185,26 @@ class SessionUIBase:
             self._flush_all_chunk_batches_locked()
             self._reset_inflight_buffers_locked()
 
+    def on_stream_discarded(self) -> None:
+        """Drop a dead stream attempt's text from every server buffer.
+
+        The mid-stream retry re-issues the turn; the dead attempt's tokens
+        were finalized client-side (``stream_end``) but its batches also
+        landed in ``_ws_turn_content`` — the multi-segment buffer the IDLE
+        payload drains — which :meth:`on_turn_committed` deliberately does
+        NOT clear (earlier segments of a tool-looping turn must survive
+        commits).  Truncating back to the segment watermark removes exactly
+        the dead attempt's contribution; the pending token batch is
+        dropped, not flushed (its text was never displayed and must not
+        be).
+        """
+        with self._ws_lock:
+            self._reset_pending_locked()
+            watermark_len, watermark_size = self._turn_content_watermark
+            del self._ws_turn_content[watermark_len:]
+            self._ws_turn_content_size = watermark_size
+            self._reset_inflight_buffers_locked()
+
     def on_thinking_start(self) -> None:
         """Track that the model is thinking; broadcast activity + enqueue.
 
@@ -3190,6 +3214,16 @@ class SessionUIBase:
         ``thinking_start`` event still flows for the spinner UIs.
         """
         with self._ws_lock:
+            # Segment watermark for on_stream_discarded: thinking_start
+            # precedes every stream segment (send start, mid-stream retry,
+            # compaction wrap), and no content batch lands between it and
+            # the segment's first token — so the buffer position here is
+            # the truncation point should the segment that follows be
+            # discarded.
+            self._turn_content_watermark = (
+                len(self._ws_turn_content),
+                self._ws_turn_content_size,
+            )
             if not self._compaction_activity_live:
                 self._ws_current_activity = "Thinking…"
                 self._ws_activity_state = "thinking"

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -3194,9 +3194,11 @@ class SessionUIBase:
         payload drains — which :meth:`on_turn_committed` deliberately does
         NOT clear (earlier segments of a tool-looping turn must survive
         commits).  Truncating back to the segment watermark removes exactly
-        the dead attempt's contribution; the pending token batch is
-        dropped, not flushed (its text was never displayed and must not
-        be).
+        the dead attempt's contribution.  The pending-batch reset is
+        DEFENSIVE: in the shipped sequence the preceding ``stream_end``
+        already flushed (and broadcast) any pending tail, so the reset
+        no-ops — it matters only for a caller that discards without
+        finalizing first, whose tail genuinely was never displayed.
         """
         with self._ws_lock:
             self._reset_pending_locked()

--- a/turnstone/core/streaming_text.py
+++ b/turnstone/core/streaming_text.py
@@ -1,0 +1,82 @@
+"""Streaming think-tag splitting for interactive content streams."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class ThinkTagSplitter:
+    """Split streamed content into content vs reasoning around think tags.
+
+    Local-model servers without a reasoning parser emit reasoning inline
+    as ``<think>``/``<reasoning>`` blocks inside the content stream, and
+    a tag can arrive split across chunk boundaries.  This class owns the
+    carry buffer and the in-tag state: :meth:`feed` buffers a chunk and
+    emits every span that provably cannot be part of an unresolved tag;
+    the trailing :data:`MAX_TAG_LEN` chars are held until a later chunk
+    (or a final :meth:`flush_pending`) resolves them.
+
+    Emission goes through the *emit* callback ``(text, is_reasoning)`` —
+    spans arrive in stream order, never empty, exactly once.  The
+    consumer owns dispatch (UI callbacks, accumulation) and may
+    read/write :attr:`in_think` directly to mirror out-of-band
+    transitions (the provider-normalized ``reasoning_delta`` path,
+    tool-call starts).
+
+    Tag selection: at each step the EARLIEST occurrence wins among the
+    tag variants for the current state (open tags outside a block, close
+    tags inside).
+    """
+
+    OPEN_TAGS: tuple[str, ...] = ("<think>", "<reasoning>")
+    CLOSE_TAGS: tuple[str, ...] = ("</think>", "</reasoning>")
+    MAX_TAG_LEN = max(len(t) for t in OPEN_TAGS + CLOSE_TAGS)
+
+    def __init__(self, emit: Callable[[str, bool], None]) -> None:
+        self._emit = emit
+        self.pending = ""
+        self.in_think = False
+
+    def feed(self, text: str) -> None:
+        """Buffer *text* and emit every tag-resolved span."""
+        self.pending += text
+        self._drain()
+
+    def flush_pending(self) -> None:
+        """Emit the raw carry buffer at the current state, with no tag scan.
+
+        For stream boundaries where a partial tag is no longer possible:
+        end of stream, tool calls beginning, cancellation.
+        """
+        if self.pending:
+            self._emit(self.pending, self.in_think)
+            self.pending = ""
+
+    def _drain(self) -> None:
+        while self.pending:
+            tags = self.CLOSE_TAGS if self.in_think else self.OPEN_TAGS
+            best_idx, best_tag = None, None
+            for tag in tags:
+                idx = self.pending.find(tag)
+                if idx != -1 and (best_idx is None or idx < best_idx):
+                    best_idx, best_tag = idx, tag
+
+            if best_idx is not None:
+                assert best_tag is not None
+                if best_idx:
+                    self._emit(self.pending[:best_idx], self.in_think)
+                self.pending = self.pending[best_idx + len(best_tag) :]
+                self.in_think = not self.in_think
+                continue
+
+            # No tag in sight — everything but a possible partial-tag tail
+            # is provably safe to emit now (live streaming beats holding
+            # the whole buffer for a tag that may never come).
+            safe = len(self.pending) - self.MAX_TAG_LEN
+            if safe > 0:
+                self._emit(self.pending[:safe], self.in_think)
+                self.pending = self.pending[safe:]
+            break

--- a/turnstone/eval/core.py
+++ b/turnstone/eval/core.py
@@ -90,6 +90,9 @@ class NullUI:
     def on_turn_committed(self) -> None:
         pass
 
+    def on_stream_discarded(self) -> None:
+        pass
+
     def on_thinking_start(self) -> None:
         pass
 


### PR DESCRIPTION
Fixes #937.

## Problem

A TLS/transport death during response streaming (`ReadError: [SSL] record layer failure`, connection resets) surfaces after the request has already returned its stream handle, so neither the SDK's request-level retries nor the creation-time retry ladder ever saw it. The interactive turn died with a bare exception string, the partial output was discarded, and nothing was logged — while the utility lanes (title, compaction) already survived the same failure through `drain_stream`'s transport normalization.

## Mechanism

- `transport_guarded()` (providers/_protocol.py): drain's transport-death conversion made reusable for consumers that keep streaming semantics. Pre-finish deaths raise the retryable `IncompleteStreamError`; post-finish blips end the stream cleanly (forfeiting only trailing metadata, with `usage_captured` logged for spend attribution). `drain_stream` now consumes the same wrapper — one conversion rule for both lanes.
- The single-pass chunk consumer is renamed `_stream_attempt`; `_stream_response` is the resilient wrapper owning ALL stream acquisition plus a bounded re-issue ladder (`_MID_STREAM_RETRIES = 2`, the shared `_stop_retrying` predicate with a per-loop cap, cancel-aware backoff). Send()'s overflow compact-and-retry arm wraps the whole turn.
- Dead attempts are finalized in every UI consumer before re-issue (`stream_end`, then a backoff-gated `on_stream_discarded` — a new server-side protocol method that truncates the multi-segment turn buffer to a per-segment watermark), so retried text never double-renders in the browser transcript, CLI markdown fences, chat-channel streamed messages, the SSE replay ring, or the idle-state payload.
- Before re-creating, the session re-resolves its registry binding (a concurrent reload closes cached clients) and re-prepares the wire fold when the binding changed; a failing re-create surfaces a context overflow as itself (so compaction can recover the turn) and otherwise re-raises the original stream-death error rather than masking it.
- Cancellation semantics hold everywhere in the retry window: a Stop during an attempt, the backoff, or the re-create/TTFT wait persists the latest user-visible partial with the cancellation marker (empty partials still persist the marker row); a Stop racing the trailing-metadata window aborts before tool execution; superseded (force-cancelled) threads can touch neither the UI, the shared partial slot, nor the fatal-error path.
- `_format_backend_error` gains a stream-death branch naming provider, endpoint, and model; every fatal turn now leaves a `session.fatal.recorded` journal line (INFO for Ctrl-C), and `stream.retry` carries the abandoned generation's delivered usage and discarded char count.

## Also in this branch

Behavior-preserving consolidations riding the same seam: the transport conversion, usage max-merge (`merge_usage`), and cancel-finalize sequences each collapse to one rule; think-tag splitting extracts to a standalone `ThinkTagSplitter` (table-driven pin tests written against the closures first) with its vocabulary now the single source for the compaction and title strips; `TerminalUI.on_thinking_start` is idempotent at the callee.

## Verification

- Full suite: 10357 passed / 0 failed; new coverage includes session-level retry/cancel/orphan paths, real-`SessionUIBase`-buffer pins for the discard semantics, and offline SDK boundary tests (MockTransport plus a real-socket cross-thread close) pinning that both SDKs surface mid-body deaths as raw `httpx.TransportError` and that request-level `max_retries` never engages mid-body.
- Five review rounds (two external unprimed, three workflow-backed with adversarial verification); all confirmed findings fixed or explicitly dispositioned. The recurring orphaned-generation/shared-slot defect family was eliminated structurally: per-attempt state rides the raised exception and the returned message dict rather than session slots.

## Follow-ups filed

- #964 — stamp the producing (alias, backend id, registry generation) onto accepted turns; a fallback or mid-turn rebind currently attributes output to the primary alias.