### PR TITLE
temporal attribution concept to discuss #955

### DIFF
--- a/docs/temporal-attribution.md
+++ b/docs/temporal-attribution.md
@@ -1,0 +1,202 @@
+# Excursion attribution in shared coordinator workstreams
+
+Status: design note and review companion for issue #954.
+
+This note uses the vocabulary already established by `PRIMER.md` and
+`HYPOTHESIS.md`. It deliberately avoids “priority”: Turnstone already uses
+priority for message scheduling, while the property here is identity and
+causality.
+
+## The claim
+
+*Informal.* A workstream has a durable **owner**, but each trigger-to-ready
+**excursion** has a **trusted principal**. Per-user credentials must follow the
+excursion's causal lineage, not the workstream owner, the most recent sender,
+or the most recently completed child.
+
+*In plain terms.* Jared can own a coordinator forever without every future
+action being Jared's. A human message starts an excursion as that human. A
+spawn edge carries that trusted principal into the child while preserving
+Jared as the child's tenant owner. The child's terminal ledger returns as the
+parent's effect record; when that record is the cause of continued work, its
+trusted principal returns with it.
+
+*Operationally.* The shell owns a durable tuple
+
+```text
+(excursion_id, principal_id, cause_action_id, cause_workstream_id)
+```
+
+and permits one of two states at an action boundary:
+
+1. attribution is **resolved** to exactly one trusted principal; or
+2. attribution is **ambiguous**, in which case per-user delegated auth fails
+   closed until a new human trigger begins an excursion or an authorized action
+   names a trusted causal workstream.
+
+The model may propose `cause_workstream_id`. It may never propose
+`principal_id`. The authorization gate verifies that the cause is in the
+coordinator's own subtree and reads its shell-persisted attribution.
+
+## Why owner and last sender are both falsified
+
+### Scenario A: a shared interactive workstream
+
+1. Jared creates workstream `W`, sends a message, and completes an excursion.
+2. John enters the shared project and sends: “I have the Certbot permission;
+   try again with mine.”
+3. The next model and tool calls must use John's delegated credentials.
+4. The harness reaches its stop token and returns to ready.
+5. Jared sends the next message.
+6. The next excursion must use Jared's delegated credentials.
+
+The durable owner rule fails at step 3. A mutable global “last sender” happens
+to work here only because the stop token serializes the two excursions.
+
+### Scenario B: independent coordinator fan-out
+
+1. Jared's message starts excursion `EJ` and spawns children A, B, and C.
+2. Each spawn is an authorized action. A, B, and C keep owner Jared for tenancy
+   and inherit trusted principal Jared through their spawn edges.
+3. After the coordinator returns to ready, John's message starts excursion
+   `EN` and spawns D and E.
+4. D and E keep owner Jared but inherit trusted principal John.
+
+Changing child ownership to John is not the repair: it breaks subtree tenancy
+and confuses “whose durable object is this?” with “whose authority caused this
+run?”
+
+### Scenario C: B returns after John spoke
+
+1. The coordinator's last human sender is John.
+2. Child B, descended from `EJ`, reaches its halt and persists its terminal
+   ledger.
+3. If the coordinator waits on B, B's result enters the parent as an effect
+   record at the tool-result boundary.
+4. Before the next model run, the shell restores Jared as the trusted principal
+   from B's persisted attribution.
+5. Work causally continued from B therefore spawns as Jared, not John.
+
+This is the minimal counterexample to last-sender attribution. Wall-clock
+recency and causal ancestry disagree, and only the latter is an authorization
+fact.
+
+### Scenario D: B returns while another tool call is in flight
+
+A child completion does not splice itself into a running model generation or
+an unrelated tool call. The child state and transcript are persisted, an SSE
+event is emitted, and the child event bus wakes an active
+`wait_for_workstream` waiter if one exists. With no waiter, the notification is
+observational; the idle-coordinator liveness nudge can prompt a later wait.
+
+The return becomes model input only when a wait/inspect effect is folded back
+by the parent shell. Attribution changes at that deterministic fold boundary,
+not at arbitrary completion time. This preserves the stopped-process shape:
+asynchronous environment timing is a coin in `Q_E`; `rho` still owns when the
+observed receipt becomes controller state.
+
+### Scenario E: Jared's B and John's D return together
+
+If one wait result lowers both terminal effect records into the next context,
+neither arrival order nor list order can choose a trusted principal. The join
+is explicitly ambiguous. The same rule applies when separate wait tool calls
+run in one parallel batch: the shell folds all sibling receipts together only
+after the batch settles, so executor completion order cannot pick an identity.
+
+An `entra_obo` coordinator model must fail closed at that point: the model
+inference is itself a delegated action, so asking the model which user it meant
+to run as would already require choosing a user's token. A deployment that
+intentionally synthesizes mixed-principal results must configure the
+coordinator lane with `entra_app` (or another explicit deployment identity).
+From that neutral lane, a subsequent child action may cite one causal
+workstream; the shell resolves its trusted principal and the normal approval
+gate authorizes the spawn/send. There is no silent runtime fallback from OBO to
+app identity.
+
+An OBO-only coordinator can avoid the join by collecting and processing one
+causal lane at a time. Waiting on B alone restores Jared before the next model
+run; waiting on D alone restores John.
+
+## Derived rules
+
+1. **Owner is tenancy, not execution identity.** JWT `sub`, workstream rows,
+   project membership, and subtree ownership remain bound to the durable owner.
+2. **Trusted principal is excursion control state.** Model backend OBO, MCP
+   user pools, delegated-action audit attribution, and child propagation read
+   the excursion principal.
+3. **Attribution is signed and durable.** Coordinator JWT custom claims carry
+   it through console-to-node routing; `workstream_config` restores it before a
+   rehydrated session can perform autonomous work.
+4. **Spawn attenuates authority.** A child inherits the parent's resolved
+   principal along a spawn edge. The body cannot name a user, and ownership
+   does not change.
+5. **Child completion is an effect record.** A terminal child's attribution is
+   returned alongside its wait result and folded before the next model run.
+6. **A causal join is not a race.** Multiple distinct principals produce an
+   ambiguous state; no ordering heuristic chooses a credential.
+7. **Auxiliary lanes do not invent identities.** Judge, output guard,
+   perception, MCP, and the primary model all resolve through the same
+   excursion state. A lane that needs neutral multi-principal synthesis must be
+   configured with app identity explicitly.
+8. **Shared transcript visibility is a separate policy.** This design accepts
+   the current project/workstream co-working domain: members may see content
+   other members caused the system to retrieve. It prevents credential
+   misattribution; it does not create per-message transcript tenancy.
+
+## Implementation shape in this branch
+
+- `ExcursionAttribution` defines one versioned config/claim representation.
+- A fresh authenticated human send creates a new excursion, including when the
+  same user sent the previous completed turn.
+- Coordinator tokens keep the owner in `sub` and add signed excursion claims.
+- The console routing proxy preserves those claims when it re-mints for a node.
+- Child create/send handlers accept attribution only from a validated
+  coordinator token; request JSON cannot supply it.
+- Session rehydration restores resolved or ambiguous attribution before model
+  and MCP use.
+- `wait_for_workstream` returns terminal-child attribution. The coordinator
+  adopts one principal, joins same-principal branches under a fresh excursion,
+  or records a mixed-principal ambiguity.
+- `spawn_workstream`, `spawn_batch`, and `send_to_workstream` accept an optional
+  `cause_workstream_id`. In an ambiguous state it is required; the shell
+  resolves it through the owned-subtree gate and stamps the outgoing action.
+
+This is control-plane attribution, not yet the full per-action-capability ideal
+from `HYPOTHESIS.md`: the signed JWT binds the routed request and its causal
+action id, while downstream OAuth providers may still mint audience-scoped
+tokens rather than credentials cryptographically restricted to one
+`action_id`. The branch closes principal selection and propagation; provider
+token attenuation remains a separate layer.
+
+## Falsifiers
+
+The implementation is wrong if any of these observations is possible:
+
+- John's human-triggered excursion mints or dispatches with Jared's OBO token
+  because Jared owns the coordinator.
+- B's returned ledger continues under John merely because John was the last
+  human sender.
+- a request body can set `principal_id` or forge excursion lineage;
+- child ownership changes to the acting principal and escapes the owner's
+  subtree;
+- a mixed Jared/John result selects either token by completion, list, or message
+  order;
+- rehydration performs a model/tool action before restoring the persisted
+  attribution state;
+- an auxiliary lane resolves a different user from the primary lane for the
+  same excursion; or
+- an OBO failure silently changes grant type to app identity.
+
+## Relation to issue #954's permission question
+
+This ruling answers what a model-auth configuration gate is protecting: OBO is
+allowed in shared sessions only while the current excursion has one resolved
+trusted principal. Shared transcript visibility remains the accepted project
+co-working property. Mixed-principal synthesis uses an explicitly configured
+app lane or fails closed.
+
+It does not decide whether the configuration capability should be
+`admin.model_auth` or a host allow-list. That is an orthogonal gate-placement
+decision: attribution determines *whose credential may be minted*; destination
+confinement determines *where that credential may be sent*. Neither substitutes
+for the other.

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,63 @@
+"""Excursion-attribution control-state tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from turnstone.core.attribution import (
+    ATTRIBUTION_STATE_AMBIGUOUS,
+    CONFIG_STATE_KEY,
+    ExcursionAttribution,
+    ambiguous_attribution_config,
+    attribution_from_auth,
+    conflicting_principals_from_config,
+)
+from turnstone.core.auth import AuthResult
+
+
+def test_excursion_attribution_round_trips_config_and_claims():
+    attribution = ExcursionAttribution.start(
+        "john",
+        excursion_id="exc-1",
+        cause_action_id="call-1",
+        cause_workstream_id="coord-1",
+    )
+
+    assert ExcursionAttribution.from_config(attribution.to_config()) == attribution
+    assert ExcursionAttribution.from_claims(attribution.to_claims()) == attribution
+
+
+def test_ambiguous_config_has_no_implicit_principal():
+    config = ambiguous_attribution_config({"john", "jared"})
+
+    assert config[CONFIG_STATE_KEY] == ATTRIBUTION_STATE_AMBIGUOUS
+    assert ExcursionAttribution.from_config(config) is None
+    assert conflicting_principals_from_config(config) == frozenset({"jared", "john"})
+
+
+def test_partial_or_unknown_attribution_fails_loudly():
+    with pytest.raises(ValueError, match="version"):
+        ExcursionAttribution.from_config({"excursion_principal_id": "john"})
+    with pytest.raises(ValueError, match="version"):
+        ExcursionAttribution.from_claims({"excursion_principal_id": "john"})
+
+
+def test_only_coordinator_auth_may_supply_inherited_attribution():
+    attribution = ExcursionAttribution.start("john", excursion_id="exc-1")
+    human = AuthResult(
+        user_id="jared",
+        scopes=frozenset({"write"}),
+        token_source="jwt",
+        permissions=frozenset(),
+        extra_claims=attribution.to_claims(),
+    )
+    coordinator = AuthResult(
+        user_id="jared",
+        scopes=frozenset({"write"}),
+        token_source="coordinator",
+        permissions=frozenset({"admin.coordinator"}),
+        extra_claims=attribution.to_claims(),
+    )
+
+    assert attribution_from_auth(human) is None
+    assert attribution_from_auth(coordinator) == attribution

--- a/tests/test_coordinator_client.py
+++ b/tests/test_coordinator_client.py
@@ -21,6 +21,7 @@ from turnstone.console.coordinator_client import (
     CoordinatorClient,
     CoordinatorTokenManager,
 )
+from turnstone.core.attribution import ExcursionAttribution
 from turnstone.core.auth import JWT_AUD_CONSOLE, validate_jwt
 from turnstone.core.child_event_bus import ChildEventBus
 from turnstone.core.storage._sqlite import SQLiteBackend
@@ -67,6 +68,36 @@ def test_token_manager_embeds_coord_ws_id_claim():
     decoded = jwt.decode(token, _SECRET, algorithms=["HS256"], audience=JWT_AUD_CONSOLE)
     assert decoded["coord_ws_id"] == "coord-42"
     assert decoded["src"] == "coordinator"
+
+
+def test_token_manager_keeps_owner_sub_and_signs_excursion_principal():
+    import jwt
+
+    tm = CoordinatorTokenManager(
+        user_id="jared",
+        scopes=frozenset({"write"}),
+        permissions=frozenset({"admin.coordinator"}),
+        secret=_SECRET,
+        coord_ws_id="coord-42",
+    )
+    attribution = ExcursionAttribution.start(
+        "john",
+        excursion_id="exc-john",
+        cause_action_id="call-d",
+        cause_workstream_id="coord-42",
+    )
+
+    decoded = jwt.decode(
+        tm.token_for(attribution),
+        _SECRET,
+        algorithms=["HS256"],
+        audience=JWT_AUD_CONSOLE,
+    )
+
+    assert decoded["sub"] == "jared"
+    assert decoded["excursion_principal_id"] == "john"
+    assert decoded["excursion_id"] == "exc-john"
+    assert decoded["excursion_cause_action_id"] == "call-d"
 
 
 def test_token_manager_refreshes_near_expiry(monkeypatch):
@@ -1287,6 +1318,21 @@ def test_wait_for_workstream_returns_immediately_when_already_terminal(
     assert result["results"]["child-a"]["state"] == "idle"
     # Must finish in well under the requested timeout.
     assert result["elapsed"] < 1.0
+
+
+def test_wait_for_workstream_returns_trusted_excursion_attribution(populated_storage):
+    attribution = ExcursionAttribution.start(
+        "john",
+        excursion_id="exc-john",
+        cause_action_id="spawn-b",
+        cause_workstream_id="coord-1",
+    )
+    populated_storage.save_workstream_config("child-a", attribution.to_config())
+    client = _make_read_client(populated_storage)
+
+    result = client.wait_for_workstream(["child-a"], timeout=5, mode="any")
+
+    assert result["results"]["child-a"]["excursion_attribution"] == (attribution.to_public_dict())
 
 
 def test_wait_for_workstream_any_mode_returns_when_first_terminal(

--- a/tests/test_coordinator_proxy_auth.py
+++ b/tests/test_coordinator_proxy_auth.py
@@ -67,6 +67,30 @@ def test_coordinator_source_is_preserved_on_remint():
     assert payload["coord_ws_id"] == "coord-42"
 
 
+def test_coordinator_excursion_claims_are_preserved_on_remint():
+    claims = {
+        "coord_ws_id": "coord-42",
+        "excursion_attribution_version": "1",
+        "excursion_principal_id": "john",
+        "excursion_id": "exc-john",
+        "excursion_cause_action_id": "call-d",
+        "excursion_cause_workstream_id": "coord-42",
+    }
+    auth = AuthResult(
+        user_id="jared",
+        scopes=frozenset({"write"}),
+        token_source="coordinator",
+        permissions=frozenset({"admin.coordinator"}),
+        extra_claims=claims,
+    )
+
+    payload = _decode(_proxy_auth_headers(_build_request(auth)))
+
+    assert payload["sub"] == "jared"
+    for key, value in claims.items():
+        assert payload[key] == value
+
+
 def test_coord_ws_id_absent_when_not_in_inbound_claims():
     """Defensive: if the inbound token is src=coordinator but missing the
     coord_ws_id claim (shouldn't happen in practice), the re-mint skips

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -15,6 +15,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from turnstone.core.attribution import ExcursionAttribution
 from turnstone.core.metacognition import TASK_NOTE_MAX, TASK_TITLE_MAX
 from turnstone.core.session import ChatSession
 from turnstone.core.storage._sqlite import SQLiteBackend
@@ -251,6 +252,24 @@ def test_spawn_exec_calls_client_and_returns_summary(coord_session):
     assert "child-7" in output
 
 
+def test_spawn_prepare_pins_principal_if_context_changes_before_execute(coord_session):
+    """An already-proposed action retains its prepare-time attribution
+    rather than rereading mutable session state in its executor."""
+
+    sess, coord, _ui = coord_session
+    john = sess.begin_excursion("john")
+    item = sess._prepare_tool(_tc("spawn_workstream", {"initial_message": "already proposed"}))
+    jared = ExcursionAttribution.start("jared", excursion_id="exc-jared")
+    sess.begin_excursion("jared", inherited=jared)
+    coord.spawn.return_value = {"ws_id": "child-7", "status": 200}
+
+    sess._exec_spawn_workstream(item)
+
+    sent = coord.spawn.call_args.kwargs["attribution"]
+    assert sent.principal_id == "john"
+    assert sent.excursion_id == john.excursion_id
+
+
 def test_spawn_exec_does_not_surface_misleading_status_field(coord_session):
     """The routing-proxy ``status`` is the HTTP code (always 200 on
     success), not a lifecycle state — leaking it into the tool's
@@ -389,7 +408,7 @@ def test_send_exec_dispatches(coord_session):
     coord.send.return_value = {"status": 200}
     item = sess._prepare_tool(_tc("send_to_workstream", {"ws_id": "x", "message": "hi"}))
     _call_id, output = sess._exec_send_to_workstream(item)
-    coord.send.assert_called_once_with("x", "hi")
+    coord.send.assert_called_once_with("x", "hi", attribution=ANY)
     assert "x" in output
 
 
@@ -590,6 +609,115 @@ def test_wait_exec_preserves_explicit_zero_timeout(coord_session):
     coord.wait_for_workstream.assert_called_once_with(
         ["a"], timeout=0, mode="any", since=None, progress_callback=ANY
     )
+
+
+def test_wait_adopts_returned_child_trusted_principal(coord_session):
+    sess, coord, _ui = coord_session
+    sess.begin_excursion("john")
+    jared = ExcursionAttribution.start("jared", excursion_id="exc-jared")
+    coord.wait_for_workstream.return_value = {
+        "results": {
+            "child-b": {
+                "state": "idle",
+                "tokens": 1,
+                "excursion_attribution": jared.to_public_dict(),
+            }
+        },
+        "complete": True,
+        "elapsed": 0.1,
+        "mode": "any",
+    }
+
+    item = sess._prepare_tool(_tc("wait_for_workstream", {"ws_ids": ["child-b"]}))
+    sess._exec_wait_for_workstream(item)
+    sess._fold_child_effect_attribution([item])
+
+    assert sess._excursion_attribution == jared
+    assert sess._mcp_effective_user_id == "jared"
+
+
+def test_mixed_child_principals_require_a_trusted_causal_reference(coord_session):
+    sess, coord, ui = coord_session
+    john = ExcursionAttribution.start("john", excursion_id="exc-john")
+    jared = ExcursionAttribution.start("jared", excursion_id="exc-jared")
+    coord.wait_for_workstream.return_value = {
+        "results": {
+            "child-d": {
+                "state": "idle",
+                "tokens": 1,
+                "excursion_attribution": john.to_public_dict(),
+            },
+            "child-b": {
+                "state": "idle",
+                "tokens": 1,
+                "excursion_attribution": jared.to_public_dict(),
+            },
+        },
+        "complete": True,
+        "elapsed": 0.1,
+        "mode": "all",
+    }
+    wait_item = sess._prepare_tool(
+        _tc("wait_for_workstream", {"ws_ids": ["child-d", "child-b"], "mode": "all"})
+    )
+    sess._exec_wait_for_workstream(wait_item)
+    sess._fold_child_effect_attribution([wait_item])
+    assert sess._excursion_conflicting_principals == frozenset({"jared", "john"})
+    assert sess._mcp_effective_user_id is None
+
+    coord.spawn.reset_mock()
+    spawn_item = sess._prepare_tool(_tc("spawn_workstream", {"initial_message": "continue"}))
+    assert "cause_workstream_id is required" in spawn_item["error"]
+    coord.spawn.assert_not_called()
+
+    coord.attribution_for_workstream.return_value = (jared, "")
+    coord.spawn.return_value = {"ws_id": "child-next", "status": 200}
+    caused_item = sess._prepare_tool(
+        _tc(
+            "spawn_workstream",
+            {"initial_message": "continue B", "cause_workstream_id": "child-b"},
+            call_id="call-next",
+        )
+    )
+    _call_id, output = sess._exec_spawn_workstream(caused_item)
+    assert "child-next" in output
+    sent = coord.spawn.call_args.kwargs["attribution"]
+    assert sent.principal_id == "jared"
+    assert sent.cause_action_id == "call-next"
+
+
+def test_parallel_wait_calls_join_principals_after_every_sibling_settles(coord_session):
+    sess, coord, _ui = coord_session
+    john = ExcursionAttribution.start("john", excursion_id="exc-john")
+    jared = ExcursionAttribution.start("jared", excursion_id="exc-jared")
+
+    def wait_result(ws_ids, **_kwargs):
+        ws_id = ws_ids[0]
+        attribution = john if ws_id == "child-d" else jared
+        return {
+            "results": {
+                ws_id: {
+                    "state": "idle",
+                    "tokens": 1,
+                    "excursion_attribution": attribution.to_public_dict(),
+                }
+            },
+            "complete": True,
+            "elapsed": 0.1,
+            "mode": "any",
+        }
+
+    coord.wait_for_workstream.side_effect = wait_result
+
+    sess._execute_tools(
+        [
+            _tc("wait_for_workstream", {"ws_ids": ["child-d"]}, call_id="wait-d"),
+            _tc("wait_for_workstream", {"ws_ids": ["child-b"]}, call_id="wait-b"),
+        ]
+    )
+
+    assert sess._excursion_conflicting_principals == frozenset({"jared", "john"})
+    assert sess._mcp_effective_user_id is None
 
 
 def test_delete_prepare_needs_approval(coord_session):

--- a/tests/test_model_provider_obo.py
+++ b/tests/test_model_provider_obo.py
@@ -630,6 +630,16 @@ class TestModelOboToken:
             user_id=USER, audience=AUDIENCE
         )
 
+    def test_obo_alias_refuses_mixed_principal_excursion(self) -> None:
+        reg = _registry_with(self._obo_cfg())
+        sess = _fake_session(registry=reg, user_id=USER, mint_token="minted-jwt")
+        sess._excursion_conflicting_principals = frozenset({"jared", "john"})
+
+        with pytest.raises(BackendAuthUnavailableError, match="ambiguous"):
+            ChatSession._model_backend_auth_token(sess, "tf")
+
+        sess._mcp_mint_client.mint_model_obo_token_sync.assert_not_called()
+
     def test_token_is_provider_agnostic(self) -> None:
         # The raw token is returned regardless of provider surface — the caller
         # binds it via ``with_options(api_key=...)``, so there is no per-provider

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from turnstone.core.attribution import ExcursionAttribution
 from turnstone.core.session_manager import SessionKindAdapter, SessionManager
 from turnstone.core.workstream import (
     BULK_CLOSE_STATE_VALUES,
@@ -781,6 +782,29 @@ def test_open_threads_saved_model_alias_into_build_session() -> None:
 
     assert reopened is not None
     assert adapter.last_build_model == "gpt-5-pro"
+
+
+def test_open_restores_excursion_attribution_before_session_build() -> None:
+    class AttributionRecordingAdapter(FakeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.last_excursion_attribution: object | None = None
+
+        def build_session(self, ws: Workstream, **kwargs: object) -> Any:
+            self.last_excursion_attribution = kwargs.get("excursion_attribution")
+            return super().build_session(ws, **kwargs)
+
+    adapter = AttributionRecordingAdapter()
+    mgr, _, storage = _make_manager(adapter)
+    ws = mgr.create(user_id="jared")
+    attribution = ExcursionAttribution.start("john", excursion_id="exc-john")
+    storage.ws_config[ws.id] = attribution.to_config()
+    mgr.close(ws.id)
+
+    reopened = mgr.open(ws.id)
+
+    assert reopened is not None
+    assert adapter.last_excursion_attribution == attribution
 
 
 def test_open_drops_saved_alias_when_validator_rejects() -> None:

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import httpx
 
+from turnstone.core.attribution import ExcursionAttribution
 from turnstone.core.auth import JWT_AUD_CONSOLE, create_jwt
 from turnstone.core.log import get_logger
 from turnstone.core.memory import LAST_ERROR_CONFIG_KEY
@@ -445,9 +446,13 @@ class CoordinatorTokenManager:
         self._margin = ttl_seconds * refresh_margin
         self._token: str = ""
         self._expires_at: float = 0.0
+        self._attribution_key: tuple[str, str, str, str] | None = None
         self._lock = threading.Lock()
 
-    def _mint(self) -> None:
+    def _mint(self, attribution: ExcursionAttribution | None = None) -> None:
+        extra_claims = {"coord_ws_id": self._coord_ws_id}
+        if attribution is not None:
+            extra_claims.update(attribution.to_claims())
         self._token = create_jwt(
             user_id=self._user_id,
             scopes=self._scopes,
@@ -456,7 +461,7 @@ class CoordinatorTokenManager:
             audience=JWT_AUD_CONSOLE,
             permissions=self._permissions,
             expiry_seconds=self._ttl,
-            extra_claims={"coord_ws_id": self._coord_ws_id},
+            extra_claims=extra_claims,
         )
         self._expires_at = time.time() + self._ttl
         # Observability — without this, mint races + premature-401
@@ -472,9 +477,28 @@ class CoordinatorTokenManager:
 
     @property
     def token(self) -> str:
+        return self.token_for(None)
+
+    def token_for(self, attribution: ExcursionAttribution | None) -> str:
+        """Mint for the owner ``sub`` plus optional excursion claims."""
+
+        key = (
+            (
+                attribution.principal_id,
+                attribution.excursion_id,
+                attribution.cause_action_id,
+                attribution.cause_workstream_id,
+            )
+            if attribution is not None
+            else None
+        )
         with self._lock:
-            if time.time() >= self._expires_at - self._margin:
-                self._mint()
+            if key != self._attribution_key or time.time() >= self._expires_at - self._margin:
+                if attribution is None:
+                    self._mint()
+                else:
+                    self._mint(attribution)
+                self._attribution_key = key
             return self._token
 
 
@@ -528,10 +552,13 @@ class CoordinatorClient:
         timeout: float = 30.0,
         http_client: httpx.Client | None = None,
         child_event_bus: ChildEventBus,
+        attribution_token_factory: Callable[[ExcursionAttribution | None], str] | None = None,
     ) -> None:
         self._base_url = console_base_url.rstrip("/")
         self._storage = storage
         self._token_factory = token_factory
+        self._attribution_token_factory = attribution_token_factory
+        self._excursion_attribution: ExcursionAttribution | None = None
         self._coord_ws_id = coord_ws_id
         self._user_id = user_id
         self._timeout = timeout
@@ -579,8 +606,61 @@ class CoordinatorClient:
 
     # -- internal helpers ---------------------------------------------------
 
-    def _headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {self._token_factory()}"}
+    def bind_excursion(self, attribution: ExcursionAttribution | None) -> None:
+        """Set the signed control context for subsequent routed actions."""
+
+        self._excursion_attribution = attribution
+
+    def _headers(
+        self,
+        attribution: ExcursionAttribution | None = None,
+    ) -> dict[str, str]:
+        effective = attribution if attribution is not None else self._excursion_attribution
+        if self._attribution_token_factory is not None:
+            token = self._attribution_token_factory(effective)
+        else:
+            token = self._token_factory()
+        return {"Authorization": f"Bearer {token}"}
+
+    def attribution_for_workstream(
+        self,
+        ws_id: str,
+    ) -> tuple[ExcursionAttribution | None, str]:
+        """Resolve trusted causal attribution from an owned workstream.
+
+        This is the gate behind model-supplied causal references: ownership is
+        checked first and the principal is read from shell-persisted config,
+        never accepted from tool arguments.
+        """
+
+        resolved, ref_err = self._resolve_ws_ref(ws_id)
+        if ref_err is not None:
+            return None, str(ref_err.get("error") or "workstream not found")
+        if not self._is_own_subtree(resolved):
+            return None, f"workstream not in coordinator subtree: {resolved}"
+        return self._load_excursion_attribution(resolved)
+
+    def _load_excursion_attribution(
+        self,
+        ws_id: str,
+    ) -> tuple[ExcursionAttribution | None, str]:
+        """Load attribution after the caller has established subtree ownership."""
+
+        try:
+            config = self._storage.load_workstream_config(ws_id) or {}
+            attribution = ExcursionAttribution.from_config(config)
+        except (TypeError, ValueError):
+            return None, f"workstream has invalid excursion attribution: {ws_id}"
+        except Exception:
+            log.debug(
+                "coord_client.attribution_load_failed ws=%s",
+                ws_id[:8],
+                exc_info=True,
+            )
+            return None, f"workstream attribution unavailable: {ws_id}"
+        if attribution is None:
+            return None, f"workstream has no resolved excursion attribution: {ws_id}"
+        return attribution, ""
 
     def _post(
         self,
@@ -588,6 +668,7 @@ class CoordinatorClient:
         body: dict[str, Any],
         *,
         ws_id: str | None = None,
+        attribution: ExcursionAttribution | None = None,
     ) -> dict[str, Any]:
         """POST to a routing-proxy path. ``ws_id`` is interpolated into
         the path template when it has a ``{ws_id}`` slot (post-#422
@@ -602,7 +683,12 @@ class CoordinatorClient:
             path = template.format(ws_id=ws_id)
         else:
             path = template
-        return self._post_url(f"{self._base_url}{path}", body, log_path=template)
+        return self._post_url(
+            f"{self._base_url}{path}",
+            body,
+            log_path=template,
+            attribution=attribution,
+        )
 
     def _post_url(
         self,
@@ -610,6 +696,7 @@ class CoordinatorClient:
         body: dict[str, Any],
         *,
         log_path: str,
+        attribution: ExcursionAttribution | None = None,
     ) -> dict[str, Any]:
         """POST a pre-built URL with the canonical error handling.
 
@@ -621,7 +708,11 @@ class CoordinatorClient:
         per-session ids that would fragment log aggregation.
         """
         try:
-            resp = self._http.post(url, json=body, headers=self._headers())
+            resp = self._http.post(
+                url,
+                json=body,
+                headers=self._headers(attribution),
+            )
         except httpx.HTTPError as exc:
             log.warning("coord_client.http_error path=%s err=%s", log_path, exc)
             return {"error": f"upstream unreachable: {exc}", "status": 0}
@@ -874,6 +965,7 @@ class CoordinatorClient:
         target_node: str = "",
         project: str = "",
         persona: str = "",
+        attribution: ExcursionAttribution | None = None,
     ) -> dict[str, Any]:
         """Create a child workstream via the routing proxy."""
         body: dict[str, Any] = {
@@ -897,15 +989,32 @@ class CoordinatorClient:
             # handler at child-creation time.  Omitted = the interactive
             # kind default — never the parent's persona.
             body["persona"] = persona
-        return self._post("spawn", body)
+        return self._post("spawn", body, attribution=attribution)
 
-    def send(self, ws_id: str, message: str) -> dict[str, Any]:
+    def send(
+        self,
+        ws_id: str,
+        message: str,
+        *,
+        attribution: ExcursionAttribution | None = None,
+    ) -> dict[str, Any]:
         resolved, ref_err = self._resolve_owned(ws_id)
         if ref_err is not None:
             return ref_err
-        return self._post("send", {"message": message}, ws_id=resolved)
+        return self._post(
+            "send",
+            {"message": message},
+            ws_id=resolved,
+            attribution=attribution,
+        )
 
-    def emit_audit(self, action: str, detail: dict[str, Any]) -> None:
+    def emit_audit(
+        self,
+        action: str,
+        detail: dict[str, Any],
+        *,
+        attribution: ExcursionAttribution | None = None,
+    ) -> None:
         """Record an audit row attributed to this coordinator session.
 
         Uses the client's own ``storage``, ``user_id``, and
@@ -917,11 +1026,18 @@ class CoordinatorClient:
 
         record_audit(
             self._storage,
-            user_id=self._user_id,
+            user_id=(attribution.principal_id if attribution is not None else self._user_id),
             action=action,
             resource_type="coordinator",
             resource_id=self._coord_ws_id,
-            detail=detail,
+            detail={
+                **detail,
+                **(
+                    {"excursion_attribution": attribution.to_public_dict()}
+                    if attribution is not None
+                    else {}
+                ),
+            },
         )
 
     def close_workstream(self, ws_id: str, reason: str = "") -> dict[str, Any]:
@@ -1370,10 +1486,11 @@ class CoordinatorClient:
                 bus.unregister_waiter(own_subtree, wake_event)
         # Bundle each terminal child's last assistant message inline so the
         # coordinator LLM doesn't have to follow up with one
-        # ``inspect_workstream`` per ws.  Only ``idle`` / ``error`` ws_ids
-        # actually hit storage (``closed`` / ``not_found`` return a sentinel
-        # without I/O), so split them and parallelize the storage-bound
-        # subset across a small thread pool — at the WAIT_MAX_WS_IDS=32
+        # ``inspect_workstream`` per ws. Real terminal children also load
+        # their durable attribution in this pass (message extraction for
+        # ``closed`` / ``deleted`` remains a no-I/O sentinel), so parallelize
+        # the storage-bound subset across a small thread pool — at the
+        # WAIT_MAX_WS_IDS=32
         # cap, 8 workers cuts a worst-case all-idle fan-out from 32
         # sequential storage round-trips down to 4 batches, which lands
         # inside the WAIT_HEARTBEAT_INTERVAL the model already tolerates
@@ -1383,22 +1500,37 @@ class CoordinatorClient:
         io_wids = [
             wid
             for wid, snap in last_results.items()
-            if str(snap.get("state") or "") in ("idle", "error")
+            if str(snap.get("state") or "") in self._WAIT_REAL_TERMINAL_STATES
         ]
-        io_pairs: dict[str, tuple[str | None, bool]] = {}
+        io_pairs: dict[
+            str,
+            tuple[str | None, bool, dict[str, str] | None, str],
+        ] = {}
         if io_wids:
 
-            def _enrich(wid: str) -> tuple[str, str | None, bool]:
+            def _enrich(
+                wid: str,
+            ) -> tuple[str, str | None, bool, dict[str, str] | None, str]:
                 state = str(last_results[wid].get("state") or "")
                 msg, trunc = _wait_message_for(self._storage, wid, state)
-                return wid, msg, trunc
+                # Ownership was already established by the batched pre-filter
+                # and every loop snapshot. Avoid a per-id get_workstream read
+                # in the final enrichment pass.
+                attribution, attribution_error = self._load_excursion_attribution(wid)
+                return (
+                    wid,
+                    msg,
+                    trunc,
+                    attribution.to_public_dict() if attribution is not None else None,
+                    attribution_error,
+                )
 
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=min(8, len(io_wids)),
                 thread_name_prefix="coord-wait-enrich",
             ) as ex:
-                for wid, msg, trunc in ex.map(_enrich, io_wids):
-                    io_pairs[wid] = (msg, trunc)
+                for wid, msg, trunc, attribution, attribution_error in ex.map(_enrich, io_wids):
+                    io_pairs[wid] = (msg, trunc, attribution, attribution_error)
 
         # Build the final dict.  Fresh per-ws dicts (not in-place
         # mutation) so any in-flight ``wait_progress`` SSE event still
@@ -1410,12 +1542,21 @@ class CoordinatorClient:
         for wid, snap in last_results.items():
             state = str(snap.get("state") or "")
             if wid in io_pairs:
-                msg, trunc = io_pairs[wid]
+                msg, trunc, attribution, attribution_error = io_pairs[wid]
             elif state in WAIT_TERMINAL_STATES:
                 msg, trunc = _wait_message_for(self._storage, wid, state)
+                attribution, attribution_error = None, ""
             else:
                 msg, trunc = None, False
+                attribution, attribution_error = None, ""
             enriched_results[wid] = {**snap, "message": msg, "truncated": trunc}
+            if attribution is not None:
+                enriched_results[wid]["excursion_attribution"] = attribution
+            elif (
+                attribution_error
+                and "has no resolved excursion attribution" not in attribution_error
+            ):
+                enriched_results[wid]["attribution_error"] = attribution_error
         response: dict[str, Any] = {
             "results": enriched_results,
             "complete": complete,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -317,6 +317,27 @@ def _proxy_auth_headers(request: Request) -> dict[str, str]:
             coord_ws_id = auth_result.extra_claims.get("coord_ws_id")
             if coord_ws_id:
                 extra["coord_ws_id"] = coord_ws_id
+            # These values arrived inside a validated coordinator JWT.
+            # Preserve them across the console→node re-mint; never copy
+            # similarly named request-body fields into this control plane.
+            from turnstone.core.attribution import (
+                CLAIM_CAUSE_ACTION_KEY,
+                CLAIM_CAUSE_WORKSTREAM_KEY,
+                CLAIM_EXCURSION_KEY,
+                CLAIM_PRINCIPAL_KEY,
+                CLAIM_VERSION_KEY,
+            )
+
+            for claim_key in (
+                CLAIM_VERSION_KEY,
+                CLAIM_PRINCIPAL_KEY,
+                CLAIM_EXCURSION_KEY,
+                CLAIM_CAUSE_ACTION_KEY,
+                CLAIM_CAUSE_WORKSTREAM_KEY,
+            ):
+                claim_value = auth_result.extra_claims.get(claim_key)
+                if claim_value:
+                    extra[claim_key] = claim_value
         token = create_jwt(
             user_id=auth_result.user_id,
             scopes=auth_result.scopes,
@@ -4795,6 +4816,7 @@ def _bootstrap_coord_subsystem(
             console_base_url=console_bind_url,
             storage=storage,
             token_factory=_token_factory,
+            attribution_token_factory=tm.token_for,
             coord_ws_id=ws_id,
             user_id=user_id,
             child_event_bus=coord_adapter.child_event_bus,

--- a/turnstone/console/session_factory.py
+++ b/turnstone/console/session_factory.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from turnstone.console.coordinator_client import CoordinatorClient
+    from turnstone.core.attribution import ExcursionAttribution
     from turnstone.core.config_store import ConfigStore
     from turnstone.core.mcp_client import MCPClientManager
     from turnstone.core.model_registry import ModelRegistry
@@ -106,6 +107,8 @@ def build_console_session_factory(
         project_id: str = "",
         judge_model: str | None = None,
         persona_snapshot: PersonaSnapshot | None = None,
+        excursion_attribution: ExcursionAttribution | None = None,
+        excursion_conflicting_principals: frozenset[str] | None = None,
     ) -> ChatSession:
         assert ui is not None, "console session_factory requires a non-None UI"
         if kind != WorkstreamKind.COORDINATOR:
@@ -236,6 +239,8 @@ def build_console_session_factory(
             project_id=project_id,
             coord_client=coord_client,
             persona_snapshot=persona_snapshot,
+            excursion_attribution=excursion_attribution,
+            excursion_conflicting_principals=excursion_conflicting_principals,
         )
 
     return factory

--- a/turnstone/core/attribution.py
+++ b/turnstone/core/attribution.py
@@ -1,0 +1,236 @@
+"""Durable attribution for one trigger-to-ready harness excursion.
+
+Turnstone's Primer models a coordinator as a daemon made from ordinary
+trigger -> work -> ready runs ("excursions").  A long-lived workstream owner
+is therefore not necessarily the trusted principal whose authority drives a
+particular excursion.  This module keeps those identities separate and gives
+the excursion attribution one wire/storage representation.
+
+The values are shell-owned control state.  Models may reference a trusted
+workstream that already carries attribution, but they never provide a raw
+``principal_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import Any
+
+ATTRIBUTION_VERSION = "1"
+
+CONFIG_VERSION_KEY = "excursion_attribution_version"
+CONFIG_STATE_KEY = "excursion_attribution_state"
+CONFIG_PRINCIPAL_KEY = "excursion_principal_id"
+CONFIG_EXCURSION_KEY = "excursion_id"
+CONFIG_CAUSE_ACTION_KEY = "excursion_cause_action_id"
+CONFIG_CAUSE_WORKSTREAM_KEY = "excursion_cause_workstream_id"
+CONFIG_CONFLICTING_PRINCIPALS_KEY = "excursion_conflicting_principal_ids"
+
+ATTRIBUTION_STATE_RESOLVED = "resolved"
+ATTRIBUTION_STATE_AMBIGUOUS = "ambiguous"
+
+CLAIM_VERSION_KEY = "excursion_attribution_version"
+CLAIM_PRINCIPAL_KEY = "excursion_principal_id"
+CLAIM_EXCURSION_KEY = "excursion_id"
+CLAIM_CAUSE_ACTION_KEY = "excursion_cause_action_id"
+CLAIM_CAUSE_WORKSTREAM_KEY = "excursion_cause_workstream_id"
+
+_MAX_PRINCIPAL = 256
+_MAX_ID = 256
+
+
+def _clean(value: Any, *, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()[:limit]
+
+
+@dataclass(frozen=True, slots=True)
+class ExcursionAttribution:
+    """Trusted principal and causal lineage for one harness excursion."""
+
+    principal_id: str
+    excursion_id: str
+    cause_action_id: str = ""
+    cause_workstream_id: str = ""
+
+    def __post_init__(self) -> None:
+        principal = _clean(self.principal_id, limit=_MAX_PRINCIPAL)
+        excursion = _clean(self.excursion_id, limit=_MAX_ID)
+        cause_action = _clean(self.cause_action_id, limit=_MAX_ID)
+        cause_ws = _clean(self.cause_workstream_id, limit=_MAX_ID)
+        if not principal:
+            raise ValueError("excursion attribution requires a principal_id")
+        if not excursion:
+            raise ValueError("excursion attribution requires an excursion_id")
+        object.__setattr__(self, "principal_id", principal)
+        object.__setattr__(self, "excursion_id", excursion)
+        object.__setattr__(self, "cause_action_id", cause_action)
+        object.__setattr__(self, "cause_workstream_id", cause_ws)
+
+    @classmethod
+    def start(
+        cls,
+        principal_id: str,
+        *,
+        cause_action_id: str = "",
+        cause_workstream_id: str = "",
+        excursion_id: str = "",
+    ) -> ExcursionAttribution:
+        """Create a new root excursion, or reconstruct a trusted inherited one."""
+
+        return cls(
+            principal_id=principal_id,
+            excursion_id=excursion_id or uuid.uuid4().hex,
+            cause_action_id=cause_action_id,
+            cause_workstream_id=cause_workstream_id,
+        )
+
+    def for_spawn_edge(
+        self,
+        *,
+        action_id: str,
+        cause_workstream_id: str,
+    ) -> ExcursionAttribution:
+        """Carry the principal/excursion across a newly-authorized spawn edge."""
+
+        return replace(
+            self,
+            cause_action_id=action_id,
+            cause_workstream_id=cause_workstream_id,
+        )
+
+    def to_config(self) -> dict[str, str]:
+        return {
+            CONFIG_VERSION_KEY: ATTRIBUTION_VERSION,
+            CONFIG_STATE_KEY: ATTRIBUTION_STATE_RESOLVED,
+            CONFIG_PRINCIPAL_KEY: self.principal_id,
+            CONFIG_EXCURSION_KEY: self.excursion_id,
+            CONFIG_CAUSE_ACTION_KEY: self.cause_action_id,
+            CONFIG_CAUSE_WORKSTREAM_KEY: self.cause_workstream_id,
+            CONFIG_CONFLICTING_PRINCIPALS_KEY: "",
+        }
+
+    def to_claims(self) -> dict[str, str]:
+        return {
+            CLAIM_VERSION_KEY: ATTRIBUTION_VERSION,
+            CLAIM_PRINCIPAL_KEY: self.principal_id,
+            CLAIM_EXCURSION_KEY: self.excursion_id,
+            CLAIM_CAUSE_ACTION_KEY: self.cause_action_id,
+            CLAIM_CAUSE_WORKSTREAM_KEY: self.cause_workstream_id,
+        }
+
+    def to_public_dict(self) -> dict[str, str]:
+        """Model/UI-facing representation; values remain trusted metadata."""
+
+        return {
+            "principal_id": self.principal_id,
+            "excursion_id": self.excursion_id,
+            "cause_action_id": self.cause_action_id,
+            "cause_workstream_id": self.cause_workstream_id,
+        }
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> ExcursionAttribution | None:
+        version = _clean(config.get(CONFIG_VERSION_KEY), limit=16)
+        state = _clean(config.get(CONFIG_STATE_KEY), limit=16)
+        principal = _clean(config.get(CONFIG_PRINCIPAL_KEY), limit=_MAX_PRINCIPAL)
+        excursion = _clean(config.get(CONFIG_EXCURSION_KEY), limit=_MAX_ID)
+        present = bool(version or state or principal or excursion)
+        if not present:
+            return None
+        if version != ATTRIBUTION_VERSION:
+            raise ValueError(f"unsupported excursion attribution version: {version!r}")
+        if state == ATTRIBUTION_STATE_AMBIGUOUS:
+            return None
+        if state not in ("", ATTRIBUTION_STATE_RESOLVED):
+            raise ValueError(f"unsupported excursion attribution state: {state!r}")
+        return cls(
+            principal_id=principal,
+            excursion_id=excursion,
+            cause_action_id=_clean(config.get(CONFIG_CAUSE_ACTION_KEY), limit=_MAX_ID),
+            cause_workstream_id=_clean(config.get(CONFIG_CAUSE_WORKSTREAM_KEY), limit=_MAX_ID),
+        )
+
+    @classmethod
+    def from_claims(cls, claims: Mapping[str, Any]) -> ExcursionAttribution | None:
+        version = _clean(claims.get(CLAIM_VERSION_KEY), limit=16)
+        principal = _clean(claims.get(CLAIM_PRINCIPAL_KEY), limit=_MAX_PRINCIPAL)
+        excursion = _clean(claims.get(CLAIM_EXCURSION_KEY), limit=_MAX_ID)
+        present = bool(version or principal or excursion)
+        if not present:
+            return None
+        if version != ATTRIBUTION_VERSION:
+            raise ValueError(f"unsupported excursion attribution version: {version!r}")
+        return cls(
+            principal_id=principal,
+            excursion_id=excursion,
+            cause_action_id=_clean(claims.get(CLAIM_CAUSE_ACTION_KEY), limit=_MAX_ID),
+            cause_workstream_id=_clean(claims.get(CLAIM_CAUSE_WORKSTREAM_KEY), limit=_MAX_ID),
+        )
+
+
+def attribution_from_auth(auth: Any) -> ExcursionAttribution | None:
+    """Read signed coordinator attribution from an ``AuthResult``-like object.
+
+    Ordinary human/service JWTs cannot opt into delegated identity by adding
+    body fields.  Only a token whose validated ``src`` is ``coordinator`` may
+    carry the claims across the console -> node proxy boundary.
+    """
+
+    if auth is None or getattr(auth, "token_source", "") != "coordinator":
+        return None
+    claims = getattr(auth, "extra_claims", None)
+    if not isinstance(claims, Mapping):
+        return None
+    return ExcursionAttribution.from_claims(claims)
+
+
+def ambiguous_attribution_config(principal_ids: set[str] | frozenset[str]) -> dict[str, str]:
+    """Persist a fail-closed multi-principal attribution state.
+
+    The principal list is diagnostic control metadata, not an authority set:
+    no member may be selected implicitly for a delegated call.
+    """
+
+    cleaned = sorted(
+        {principal for raw in principal_ids if (principal := _clean(raw, limit=_MAX_PRINCIPAL))}
+    )
+    if len(cleaned) < 2:
+        raise ValueError("ambiguous attribution requires at least two principals")
+    return {
+        CONFIG_VERSION_KEY: ATTRIBUTION_VERSION,
+        CONFIG_STATE_KEY: ATTRIBUTION_STATE_AMBIGUOUS,
+        CONFIG_PRINCIPAL_KEY: "",
+        CONFIG_EXCURSION_KEY: "",
+        CONFIG_CAUSE_ACTION_KEY: "",
+        CONFIG_CAUSE_WORKSTREAM_KEY: "",
+        CONFIG_CONFLICTING_PRINCIPALS_KEY: json.dumps(cleaned, separators=(",", ":")),
+    }
+
+
+def conflicting_principals_from_config(config: Mapping[str, Any]) -> frozenset[str]:
+    """Return persisted ambiguous principals, validating the state envelope."""
+
+    state = _clean(config.get(CONFIG_STATE_KEY), limit=16)
+    if state != ATTRIBUTION_STATE_AMBIGUOUS:
+        return frozenset()
+    version = _clean(config.get(CONFIG_VERSION_KEY), limit=16)
+    if version != ATTRIBUTION_VERSION:
+        raise ValueError(f"unsupported excursion attribution version: {version!r}")
+    raw = config.get(CONFIG_CONFLICTING_PRINCIPALS_KEY)
+    try:
+        decoded = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid conflicting excursion principals") from exc
+    if not isinstance(decoded, list):
+        raise ValueError("invalid conflicting excursion principals")
+    principals = frozenset(
+        principal for item in decoded if (principal := _clean(item, limit=_MAX_PRINCIPAL))
+    )
+    if len(principals) < 2:
+        raise ValueError("ambiguous attribution requires at least two principals")
+    return principals

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -47,6 +47,11 @@ from turnstone.core.attachments import (
     safe_attachment_label,
     unreadable_placeholder,
 )
+from turnstone.core.attribution import (
+    ExcursionAttribution,
+    ambiguous_attribution_config,
+    conflicting_principals_from_config,
+)
 from turnstone.core.background_shells import (
     _FILTER_MAX_LINE_CHARS,
     BackgroundShell,
@@ -1480,6 +1485,8 @@ class ChatSession:
         coord_client: Any = None,
         project_id: str = "",
         persona_snapshot: PersonaSnapshot | None = None,
+        excursion_attribution: ExcursionAttribution | None = None,
+        excursion_conflicting_principals: frozenset[str] | None = None,
     ):
         if kind == WorkstreamKind.COORDINATOR and not user_id:
             # Coordinators carry real authority — they mint child-spawn
@@ -1571,18 +1578,24 @@ class ChatSession:
         # Listener identity, catalog merge, and dispatch all consume
         # this through ``_mcp_user_id``.
         self._mcp_user_id: str | None = user_id or None
-        # Acting user for per-user MCP credential resolution on SHARED
-        # workstreams: the authenticated principal who most recently
-        # initiated a turn (bound by ``bind_acting_user`` from the send
-        # path). Empty until the first authenticated send, and empty
-        # forever on CLI / eval / scheduled sessions — every consumer
-        # goes through ``_mcp_effective_user_id``, which falls back to
-        # the session owner. Rebinding also swaps the user-scoped MCP
-        # listeners; ``_mcp_listener_user_id`` tracks the identity the
-        # current registrations were made under (listener identity is
-        # the ``(user_id, callback)`` pair).
-        self._acting_user_id: str = ""
-        self._mcp_listener_user_id: str | None = user_id or None
+        # The workstream owner is durable tenancy metadata; an excursion's
+        # trusted principal is the human whose trigger (or causally-returned
+        # child ledger) authorizes the current trigger→work→ready run.  They
+        # coincide in a single-user session but MUST remain separate in a
+        # shared coordinator.  Conflicting principals are an explicit,
+        # fail-closed state: per-user MCP/model auth gets no owner fallback.
+        self._excursion_attribution = excursion_attribution
+        self._excursion_conflicting_principals = frozenset(excursion_conflicting_principals or ())
+        if self._excursion_attribution is not None and self._excursion_conflicting_principals:
+            raise ValueError("excursion attribution cannot be resolved and ambiguous")
+        self._acting_user_id: str = (
+            self._excursion_attribution.principal_id if self._excursion_attribution else ""
+        )
+        self._mcp_listener_user_id: str | None = (
+            None
+            if self._excursion_conflicting_principals
+            else (self._acting_user_id or user_id or None)
+        )
         # Shared-workstream context state: the model must be TOLD when more
         # than one human is in the room. ``_shared_workstream`` flips True once
         # a non-owner sender appears (live send OR rehydrated history) and
@@ -2010,6 +2023,7 @@ class ChatSession:
         # recompose to the first user turn (keeps the cached prefix stable).
         self._system_composed_with_context: bool = False
         self._init_system_messages()
+        self._sync_coordinator_excursion()
         # Skip on rehydrate — ``_save_config`` is ``INSERT OR
         # REPLACE`` per-key, and the persisted row is what
         # ``ChatSession.resume`` is about to read back.  Pairs with
@@ -2366,6 +2380,10 @@ class ChatSession:
         snap = self._current_persona_snapshot()
         if snap is not None:
             config.update(snap.to_config())
+        if self._excursion_conflicting_principals:
+            config.update(ambiguous_attribution_config(set(self._excursion_conflicting_principals)))
+        elif self._excursion_attribution is not None:
+            config.update(self._excursion_attribution.to_config())
         save_workstream_config(self._ws_id, config)
 
     def _render_skill_body(
@@ -3758,6 +3776,11 @@ class ChatSession:
         # after which the next _save_config would "repair" the target's
         # stamp with a persona the operator never chose for it.
         config = load_workstream_config(ws_id)
+        resumed_attribution: ExcursionAttribution | None = None
+        resumed_conflicts: frozenset[str] = frozenset()
+        if not fork:
+            resumed_attribution = ExcursionAttribution.from_config(config or {})
+            resumed_conflicts = conflicting_principals_from_config(config or {})
         snap: PersonaSnapshot | None = None
         if not fork:
             snap = snapshot_from_config(config or {})
@@ -3894,6 +3917,13 @@ class ChatSession:
                     self._skill_name = None
             if "notify_on_complete" in config:
                 self._notify_on_complete = config["notify_on_complete"]
+        if not fork:
+            self._excursion_attribution = resumed_attribution
+            self._excursion_conflicting_principals = resumed_conflicts
+            self._rebind_effective_principal(
+                resumed_attribution.principal_id if resumed_attribution else ""
+            )
+            self._sync_coordinator_excursion()
         # When forking, persist the copied messages and restored config under
         # the fork's own ws_id so they survive restarts.
         if fork:
@@ -6058,16 +6088,15 @@ class ChatSession:
 
     @property
     def _mcp_effective_user_id(self) -> str | None:
-        """Identity for per-user MCP (oauth_user) credential resolution.
+        """Trusted principal for per-user credential resolution.
 
-        The acting user — the authenticated principal who last initiated
-        a turn on this session — when one is bound; otherwise the session
-        owner. On a shared workstream this makes MCP tool calls run under
-        the credentials (and catalog) of whoever is actually driving,
-        rather than whoever created the workstream. Falls back to the
-        owner for CLI / eval / scheduled / internal turns, preserving the
-        pre-existing single-user behaviour.
+        A multi-principal causal merge has no implicit answer and therefore
+        returns ``None`` rather than borrowing the durable workstream owner.
+        Legacy/single-user lanes retain the owner fallback until their first
+        explicit excursion is bound.
         """
+        if self._excursion_conflicting_principals:
+            return None
         return self._acting_user_id or self._mcp_user_id
 
     def _model_backend_auth_token(self, alias: str) -> str | None:
@@ -6106,6 +6135,24 @@ class ChatSession:
         must_fail_closed = configured_fail_closed or not has_static_key
         user_id = ""
         if mode == "entra_obo":
+            # Auth-resolver unit doubles predate excursion state and invoke
+            # this method unbound on a SimpleNamespace.  Absence means the
+            # legacy, non-ambiguous case; a real ChatSession always owns the
+            # field from construction onward.
+            conflicting_principals = getattr(self, "_excursion_conflicting_principals", frozenset())
+            if conflicting_principals:
+                principals = ",".join(sorted(conflicting_principals))
+                log.warning(
+                    "model_obo.ambiguous_excursion",
+                    alias=alias,
+                    audience=cfg.obo_audience,
+                    principals=principals,
+                )
+                raise BackendAuthUnavailableError(
+                    "Delegated backend authentication is ambiguous after combining "
+                    f"multiple trusted principals for model alias {alias!r}; "
+                    "use an app-identity coordinator model or begin a new human excursion"
+                )
             user_id = (self._mcp_effective_user_id or "").strip()
             if not user_id:
                 log.warning(
@@ -6185,15 +6232,166 @@ class ChatSession:
         a plain user, even when an admin is driving — bypass is a surface
         property (cluster inspect), not a principal property.
         """
+        if self._excursion_conflicting_principals:
+            return None
         return self._acting_user_id or self._user_id or None
 
+    def _sync_coordinator_excursion(self) -> None:
+        """Publish the current control state to the coordinator HTTP client."""
+
+        client = self._coord_client
+        bind = getattr(client, "bind_excursion", None)
+        if callable(bind):
+            bind(self._excursion_attribution)
+
+    def _rebind_effective_principal(self, user_id: str) -> None:
+        """Re-scope per-user catalogs/listeners without minting an excursion."""
+
+        user_id = user_id.strip()
+        new_listener_uid: str | None = (
+            None if self._excursion_conflicting_principals else (user_id or self._mcp_user_id)
+        )
+        if user_id == self._acting_user_id and new_listener_uid == self._mcp_listener_user_id:
+            return
+        self._acting_user_id = user_id
+        mcp = self._mcp_client
+        if not mcp:
+            self._mcp_listener_user_id = new_listener_uid
+            return
+        old_listener_uid = self._mcp_listener_user_id
+        if new_listener_uid == old_listener_uid:
+            return
+        if self._mcp_refresh_cb:
+            mcp.remove_listener(self._mcp_refresh_cb, user_id=old_listener_uid)
+            mcp.add_listener(self._mcp_refresh_cb, user_id=new_listener_uid)
+        if self._mcp_resource_cb:
+            mcp.remove_resource_listener(self._mcp_resource_cb, user_id=old_listener_uid)
+            mcp.add_resource_listener(self._mcp_resource_cb, user_id=new_listener_uid)
+        if self._mcp_prompt_cb:
+            mcp.remove_prompt_listener(self._mcp_prompt_cb, user_id=old_listener_uid)
+            mcp.add_prompt_listener(self._mcp_prompt_cb, user_id=new_listener_uid)
+        self._mcp_listener_user_id = new_listener_uid
+        try_prime_user_pools(mcp, new_listener_uid, context="excursion-principal-change")
+        self._on_mcp_tools_changed()
+        self._init_system_messages()
+
+    def begin_excursion(
+        self,
+        principal_id: str,
+        *,
+        inherited: ExcursionAttribution | None = None,
+        cause_action_id: str = "",
+        cause_workstream_id: str = "",
+    ) -> ExcursionAttribution:
+        """Bind and durably persist one trigger-to-ready excursion.
+
+        ``inherited`` is accepted only from host code that already validated a
+        signed coordinator JWT.  Model/tool payloads never provide a raw
+        principal.  A human trigger creates a fresh excursion id even when the
+        same human drove the preceding turn.
+        """
+
+        attribution = inherited or ExcursionAttribution.start(
+            principal_id,
+            cause_action_id=cause_action_id,
+            cause_workstream_id=cause_workstream_id or self._ws_id,
+        )
+        self._excursion_conflicting_principals = frozenset()
+        self._excursion_attribution = attribution
+        self._rebind_effective_principal(attribution.principal_id)
+        self._sync_coordinator_excursion()
+        self._save_config()
+        return attribution
+
+    def _mark_excursion_ambiguous(self, principal_ids: set[str]) -> None:
+        """Fail closed after folding effect records from multiple principals."""
+
+        principals = frozenset(p.strip() for p in principal_ids if p.strip())
+        if len(principals) < 2:
+            raise ValueError("ambiguous excursion requires at least two principals")
+        self._excursion_attribution = None
+        self._excursion_conflicting_principals = principals
+        self._rebind_effective_principal("")
+        self._sync_coordinator_excursion()
+        self._save_config()
+
+    def _fold_child_effect_attribution(self, items: list[dict[str, Any]]) -> None:
+        """Fold all terminal-child effects at the parallel-batch boundary.
+
+        Wait tools execute concurrently with their siblings.  Mutating session
+        attribution inside each wait worker would make two independent waits
+        from different principals resolve by scheduler order.  Each worker
+        therefore records its trusted result on its own prepared item; this
+        method joins every returned effect once all workers have completed.
+        """
+
+        effect_results: list[dict[str, Any]] = []
+        action_ids: set[str] = set()
+        for item in items:
+            result = item.pop("_excursion_effect_result", None)
+            if not isinstance(result, dict):
+                continue
+            effect_results.append(result)
+            action_ids.add(str(item.get("call_id") or ""))
+        if not effect_results:
+            return
+
+        # Inline/lazy to keep ordinary interactive tool batches independent
+        # from the console layer, matching the wait executor's import seam.
+        from turnstone.console.coordinator_client import WAIT_REAL_TERMINAL_STATES
+
+        attributions: list[ExcursionAttribution] = []
+        for result in effect_results:
+            for snap in (result.get("results") or {}).values():
+                if not isinstance(snap, dict) or snap.get("state") not in WAIT_REAL_TERMINAL_STATES:
+                    continue
+                raw = snap.get("excursion_attribution")
+                if not isinstance(raw, dict):
+                    # Legacy children have no attribution envelope. Preserve
+                    # current context rather than manufacturing a principal
+                    # from the owner; newly-created children always carry it.
+                    continue
+                try:
+                    attributions.append(
+                        ExcursionAttribution(
+                            principal_id=str(raw.get("principal_id") or ""),
+                            excursion_id=str(raw.get("excursion_id") or ""),
+                            cause_action_id=str(raw.get("cause_action_id") or ""),
+                            cause_workstream_id=str(raw.get("cause_workstream_id") or ""),
+                        )
+                    )
+                except ValueError:
+                    log.warning("coord.wait.invalid_child_attribution", ws_id=self._ws_id)
+        if not attributions:
+            return
+        principals = {a.principal_id for a in attributions}
+        if len(principals) > 1:
+            self._mark_excursion_ambiguous(principals)
+            return
+        distinct = {
+            (a.principal_id, a.excursion_id, a.cause_action_id, a.cause_workstream_id): a
+            for a in attributions
+        }
+        if len(distinct) == 1:
+            inherited = next(iter(distinct.values()))
+            self.begin_excursion(inherited.principal_id, inherited=inherited)
+            return
+        # Several causal branches from the same trusted principal may be
+        # synthesized under that principal, but no single prior excursion id
+        # truthfully represents the join. Start a new, explicitly joined
+        # excursion instead of choosing one branch by ordering.
+        self.begin_excursion(
+            next(iter(principals)),
+            cause_action_id=(next(iter(action_ids)) if len(action_ids) == 1 else ""),
+            cause_workstream_id=self._ws_id,
+        )
+
     def bind_acting_user(self, user_id: str) -> None:
-        """Bind the authenticated initiator of the current turn.
+        """Begin an excursion for an authenticated human turn.
 
         Called from the HTTP send path with the caller's authenticated
-        user id. No-ops when ``user_id`` is empty (unauthenticated lanes
-        keep the owner fallback) or unchanged. On a genuine change this
-        re-scopes the session's MCP view to the new acting user:
+        user id. Empty ids leave legacy/unauthenticated lanes untouched.
+        Rebinding scopes the session's MCP view to the trusted principal:
 
         - swaps the user-scoped tool/resource/prompt listeners so pool
           catalog changes for the acting user reach this session
@@ -6203,55 +6401,13 @@ class ChatSession:
         - rebuilds the merged tool list and catalog-dependent state via
           the same callbacks a pool notification would fire.
 
-        The binding is sticky — it persists until the next authenticated
-        send — so wake nudges and auto-resume continuations keep running
-        under the user whose turn they continue. It intentionally does
-        NOT rebind mid-turn: queued interjections fold into the current
-        turn under the initiator's identity, and prepared tool items pin
-        the identity at prepare time (see ``_prepare_mcp_tool``).
+        The attribution is sticky through wake nudges and autonomous
+        continuations, but a later authenticated send always starts a new
+        excursion. It intentionally does NOT rebind mid-turn.
         """
-        if not user_id or user_id == (self._acting_user_id or self._user_id):
-            self._acting_user_id = self._acting_user_id or user_id
+        if not user_id:
             return
-        self._acting_user_id = user_id
-        mcp = self._mcp_client
-        # Coordinators participate fully (#725): they are multi-sender by
-        # design (any admin.coordinator operator with project visibility
-        # may drive one — ownership is not enforced), so an acting-user
-        # change MUST re-scope the listeners and prime the new user's
-        # pools below; otherwise operator B would dispatch against
-        # operator A's primed pool catalog.
-        if not mcp:
-            return
-        old_listener_uid = self._mcp_listener_user_id
-        new_listener_uid: str | None = self._mcp_effective_user_id
-        if new_listener_uid != old_listener_uid:
-            if self._mcp_refresh_cb:
-                mcp.remove_listener(self._mcp_refresh_cb, user_id=old_listener_uid)
-                mcp.add_listener(self._mcp_refresh_cb, user_id=new_listener_uid)
-            if self._mcp_resource_cb:
-                mcp.remove_resource_listener(self._mcp_resource_cb, user_id=old_listener_uid)
-                mcp.add_resource_listener(self._mcp_resource_cb, user_id=new_listener_uid)
-            if self._mcp_prompt_cb:
-                mcp.remove_prompt_listener(self._mcp_prompt_cb, user_id=old_listener_uid)
-                mcp.add_prompt_listener(self._mcp_prompt_cb, user_id=new_listener_uid)
-            self._mcp_listener_user_id = new_listener_uid
-        try_prime_user_pools(mcp, new_listener_uid, context="acting-user-change")
-        # Rebuild the merged tool list and resource/prompt-dependent
-        # state under the new identity NOW — the prime above completes
-        # asynchronously and only notifies on catalog changes, while
-        # already-warm pool entries for this user produce no
-        # notification at all.  ONE _init_system_messages() covers both
-        # the resource and prompt catalogs: the _on_mcp_resources_changed
-        # / _on_mcp_prompts_changed wrappers are pure passthroughs to it
-        # (they exist for the manager's separate notification channels,
-        # which still fire them independently), and it rebuilds the full
-        # system message copy-on-write — calling it twice per handoff was
-        # a redundant list_prompt_policies() read + compose per rebind.
-        # The persona-catalog read inside the tools rebuild stays as-is:
-        # sender-independent but handoff-frequency, not worth memoizing.
-        self._on_mcp_tools_changed()
-        self._init_system_messages()
+        self.begin_excursion(user_id)
 
     def send(
         self,
@@ -8483,6 +8639,14 @@ class ChatSession:
         """
         if not rows or budget <= 0:
             return ""
+        # A complete section needs no truncation pointer.  Check that case
+        # first: the incremental loop below reserves a pointer while rows are
+        # still behind, which can otherwise reject the first row even though
+        # all rows fit once that pointer disappears (notably a short child
+        # workstream list in its reserved slice of the handles budget).
+        complete = heading + "".join(rows)
+        if len(complete) <= budget:
+            return complete
         kept: list[str] = []
         used = len(heading)
         for i, row in enumerate(rows):
@@ -10456,6 +10620,10 @@ class ChatSession:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
                     results = list(pool.map(run_one, items))
 
+        # Child wait receipts are causal effect records.  Fold them only after
+        # every parallel sibling has settled so principal selection is a set
+        # join, never a ThreadPoolExecutor completion-order race.
+        self._fold_child_effect_attribution(items)
         return results, user_feedback
 
     @staticmethod
@@ -12698,6 +12866,44 @@ class ChatSession:
         the sanitized value."""
         return " ".join((value or "").split())[:cap]
 
+    def _coordinator_action_attribution(
+        self,
+        *,
+        call_id: str,
+        cause_workstream_id: str = "",
+    ) -> tuple[ExcursionAttribution | None, str]:
+        """Resolve one delegated action's principal through trusted state."""
+
+        # A few compatibility/unit shells deliberately allocate ChatSession
+        # with ``__new__`` and exercise only coordinator approval shaping.  A
+        # real session always initializes this field; retain the old shell
+        # behavior without inventing an identity for the incomplete object.
+        if not hasattr(self, "_excursion_attribution") and not cause_workstream_id:
+            return None, ""
+        attribution = self._excursion_attribution
+        if cause_workstream_id:
+            attribution, error = self._coord_client.attribution_for_workstream(cause_workstream_id)
+            if error:
+                return None, error
+        elif self._excursion_conflicting_principals:
+            return (
+                None,
+                "multiple trusted principals contributed to this coordinator step; "
+                "cause_workstream_id is required",
+            )
+        if attribution is None:
+            principal_id = (self._mcp_effective_user_id or "").strip()
+            if not principal_id:
+                return None, "no trusted principal is bound to this excursion"
+            attribution = self.begin_excursion(principal_id)
+        return (
+            attribution.for_spawn_edge(
+                action_id=call_id,
+                cause_workstream_id=self._ws_id,
+            ),
+            "",
+        )
+
     def _prepare_spawn_workstream(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         if self._coord_client is None:
             return self._coord_tool_error(
@@ -12718,6 +12924,7 @@ class ChatSession:
         name = self._flatten_spawn_arg(args.get("name"), 120)
         target_node = self._flatten_spawn_arg(args.get("target_node"), 64)
         persona = self._flatten_spawn_arg(args.get("persona"), 64)
+        cause_workstream_id = self._coord_str_arg(args, "cause_workstream_id").strip()
         if persona:
             persona, persona_err = self._validate_child_persona(persona)
             if persona_err:
@@ -12743,6 +12950,12 @@ class ChatSession:
         if target_node:
             header_bits.append(f"node={target_node}")
         header = " ".join(header_bits)
+        attribution, attribution_error = self._coordinator_action_attribution(
+            call_id=call_id,
+            cause_workstream_id=cause_workstream_id,
+        )
+        if attribution_error:
+            return self._coord_tool_error(call_id, "spawn_workstream", attribution_error)
         return {
             "call_id": call_id,
             "func_name": "spawn_workstream",
@@ -12758,6 +12971,8 @@ class ChatSession:
             "target_node": target_node,
             "project": project,
             "persona": persona,
+            "cause_workstream_id": cause_workstream_id,
+            "excursion_attribution": attribution,
         }
 
     def _validate_child_persona(self, persona: str) -> tuple[str, str]:
@@ -12789,6 +13004,7 @@ class ChatSession:
 
     def _exec_spawn_workstream(self, item: dict[str, Any]) -> tuple[str, str]:
         call_id = item["call_id"]
+        attribution = item.get("excursion_attribution")
         try:
             result = self._coord_client.spawn(
                 initial_message=item["initial_message"],
@@ -12800,6 +13016,7 @@ class ChatSession:
                 target_node=item["target_node"],
                 project=item["project"],
                 persona=item["persona"],
+                attribution=attribution,
             )
         except Exception as e:
             msg = f"Error: spawn_workstream failed: {e}"
@@ -12897,6 +13114,7 @@ class ChatSession:
             name = self._flatten_spawn_arg(self._coord_str_arg(raw, "name"), 120)
             target_node = self._flatten_spawn_arg(self._coord_str_arg(raw, "target_node"), 64)
             persona = self._flatten_spawn_arg(self._coord_str_arg(raw, "persona"), 64)
+            cause_workstream_id = self._coord_str_arg(raw, "cause_workstream_id").strip()
             spec: dict[str, Any] = {
                 "idx": idx,
                 "initial_message": initial_message,
@@ -12905,7 +13123,16 @@ class ChatSession:
                 "model": model,
                 "target_node": target_node,
                 "persona": persona,
+                "cause_workstream_id": cause_workstream_id,
             }
+            attribution, attribution_error = self._coordinator_action_attribution(
+                call_id=f"{call_id}:{idx}",
+                cause_workstream_id=cause_workstream_id,
+            )
+            if attribution_error:
+                spec["_error"] = attribution_error
+            else:
+                spec["excursion_attribution"] = attribution
             if persona:
                 # Same prep-time gate as spawn_workstream, but surfaced as
                 # a per-row denial (partial-success semantics) rather than
@@ -13005,6 +13232,7 @@ class ChatSession:
             if "_error" in spec:
                 denied.append({"idx": idx, "reason": spec["_error"]})
                 continue
+            attribution = spec.get("excursion_attribution")
             try:
                 result = self._coord_client.spawn(
                     initial_message=spec["initial_message"],
@@ -13015,6 +13243,7 @@ class ChatSession:
                     model=spec["model"],
                     target_node=spec["target_node"],
                     persona=spec["persona"],
+                    attribution=attribution,
                 )
             except Exception as e:
                 denied.append({"idx": idx, "reason": f"spawn failed: {e}"})
@@ -13139,6 +13368,7 @@ class ChatSession:
             )
         ws_id = (args.get("ws_id") or "").strip()
         message = args.get("message") or ""
+        cause_workstream_id = self._coord_str_arg(args, "cause_workstream_id").strip()
         if not ws_id:
             return self._coord_tool_error(call_id, "send_to_workstream", "ws_id is required")
         if not message.strip():
@@ -13154,6 +13384,12 @@ class ChatSession:
         if self._trust_send and self._coord_client._is_own_subtree(ws_id):
             needs_approval = False
             trust_auto_approved = True
+        attribution, attribution_error = self._coordinator_action_attribution(
+            call_id=call_id,
+            cause_workstream_id=cause_workstream_id,
+        )
+        if attribution_error:
+            return self._coord_tool_error(call_id, "send_to_workstream", attribution_error)
         return {
             "call_id": call_id,
             "func_name": "send_to_workstream",
@@ -13164,11 +13400,14 @@ class ChatSession:
             "execute": self._exec_send_to_workstream,
             "ws_id": ws_id,
             "message": message,
+            "cause_workstream_id": cause_workstream_id,
+            "excursion_attribution": attribution,
             "trust_auto_approved": trust_auto_approved,
         }
 
     def _exec_send_to_workstream(self, item: dict[str, Any]) -> tuple[str, str]:
         call_id = item["call_id"]
+        attribution = item.get("excursion_attribution")
         if item.get("trust_auto_approved"):
             # Audit before dispatch so a downstream failure doesn't drop the trail.
             try:
@@ -13182,11 +13421,16 @@ class ChatSession:
                         "ws_id": item["ws_id"],
                         "message_preview": preview_line[:120],
                     },
+                    attribution=attribution,
                 )
             except Exception:
                 log.debug("coord.trust_send.audit_failed", exc_info=True)
         try:
-            result = self._coord_client.send(item["ws_id"], item["message"])
+            result = self._coord_client.send(
+                item["ws_id"],
+                item["message"],
+                attribution=attribution,
+            )
         except Exception as e:
             msg = f"Error: send_to_workstream failed: {e}"
             self._report_tool_result(call_id, "send_to_workstream", msg, is_error=True)
@@ -15320,7 +15564,12 @@ class ChatSession:
                 "resolved": resolved_count,
             },
         )
-        return call_id, self._truncate_output(output)
+        # Record the terminal ledger only after the ordinary result/reporting
+        # path succeeds. _execute_tools folds all sibling wait effects together
+        # after the parallel batch settles, before the next model run.
+        rendered_output = self._truncate_output(output)
+        item["_excursion_effect_result"] = result
+        return call_id, rendered_output
 
     def _emit_wait_event(self, event_type: str, payload: dict[str, Any]) -> None:
         """Fan out a ``wait_*`` SSE event via the session UI.

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -16,6 +16,10 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Protocol
 
+from turnstone.core.attribution import (
+    ExcursionAttribution,
+    conflicting_principals_from_config,
+)
 from turnstone.core.log import get_logger
 from turnstone.core.personas import snapshot_from_config
 from turnstone.core.workstream import Workstream, WorkstreamKind, WorkstreamState
@@ -683,6 +687,12 @@ class SessionManager:
                     extra_build_kwargs: dict[str, Any] = {}
                     if persona_snapshot is not None:
                         extra_build_kwargs["persona_snapshot"] = persona_snapshot
+                    excursion_attribution = ExcursionAttribution.from_config(saved_cfg or {})
+                    excursion_conflicts = conflicting_principals_from_config(saved_cfg or {})
+                    if excursion_attribution is not None:
+                        extra_build_kwargs["excursion_attribution"] = excursion_attribution
+                    if excursion_conflicts:
+                        extra_build_kwargs["excursion_conflicting_principals"] = excursion_conflicts
                     ws.session = self._adapter.build_session(
                         ws, model=saved_alias, **extra_build_kwargs
                     )

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from starlette.routing import BaseRoute
 
     from turnstone.core.attachments import UploadRejection
+    from turnstone.core.attribution import ExcursionAttribution
     from turnstone.core.session import ChatSession
     from turnstone.core.session_manager import SessionManager
     from turnstone.core.session_ui_base import SessionUIBase
@@ -2814,6 +2815,15 @@ def make_create_handler(
             kwargs = cfg.create_build_kwargs(
                 request, body, uid, skill_data, skill_id_resolved, applied_skill_version
             )
+            # Delegated execution identity is accepted only from validated,
+            # signed coordinator claims.  The body still controls tenancy
+            # metadata (under its existing service-only override gate), never
+            # the trusted principal whose OBO token the child may use.
+            from turnstone.core.attribution import attribution_from_auth
+
+            inherited_attribution = attribution_from_auth(auth)
+            if inherited_attribution is not None:
+                kwargs["excursion_attribution"] = inherited_attribution
             if persona_snapshot is not None:
                 # ``persona`` is SessionManager.create's explicit param
                 # (Workstream attr + workstreams row); the snapshot rides
@@ -4256,6 +4266,7 @@ def _make_dispatch_attempt(
     ordered_taken: list[str],
     send_id: str,
     acting_uid: str,
+    excursion_attribution: ExcursionAttribution | None = None,
     defer_fidelity: bool = False,
 ) -> Callable[[ChatSession], tuple[bool, dict[str, Any]]]:
     """Build one atomic queue-or-spawn attempt bound to ONE session capture.
@@ -4323,7 +4334,9 @@ def _make_dispatch_attempt(
                     message,
                     attachment_ids=list(ordered_taken),
                     queue_msg_id=send_id or None,
-                    interjector_user_id=acting_uid,
+                    interjector_user_id=(
+                        getattr(excursion_attribution, "principal_id", "") or acting_uid
+                    ),
                 )
             except AttachmentsNotQueueableError:
                 queue_outcome["rejected"] = "attachments_busy"
@@ -4353,9 +4366,18 @@ def _make_dispatch_attempt(
                 # kwarg) so per-kind session stubs with explicit send
                 # signatures keep working; getattr-guarded for the same
                 # reason. The queue path above never rebinds.
-                bind = getattr(session, "bind_acting_user", None)
-                if acting_uid and callable(bind):
-                    bind(acting_uid)
+                begin = getattr(session, "begin_excursion", None)
+                if callable(begin) and (acting_uid or excursion_attribution is not None):
+                    begin(
+                        acting_uid,
+                        inherited=excursion_attribution,
+                        cause_action_id=send_id,
+                        cause_workstream_id=ws.id,
+                    )
+                else:
+                    bind = getattr(session, "bind_acting_user", None)
+                    if acting_uid and callable(bind):
+                        bind(acting_uid)
                 session.send(message, **kwargs)
             except GenerationCancelled:
                 # Safety net — send() normally handles this internally.
@@ -4712,6 +4734,17 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
         # turn under the initiator's identity (no mid-turn credential
         # switch); the next fresh turn rebinds.
         acting_uid = auth_user_id(request)
+        from turnstone.core.attribution import attribution_from_auth
+
+        try:
+            excursion_attribution = attribution_from_auth(
+                getattr(getattr(request, "state", None), "auth_result", None)
+            )
+        except ValueError:
+            return JSONResponse(
+                {"error": "invalid coordinator excursion attribution"},
+                status_code=401,
+            )
 
         # ----- Attachment resolution (from the per-node upload buffer) -----
         send_id = ""
@@ -4854,6 +4887,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
                         ordered_taken=ordered_taken,
                         send_id=pending_msg_id,
                         acting_uid=acting_uid,
+                        excursion_attribution=excursion_attribution,
                         defer_fidelity=True,
                     ),
                 )
@@ -4950,6 +4984,7 @@ def make_send_handler(cfg: SessionEndpointConfig) -> Handler:
             ordered_taken=ordered_taken,
             send_id=send_id,
             acting_uid=acting_uid,
+            excursion_attribution=excursion_attribution,
         )
         session_now = ws.session
         if session_now is None:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
+    from turnstone.core.attribution import ExcursionAttribution
+
 from sse_starlette import EventSourceResponse
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -2767,6 +2769,18 @@ async def _interactive_create_post_install(
         def _run_initial() -> None:
             me = threading.current_thread()
             try:
+                # A coordinator-spawned child was constructed with signed,
+                # inherited excursion attribution; preserve it.  A direct
+                # human create has no inherited context, so its initial
+                # message starts an ordinary root excursion here.
+                if getattr(session, "_excursion_attribution", None) is None:
+                    begin = getattr(session, "begin_excursion", None)
+                    if uid and callable(begin):
+                        begin(
+                            uid,
+                            cause_action_id=send_id,
+                            cause_workstream_id=ws.id,
+                        )
                 session.send(
                     initial_message,
                     attachments=resolved_atts or None,
@@ -5629,6 +5643,8 @@ def main() -> None:
         parent_ws_id: str | None = None,
         project_id: str = "",
         persona_snapshot: PersonaSnapshot | None = None,
+        excursion_attribution: ExcursionAttribution | None = None,
+        excursion_conflicting_principals: frozenset[str] | None = None,
     ) -> ChatSession:
         assert ui is not None
         # Resolve the effective alias once and use it consistently
@@ -5734,6 +5750,8 @@ def main() -> None:
             parent_ws_id=parent_ws_id,
             project_id=project_id,
             persona_snapshot=persona_snapshot,
+            excursion_attribution=excursion_attribution,
+            excursion_conflicting_principals=excursion_conflicting_principals,
         )
 
     # Create WatchRunner (periodic command polling, server-level)

--- a/turnstone/tools/send_to_workstream.json
+++ b/turnstone/tools/send_to_workstream.json
@@ -11,6 +11,10 @@
       "message": {
         "type": "string",
         "description": "Message text to append as a user turn."
+      },
+      "cause_workstream_id": {
+        "type": "string",
+        "description": "Optional causal child workstream id. Use after combining results from multiple trusted principals; the shell resolves the delegated principal from that owned child's persisted attribution. Omit to inherit the coordinator's unambiguous current excursion."
       }
     },
     "required": ["ws_id", "message"]

--- a/turnstone/tools/spawn_batch.json
+++ b/turnstone/tools/spawn_batch.json
@@ -33,6 +33,10 @@
             "persona": {
               "type": "string",
               "description": "Optional persona name for the child (must apply to interactive workstreams). Snapshotted at spawn; invalid names land in denied[]. Omit for the interactive default — children never inherit this coordinator's persona."
+            },
+            "cause_workstream_id": {
+              "type": "string",
+              "description": "Optional causal child workstream id. Required per item when a mixed-principal coordinator step cannot inherit one principal. The shell resolves attribution from that owned child."
             }
           },
           "required": []

--- a/turnstone/tools/spawn_workstream.json
+++ b/turnstone/tools/spawn_workstream.json
@@ -31,6 +31,10 @@
       "persona": {
         "type": "string",
         "description": "Optional persona name for the child (children are always interactive-kind, so the persona must apply to interactive workstreams). The persona is resolved and snapshotted at spawn time. Omit for the interactive default persona — the child never inherits this coordinator's persona."
+      },
+      "cause_workstream_id": {
+        "type": "string",
+        "description": "Optional causal child workstream id. Use when this action follows a returned child result and the coordinator step contains multiple trusted principals. The shell reads that owned child's persisted excursion attribution; you cannot supply a principal directly. Omit to inherit the coordinator's unambiguous current excursion."
       }
     },
     "required": []


### PR DESCRIPTION
TL;DR - Don't merge this, it was created as a concept to address https://github.com/turnstonelabs/turnstone/issues/955 and more complex multi-user orchestrated workflows. I have not actually deployed this for testing in the lab, its more of a conversation topic than well formed decision.

# Excursion attribution in shared coordinator workstreams

Status: design note and review companion for issue #954.

This note uses the vocabulary already established by `PRIMER.md` and
`HYPOTHESIS.md`. It deliberately avoids “priority”: Turnstone already uses
priority for message scheduling, while the property here is identity and
causality.

## The claim

*Informal.* A workstream has a durable **owner**, but each trigger-to-ready
**excursion** has a **trusted principal**. Per-user credentials must follow the
excursion's causal lineage, not the workstream owner, the most recent sender,
or the most recently completed child.

*In plain terms.* Brett can own a coordinator forever without every future
action being Brett's. A human message starts an excursion as that human. A
spawn edge carries that trusted principal into the child while preserving
Brett as the child's tenant owner. The child's terminal ledger returns as the
parent's effect record; when that record is the cause of continued work, its
trusted principal returns with it.

*Operationally.* The shell owns a durable tuple

```text
(excursion_id, principal_id, cause_action_id, cause_workstream_id)
```

and permits one of two states at an action boundary:

1. attribution is **resolved** to exactly one trusted principal; or
2. attribution is **ambiguous**, in which case per-user delegated auth fails
   closed until a new human trigger begins an excursion or an authorized action
   names a trusted causal workstream.

The model may propose `cause_workstream_id`. It may never propose
`principal_id`. The authorization gate verifies that the cause is in the
coordinator's own subtree and reads its shell-persisted attribution.

## Why owner and last sender are both falsified

### Scenario A: a shared interactive workstream

1. Brett creates workstream `W`, sends a message, and completes an excursion.
2. Ed enters the shared project and sends: “I have the CERT-TOOL-MCP permission;
   try again with mine.”
3. The next model and tool calls must use Ed's delegated credentials.
4. The harness reaches its stop token and returns to ready.
5. Brett sends the next message.
6. The next excursion must use Brett's delegated credentials.

The durable owner rule fails at step 3. A mutable global “last sender” happens
to work here only because the stop token serializes the two excursions.

### Scenario B: independent coordinator fan-out

1. Brett's message starts excursion `EJ` and spawns children A, B, and C.
2. Each spawn is an authorized action. A, B, and C keep owner Brett for tenancy
   and inherit trusted principal Brett through their spawn edges.
3. After the coordinator returns to ready, Ed's message starts excursion
   `EN` and spawns D and E.
4. D and E keep owner Brett but inherit trusted principal Ed.

Changing child ownership to Ed is not the repair: it breaks subtree tenancy
and confuses “whose durable object is this?” with “whose authority caused this
run?”

### Scenario C: B returns after Ed spoke

1. The coordinator's last human sender is Ed.
2. Child B, descended from `EJ`, reaches its halt and persists its terminal
   ledger.
3. If the coordinator waits on B, B's result enters the parent as an effect
   record at the tool-result boundary.
4. Before the next model run, the shell restores Brett as the trusted principal
   from B's persisted attribution.
5. Work causally continued from B therefore spawns as Brett, not Ed.

This is the minimal counterexample to last-sender attribution. Wall-clock
recency and causal ancestry disagree, and only the latter is an authorization
fact.

### Scenario D: B returns while another tool call is in flight

A child completion does not splice itself into a running model generation or
an unrelated tool call. The child state and transcript are persisted, an SSE
event is emitted, and the child event bus wakes an active
`wait_for_workstream` waiter if one exists. With no waiter, the notification is
observational; the idle-coordinator liveness nudge can prompt a later wait.

The return becomes model input only when a wait/inspect effect is folded back
by the parent shell. Attribution changes at that deterministic fold boundary,
not at arbitrary completion time. This preserves the stopped-process shape:
asynchronous environment timing is a coin in `Q_E`; `rho` still owns when the
observed receipt becomes controller state.

### Scenario E: Brett's B and Ed's D return together

If one wait result lowers both terminal effect records into the next context,
neither arrival order nor list order can choose a trusted principal. The join
is explicitly ambiguous. The same rule applies when separate wait tool calls
run in one parallel batch: the shell folds all sibling receipts together only
after the batch settles, so executor completion order cannot pick an identity.

An `entra_obo` coordinator model must fail closed at that point: the model
inference is itself a delegated action, so asking the model which user it meant
to run as would already require choosing a user's token. A deployment that
intentionally synthesizes mixed-principal results must configure the
coordinator lane with `entra_app` (or another explicit deployment identity).
From that neutral lane, a subsequent child action may cite one causal
workstream; the shell resolves its trusted principal and the normal approval
gate authorizes the spawn/send. There is no silent runtime fallback from OBO to
app identity.

An OBO-only coordinator can avoid the join by collecting and processing one
causal lane at a time. Waiting on B alone restores Brett before the next model
run; waiting on D alone restores Ed.

## Derived rules

1. **Owner is tenancy, not execution identity.** JWT `sub`, workstream rows,
   project membership, and subtree ownership remain bound to the durable owner.
2. **Trusted principal is excursion control state.** Model backend OBO, MCP
   user pools, delegated-action audit attribution, and child propagation read
   the excursion principal.
3. **Attribution is signed and durable.** Coordinator JWT custom claims carry
   it through console-to-node routing; `workstream_config` restores it before a
   rehydrated session can perform autonomous work.
4. **Spawn attenuates authority.** A child inherits the parent's resolved
   principal along a spawn edge. The body cannot name a user, and ownership
   does not change.
5. **Child completion is an effect record.** A terminal child's attribution is
   returned alongside its wait result and folded before the next model run.
6. **A causal join is not a race.** Multiple distinct principals produce an
   ambiguous state; no ordering heuristic chooses a credential.
7. **Auxiliary lanes do not invent identities.** Judge, output guard,
   perception, MCP, and the primary model all resolve through the same
   excursion state. A lane that needs neutral multi-principal synthesis must be
   configured with app identity explicitly.
8. **Shared transcript visibility is a separate policy.** This design accepts
   the current project/workstream co-working domain: members may see content
   other members caused the system to retrieve. It prevents credential
   misattribution; it does not create per-message transcript tenancy.

## Implementation shape in this branch

- `ExcursionAttribution` defines one versioned config/claim representation.
- A fresh authenticated human send creates a new excursion, including when the
  same user sent the previous completed turn.
- Coordinator tokens keep the owner in `sub` and add signed excursion claims.
- The console routing proxy preserves those claims when it re-mints for a node.
- Child create/send handlers accept attribution only from a validated
  coordinator token; request JSON cannot supply it.
- Session rehydration restores resolved or ambiguous attribution before model
  and MCP use.
- `wait_for_workstream` returns terminal-child attribution. The coordinator
  adopts one principal, joins same-principal branches under a fresh excursion,
  or records a mixed-principal ambiguity.
- `spawn_workstream`, `spawn_batch`, and `send_to_workstream` accept an optional
  `cause_workstream_id`. In an ambiguous state it is required; the shell
  resolves it through the owned-subtree gate and stamps the outgoing action.

This is control-plane attribution, not yet the full per-action-capability ideal
from `HYPOTHESIS.md`: the signed JWT binds the routed request and its causal
action id, while downstream OAuth providers may still mint audience-scoped
tokens rather than credentials cryptographically restricted to one
`action_id`. The branch closes principal selection and propagation; provider
token attenuation remains a separate layer.

## Falsifiers

The implementation is wrong if any of these observations is possible:

- Ed's human-triggered excursion mints or dispatches with Brett's OBO token
  because Brett owns the coordinator.
- B's returned ledger continues under Ed merely because Ed was the last
  human sender.
- a request body can set `principal_id` or forge excursion lineage;
- child ownership changes to the acting principal and escapes the owner's
  subtree;
- a mixed Brett/Ed result selects either token by completion, list, or message
  order;
- rehydration performs a model/tool action before restoring the persisted
  attribution state;
- an auxiliary lane resolves a different user from the primary lane for the
  same excursion; or
- an OBO failure silently changes grant type to app identity.

## Relation to issue #954's permission question

This ruling answers what a model-auth configuration gate is protecting: OBO is
allowed in shared sessions only while the current excursion has one resolved
trusted principal. Shared transcript visibility remains the accepted project
co-working property. Mixed-principal synthesis uses an explicitly configured
app lane or fails closed.

It does not decide whether the configuration capability should be
`admin.model_auth` or a host allow-list. That is an orthogonal gate-placement
decision: attribution determines *whose credential may be minted*; destination
confinement determines *where that credential may be sent*. Neither substitutes
for the other.