### PR TITLE
Fold the main streaming loop onto model_turn (#832)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,10 +132,12 @@ A user message flows through the system as follows:
      |                                  lane-swap fallback walk; per-lane ladder:
      |                                  up to 3 retries (4 total attempts), exponential backoff
      v
- the on_chunk consumer  ----------->  dispatch tokens to UI:
+ the on_chunk consumer  ----------->  display grid ONLY:
      |                                  on_reasoning_token() / on_content_token()
-     |                                  accumulate tool_calls from deltas
-     |                                  track finish_reason
+     |                                  tool-call deltas just flush the splitter
+     |                                    (assembly lives in drain_stream, inside
+     |                                    model_turn — the consumer never accumulates)
+     |                                  track finish_reason (citations-footer gate)
      |                                  _check_cancelled() per chunk (cooperative cancel)
      v
  finish_reason check:
@@ -1261,28 +1263,34 @@ warns if the summary was truncated.
 `_run_single_test()`: wraps `session.send_headless()` in a retry loop (3
 attempts) to avoid transient API errors from poisoning evaluation scores.
 
-### Health Monitor & Circuit Breaker
+### Backend Health Tracking
 
-`BackendHealthMonitor` (`turnstone/core/healthcheck.py`) runs a daemon thread
-that probes the LLM backend by calling `client.models.list()` every
-`backend_probe_interval` seconds (default 30). Probe results drive a three-state
-circuit breaker:
+`BackendHealthTracker` (`turnstone/core/healthcheck.py`) records LLM backend
+health passively from real request outcomes — there is no probe thread and no
+circuit breaker, and requests are never blocked. Two states:
 
 ```
-CLOSED  ──(N consecutive failures)──>  OPEN
-OPEN    ──(cooldown expires)────────>  HALF_OPEN
-HALF_OPEN ──(probe succeeds)────────>  CLOSED
-HALF_OPEN ──(probe fails)──────────>  OPEN
+healthy  ──(failure_threshold consecutive failures)──>  degraded
+degraded ──(any success)───────────────────────────>  healthy
 ```
 
-- `record_success()` / `record_failure()` update `_consecutive_failures` and
-  transition the `_state` (`CircuitState` enum: `CLOSED`, `OPEN`, `HALF_OPEN`).
-- `acquire_request_permit()` returns `False` when the circuit is `OPEN` or when
-  in `HALF_OPEN` and the single probe permit has already been consumed. Causes
-  `ChatSession._model_turn_with_fallback` to skip the backend and surface an
-  error immediately.
-- The `/health` endpoint reads the monitor's state: `"status": "ok"` when the
-  circuit is closed, `"status": "degraded"` when open or half-open.
+- `record_success()` fires at the request-accepted instant: the streaming
+  consumer's `on_stream_armed` hook, driven by the eager `cancel_ref` append
+  every adapter performs at HTTP-response time.
+- `record_failure()` fires once per lane's whole creation ladder, in
+  `ChatSession._model_turn_with_fallback` / `_try_fallback_lane`. A mid-stream
+  death (the stream armed, then died) records neither — it belongs to the
+  re-issue ladder, not the fallback walk. `BackendAuthUnavailableError` and
+  `WirePreparationError` also record nothing: an auth refusal is fail-closed
+  configuration policy and a wire-preparation fault is session data — neither
+  says anything about the backend.
+- `is_degraded` is advisory ordering, not admission: the fallback walk tries
+  non-degraded aliases first and degraded ones as a last resort, and the
+  primary lane is always dialed.
+- `HealthTrackerRegistry` keys trackers by `(provider, base_url)` so aliases
+  sharing a backend share one tracker. The `/health` endpoint projects the
+  same trackers: `"status": "ok"` when the backend is healthy, `"degraded"`
+  otherwise.
 
 ### Rate Limiting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,10 +128,11 @@ A user message flows through the system as follows:
  _emit_state("thinking")
      |
      v
- _create_stream_with_retry()  ---->  provider.create_streaming(client, model, messages, ...)
+ _stream_response()  ------------->  model_turn(lane, turns, on_chunk=...) per attempt
+     |                                  lane-swap fallback walk; per-lane ladder:
      |                                  up to 3 retries (4 total attempts), exponential backoff
      v
- _stream_response(stream)  -------->  dispatch tokens to UI:
+ the on_chunk consumer  ----------->  dispatch tokens to UI:
      |                                  on_reasoning_token() / on_content_token()
      |                                  accumulate tool_calls from deltas
      |                                  track finish_reason
@@ -243,7 +244,9 @@ class SessionUI(Protocol):
     def on_content_token(self, text: str) -> None: ...
     def on_stream_end(self) -> None: ...
     def approve_tools(self, items: list[dict]) -> tuple[bool, str | None]: ...
-    def on_tool_result(self, call_id: str, name: str, output: str, *, is_error: bool = False) -> None: ...
+    def on_tool_result(
+        self, call_id: str, name: str, output: str, *, is_error: bool = False
+    ) -> None: ...
     def on_tool_output_chunk(self, call_id: str, chunk: str) -> None: ...
     def on_status(self, usage: dict, context_window: int, effort: str) -> None: ...
     def on_info(self, message: str) -> None: ...
@@ -313,15 +316,15 @@ ERROR      last operation failed
 ```python
 @dataclass
 class Workstream:
-    id: str                              # uuid hex, 8 chars
-    name: str                            # user-visible label
-    state: WorkstreamState               # current state
-    session: ChatSession | None          # the conversation engine
-    ui: SessionUI | None                 # frontend adapter
+    id: str  # uuid hex, 8 chars
+    name: str  # user-visible label
+    state: WorkstreamState  # current state
+    session: ChatSession | None  # the conversation engine
+    ui: SessionUI | None  # frontend adapter
     worker_thread: threading.Thread | None
     error_message: str
-    last_active: float                   # time.monotonic() timestamp, updated on every state change
-    _lock: threading.Lock                # per-workstream state lock
+    last_active: float  # time.monotonic() timestamp, updated on every state change
+    _lock: threading.Lock  # per-workstream state lock
 ```
 
 ### WorkstreamManager
@@ -333,7 +336,9 @@ class WorkstreamManager:
     def __init__(self, session_factory: Callable[[SessionUI], ChatSession]): ...
     def create(self, name="", ui_factory=None) -> Workstream: ...
     def close(self, ws_id: str) -> bool: ...
-    def close_idle(self, max_age_seconds: float) -> list[str]: ...  # auto-close stale IDLE workstreams
+    def close_idle(
+        self, max_age_seconds: float
+    ) -> list[str]: ...  # auto-close stale IDLE workstreams
     def get(self, ws_id: str) -> Workstream | None: ...
     def get_active(self) -> Workstream | None: ...
     def list_all(self) -> list[Workstream]: ...
@@ -508,7 +513,7 @@ then returns the final content as the tool result.
   response without tools. When unlimited, the loop only exits when the model
   stops calling tools or hits `finish_reason: "length"`.
 - **Retry**: each API call in the agent loop uses the same retry+backoff logic
-  as the main `_create_stream_with_retry()`.
+  as the main loop's per-lane ladder (`_model_turn_with_retry`).
 - **Finish reason handling**: `finish_reason: "length"` stops the agent early
   and returns whatever content was generated. `finish_reason: "content_filter"`
   returns a placeholder.
@@ -941,8 +946,8 @@ with the same alias in-memory (the DB rows are never modified).
 5. `/model` command shows available models; `/model <alias>` switches the
    active workstream's client, model, context window, and per-model sampling
    parameters
-6. `_create_stream_with_retry()` tries the primary model, then each fallback
-   alias in order if the primary is unreachable
+6. `_model_turn_with_fallback()` tries the primary lane, then each fallback
+   alias's lane in order if the primary is unreachable
 7. `_run_agent()` resolves `registry.agent_model` (if set) for task
    sub-agents, allowing a cheaper model for autonomous loops
 
@@ -1178,9 +1183,9 @@ Named (aliased) workstreams are never age-pruned. Configure with
 
 Every model call streams (#831); retry lives at two stacked layers:
 
-- **Caller ladders** — `ChatSession._create_stream_with_retry()` (chat
-  loop) and the agent `_api_call()` (drained via `model_turn`) use the
-  same pattern: 4 total attempts (1 initial + 3 retries,
+- **Caller ladders** — `ChatSession._model_turn_with_retry()` (chat
+  loop, one ladder per lane) and the agent `_api_call()` (drained via
+  `model_turn`) use the same pattern: 4 total attempts (1 initial + 3 retries,
   `_MAX_RETRIES = 3`), exponential backoff base 1 second
   (`delay = 1s * 2^attempt`), `ui.on_info()` on retry, exception
   propagates on final failure. `_compact_messages()` wraps its drained
@@ -1274,7 +1279,7 @@ HALF_OPEN ──(probe fails)──────────>  OPEN
   transition the `_state` (`CircuitState` enum: `CLOSED`, `OPEN`, `HALF_OPEN`).
 - `acquire_request_permit()` returns `False` when the circuit is `OPEN` or when
   in `HALF_OPEN` and the single probe permit has already been consumed. Causes
-  `ChatSession._create_stream_with_retry` to skip the backend and surface an
+  `ChatSession._model_turn_with_fallback` to skip the backend and surface an
   error immediately.
 - The `/health` endpoint reads the monitor's state: `"status": "ok"` when the
   circuit is closed, `"status": "degraded"` when open or half-open.

--- a/docs/diagrams/03-core-engine-classes.puml
+++ b/docs/diagrams/03-core-engine-classes.puml
@@ -148,9 +148,9 @@ class "ChatSession" as ChatSession {
     + handle_command(command: str)
     + resume(ws_id: str)
     - _save_config()
-    - _stream_response(stream) → dict
-    - _create_stream_with_retry(msgs) → Stream (+ fallback)
-    - _try_stream(client, model, msgs) → Stream
+    - _stream_response(my_generation) → ModelTurnResult
+    - _model_turn_with_fallback(consumer, prepare_wire) → ModelTurnResult
+    - _model_turn_with_retry(lane, tracker, ...) → ModelTurnResult
     - _execute_tools(tool_calls) → (results, feedback)
     - _prepare_tool(tc) → item dict
     - _prepare_mcp_tool(call_id, name, args) → item dict

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -177,7 +177,11 @@ def run_scenario(name: str) -> dict[str, Any]:
     record: dict[str, Any] = {"scenario": name}
     try:
         if pre_fold:
-            msg = session._stream_response([{"role": "user", "content": "hi"}], 0)
+            # Splatted: the pre-fold seam took (msgs, my_generation), and a
+            # literal two-argument call reads as an arity error against the
+            # signature this tree actually has.
+            pre_fold_args: tuple[Any, ...] = ([{"role": "user", "content": "hi"}], 0)
+            msg = session._stream_response(*pre_fold_args)
             msg.pop("_wire_msgs", None)
             record["result"] = {
                 "content": msg.get("content", ""),

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -40,6 +40,7 @@ from turnstone.core.providers._protocol import (
     ToolCallDelta,
     UsageInfo,
 )
+from turnstone.core.trajectory import Turn
 
 FIXTURE_DIR = Path(__file__).parent / "data" / "parity_832"
 UPDATE = os.environ.get("UPDATE_832_PARITY") == "1"
@@ -198,16 +199,17 @@ def run_scenario(name: str) -> dict[str, Any]:
     ui = RecordingUI()
     session = make_session(ui=ui)
     session._provider = scripted_provider(SCENARIOS[name])
-    msgs = [{"role": "user", "content": "hi"}]
+    session.messages.append(Turn.user("hi"))
 
     record: dict[str, Any] = {"scenario": name}
     try:
-        msg = session._stream_response(msgs, 0)
-        msg.pop("_wire_msgs", None)
+        result = session._stream_response(0)
         record["result"] = {
-            "content": msg.get("content", ""),
-            "tool_calls": msg.get("tool_calls"),
-            "provider_content": msg.get("_provider_content"),
+            "content": result.content,
+            "tool_calls": result.tool_calls or None,
+            "provider_content": (
+                [dict(b) for b in result.turn.native.blocks] if result.turn.native else None
+            ),
         }
         record["raised"] = None
     except BaseException as exc:  # noqa: BLE001 — the record IS the observation

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -1,32 +1,28 @@
 """#832 replay-parity harness: scenario table + runner.
 
-The fold's acceptance is a controller-determinism audit: with the plant's
-chunk sequence held fixed, the streaming phase must produce an identical
-UI event sequence and an identical committed message — modulo the small
-set of RULED behavior changes restated (in full) on the transforms in
-``test_832_parity.py``.  This module is the shared half: the scenario
-scripts (one row per chunk-field→UI translation the consumer performs)
-and the runner that drives one scenario through the session's streaming
-seam, recording everything the turn observably produced.
+The audit is controller determinism: with the plant's chunk sequence held
+fixed, the streaming phase must produce an identical UI event sequence
+and an identical committed message — modulo the RULED behavior changes
+restated in full on the transforms in ``test_832_parity.py``.  This
+module is the shared half: the scenario scripts (one row per
+chunk-field→UI translation the consumer performs) and the runner that
+drives one through the streaming seam, recording everything the turn
+observably produced.
 
 Baselines are captured from the PRE-FOLD path (``UPDATE_832_PARITY=1``,
-run at a tree where ``session.py`` is byte-identical to pre-fold main —
-the fixture commit's history proves it) into ``tests/data/parity_832/``.
-The runner adapts to EITHER world by signature (pre-fold
-``_stream_response(msgs, my_generation)`` took the prepared wire list;
-post-fold ``_stream_response(my_generation)`` prepares inside), so a
-recapture at an old tree records real old-world behavior — and capture
-mode refuses to write a record whose failure is the harness's own call
-shape.  The assert mode replays the same scripts through the current
-tree and compares against the baseline, applying the ruled transforms.
-A mismatch outside a ruled transform is a fold regression.
+run at a tree where ``session.py`` is byte-identical to pre-fold main)
+into ``tests/data/parity_832/``.  The runner adapts to EITHER world by
+signature, so a recapture at an old tree records real old-world
+behavior, and capture mode refuses to write a record whose failure is
+the harness's own call shape.  Assert mode replays the same scripts
+through the current tree and compares against the baseline, applying the
+ruled transforms; a mismatch outside a ruled transform is a regression.
 
 The provider fake arms ``cancel_ref`` EAGERLY (a closeable sentinel
 appended inside ``create_streaming``, before the iterator is returned),
-mirroring every real adapter — the post-fold wrapper classifies
-creation-vs-midstream failures by that arming, so a fake that skipped
-it would exercise only the creation arm and the parity audit would
-never reach the mid-stream ladder.
+mirroring every real adapter: the wrapper classifies
+creation-vs-midstream failures by that arming, so a fake that skipped it
+would exercise only the creation arm.
 """
 
 from __future__ import annotations
@@ -155,20 +151,18 @@ def _mask_synth_ids(record: dict[str, Any]) -> dict[str, Any]:
 def run_scenario(name: str) -> dict[str, Any]:
     """Drive one scenario through the streaming seam; return the record.
 
-    The record is everything the streaming phase observably produced:
-    the ordered UI events, the committed-message projection, the
-    mid-stream usage slot, and the exception class if the seam raised.
-    Deliberately seam-level (the ``_stream_response`` boundary pre-fold,
-    its wrapper successor post-fold) — full ``send()`` scenarios ride the
-    ported ladder suites instead.
+    The record is everything the streaming phase observably produced: the
+    ordered UI events, the committed-message projection, the mid-stream
+    usage slot, and the exception class if the seam raised.  Deliberately
+    seam-level at ``_stream_response`` — full ``send()`` scenarios ride
+    the ported ladder suites instead.
 
     Signature-adaptive so ``UPDATE_832_PARITY=1`` at a PRE-fold tree
     records real old-world behavior: the pre-fold seam was
-    ``_stream_response(msgs, my_generation) -> dict`` (wire list built
-    by the caller), the post-fold seam is
-    ``_stream_response(my_generation) -> ModelTurnResult`` (wire
-    prepared inside).  A harness-shape failure must never be recorded
-    as behavior — ``write_fixture`` refuses one.
+    ``_stream_response(msgs, my_generation) -> dict``, the post-fold one
+    is ``_stream_response(my_generation) -> ModelTurnResult`` (wire
+    prepared inside).  A harness-shape failure must never be recorded as
+    behavior — ``write_fixture`` refuses one.
     """
     ui = RecordingUI()
     session = make_session(ui=ui)

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -34,13 +34,52 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from tests._session_helpers import RecordingUI, make_session
+from turnstone.core.model_turn import ModelTurnResult
 from turnstone.core.providers._protocol import (
     ModelCapabilities,
     StreamChunk,
     ToolCallDelta,
     UsageInfo,
 )
-from turnstone.core.trajectory import Turn
+from turnstone.core.trajectory import ProviderNative, ToolCall, Turn
+
+
+def make_result(
+    content: str = "",
+    *,
+    tool_calls: list[dict[str, Any]] | None = None,
+    finish_reason: str = "stop",
+    usage: UsageInfo | None = None,
+    native_blocks: list[dict[str, Any]] | None = None,
+    producer: str = "openai-compatible",
+    wire_msgs: list[dict[str, Any]] | None = None,
+) -> ModelTurnResult:
+    """A ``ModelTurnResult`` shaped like the streaming wrapper's return —
+    triage recipe R1's patched-result form, for tests that only need "a
+    turn happened" and patch ``_stream_response`` wholesale.  The Turn and
+    the ``tool_calls`` mirror are built from the same dicts, preserving
+    the #825 pairing invariant fakes must not break."""
+    calls = list(tool_calls or [])
+    tc_tuple = tuple(
+        ToolCall(
+            id=tc.get("id", ""),
+            name=tc.get("function", {}).get("name", ""),
+            arguments=tc.get("function", {}).get("arguments", ""),
+        )
+        for tc in calls
+    )
+    native = (
+        ProviderNative(producer=producer, blocks=tuple(native_blocks)) if native_blocks else None
+    )
+    return ModelTurnResult(
+        turn=Turn.assistant(content, tool_calls=tc_tuple, native=native),
+        finish_reason=finish_reason,
+        usage=usage,
+        tool_calls=calls,
+        wire_msgs=wire_msgs,
+        producer=producer,
+    )
+
 
 FIXTURE_DIR = Path(__file__).parent / "data" / "parity_832"
 UPDATE = os.environ.get("UPDATE_832_PARITY") == "1"

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -95,6 +95,51 @@ class ArmedHandle:
         self.closed = True
 
 
+def arm_session(
+    session: Any,
+    *streams: Any,
+    retryable: frozenset[str] = frozenset({"IncompleteStreamError"}),
+    name: str = "openai-compatible",
+) -> MagicMock:
+    """Install a sequential multi-turn armed provider fake on *session*.
+
+    Each ``create_streaming`` call serves the next element of *streams*:
+    an iterable/generator is armed (a closeable sentinel appended to
+    ``cancel_ref`` — the eager append every real adapter performs, which
+    the fold's creation-vs-midstream classifier keys on) and returned to
+    be consumed once; an EXCEPTION instance is raised at create time
+    WITHOUT arming — a creation-phase failure the per-lane ladder owns.
+    Calls beyond the script fail loudly (the pre-fold lax consumer used
+    to absorb an exhausted iterator as a silent empty turn; the strict
+    finish gate rejects that now, so an under-scripted test must say so).
+
+    Title generation is latched off — with a provider-LEVEL fake the
+    best-effort title lane would otherwise consume the first script
+    before the main loop ran.
+    """
+    session._title_generated = True
+    provider = MagicMock()
+    provider.provider_name = name
+    provider.get_capabilities.return_value = ModelCapabilities()
+    provider.retryable_error_names = retryable
+    provider._armed_handle = MagicMock()
+    remaining = list(streams)
+
+    def _create(**kwargs: Any):
+        assert remaining, "arm_session: script exhausted — send looped for more turns than scripted"
+        nxt = remaining.pop(0)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        ref = kwargs.get("cancel_ref")
+        if ref is not None:
+            ref.append(provider._armed_handle)
+        return iter(nxt) if not hasattr(nxt, "__next__") else nxt
+
+    provider.create_streaming = MagicMock(side_effect=_create)
+    session._provider = provider
+    return provider
+
+
 def scripted_provider(chunks: list[StreamChunk]) -> MagicMock:
     """Provider fake replaying *chunks*, arming ``cancel_ref`` eagerly.
 

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -172,6 +172,11 @@ def run_scenario(name: str) -> dict[str, Any]:
     """
     ui = RecordingUI()
     session = make_session(ui=ui)
+    # Zero the ladder backoff: a scenario that reaches the mid-stream
+    # re-issue ladder (no_finish_clean_exhaust) must not sleep real
+    # exponential delays in a unit run.  The retry-notice transform in
+    # test_832_parity hardcodes the matching "0s" wording.
+    session._RETRY_BASE_DELAY = 0
     session._provider = scripted_provider(SCENARIOS[name])
 
     pre_fold = "msgs" in inspect.signature(type(session)._stream_response).parameters

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -1,0 +1,232 @@
+"""#832 replay-parity harness: scenario table + runner.
+
+The fold's acceptance is a controller-determinism audit: with the plant's
+chunk sequence held fixed, the streaming phase must produce an identical
+UI event sequence and an identical committed message — modulo the deltas
+the design's D12 table rules (docs/design/832-main-loop-model-turn.md,
+local).  This module is the shared half: the scenario scripts (drawn from
+the dataflow map's V11 chunk-field→UI grid) and the runner that drives one
+scenario through the session's streaming seam, recording everything the
+turn observably produced.
+
+Baselines are captured from the PRE-FOLD path (``UPDATE_832_PARITY=1``,
+run at a tree where ``session.py`` is byte-identical to main — the fixture
+commit's history proves it) into ``tests/data/parity_832/``.  The assert
+mode replays the same scripts through the current tree and compares
+against the baseline, applying the D12 transforms where the design ruled
+a behavior change.  A mismatch outside a ruled transform is a fold
+regression.
+
+The provider fake arms ``cancel_ref`` EAGERLY (a closeable sentinel
+appended inside ``create_streaming``, before the iterator is returned),
+mirroring every real adapter — the post-fold wrapper classifies
+creation-vs-midstream failures by that arming, so a fake that skipped it
+would exercise only the creation arm (design gap-check G8).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from tests._session_helpers import RecordingUI, make_session
+from turnstone.core.providers._protocol import (
+    ModelCapabilities,
+    StreamChunk,
+    ToolCallDelta,
+    UsageInfo,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "data" / "parity_832"
+UPDATE = os.environ.get("UPDATE_832_PARITY") == "1"
+
+
+class ArmedHandle:
+    """Closeable sentinel standing in for the SDK stream handle."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def scripted_provider(chunks: list[StreamChunk]) -> MagicMock:
+    """Provider fake replaying *chunks*, arming ``cancel_ref`` eagerly.
+
+    Assign to ``session._provider`` (never mutate a resolved provider —
+    the create_provider singleton rule in ``_session_helpers``).  Each
+    call returns a FRESH iterator over the same script so ladder tests
+    re-drive it; the armed handle is appended per call, matching the
+    one-handle-per-create behavior of every real adapter.
+    """
+    provider = MagicMock()
+    provider.provider_name = "openai-compatible"
+    provider.get_capabilities.return_value = ModelCapabilities()
+    provider.retryable_error_names = frozenset({"IncompleteStreamError"})
+
+    def _create(**kwargs: Any):
+        ref = kwargs.get("cancel_ref")
+        if ref is not None:
+            ref.append(ArmedHandle())
+        return iter(chunks)
+
+    provider.create_streaming = MagicMock(side_effect=_create)
+    return provider
+
+
+def _tc(index: int, call_id: str, name: str = "", args: str = "") -> ToolCallDelta:
+    return ToolCallDelta(index=index, id=call_id, name=name, arguments_delta=args)
+
+
+_USAGE_A = UsageInfo(prompt_tokens=11, completion_tokens=0, total_tokens=11)
+_USAGE_B = UsageInfo(prompt_tokens=11, completion_tokens=7, total_tokens=18)
+
+# Scenario table — the V11 grid, one script per row.  Scripts are chunk
+# LISTS; the runner re-iterates a fresh iterator per attempt.
+SCENARIOS: dict[str, list[StreamChunk]] = {
+    "content_only": [
+        StreamChunk(content_delta="Hello "),
+        StreamChunk(content_delta="world."),
+        StreamChunk(finish_reason="stop", usage=_USAGE_B),
+    ],
+    "reasoning_then_content": [
+        StreamChunk(reasoning_delta="think a", usage=_USAGE_A),
+        StreamChunk(reasoning_delta=" think b"),
+        StreamChunk(content_delta="Answer."),
+        StreamChunk(finish_reason="stop", usage=_USAGE_B),
+    ],
+    "tools_simple": [
+        StreamChunk(content_delta="Calling."),
+        StreamChunk(tool_call_deltas=[_tc(0, "call_1", "get_weather", '{"city": ')]),
+        StreamChunk(tool_call_deltas=[_tc(0, "", "", '"Paris"}')]),
+        StreamChunk(finish_reason="tool_calls", usage=_USAGE_B),
+    ],
+    "combined_content_tools_finish": [
+        StreamChunk(content_delta="Before "),
+        StreamChunk(
+            content_delta="tools",
+            tool_call_deltas=[_tc(0, "call_1", "get_weather", '{"city": "Nice"}')],
+            finish_reason="tool_calls",
+        ),
+        StreamChunk(usage=_USAGE_B),
+    ],
+    "info_prefinish": [
+        StreamChunk(info_delta="[Searching: pinniped taxonomy]"),
+        StreamChunk(content_delta="Seals are pinnipeds."),
+        StreamChunk(finish_reason="stop", usage=_USAGE_B),
+    ],
+    "info_postfinish_footer": [
+        StreamChunk(content_delta="Answer with sources."),
+        StreamChunk(finish_reason="stop", usage=_USAGE_B),
+        StreamChunk(info_delta="Sources:\n- example.com/page"),
+    ],
+    "think_tags_split_across_chunks": [
+        StreamChunk(content_delta="<thi"),
+        StreamChunk(content_delta="nk>plan</think>\n\nAnswer"),
+        StreamChunk(finish_reason="stop", usage=_USAGE_B),
+    ],
+    "blank_id_tools": [
+        StreamChunk(tool_call_deltas=[_tc(0, "", "get_weather", '{"city": "Oslo"}')]),
+        StreamChunk(finish_reason="tool_calls", usage=_USAGE_B),
+    ],
+    "length_with_tools": [
+        StreamChunk(content_delta="Partial answer"),
+        StreamChunk(tool_call_deltas=[_tc(0, "call_1", "get_weather", '{"city": "Par')]),
+        StreamChunk(finish_reason="length", usage=_USAGE_B),
+    ],
+    "content_filter": [
+        StreamChunk(content_delta="Redac"),
+        StreamChunk(finish_reason="content_filter", usage=_USAGE_B),
+    ],
+    "no_finish_clean_exhaust": [
+        StreamChunk(content_delta="Half an ans"),
+        StreamChunk(usage=_USAGE_A),
+    ],
+    "finish_only_no_content": [
+        StreamChunk(finish_reason="stop", usage=_USAGE_B),
+    ],
+    "provider_blocks_on_terminal": [
+        StreamChunk(content_delta="Blocked."),
+        StreamChunk(
+            finish_reason="stop",
+            usage=_USAGE_B,
+            provider_blocks=[{"type": "reasoning_text", "text": "captured"}],
+        ),
+    ],
+}
+
+
+_SYNTH_ID = re.compile(r"^call_[0-9a-f]{32}$")
+
+
+def _mask_synth_ids(record: dict[str, Any]) -> dict[str, Any]:
+    """Replace uuid-backfilled tool-call ids with stable placeholders.
+
+    The blank-id repair mints ``call_<uuid4hex>`` per run — real
+    nondeterminism inside the seam, but not behavior: mask ONLY that exact
+    shape (never a scripted provider id) with an index-stable token so
+    captures compare across runs.  Applied to the committed projection;
+    UI events never carry call ids in this harness.
+    """
+    result = record.get("result")
+    if not result:
+        return record
+    for i, tc in enumerate(result.get("tool_calls") or []):
+        if _SYNTH_ID.match(tc.get("id", "")):
+            tc["id"] = f"synth-id-{i}"
+    for i, block in enumerate(result.get("provider_content") or []):
+        if isinstance(block, dict) and _SYNTH_ID.match(str(block.get("id", ""))):
+            block["id"] = f"synth-id-{i}"
+    return record
+
+
+def run_scenario(name: str) -> dict[str, Any]:
+    """Drive one scenario through the streaming seam; return the record.
+
+    The record is everything the streaming phase observably produced:
+    the ordered UI events, the committed-message projection, the
+    mid-stream usage slot, and the exception class if the seam raised.
+    Deliberately seam-level (the ``_stream_response`` boundary pre-fold,
+    its wrapper successor post-fold) — full ``send()`` scenarios ride the
+    ported ladder suites instead.
+    """
+    ui = RecordingUI()
+    session = make_session(ui=ui)
+    session._provider = scripted_provider(SCENARIOS[name])
+    msgs = [{"role": "user", "content": "hi"}]
+
+    record: dict[str, Any] = {"scenario": name}
+    try:
+        msg = session._stream_response(msgs, 0)
+        msg.pop("_wire_msgs", None)
+        record["result"] = {
+            "content": msg.get("content", ""),
+            "tool_calls": msg.get("tool_calls"),
+            "provider_content": msg.get("_provider_content"),
+        }
+        record["raised"] = None
+    except BaseException as exc:  # noqa: BLE001 — the record IS the observation
+        record["result"] = None
+        record["raised"] = type(exc).__name__
+    record["ui_events"] = [[k, d] for k, d in ui.events]
+    record["last_usage"] = session._last_usage
+    record["cancelled_partial"] = session._cancelled_partial_msg
+    return _mask_synth_ids(record)
+
+
+def fixture_path(name: str) -> Path:
+    return FIXTURE_DIR / f"{name}.json"
+
+
+def load_fixture(name: str) -> dict[str, Any]:
+    return json.loads(fixture_path(name).read_text())
+
+
+def write_fixture(name: str, record: dict[str, Any]) -> None:
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    fixture_path(name).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")

--- a/tests/_parity_832.py
+++ b/tests/_parity_832.py
@@ -2,166 +2,48 @@
 
 The fold's acceptance is a controller-determinism audit: with the plant's
 chunk sequence held fixed, the streaming phase must produce an identical
-UI event sequence and an identical committed message — modulo the deltas
-the design's D12 table rules (docs/design/832-main-loop-model-turn.md,
-local).  This module is the shared half: the scenario scripts (drawn from
-the dataflow map's V11 chunk-field→UI grid) and the runner that drives one
-scenario through the session's streaming seam, recording everything the
-turn observably produced.
+UI event sequence and an identical committed message — modulo the small
+set of RULED behavior changes restated (in full) on the transforms in
+``test_832_parity.py``.  This module is the shared half: the scenario
+scripts (one row per chunk-field→UI translation the consumer performs)
+and the runner that drives one scenario through the session's streaming
+seam, recording everything the turn observably produced.
 
 Baselines are captured from the PRE-FOLD path (``UPDATE_832_PARITY=1``,
-run at a tree where ``session.py`` is byte-identical to main — the fixture
-commit's history proves it) into ``tests/data/parity_832/``.  The assert
-mode replays the same scripts through the current tree and compares
-against the baseline, applying the D12 transforms where the design ruled
-a behavior change.  A mismatch outside a ruled transform is a fold
-regression.
+run at a tree where ``session.py`` is byte-identical to pre-fold main —
+the fixture commit's history proves it) into ``tests/data/parity_832/``.
+The runner adapts to EITHER world by signature (pre-fold
+``_stream_response(msgs, my_generation)`` took the prepared wire list;
+post-fold ``_stream_response(my_generation)`` prepares inside), so a
+recapture at an old tree records real old-world behavior — and capture
+mode refuses to write a record whose failure is the harness's own call
+shape.  The assert mode replays the same scripts through the current
+tree and compares against the baseline, applying the ruled transforms.
+A mismatch outside a ruled transform is a fold regression.
 
 The provider fake arms ``cancel_ref`` EAGERLY (a closeable sentinel
 appended inside ``create_streaming``, before the iterator is returned),
 mirroring every real adapter — the post-fold wrapper classifies
-creation-vs-midstream failures by that arming, so a fake that skipped it
-would exercise only the creation arm (design gap-check G8).
+creation-vs-midstream failures by that arming, so a fake that skipped
+it would exercise only the creation arm and the parity audit would
+never reach the mid-stream ladder.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import re
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
-from tests._session_helpers import RecordingUI, make_session
-from turnstone.core.model_turn import ModelTurnResult
-from turnstone.core.providers._protocol import (
-    ModelCapabilities,
-    StreamChunk,
-    ToolCallDelta,
-    UsageInfo,
-)
-from turnstone.core.trajectory import ProviderNative, ToolCall, Turn
-
-
-def make_result(
-    content: str = "",
-    *,
-    tool_calls: list[dict[str, Any]] | None = None,
-    finish_reason: str = "stop",
-    usage: UsageInfo | None = None,
-    native_blocks: list[dict[str, Any]] | None = None,
-    producer: str = "openai-compatible",
-    wire_msgs: list[dict[str, Any]] | None = None,
-) -> ModelTurnResult:
-    """A ``ModelTurnResult`` shaped like the streaming wrapper's return —
-    triage recipe R1's patched-result form, for tests that only need "a
-    turn happened" and patch ``_stream_response`` wholesale.  The Turn and
-    the ``tool_calls`` mirror are built from the same dicts, preserving
-    the #825 pairing invariant fakes must not break."""
-    calls = list(tool_calls or [])
-    tc_tuple = tuple(
-        ToolCall(
-            id=tc.get("id", ""),
-            name=tc.get("function", {}).get("name", ""),
-            arguments=tc.get("function", {}).get("arguments", ""),
-        )
-        for tc in calls
-    )
-    native = (
-        ProviderNative(producer=producer, blocks=tuple(native_blocks)) if native_blocks else None
-    )
-    return ModelTurnResult(
-        turn=Turn.assistant(content, tool_calls=tc_tuple, native=native),
-        finish_reason=finish_reason,
-        usage=usage,
-        tool_calls=calls,
-        wire_msgs=wire_msgs,
-        producer=producer,
-    )
-
+from tests._session_helpers import RecordingUI, make_session, scripted_provider
+from turnstone.core.providers._protocol import StreamChunk, ToolCallDelta, UsageInfo
+from turnstone.core.trajectory import Turn
 
 FIXTURE_DIR = Path(__file__).parent / "data" / "parity_832"
 UPDATE = os.environ.get("UPDATE_832_PARITY") == "1"
-
-
-class ArmedHandle:
-    """Closeable sentinel standing in for the SDK stream handle."""
-
-    def __init__(self) -> None:
-        self.closed = False
-
-    def close(self) -> None:
-        self.closed = True
-
-
-def arm_session(
-    session: Any,
-    *streams: Any,
-    retryable: frozenset[str] = frozenset({"IncompleteStreamError"}),
-    name: str = "openai-compatible",
-) -> MagicMock:
-    """Install a sequential multi-turn armed provider fake on *session*.
-
-    Each ``create_streaming`` call serves the next element of *streams*:
-    an iterable/generator is armed (a closeable sentinel appended to
-    ``cancel_ref`` — the eager append every real adapter performs, which
-    the fold's creation-vs-midstream classifier keys on) and returned to
-    be consumed once; an EXCEPTION instance is raised at create time
-    WITHOUT arming — a creation-phase failure the per-lane ladder owns.
-    Calls beyond the script fail loudly (the pre-fold lax consumer used
-    to absorb an exhausted iterator as a silent empty turn; the strict
-    finish gate rejects that now, so an under-scripted test must say so).
-
-    Title generation is latched off — with a provider-LEVEL fake the
-    best-effort title lane would otherwise consume the first script
-    before the main loop ran.
-    """
-    session._title_generated = True
-    provider = MagicMock()
-    provider.provider_name = name
-    provider.get_capabilities.return_value = ModelCapabilities()
-    provider.retryable_error_names = retryable
-    provider._armed_handle = MagicMock()
-    remaining = list(streams)
-
-    def _create(**kwargs: Any):
-        assert remaining, "arm_session: script exhausted — send looped for more turns than scripted"
-        nxt = remaining.pop(0)
-        if isinstance(nxt, BaseException):
-            raise nxt
-        ref = kwargs.get("cancel_ref")
-        if ref is not None:
-            ref.append(provider._armed_handle)
-        return iter(nxt) if not hasattr(nxt, "__next__") else nxt
-
-    provider.create_streaming = MagicMock(side_effect=_create)
-    session._provider = provider
-    return provider
-
-
-def scripted_provider(chunks: list[StreamChunk]) -> MagicMock:
-    """Provider fake replaying *chunks*, arming ``cancel_ref`` eagerly.
-
-    Assign to ``session._provider`` (never mutate a resolved provider —
-    the create_provider singleton rule in ``_session_helpers``).  Each
-    call returns a FRESH iterator over the same script so ladder tests
-    re-drive it; the armed handle is appended per call, matching the
-    one-handle-per-create behavior of every real adapter.
-    """
-    provider = MagicMock()
-    provider.provider_name = "openai-compatible"
-    provider.get_capabilities.return_value = ModelCapabilities()
-    provider.retryable_error_names = frozenset({"IncompleteStreamError"})
-
-    def _create(**kwargs: Any):
-        ref = kwargs.get("cancel_ref")
-        if ref is not None:
-            ref.append(ArmedHandle())
-        return iter(chunks)
-
-    provider.create_streaming = MagicMock(side_effect=_create)
-    return provider
 
 
 def _tc(index: int, call_id: str, name: str = "", args: str = "") -> ToolCallDelta:
@@ -279,22 +161,40 @@ def run_scenario(name: str) -> dict[str, Any]:
     Deliberately seam-level (the ``_stream_response`` boundary pre-fold,
     its wrapper successor post-fold) — full ``send()`` scenarios ride the
     ported ladder suites instead.
+
+    Signature-adaptive so ``UPDATE_832_PARITY=1`` at a PRE-fold tree
+    records real old-world behavior: the pre-fold seam was
+    ``_stream_response(msgs, my_generation) -> dict`` (wire list built
+    by the caller), the post-fold seam is
+    ``_stream_response(my_generation) -> ModelTurnResult`` (wire
+    prepared inside).  A harness-shape failure must never be recorded
+    as behavior — ``write_fixture`` refuses one.
     """
     ui = RecordingUI()
     session = make_session(ui=ui)
     session._provider = scripted_provider(SCENARIOS[name])
-    session.messages.append(Turn.user("hi"))
 
+    pre_fold = "msgs" in inspect.signature(type(session)._stream_response).parameters
     record: dict[str, Any] = {"scenario": name}
     try:
-        result = session._stream_response(0)
-        record["result"] = {
-            "content": result.content,
-            "tool_calls": result.tool_calls or None,
-            "provider_content": (
-                [dict(b) for b in result.turn.native.blocks] if result.turn.native else None
-            ),
-        }
+        if pre_fold:
+            msg = session._stream_response([{"role": "user", "content": "hi"}], 0)
+            msg.pop("_wire_msgs", None)
+            record["result"] = {
+                "content": msg.get("content", ""),
+                "tool_calls": msg.get("tool_calls"),
+                "provider_content": msg.get("_provider_content"),
+            }
+        else:
+            session.messages.append(Turn.user("hi"))
+            result = session._stream_response(0)
+            record["result"] = {
+                "content": result.content,
+                "tool_calls": result.tool_calls or None,
+                "provider_content": (
+                    [dict(b) for b in result.turn.native.blocks] if result.turn.native else None
+                ),
+            }
         record["raised"] = None
     except BaseException as exc:  # noqa: BLE001 — the record IS the observation
         record["result"] = None
@@ -314,5 +214,14 @@ def load_fixture(name: str) -> dict[str, Any]:
 
 
 def write_fixture(name: str, record: dict[str, Any]) -> None:
+    # A TypeError before ANY UI event is the harness's own call-shape
+    # failure (run_scenario's signature adapter no longer matches this
+    # tree's seam), not old-world behavior — refuse to destroy the
+    # baseline with it.
+    if record.get("raised") == "TypeError" and not record.get("ui_events"):
+        raise AssertionError(
+            f"parity capture for {name!r} died calling the seam (TypeError before "
+            f"any UI event) — fix run_scenario's signature adapter; do not record"
+        )
     FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
     fixture_path(name).write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -1,14 +1,13 @@
 """Shared session-test helpers.
 
 The minimal ``ChatSession`` factory, the ``SessionUIBase`` no-op/recording
-subclasses, and — since #832 — the tree's standard streaming provider
-fakes (``make_result`` / ``arm_session`` / ``scripted_provider`` /
-``ArmedHandle``, at the bottom): every suite that drives the streaming
-seam imports them from here so the eager-arming contract lives in one
-place.  Hoisting keeps callers from drifting on the defaults — the one
-deliberate exception, ``test_model_registry.py``'s ``_make_session``,
-takes a different signature (registry / model_alias / reasoning_effort
-+ ``_FakeUI``) and is NOT a candidate for sharing this helper.
+subclasses, and the tree's standard streaming provider fakes
+(``make_result`` / ``arm_session`` / ``scripted_provider`` /
+``ArmedHandle``, at the bottom): every suite driving the streaming seam
+imports them from here, so the eager-arming contract lives in one place.
+The one deliberate exception, ``test_model_registry.py``'s
+``_make_session``, takes a different signature (registry / model_alias /
+reasoning_effort + ``_FakeUI``) and is NOT a candidate for sharing.
 
 Module is named with a leading underscore so pytest doesn't try to
 collect it as a test file — it's an importable utility, not a test.
@@ -485,11 +484,10 @@ def make_result(
     producer: str = "openai-compatible",
     wire_msgs: list[dict[str, Any]] | None = None,
 ) -> ModelTurnResult:
-    """A ``ModelTurnResult`` shaped like the streaming wrapper's return —
+    """A ``ModelTurnResult`` shaped like the streaming wrapper's return,
     for tests that only need "a turn happened" and patch
-    ``_stream_response`` wholesale.  The Turn and the ``tool_calls``
-    mirror are built from the same dicts, preserving the #825 pairing
-    invariant fakes must not break."""
+    ``_stream_response`` wholesale.  Turn and ``tool_calls`` mirror are
+    built from the same dicts, preserving the #825 pairing invariant."""
     calls = list(tool_calls or [])
     tc_tuple = tuple(
         ToolCall(
@@ -533,12 +531,12 @@ def arm_session(
     Each ``create_streaming`` call serves the next element of *streams*:
     an iterable/generator is armed (a closeable sentinel appended to
     ``cancel_ref`` — the eager append every real adapter performs, which
-    the fold's creation-vs-midstream classifier keys on) and returned to
-    be consumed once; an EXCEPTION instance is raised at create time
-    WITHOUT arming — a creation-phase failure the per-lane ladder owns.
-    Calls beyond the script fail loudly (the pre-fold lax consumer used
-    to absorb an exhausted iterator as a silent empty turn; the strict
-    finish gate rejects that now, so an under-scripted test must say so).
+    the creation-vs-midstream classifier keys on) and returned to be
+    consumed once; an EXCEPTION instance is raised at create time WITHOUT
+    arming, a creation-phase failure the per-lane ladder owns.  Calls
+    beyond the script fail loudly: the strict finish gate rejects an
+    exhausted iterator rather than absorbing it as a silent empty turn,
+    so an under-scripted test must say so.
 
     Title generation is latched off — with a provider-LEVEL fake the
     best-effort title lane would otherwise consume the first script

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -547,7 +547,10 @@ def arm_session(
     provider.provider_name = name
     provider.get_capabilities.return_value = ModelCapabilities()
     provider.retryable_error_names = retryable
-    provider._armed_handle = ArmedHandle()
+    # One handle PER CREATE (the real adapters' rule): `handles` records
+    # them all, `_armed_handle` is the latest.
+    provider._armed_handle = None
+    provider.handles = []
     remaining = list(streams)
 
     def _create(**kwargs: Any):
@@ -557,7 +560,10 @@ def arm_session(
             raise nxt
         ref = kwargs.get("cancel_ref")
         if ref is not None:
-            ref.append(provider._armed_handle)
+            handle = ArmedHandle()
+            provider.handles.append(handle)
+            provider._armed_handle = handle
+            ref.append(handle)
         return iter(nxt) if not hasattr(nxt, "__next__") else nxt
 
     provider.create_streaming = MagicMock(side_effect=_create)

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -1,10 +1,12 @@
 """Shared session-test helpers.
 
-Two reasoning-test modules (``test_session_replay_reasoning.py`` and
-``test_session_synth_reasoning_block.py``) need the same minimal
-``ChatSession`` factory + a ``SessionUIBase`` no-op subclass.  Hoisting
-keeps a future third caller from drifting on the defaults — the third
-existing ``_make_session`` (``test_model_registry.py``) deliberately
+The minimal ``ChatSession`` factory, the ``SessionUIBase`` no-op/recording
+subclasses, and — since #832 — the tree's standard streaming provider
+fakes (``make_result`` / ``arm_session`` / ``scripted_provider`` /
+``ArmedHandle``, at the bottom): every suite that drives the streaming
+seam imports them from here so the eager-arming contract lives in one
+place.  Hoisting keeps callers from drifting on the defaults — the one
+deliberate exception, ``test_model_registry.py``'s ``_make_session``,
 takes a different signature (registry / model_alias / reasoning_effort
 + ``_FakeUI``) and is NOT a candidate for sharing this helper.
 
@@ -19,9 +21,11 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
-from turnstone.core.providers import ModelCapabilities, StreamChunk, ToolCallDelta
+from turnstone.core.model_turn import ModelTurnResult
+from turnstone.core.providers import ModelCapabilities, StreamChunk, ToolCallDelta, UsageInfo
 from turnstone.core.session import ChatSession
 from turnstone.core.session_ui_base import SessionUIBase
+from turnstone.core.trajectory import ProviderNative, ToolCall, Turn
 
 
 class NullUI(SessionUIBase):
@@ -464,3 +468,124 @@ class RecordingUI:
 
     def of(self, kind):
         return [d for k, d in self.events if k == kind]
+
+
+# ---------------------------------------------------------------------------
+# Streaming provider fakes — the #832 seam contract
+# ---------------------------------------------------------------------------
+
+
+def make_result(
+    content: str = "",
+    *,
+    tool_calls: list[dict[str, Any]] | None = None,
+    finish_reason: str = "stop",
+    usage: UsageInfo | None = None,
+    native_blocks: list[dict[str, Any]] | None = None,
+    producer: str = "openai-compatible",
+    wire_msgs: list[dict[str, Any]] | None = None,
+) -> ModelTurnResult:
+    """A ``ModelTurnResult`` shaped like the streaming wrapper's return —
+    for tests that only need "a turn happened" and patch
+    ``_stream_response`` wholesale.  The Turn and the ``tool_calls``
+    mirror are built from the same dicts, preserving the #825 pairing
+    invariant fakes must not break."""
+    calls = list(tool_calls or [])
+    tc_tuple = tuple(
+        ToolCall(
+            id=tc.get("id", ""),
+            name=tc.get("function", {}).get("name", ""),
+            arguments=tc.get("function", {}).get("arguments", ""),
+        )
+        for tc in calls
+    )
+    native = (
+        ProviderNative(producer=producer, blocks=tuple(native_blocks)) if native_blocks else None
+    )
+    return ModelTurnResult(
+        turn=Turn.assistant(content, tool_calls=tc_tuple, native=native),
+        finish_reason=finish_reason,
+        usage=usage,
+        tool_calls=calls,
+        wire_msgs=wire_msgs,
+        producer=producer,
+    )
+
+
+class ArmedHandle:
+    """Closeable sentinel standing in for the SDK stream handle."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def arm_session(
+    session: Any,
+    *streams: Any,
+    retryable: frozenset[str] = frozenset({"IncompleteStreamError"}),
+    name: str = "openai-compatible",
+) -> MagicMock:
+    """Install a sequential multi-turn armed provider fake on *session*.
+
+    Each ``create_streaming`` call serves the next element of *streams*:
+    an iterable/generator is armed (a closeable sentinel appended to
+    ``cancel_ref`` — the eager append every real adapter performs, which
+    the fold's creation-vs-midstream classifier keys on) and returned to
+    be consumed once; an EXCEPTION instance is raised at create time
+    WITHOUT arming — a creation-phase failure the per-lane ladder owns.
+    Calls beyond the script fail loudly (the pre-fold lax consumer used
+    to absorb an exhausted iterator as a silent empty turn; the strict
+    finish gate rejects that now, so an under-scripted test must say so).
+
+    Title generation is latched off — with a provider-LEVEL fake the
+    best-effort title lane would otherwise consume the first script
+    before the main loop ran.
+    """
+    session._title_generated = True
+    provider = MagicMock()
+    provider.provider_name = name
+    provider.get_capabilities.return_value = ModelCapabilities()
+    provider.retryable_error_names = retryable
+    provider._armed_handle = MagicMock()
+    remaining = list(streams)
+
+    def _create(**kwargs: Any):
+        assert remaining, "arm_session: script exhausted — send looped for more turns than scripted"
+        nxt = remaining.pop(0)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        ref = kwargs.get("cancel_ref")
+        if ref is not None:
+            ref.append(provider._armed_handle)
+        return iter(nxt) if not hasattr(nxt, "__next__") else nxt
+
+    provider.create_streaming = MagicMock(side_effect=_create)
+    session._provider = provider
+    return provider
+
+
+def scripted_provider(chunks: list[StreamChunk]) -> MagicMock:
+    """Provider fake replaying *chunks*, arming ``cancel_ref`` eagerly.
+
+    Assign to ``session._provider`` (never mutate a resolved provider —
+    the create_provider singleton rule above).  Each call returns a FRESH
+    iterator over the same script so ladder tests re-drive it; the armed
+    handle is appended per call, matching the one-handle-per-create
+    behavior of every real adapter.
+    """
+    provider = MagicMock()
+    provider.provider_name = "openai-compatible"
+    provider.get_capabilities.return_value = ModelCapabilities()
+    provider.retryable_error_names = frozenset({"IncompleteStreamError"})
+
+    def _create(**kwargs: Any):
+        ref = kwargs.get("cancel_ref")
+        if ref is not None:
+            ref.append(ArmedHandle())
+        return iter(chunks)
+
+    provider.create_streaming = MagicMock(side_effect=_create)
+    return provider

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -382,9 +382,7 @@ def seam_provider(utterance: str, *, provider_name: str = "openai-compatible") -
     later session in the test run (the SSE-recovery e2e servers resolve
     the same instance).
     """
-    provider = MagicMock()
-    provider.provider_name = provider_name
-    provider.get_capabilities.return_value = ModelCapabilities()
+    provider = provider_shell(provider_name)
     provider.create_streaming = MagicMock(return_value=think_tag_stream(utterance))
     return provider
 
@@ -520,6 +518,20 @@ class ArmedHandle:
         self.closed = True
 
 
+def provider_shell(
+    name: str = "openai-compatible",
+    retryable: frozenset[str] = frozenset({"IncompleteStreamError"}),
+) -> MagicMock:
+    """The armed-provider fake skeleton every streaming fake builds on:
+    provider_name / capabilities / retryable set.  ONE spelling, so a new
+    attribute the seam starts probing lands in every fake at once."""
+    provider = MagicMock()
+    provider.provider_name = name
+    provider.get_capabilities.return_value = ModelCapabilities()
+    provider.retryable_error_names = retryable
+    return provider
+
+
 def arm_session(
     session: Any,
     *streams: Any,
@@ -543,10 +555,7 @@ def arm_session(
     before the main loop ran.
     """
     session._title_generated = True
-    provider = MagicMock()
-    provider.provider_name = name
-    provider.get_capabilities.return_value = ModelCapabilities()
-    provider.retryable_error_names = retryable
+    provider = provider_shell(name, retryable)
     # One handle PER CREATE (the real adapters' rule): `handles` records
     # them all, `_armed_handle` is the latest.
     provider._armed_handle = None
@@ -580,10 +589,7 @@ def scripted_provider(chunks: list[StreamChunk]) -> MagicMock:
     handle is appended per call, matching the one-handle-per-create
     behavior of every real adapter.
     """
-    provider = MagicMock()
-    provider.provider_name = "openai-compatible"
-    provider.get_capabilities.return_value = ModelCapabilities()
-    provider.retryable_error_names = frozenset({"IncompleteStreamError"})
+    provider = provider_shell()
 
     def _create(**kwargs: Any):
         ref = kwargs.get("cancel_ref")

--- a/tests/_session_helpers.py
+++ b/tests/_session_helpers.py
@@ -549,7 +549,7 @@ def arm_session(
     provider.provider_name = name
     provider.get_capabilities.return_value = ModelCapabilities()
     provider.retryable_error_names = retryable
-    provider._armed_handle = MagicMock()
+    provider._armed_handle = ArmedHandle()
     remaining = list(streams)
 
     def _create(**kwargs: Any):

--- a/tests/data/parity_832/blank_id_tools.json
+++ b/tests/data/parity_832/blank_id_tools.json
@@ -1,0 +1,36 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "",
+    "provider_content": null,
+    "tool_calls": [
+      {
+        "function": {
+          "arguments": "{\"city\": \"Oslo\"}",
+          "name": "get_weather"
+        },
+        "id": "synth-id-0",
+        "type": "function"
+      }
+    ]
+  },
+  "scenario": "blank_id_tools",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/combined_content_tools_finish.json
+++ b/tests/data/parity_832/combined_content_tools_finish.json
@@ -1,0 +1,40 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Before tools",
+    "provider_content": null,
+    "tool_calls": [
+      {
+        "function": {
+          "arguments": "{\"city\": \"Nice\"}",
+          "name": "get_weather"
+        },
+        "id": "call_1",
+        "type": "function"
+      }
+    ]
+  },
+  "scenario": "combined_content_tools_finish",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Before tools"
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/content_filter.json
+++ b/tests/data/parity_832/content_filter.json
@@ -1,0 +1,35 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Redac",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "content_filter",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Redac"
+    ],
+    [
+      "error",
+      "Warning: response blocked by content filter."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/content_only.json
+++ b/tests/data/parity_832/content_only.json
@@ -1,0 +1,31 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Hello world.",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "content_only",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Hello world."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/finish_only_no_content.json
+++ b/tests/data/parity_832/finish_only_no_content.json
@@ -1,0 +1,23 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "finish_only_no_content",
+  "ui_events": [
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/info_postfinish_footer.json
+++ b/tests/data/parity_832/info_postfinish_footer.json
@@ -1,0 +1,39 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Answer with sources.",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "info_postfinish_footer",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Answer w"
+    ],
+    [
+      "info",
+      "Sources:\n- example.com/page"
+    ],
+    [
+      "content",
+      "ith sources."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/info_prefinish.json
+++ b/tests/data/parity_832/info_prefinish.json
@@ -1,0 +1,39 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Seals are pinnipeds.",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "info_prefinish",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "info",
+      "[Searching: pinniped taxonomy]"
+    ],
+    [
+      "content",
+      "Seals ar"
+    ],
+    [
+      "content",
+      "e pinnipeds."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/length_with_tools.json
+++ b/tests/data/parity_832/length_with_tools.json
@@ -1,0 +1,43 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Partial answer",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "length_with_tools",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Pa"
+    ],
+    [
+      "content",
+      "rtial answer"
+    ],
+    [
+      "error",
+      "Warning: response truncated (hit 4096 token limit). Use --max-tokens to increase, or /compact to free context."
+    ],
+    [
+      "error",
+      "Discarding partial tool calls from truncated response."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/no_finish_clean_exhaust.json
+++ b/tests/data/parity_832/no_finish_clean_exhaust.json
@@ -1,0 +1,31 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 0,
+    "prompt_tokens": 11,
+    "total_tokens": 11
+  },
+  "raised": null,
+  "result": {
+    "content": "Half an ans",
+    "provider_content": null,
+    "tool_calls": null
+  },
+  "scenario": "no_finish_clean_exhaust",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Half an ans"
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/provider_blocks_on_terminal.json
+++ b/tests/data/parity_832/provider_blocks_on_terminal.json
@@ -1,0 +1,36 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Blocked.",
+    "provider_content": [
+      {
+        "text": "captured",
+        "type": "reasoning_text"
+      }
+    ],
+    "tool_calls": null
+  },
+  "scenario": "provider_blocks_on_terminal",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Blocked."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/reasoning_then_content.json
+++ b/tests/data/parity_832/reasoning_then_content.json
@@ -1,0 +1,44 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Answer.",
+    "provider_content": [
+      {
+        "text": "think a think b",
+        "type": "reasoning_text"
+      }
+    ],
+    "tool_calls": null
+  },
+  "scenario": "reasoning_then_content",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "reasoning",
+      "think a"
+    ],
+    [
+      "reasoning",
+      " think b"
+    ],
+    [
+      "content",
+      "Answer."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/think_tags_split_across_chunks.json
+++ b/tests/data/parity_832/think_tags_split_across_chunks.json
@@ -1,0 +1,40 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "\n\nAnswer",
+    "provider_content": [
+      {
+        "text": "plan",
+        "type": "reasoning_text"
+      }
+    ],
+    "tool_calls": null
+  },
+  "scenario": "think_tags_split_across_chunks",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "reasoning",
+      "plan"
+    ],
+    [
+      "content",
+      "\n\nAnswer"
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/data/parity_832/tools_simple.json
+++ b/tests/data/parity_832/tools_simple.json
@@ -1,0 +1,40 @@
+{
+  "cancelled_partial": null,
+  "last_usage": {
+    "cache_creation_tokens": 0,
+    "cache_read_tokens": 0,
+    "completion_tokens": 7,
+    "prompt_tokens": 11,
+    "total_tokens": 18
+  },
+  "raised": null,
+  "result": {
+    "content": "Calling.",
+    "provider_content": null,
+    "tool_calls": [
+      {
+        "function": {
+          "arguments": "{\"city\": \"Paris\"}",
+          "name": "get_weather"
+        },
+        "id": "call_1",
+        "type": "function"
+      }
+    ]
+  },
+  "scenario": "tools_simple",
+  "ui_events": [
+    [
+      "thinking_stop",
+      ""
+    ],
+    [
+      "content",
+      "Calling."
+    ],
+    [
+      "stream_end",
+      ""
+    ]
+  ]
+}

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -1,19 +1,18 @@
 """#832 replay-parity pins: fixed chunk scripts ⇒ identical observable turn.
 
 Baseline fixtures under ``tests/data/parity_832/`` were captured from the
-pre-fold streaming path (``UPDATE_832_PARITY=1``; the capturing commit's
-``session.py`` is byte-identical to pre-fold main, which is what makes
-them THE old-world record).  Each test replays a scenario on the current
+pre-fold streaming path (``UPDATE_832_PARITY=1`` at a tree whose
+``session.py`` is byte-identical to pre-fold main), which is what makes
+them THE old-world record.  Each test replays a scenario on the current
 tree and compares the full record — UI event sequence, committed-message
-projection, mid-stream usage — against the baseline, after applying the
+projection, mid-stream usage — against the baseline after applying the
 transforms below.  Each transform IS a ruled #832 behavior change,
 restated in full where it is applied, so the pin is auditable from this
-file alone.  A difference outside a ruled transform is a fold regression.
+file alone; a difference outside one is a regression.
 
 Do not regenerate baselines casually: they encode the old world.  A
-legitimate regeneration (a ruled delta superseding capture) updates the
-matching transform below in the same commit, or the pin loses its
-meaning.
+legitimate regeneration updates the matching transform below in the same
+commit, or the pin loses its meaning.
 """
 
 from __future__ import annotations
@@ -49,11 +48,11 @@ def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
     if name == "info_postfinish_footer":
         # RULED (#832): the trailing citations footer enters the COMMITTED
         # content (conditional fold: non-blank answer, "\n\n" separator —
-        # the shared drain-side spelling) and streams as content —
-        # post-carry-flush, so displayed ordering matches committed —
+        # the shared drain-side spelling) and streams as content
+        # post-carry-flush, so displayed ordering matches committed,
         # instead of an ephemeral info bubble that never survived reload.
         # Consequence accepted with the ruling: web-controlled footer text
-        # now reaches storage/search/context/export (release-noted).
+        # reaches storage/search/context/export (release-noted).
         footer = "Sources:\n- example.com/page"
         expected["result"]["content"] += "\n\n" + footer
         events = [e for e in expected["ui_events"] if e != ["info", footer]]
@@ -63,9 +62,8 @@ def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
 
     elif name == "no_finish_clean_exhaust":
         # RULED (#832): a stream that exhausts with no finish reason no
-        # longer commits its partial silently (the pre-fold lax consumer's
-        # behavior) — it is a mid-stream death: the re-issue ladder
-        # finalizes the display and re-drives the turn
+        # longer commits its partial silently — it is a mid-stream death.
+        # The re-issue ladder finalizes the display and re-drives the turn
         # (_MID_STREAM_RETRIES times), then the terminal arm
         # finalizes+discards and the retryable error surfaces.
         expected["raised"] = "IncompleteStreamError"
@@ -116,15 +114,13 @@ class TestDisplayCommitMirror:
     """The mirror LAW (no old-world baselines): with one chunk script,
     the DISPLAYED content stream and the COMMITTED content must agree.
 
-    Post-fold the drain assembles the committed turn while the consumer
-    drives the display; these scenarios interleave provider-parsed
-    ``reasoning_delta`` with buffered content — the combination the
-    replay-parity grid never scripted, where a live review caught the
-    two lanes disagreeing (display dropped or relabeled the buffered
-    tail the commit kept; with a footer the display showed NOTHING
-    while the commit carried answer + sources).  The consumer's
-    ``close_run`` at the reasoning boundary and ``partial_tag_tail``'s
-    proper-prefix contract are what hold these together.
+    The drain assembles the committed turn while the consumer drives the
+    display; these scenarios interleave provider-parsed
+    ``reasoning_delta`` with buffered content, where the two lanes can
+    disagree (display dropping or relabeling the buffered tail the commit
+    kept, or showing nothing while the commit carries answer + sources).
+    The consumer's ``close_run`` at the reasoning boundary and
+    ``partial_tag_tail``'s proper-prefix contract hold them together.
     """
 
     _USAGE = UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2)
@@ -194,10 +190,8 @@ class TestDisplayCommitMirror:
                     StreamChunk(finish_reason="stop"),
                 ],
             ),
-            # Round-2 classes: the boundary close must run while an
-            # INLINE think block is open (the CoT-leak half), and the
-            # cross-boundary carry must survive state flips (the
-            # relabel half).
+            # The boundary close must run while an INLINE think block is
+            # open, and the cross-boundary carry must survive state flips.
             (
                 "open_inline_think_at_reasoning_boundary",
                 [

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -31,6 +31,9 @@ from tests._parity_832 import (
     run_scenario,
     write_fixture,
 )
+from tests._session_helpers import RecordingUI, make_session, scripted_provider
+from turnstone.core.providers._protocol import StreamChunk, UsageInfo
+from turnstone.core.trajectory import Turn
 
 
 def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
@@ -107,3 +110,96 @@ def test_parity(name: str) -> None:
     )
     expected = _apply_ruled_deltas(name, load_fixture(name))
     assert record == expected
+
+
+class TestDisplayCommitMirror:
+    """The mirror LAW (no old-world baselines): with one chunk script,
+    the DISPLAYED content stream and the COMMITTED content must agree.
+
+    Post-fold the drain assembles the committed turn while the consumer
+    drives the display; these scenarios interleave provider-parsed
+    ``reasoning_delta`` with buffered content — the combination the
+    replay-parity grid never scripted, where a live review caught the
+    two lanes disagreeing (display dropped or relabeled the buffered
+    tail the commit kept; with a footer the display showed NOTHING
+    while the commit carried answer + sources).  The consumer's
+    ``close_run`` at the reasoning boundary and ``partial_tag_tail``'s
+    proper-prefix contract are what hold these together.
+    """
+
+    _USAGE = UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+
+    def _mirror(self, chunks: list[StreamChunk]) -> tuple[str, str]:
+        ui = RecordingUI()
+        session = make_session(ui=ui)
+        session._provider = scripted_provider(chunks)
+        session.messages.append(Turn.user("hi"))
+        result = session._stream_response(0)
+        displayed = "".join(d for k, d in ui.events if k == "content")
+        return displayed, result.content
+
+    @pytest.mark.parametrize(
+        ("name", "chunks"),
+        [
+            (
+                "short_content_then_reasoning",
+                [
+                    StreamChunk(content_delta="Short"),
+                    StreamChunk(reasoning_delta="(r)"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "short_content_then_reasoning_with_footer",
+                [
+                    StreamChunk(content_delta="Short"),
+                    StreamChunk(reasoning_delta="(r)"),
+                    StreamChunk(finish_reason="stop"),
+                    StreamChunk(info_delta="Sources:\n- example.com"),
+                ],
+            ),
+            (
+                "long_content_then_reasoning",
+                [
+                    StreamChunk(content_delta="A much longer content run here"),
+                    StreamChunk(reasoning_delta="(r)"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "content_reasoning_content",
+                [
+                    StreamChunk(content_delta="Before "),
+                    StreamChunk(reasoning_delta="(r)"),
+                    StreamChunk(content_delta="after"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "partial_tag_spans_reasoning_boundary",
+                [
+                    StreamChunk(content_delta="Ans<thi"),
+                    StreamChunk(reasoning_delta="(r)"),
+                    StreamChunk(content_delta="nk>hidden</think>done"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "complete_tag_before_reasoning_boundary",
+                [
+                    StreamChunk(content_delta="Answer<reasoning>"),
+                    StreamChunk(reasoning_delta="(r)"),
+                    StreamChunk(content_delta=" resumed"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+        ],
+    )
+    def test_mirror(self, name: str, chunks: list[StreamChunk]) -> None:
+        stamped = [*chunks]
+        # Ride usage on the finish chunk so the strict gate passes.
+        for i, c in enumerate(stamped):
+            if c.finish_reason:
+                stamped[i] = StreamChunk(finish_reason=c.finish_reason, usage=self._USAGE)
+        displayed, committed = self._mirror(stamped)
+        assert displayed == committed

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -1,0 +1,55 @@
+"""#832 replay-parity pins: fixed chunk scripts ⇒ identical observable turn.
+
+Baseline fixtures under ``tests/data/parity_832/`` were captured from the
+pre-fold streaming path (``UPDATE_832_PARITY=1``; the capturing commit's
+``session.py`` is byte-identical to main, which is what makes them THE
+old-world record).  Each test replays a scenario on the current tree and
+compares the full record — UI event sequence, committed-message
+projection, mid-stream usage — against the baseline, after applying the
+transforms the design's D12 table RULED (each transform cites its row).
+A difference outside a ruled transform is a fold regression.
+
+Do not regenerate baselines casually: they encode the old world.  A
+legitimate regeneration (a ruled delta superseding capture) updates the
+matching transform below in the same commit, or the pin loses its
+meaning.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests._parity_832 import (
+    SCENARIOS,
+    UPDATE,
+    fixture_path,
+    load_fixture,
+    run_scenario,
+    write_fixture,
+)
+
+
+def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
+    """Transform an old-world record into the post-fold expectation.
+
+    Every transform cites its D12 row.  Pre-fold trees (fixtures being
+    captured) never reach this — capture mode writes and exits.
+    """
+    expected = json.loads(json.dumps(baseline))  # deep copy
+    return expected
+
+
+@pytest.mark.parametrize("name", sorted(SCENARIOS))
+def test_parity(name: str) -> None:
+    record = run_scenario(name)
+    if UPDATE:
+        write_fixture(name, record)
+        pytest.skip("captured baseline")
+    assert fixture_path(name).exists(), (
+        f"missing baseline {name!r}; run UPDATE_832_PARITY=1 at a pre-fold tree"
+    )
+    expected = _apply_ruled_deltas(name, load_fixture(name))
+    assert record == expected

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -35,10 +35,57 @@ from tests._parity_832 import (
 def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
     """Transform an old-world record into the post-fold expectation.
 
-    Every transform cites its D12 row.  Pre-fold trees (fixtures being
-    captured) never reach this — capture mode writes and exits.
+    Every transform cites its D12 row (docs/design/832-main-loop-model-turn.md).
+    Pre-fold trees (fixtures being captured) never reach this — capture mode
+    writes and exits.
     """
     expected = json.loads(json.dumps(baseline))  # deep copy
+
+    if name == "info_postfinish_footer":
+        # D12 row 1 (RULED adopt-drain): the trailing citations footer
+        # enters the COMMITTED content (conditional fold: non-blank answer,
+        # "\n\n" separator) and streams as content — post-carry-flush, so
+        # displayed ordering matches committed — instead of an ephemeral
+        # info bubble that never survived reload.
+        footer = "Sources:\n- example.com/page"
+        expected["result"]["content"] += "\n\n" + footer
+        events = [e for e in expected["ui_events"] if e != ["info", footer]]
+        end = events.index(["stream_end", ""])
+        events[end:end] = [["content", "\n\n" + footer]]
+        expected["ui_events"] = events
+
+    elif name == "no_finish_clean_exhaust":
+        # D12 row 2 (RULED adopt strict gate): a stream that exhausts with
+        # no finish reason no longer commits its partial silently — it is a
+        # mid-stream death: the re-issue ladder finalizes the display and
+        # re-drives the turn (_MID_STREAM_RETRIES times), then the terminal
+        # arm finalizes+discards and the retryable error surfaces.
+        expected["raised"] = "IncompleteStreamError"
+        expected["result"] = None
+        retry_theater = []
+        for attempt in (1, 2):
+            retry_theater += [
+                ["stream_end", ""],
+                [
+                    "info",
+                    f"[stream died mid-response (IncompleteStreamError) — retrying in "
+                    f"{2 ** (attempt - 1)}s ({attempt}/2)]",
+                ],
+                ["stream_discarded", ""],
+                ["thinking_start", ""],
+                ["thinking_stop", ""],
+            ]
+        expected["ui_events"] = (
+            [["thinking_stop", ""]] + retry_theater + [["stream_end", ""], ["stream_discarded", ""]]
+        )
+
+    elif name == "think_tags_split_across_chunks":
+        # D12 residue-trim row (RULED adopt; V14.1): the COMMITTED content
+        # takes the drain's single edge trim when a tag was consumed; the
+        # displayed stream keeps the raw residue ("\n\nAnswer") — the
+        # accepted snapshot-vs-history whitespace class.
+        expected["result"]["content"] = expected["result"]["content"].lstrip("\n")
+
     return expected
 
 

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -2,12 +2,13 @@
 
 Baseline fixtures under ``tests/data/parity_832/`` were captured from the
 pre-fold streaming path (``UPDATE_832_PARITY=1``; the capturing commit's
-``session.py`` is byte-identical to main, which is what makes them THE
-old-world record).  Each test replays a scenario on the current tree and
-compares the full record — UI event sequence, committed-message
+``session.py`` is byte-identical to pre-fold main, which is what makes
+them THE old-world record).  Each test replays a scenario on the current
+tree and compares the full record — UI event sequence, committed-message
 projection, mid-stream usage — against the baseline, after applying the
-transforms the design's D12 table RULED (each transform cites its row).
-A difference outside a ruled transform is a fold regression.
+transforms below.  Each transform IS a ruled #832 behavior change,
+restated in full where it is applied, so the pin is auditable from this
+file alone.  A difference outside a ruled transform is a fold regression.
 
 Do not regenerate baselines casually: they encode the old world.  A
 legitimate regeneration (a ruled delta superseding capture) updates the
@@ -35,18 +36,21 @@ from tests._parity_832 import (
 def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
     """Transform an old-world record into the post-fold expectation.
 
-    Every transform cites its D12 row (docs/design/832-main-loop-model-turn.md).
-    Pre-fold trees (fixtures being captured) never reach this — capture mode
+    Every transform restates its ruling in full — the transforms are the
+    committed registry of #832's deliberate behavior changes.  Pre-fold
+    trees (fixtures being captured) never reach this — capture mode
     writes and exits.
     """
     expected = json.loads(json.dumps(baseline))  # deep copy
 
     if name == "info_postfinish_footer":
-        # D12 row 1 (RULED adopt-drain): the trailing citations footer
-        # enters the COMMITTED content (conditional fold: non-blank answer,
-        # "\n\n" separator) and streams as content — post-carry-flush, so
-        # displayed ordering matches committed — instead of an ephemeral
-        # info bubble that never survived reload.
+        # RULED (#832): the trailing citations footer enters the COMMITTED
+        # content (conditional fold: non-blank answer, "\n\n" separator —
+        # the shared drain-side spelling) and streams as content —
+        # post-carry-flush, so displayed ordering matches committed —
+        # instead of an ephemeral info bubble that never survived reload.
+        # Consequence accepted with the ruling: web-controlled footer text
+        # now reaches storage/search/context/export (release-noted).
         footer = "Sources:\n- example.com/page"
         expected["result"]["content"] += "\n\n" + footer
         events = [e for e in expected["ui_events"] if e != ["info", footer]]
@@ -55,11 +59,12 @@ def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
         expected["ui_events"] = events
 
     elif name == "no_finish_clean_exhaust":
-        # D12 row 2 (RULED adopt strict gate): a stream that exhausts with
-        # no finish reason no longer commits its partial silently — it is a
-        # mid-stream death: the re-issue ladder finalizes the display and
-        # re-drives the turn (_MID_STREAM_RETRIES times), then the terminal
-        # arm finalizes+discards and the retryable error surfaces.
+        # RULED (#832): a stream that exhausts with no finish reason no
+        # longer commits its partial silently (the pre-fold lax consumer's
+        # behavior) — it is a mid-stream death: the re-issue ladder
+        # finalizes the display and re-drives the turn
+        # (_MID_STREAM_RETRIES times), then the terminal arm
+        # finalizes+discards and the retryable error surfaces.
         expected["raised"] = "IncompleteStreamError"
         expected["result"] = None
         retry_theater = []
@@ -80,10 +85,11 @@ def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
         )
 
     elif name == "think_tags_split_across_chunks":
-        # D12 residue-trim row (RULED adopt; V14.1): the COMMITTED content
-        # takes the drain's single edge trim when a tag was consumed; the
-        # displayed stream keeps the raw residue ("\n\nAnswer") — the
-        # accepted snapshot-vs-history whitespace class.
+        # RULED (#832): the COMMITTED content takes the drain's single
+        # blank-edge trim when an inline think tag was consumed; the
+        # DISPLAYED stream keeps the raw residue ("\n\nAnswer") — an
+        # accepted member of the existing snapshot-vs-history whitespace
+        # class, not a new divergence mechanism.
         expected["result"]["content"] = expected["result"]["content"].lstrip("\n")
 
     return expected
@@ -96,7 +102,8 @@ def test_parity(name: str) -> None:
         write_fixture(name, record)
         pytest.skip("captured baseline")
     assert fixture_path(name).exists(), (
-        f"missing baseline {name!r}; run UPDATE_832_PARITY=1 at a pre-fold tree"
+        f"missing baseline {name!r}; capture with UPDATE_832_PARITY=1 at a pre-fold "
+        f"tree (run_scenario adapts to the old seam signature by inspection)"
     )
     expected = _apply_ruled_deltas(name, load_fixture(name))
     assert record == expected

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -77,7 +77,7 @@ def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
                 [
                     "info",
                     f"[stream died mid-response (IncompleteStreamError) — retrying in "
-                    f"{2 ** (attempt - 1)}s ({attempt}/2)]",
+                    f"0s ({attempt}/2)]",
                 ],
                 ["stream_discarded", ""],
                 ["thinking_start", ""],
@@ -132,6 +132,7 @@ class TestDisplayCommitMirror:
     def _mirror(self, chunks: list[StreamChunk]) -> tuple[str, str]:
         ui = RecordingUI()
         session = make_session(ui=ui)
+        session._RETRY_BASE_DELAY = 0
         session._provider = scripted_provider(chunks)
         session.messages.append(Turn.user("hi"))
         result = session._stream_response(0)
@@ -191,6 +192,65 @@ class TestDisplayCommitMirror:
                     StreamChunk(reasoning_delta="(r)"),
                     StreamChunk(content_delta=" resumed"),
                     StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            # Round-2 classes: the boundary close must run while an
+            # INLINE think block is open (the CoT-leak half), and the
+            # cross-boundary carry must survive state flips (the
+            # relabel half).
+            (
+                "open_inline_think_at_reasoning_boundary",
+                [
+                    StreamChunk(content_delta="pre<think>secret"),
+                    StreamChunk(reasoning_delta="R"),
+                    StreamChunk(content_delta="answer"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "split_close_tag_across_reasoning_boundary",
+                [
+                    StreamChunk(content_delta="pre<think>body</thi"),
+                    StreamChunk(reasoning_delta="R"),
+                    StreamChunk(content_delta="nk>post"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "unresolved_partial_tag_at_finish",
+                [
+                    StreamChunk(content_delta="Ans<thi"),
+                    StreamChunk(reasoning_delta="R"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ),
+            (
+                "partial_tag_only_with_footer",
+                [
+                    StreamChunk(content_delta="<thi"),
+                    StreamChunk(reasoning_delta="R"),
+                    StreamChunk(finish_reason="stop"),
+                    StreamChunk(info_delta="Sources:\n- example.com"),
+                ],
+            ),
+            # Lax-gateway shape: content AFTER a post-finish footer —
+            # the fold must run once at stream end over the FULL answer
+            # (the drain's post-loop fold), never at footer arrival.
+            (
+                "late_content_after_footer",
+                [
+                    StreamChunk(content_delta="ans"),
+                    StreamChunk(finish_reason="stop"),
+                    StreamChunk(info_delta="Sources: s"),
+                    StreamChunk(content_delta="LATE"),
+                ],
+            ),
+            (
+                "footer_arrives_before_any_content",
+                [
+                    StreamChunk(finish_reason="stop"),
+                    StreamChunk(info_delta="Sources: s"),
+                    StreamChunk(content_delta="LATE"),
                 ],
             ),
         ],

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1284,3 +1284,39 @@ class TestNeverArmedStopLeavesNoRow:
         assert any("cancelled" in i.lower() for i in ui.infos)
         assistant = [m for m in dicts_from_turns(session.messages) if m["role"] == "assistant"]
         assert assistant == []
+
+
+class TestOrphanArmDutiesGate:
+    def test_superseded_arrival_in_toctou_window_fires_no_duties(self, tmp_db):
+        """The ref's supersession read and the arm hook are two lockless
+        steps; a force-cancel can claim a new generation between them.
+        The duties self-gate on the generation, so even an append whose
+        supersession read went stale cannot null the successor's usage
+        slots or record health for the abandoned lane."""
+        from turnstone.core.session import _StreamTurnConsumer
+
+        session = _make_session()
+        consumer = _StreamTurnConsumer(session, my_generation=1)
+        tracker = MagicMock()
+
+        class _StaleReadRef(_CancelRef):
+            # The stale supersession read the accepted bytecode-width
+            # window produces — the hook itself must hold the line.
+            def _superseded(self) -> bool:
+                return False
+
+        ref = _StaleReadRef(session, 1, on_first_append=consumer.on_stream_armed)
+        consumer.begin_attempt(ref, tracker, MagicMock())
+
+        session._generation = 1
+        sentinel = {"prompt_tokens": 7}
+        session._last_usage = sentinel
+        session._assistant_pending_tokens = 42
+
+        # The force-cancel claims a newer generation before the append.
+        session._generation = 2
+        ref.append(MagicMock())
+
+        assert session._last_usage is sentinel
+        assert session._assistant_pending_tokens == 42
+        tracker.record_success.assert_not_called()

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -25,6 +25,51 @@ from turnstone.core.trajectory import (
 )
 
 
+def _armed_provider(session, *streams, name="openai-compatible"):
+    """Install a provider fake for the post-#832 seam on *session*.
+
+    ``create_streaming`` arms the
+    per-attempt ``cancel_ref`` with a closeable handle (mirroring every
+    real adapter's eager append — the creation-vs-midstream classifier and
+    ``cancel()``'s stream-close path both depend on it) and serves the
+    given *streams* SEQUENTIALLY, one per create call, each consumed once —
+    so side-effectful generator scripts (yield → ``session.cancel()`` →
+    yield) drive the REAL wrapper+consumer+drain path these tests assert
+    against, and a multi-turn send (tool round-trips) scripts one stream
+    per turn.  A create call beyond the script list fails LOUDLY — the
+    old silent-empty-commit that used to absorb it is gone (the strict
+    finish gate, ruled on #832).
+
+    Title generation is quieted on the session: with a provider-LEVEL
+    fake, the best-effort title lane would otherwise consume the one-shot
+    script before the main loop ran (pre-fold, the session-level seam
+    patches hid that lane and its attempt failed silently against the
+    MagicMock client).
+    """
+    from turnstone.core.providers._protocol import ModelCapabilities
+
+    session._generate_title = lambda *a, **kw: None
+    provider = MagicMock()
+    provider.provider_name = name
+    provider.get_capabilities.return_value = ModelCapabilities()
+    provider.retryable_error_names = frozenset({"IncompleteStreamError"})
+    handle = MagicMock()
+    remaining = list(streams)
+
+    def _create(**kwargs):
+        ref = kwargs.get("cancel_ref")
+        if ref is not None:
+            ref.append(handle)
+        assert remaining, "scripted provider exhausted: send looped for more turns than scripted"
+        stream = remaining.pop(0)
+        return iter(stream) if not hasattr(stream, "__next__") else stream
+
+    provider.create_streaming = MagicMock(side_effect=_create)
+    provider._armed_handle = handle
+    session._provider = provider
+    return provider
+
+
 class NullUI:
     """UI adapter that records state changes and discards other output."""
 
@@ -156,18 +201,15 @@ class TestCancelEvent:
 
         fake_stream = iter([FakeChunk(content_delta="Hello", finish_reason="stop")])
 
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=fake_stream),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        _armed_provider(session, fake_stream)
+        session.send("test")
 
         # Should complete normally — cancel flag was cleared
         assert "idle" in ui.states
 
 
 class TestCancelDuringStreaming:
-    """Cancel while _stream_attempt is iterating chunks."""
+    """Cancel while the streaming consumer is observing chunks."""
 
     def test_preserves_partial_content(self, tmp_db):
         """Partial content already streamed should be preserved in messages."""
@@ -191,11 +233,8 @@ class TestCancelDuringStreaming:
             session.cancel()
             yield FakeChunk(content_delta=" — this should not appear")
 
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=cancelling_stream()),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        _armed_provider(session, cancelling_stream())
+        session.send("test")
 
         # Session should be idle (not error)
         assert ui.states[-1] == "idle"
@@ -253,27 +292,17 @@ class TestCancelDuringToolExecution:
                 finish_reason="tool_calls",
             )
 
-        call_count = 0
-
-        def fake_create_stream(msgs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return stream_with_tool()
-            # Should not be called a second time since cancel happens before phase 3
-            raise AssertionError("Should not stream again after cancel")
-
         def cancel_before_execute(tool_calls):
             """Simulate cancel happening before tool execution."""
             session.cancel()
             raise GenerationCancelled()
 
-        with (
-            patch.object(session, "_create_stream_with_retry", side_effect=fake_create_stream),
-            patch.object(session, "_full_messages", return_value=[]),
-            patch.object(session, "_execute_tools", side_effect=cancel_before_execute),
-        ):
+        _armed_provider(session, stream_with_tool())
+        with patch.object(session, "_execute_tools", side_effect=cancel_before_execute):
             session.send("run something")
+
+        # The stream must not be re-created after the cancel landed.
+        assert session._provider.create_streaming.call_count == 1
 
         # Session should be idle
         assert ui.states[-1] == "idle"
@@ -308,11 +337,8 @@ class TestCancelWhenIdle:
             provider_blocks: list = field(default_factory=list)
 
         fake_stream = iter([FakeChunk(content_delta="ok", finish_reason="stop")])
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=fake_stream),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("hello")
+        _armed_provider(session, fake_stream)
+        session.send("hello")
 
         # Should complete normally
         assistant_msgs = [m for m in dicts_from_turns(session.messages) if m["role"] == "assistant"]
@@ -345,10 +371,8 @@ class TestCancelThreadSafety:
             time.sleep(2)  # Simulate slow streaming
             yield FakeChunk(content_delta=" end", finish_reason="stop")
 
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=slow_stream()),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
+        _armed_provider(session, slow_stream())
+        with contextlib.nullcontext():
             # Run send() in a thread
             error = []
 
@@ -433,13 +457,17 @@ class TestStreamFlushBeforeToolCalls:
                 finish_reason="tool_calls",
             )
 
+        # Two scripted turns: the tool round-trip makes send() loop, and
+        # the follow-up turn must carry a real finish reason — the old
+        # exhausted-iterator path was silently committed as an empty turn
+        # by the pre-fold lax consumer; the strict finish gate (ruled,
+        # #832) rejects it now.
+        _armed_provider(
+            session,
+            stream_content_then_tool(),
+            iter([FakeChunk(finish_reason="stop")]),
+        )
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                return_value=stream_content_then_tool(),
-            ),
-            patch.object(session, "_full_messages", return_value=[]),
             # Prevent real tool execution (e.g., bash) during this test.
             patch.object(session, "_execute_tools", return_value=([], None)),
         ):
@@ -483,9 +511,12 @@ class TestStreamAbort:
         session.cancel()  # Should not raise
         assert session._cancel_event.is_set()
 
-    def test_cancel_ref_populated_after_first_chunk(self, tmp_db):
-        """_cancel_ref is populated by the provider after the first chunk
-        arrives (lazy generator evaluation)."""
+    def test_stream_handle_registered_during_stream_cleared_after(self, tmp_db):
+        """The per-attempt ref's eager append registers the SDK handle in
+        ``_cancel_stream`` before the first chunk is consumed — the handle
+        ``cancel()`` closes to unblock a stuck read — and send()'s finally
+        clears it (#832: the shared ref list is gone; the handle slot is
+        the surviving cancel surface)."""
         ui = NullUI()
         session = _make_session(ui=ui)
 
@@ -499,26 +530,21 @@ class TestStreamAbort:
             info_delta: str = ""
             provider_blocks: list = field(default_factory=list)
 
-        sdk_stream = MagicMock()
+        seen: dict = {}
 
-        def fake_provider_stream():
-            # Simulate provider appending to cancel_ref before first yield
-            session._cancel_ref.append(sdk_stream)
+        def observing_stream():
+            # Runs at first next(): the armed handle must ALREADY be
+            # registered (append happens inside create_streaming, before
+            # the iterator is handed back).
+            seen["handle_at_first_chunk"] = session._cancel_stream
             yield FakeChunk(content_delta="hi", finish_reason="stop")
 
-        with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                return_value=fake_provider_stream(),
-            ),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        provider = _armed_provider(session, observing_stream())
+        session.send("test")
 
+        assert seen["handle_at_first_chunk"] is provider._armed_handle
         # After stream completes, cancel_stream should be cleared
         assert session._cancel_stream is None
-        assert len(session._cancel_ref) == 0
 
     def test_transport_error_during_cancel_becomes_generation_cancelled(self, tmp_db):
         """When cancel() closes the stream, the resulting transport error
@@ -541,15 +567,8 @@ class TestStreamAbort:
             session._cancel_event.set()
             raise ConnectionError("stream closed")
 
-        with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                return_value=stream_that_errors(),
-            ),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        _armed_provider(session, stream_that_errors())
+        session.send("test")
 
         # Should complete as cancelled, not error
         assert "idle" in ui.states
@@ -582,28 +601,33 @@ class TestStreamAbort:
             yield FakeChunk(content_delta="Hello")
             raise ValueError("unexpected error")
 
-        with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                return_value=stream_that_errors(),
-            ),
-            patch.object(session, "_full_messages", return_value=[]),
-            pytest.raises(ValueError, match="unexpected error"),
-        ):
+        _armed_provider(session, stream_that_errors())
+        with pytest.raises(ValueError, match="unexpected error"):
             session.send("test")
 
-    def test_check_cancelled_between_retries(self, tmp_db):
-        """_try_stream checks for cancellation between retry attempts."""
+    def test_pre_set_cancel_no_mint_no_dispatch(self, tmp_db):
+        """A Stop already set when the streaming phase is entered issues NO
+        request and — on a dynamically authenticated alias — mints NO
+        credential (#832; the #972 pre-dispatch rule extended to the
+        interactive path).  Pre-fold, ``_try_stream`` resolved the backend
+        token BEFORE its first cancel check, so an abandoned turn still
+        paid a mint (on a cache miss: a network round trip under the
+        cluster-wide advisory lock).  Post-fold the resolver runs inside
+        ``model_turn`` after its entry abort read, and the ladder's own
+        loop-top check precedes even the lane build."""
         session = _make_session()
-        session.cancel()
+        session._cancel_event.set()
+        resolver = MagicMock(return_value=None)
+        provider = _armed_provider(session, iter(()))
 
-        with pytest.raises(GenerationCancelled):
-            session._try_stream(
-                client=MagicMock(),
-                model="test",
-                msgs=[],
-            )
+        with (
+            patch.object(session, "_model_backend_auth_token", resolver),
+            pytest.raises(GenerationCancelled),
+        ):
+            session._stream_response(0)
+
+        resolver.assert_not_called()
+        provider.create_streaming.assert_not_called()
 
 
 class TestCancelRef:
@@ -615,7 +639,7 @@ class TestCancelRef:
         mock_stream = MagicMock()
         assert session._cancel_stream is None
 
-        session._cancel_ref.append(mock_stream)
+        _CancelRef(session).append(mock_stream)
 
         assert session._cancel_stream is mock_stream
 
@@ -625,7 +649,7 @@ class TestCancelRef:
         session.cancel()  # Set cancel event before stream is created
 
         mock_stream = MagicMock()
-        session._cancel_ref.append(mock_stream)
+        _CancelRef(session).append(mock_stream)
 
         mock_stream.close.assert_called_once()
 
@@ -634,7 +658,7 @@ class TestCancelRef:
         session = _make_session()
         mock_stream = MagicMock()
 
-        session._cancel_ref.append(mock_stream)
+        _CancelRef(session).append(mock_stream)
 
         mock_stream.close.assert_not_called()
         assert session._cancel_stream is mock_stream
@@ -647,20 +671,24 @@ class TestCancelRef:
         mock_stream = MagicMock()
         mock_stream.close.side_effect = RuntimeError("already closed")
 
-        session._cancel_ref.append(mock_stream)  # Should not raise
+        _CancelRef(session).append(mock_stream)  # Should not raise
 
-    def test_cancel_ref_is_cancel_ref_instance(self, tmp_db):
-        """ChatSession._cancel_ref is a _CancelRef instance."""
+    def test_no_shared_cancel_ref_attribute(self, tmp_db):
+        """The long-lived shared ref is GONE (#832): every model-call site
+        builds a fresh per-attempt, generation-scoped _CancelRef, so a
+        force-cancelled generation's ref reads aborted via supersession.
+        This pin holds the line against the gen-0 shared instance coming
+        back through a fixture or a convenience refactor."""
         session = _make_session()
-        assert isinstance(session._cancel_ref, _CancelRef)
+        assert not hasattr(session, "_cancel_ref")
 
     def test_cancel_ref_cleared_after_stream_ends(self, tmp_db):
-        """_cancel_ref is cleared in the send() finally block after streaming."""
+        """send()'s finally clears _cancel_stream after streaming (the
+        handle registered by the per-attempt ref's eager append must not
+        linger into tool execution, where cancel() would close a dead
+        handle instead of nothing)."""
         ui = NullUI()
         session = _make_session(ui=ui)
-        mock_stream = MagicMock()
-        session._cancel_ref.append(mock_stream)
-        assert len(session._cancel_ref) == 1
 
         @dataclass
         class FakeChunk:
@@ -672,18 +700,87 @@ class TestCancelRef:
             info_delta: str = ""
             provider_blocks: list = field(default_factory=list)
 
-        with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                return_value=iter([FakeChunk(content_delta="hi", finish_reason="stop")]),
-            ),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        _armed_provider(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
+        session.send("test")
 
-        # After send() completes, _cancel_ref is cleared in the finally block
-        assert len(session._cancel_ref) == 0
+        # During the stream the armed handle was registered; after send()
+        # completes the finally block cleared it.
+        assert session._cancel_stream is None
+
+
+class TestOnFirstAppendHook:
+    """``_CancelRef.on_first_append`` — the request-accepted observation
+    point (#832): health success, the creation-vs-midstream classifier,
+    and the usage-slot resets all key on it."""
+
+    def test_fires_once_and_arms(self, tmp_db):
+        session = _make_session()
+        fired = []
+        ref = _CancelRef(session, on_first_append=lambda: fired.append(1))
+        assert not ref.armed
+        ref.append(MagicMock())
+        ref.append(MagicMock())
+        assert fired == [1]
+        assert ref.armed
+
+    def test_superseded_append_neither_fires_nor_registers(self, tmp_db):
+        """A superseded ref's zombie stream is closed on arrival and must
+        neither fire the hook (an orphan must not record health or reset
+        the successor's usage slots) nor hijack ``_cancel_stream`` from
+        the successor generation's live stream."""
+        session = _make_session()
+        session._generation = 5
+        fired = []
+        ref = _CancelRef(session, 4, on_first_append=lambda: fired.append(1))
+        zombie = MagicMock()
+        ref.append(zombie)
+        assert fired == []
+        assert not ref.armed
+        zombie.close.assert_called_once()
+        assert session._cancel_stream is None
+
+
+class TestForceCancelOrphanNoReissue:
+    """A force-cancelled generation's mid-stream death is never re-issued
+    on the orphan's behalf (#832 regression pin: the old shared gen-0 ref
+    read ``aborted`` False after a force-cancel — the successor installs a
+    fresh unset event and gen 0 never reads superseded — so the retry
+    machinery would have spent tokens for a generation nobody owns)."""
+
+    def test_orphan_death_not_reissued_no_ui_finalize(self, tmp_db):
+        ui = NullUI()
+        session = _make_session(ui=ui)
+
+        @dataclass
+        class FakeChunk:
+            content_delta: str = ""
+            reasoning_delta: str = ""
+            tool_call_deltas: list = field(default_factory=list)
+            usage: None = None
+            finish_reason: str = ""
+            info_delta: str = ""
+            provider_blocks: list = field(default_factory=list)
+
+        def dying_orphan_stream():
+            yield FakeChunk(content_delta="old ")
+            # Force-cancel: a successor claims the generation (bumped
+            # counter + fresh UNSET event) while this stream is mid-body —
+            # exactly the state where the old shared ref read aborted=False.
+            session._claim_generation()
+            raise ConnectionError("connection reset")
+
+        provider = _armed_provider(session, dying_orphan_stream())
+        my_generation = session._claim_generation()
+        ends_before = ui.stream_ends
+
+        with pytest.raises(GenerationCancelled):
+            session._stream_response(my_generation)
+
+        # ONE dispatch — the death was not re-issued for the orphan.
+        assert provider.create_streaming.call_count == 1
+        # The orphan touched no UI finalize (a stream_end here would
+        # clobber the successor generation's in-flight stream state).
+        assert ui.stream_ends == ends_before
 
 
 class TestForceCancelGeneration:
@@ -733,15 +830,8 @@ class TestForceCancelGeneration:
 
         original_event = session._cancel_event
 
-        with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                return_value=iter([FakeChunk(content_delta="hi", finish_reason="stop")]),
-            ),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        _armed_provider(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
+        session.send("test")
 
         # After send() completes, _cancel_event should be a NEW Event
         # (not the same object as before the call).
@@ -778,10 +868,8 @@ class TestForceCancelThreaded:
             yield FakeChunk(content_delta=" more", finish_reason="stop")
 
         # Start generation 1 (will get stuck)
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=slow_stream()),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
+        _armed_provider(session, slow_stream())
+        if True:
 
             def run_old():
                 with contextlib.suppress(Exception):
@@ -832,24 +920,17 @@ class TestForceCancelThreaded:
             yield FakeChunk(content_delta=" end", finish_reason="stop")
 
         # Start stuck generation
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=stuck_stream()),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            t = threading.Thread(target=lambda: session.send("old"), daemon=True)
-            t.start()
-            assert barrier.wait(timeout=5), "stream did not start"
+        _armed_provider(session, stuck_stream())
+        t = threading.Thread(target=lambda: session.send("old"), daemon=True)
+        t.start()
+        assert barrier.wait(timeout=5), "stream did not start"
 
         # Force cancel
         session.cancel()
 
         # New generation should work
-        fresh_stream = iter([FakeChunk(content_delta="Fresh response")])
-        with (
-            patch.object(session, "_create_stream_with_retry", return_value=fresh_stream),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("new message")
+        _armed_provider(session, iter([FakeChunk(content_delta="Fresh response")]))
+        session.send("new message")
 
         # The new generation should have completed successfully
         assert "idle" in ui.states

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -9,9 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests._session_helpers import arm_session
+from tests._session_helpers import arm_session, make_session
 from turnstone.core.session import (
-    ChatSession,
     GenerationCancelled,
     _CancelRef,
     _tool_turn_meta,
@@ -100,18 +99,11 @@ class NullUI:
 
 
 def _make_session(ui=None, **kwargs):
-    """Helper to construct a ChatSession with minimal setup."""
-    defaults = dict(
-        client=MagicMock(),
-        model="test-model",
-        ui=ui or NullUI(),
-        instructions=None,
-        temperature=0.5,
-        max_tokens=4096,
-        tool_timeout=30,
-    )
-    defaults.update(kwargs)
-    return ChatSession(**defaults)
+    """Wrap the shared session factory; this suite defaults to its
+    recording NullUI.  The defaults live in
+    tests/_session_helpers.make_session — duplicating them here is
+    exactly the drift its docstring warns about."""
+    return make_session(ui=ui or NullUI(), **kwargs)
 
 
 class TestCancelEvent:
@@ -1272,3 +1264,29 @@ class TestEffectStatusPersistence:
         turns = reconstruct_turns([sys_row], "ws1")
         assert turns[0].meta.extra.get("source_meta") == {"watch_name": "x"}
         assert turns[0].effect_status is None
+
+
+class TestNeverArmedStopLeavesNoRow:
+    def test_stop_during_creation_persists_nothing(self, tmp_db):
+        """A Stop landing while creation is still connecting — nothing
+        armed, zero tokens streamed — must not write an assistant row:
+        pre-fold no row existed for a turn that never streamed, and a
+        marker-only row would replay to the model as context on every
+        later turn.  (An ARMED zero-token Stop still records its marker
+        via record_cancelled_partial — TestCancelDuringStreaming pins
+        that side.)"""
+        ui = NullUI()
+        session = _make_session(ui=ui)
+        provider = arm_session(session)  # provider shell; create scripted below
+
+        def create_cancel_then_fail(**kwargs):
+            session._cancel_event.set()
+            raise ConnectionError("connect blew up mid-dial")
+
+        provider.create_streaming = MagicMock(side_effect=create_cancel_then_fail)
+        session.send("test")
+
+        assert ui.states[-1] == "idle"
+        assert any("cancelled" in i.lower() for i in ui.infos)
+        assistant = [m for m in dicts_from_turns(session.messages) if m["role"] == "assistant"]
+        assert assistant == []

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -4,12 +4,13 @@ import contextlib
 import json
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests._session_helpers import arm_session, make_session
+from turnstone.core.providers import StreamChunk
 from turnstone.core.session import (
     GenerationCancelled,
     _CancelRef,
@@ -137,17 +138,7 @@ class TestCancelEvent:
         session = _make_session(ui=ui)
         session.cancel()  # Set stale flag
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = "stop"
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
-        fake_stream = iter([FakeChunk(content_delta="Hello", finish_reason="stop")])
+        fake_stream = iter([StreamChunk(content_delta="Hello", finish_reason="stop")])
 
         arm_session(session, fake_stream)
         session.send("test")
@@ -164,22 +155,12 @@ class TestCancelDuringStreaming:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         def cancelling_stream():
             """Yield a few chunks then cancel."""
-            yield FakeChunk(content_delta="Hello ")
-            yield FakeChunk(content_delta="world")
+            yield StreamChunk(content_delta="Hello ")
+            yield StreamChunk(content_delta="world")
             session.cancel()
-            yield FakeChunk(content_delta=" — this should not appear")
+            yield StreamChunk(content_delta=" — this should not appear")
 
         arm_session(session, cancelling_stream())
         session.send("test")
@@ -213,16 +194,6 @@ class TestCancelDuringToolExecution:
         session = _make_session(ui=ui)
 
         @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
-        @dataclass
         class FakeToolDelta:
             index: int = 0
             id: str = ""
@@ -231,11 +202,11 @@ class TestCancelDuringToolExecution:
 
         # First call: return content with a tool call
         def stream_with_tool():
-            yield FakeChunk(
+            yield StreamChunk(
                 tool_call_deltas=[FakeToolDelta(index=0, id="tc_1", name="bash")],
                 finish_reason="",
             )
-            yield FakeChunk(
+            yield StreamChunk(
                 tool_call_deltas=[FakeToolDelta(index=0, arguments_delta='{"command":"echo hi"}')],
                 finish_reason="tool_calls",
             )
@@ -274,17 +245,7 @@ class TestCancelWhenIdle:
         session.cancel()
         # Next send should work normally (cancel cleared at start)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = "stop"
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
-        fake_stream = iter([FakeChunk(content_delta="ok", finish_reason="stop")])
+        fake_stream = iter([StreamChunk(content_delta="ok", finish_reason="stop")])
         arm_session(session, fake_stream)
         session.send("hello")
 
@@ -301,23 +262,13 @@ class TestCancelThreadSafety:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         barrier = threading.Event()
 
         def slow_stream():
-            yield FakeChunk(content_delta="Start")
+            yield StreamChunk(content_delta="Start")
             barrier.set()  # Signal that streaming has started
             time.sleep(2)  # Simulate slow streaming
-            yield FakeChunk(content_delta=" end", finish_reason="stop")
+            yield StreamChunk(content_delta=" end", finish_reason="stop")
 
         arm_session(session, slow_stream())
         # Run send() in a thread
@@ -375,16 +326,6 @@ class TestStreamFlushBeforeToolCalls:
         session = _make_session(ui=ui)
 
         @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
-        @dataclass
         class FakeToolDelta:
             index: int = 0
             id: str = ""
@@ -395,11 +336,11 @@ class TestStreamFlushBeforeToolCalls:
             # Content long enough to leave chars in the tag-scan carry
             # buffer (ThinkTagSplitter retains the last MAX_TAG_LEN = 12
             # chars until a flush)
-            yield FakeChunk(content_delta="Hello world, this is a test message")
-            yield FakeChunk(
+            yield StreamChunk(content_delta="Hello world, this is a test message")
+            yield StreamChunk(
                 tool_call_deltas=[FakeToolDelta(index=0, id="tc_1", name="bash")],
             )
-            yield FakeChunk(
+            yield StreamChunk(
                 tool_call_deltas=[FakeToolDelta(index=0, arguments_delta='{"command":"echo hi"}')],
                 finish_reason="tool_calls",
             )
@@ -411,7 +352,7 @@ class TestStreamFlushBeforeToolCalls:
         arm_session(
             session,
             stream_content_then_tool(),
-            iter([FakeChunk(finish_reason="stop")]),
+            iter([StreamChunk(finish_reason="stop")]),
         )
         with (
             # Prevent real tool execution (e.g., bash) during this test.
@@ -465,16 +406,6 @@ class TestStreamAbort:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = "stop"
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         seen: dict = {}
 
         def observing_stream():
@@ -482,7 +413,7 @@ class TestStreamAbort:
             # registered (append happens inside create_streaming, before
             # the iterator is handed back).
             seen["handle_at_first_chunk"] = session._cancel_stream
-            yield FakeChunk(content_delta="hi", finish_reason="stop")
+            yield StreamChunk(content_delta="hi", finish_reason="stop")
 
         provider = arm_session(session, observing_stream())
         session.send("test")
@@ -497,18 +428,8 @@ class TestStreamAbort:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         def stream_that_errors():
-            yield FakeChunk(content_delta="Hello")
+            yield StreamChunk(content_delta="Hello")
             session._cancel_event.set()
             raise ConnectionError("stream closed")
 
@@ -532,18 +453,8 @@ class TestStreamAbort:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         def stream_that_errors():
-            yield FakeChunk(content_delta="Hello")
+            yield StreamChunk(content_delta="Hello")
             raise ValueError("unexpected error")
 
         arm_session(session, stream_that_errors())
@@ -633,17 +544,7 @@ class TestCancelRef:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = "stop"
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
-        arm_session(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
+        arm_session(session, iter([StreamChunk(content_delta="hi", finish_reason="stop")]))
         session.send("test")
 
         # During the stream the armed handle was registered; after send()
@@ -694,18 +595,8 @@ class TestForceCancelOrphanNoReissue:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         def dying_orphan_stream():
-            yield FakeChunk(content_delta="old ")
+            yield StreamChunk(content_delta="old ")
             # Force-cancel: a successor claims the generation (bumped
             # counter + fresh UNSET event) while this stream is mid-body.
             session._claim_generation()
@@ -760,19 +651,9 @@ class TestForceCancelGeneration:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = "stop"
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         original_event = session._cancel_event
 
-        arm_session(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
+        arm_session(session, iter([StreamChunk(content_delta="hi", finish_reason="stop")]))
         session.send("test")
 
         # After send() completes, _cancel_event should be a NEW Event
@@ -790,24 +671,14 @@ class TestForceCancelThreaded:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = ""
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         barrier = threading.Event()
         old_done = threading.Event()
 
         def slow_stream():
-            yield FakeChunk(content_delta="Old content")
+            yield StreamChunk(content_delta="Old content")
             barrier.set()  # signal: first chunk delivered
             time.sleep(2)  # simulate stuck stream
-            yield FakeChunk(content_delta=" more", finish_reason="stop")
+            yield StreamChunk(content_delta=" more", finish_reason="stop")
 
         # Start generation 1 (will get stuck)
         arm_session(session, slow_stream())
@@ -843,23 +714,13 @@ class TestForceCancelThreaded:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeChunk:
-            content_delta: str = ""
-            reasoning_delta: str = ""
-            tool_call_deltas: list = field(default_factory=list)
-            usage: None = None
-            finish_reason: str = "stop"
-            info_delta: str = ""
-            provider_blocks: list = field(default_factory=list)
-
         barrier = threading.Event()
 
         def stuck_stream():
-            yield FakeChunk(content_delta="stuck")
+            yield StreamChunk(content_delta="stuck", finish_reason="stop")
             barrier.set()
             time.sleep(2)
-            yield FakeChunk(content_delta=" end", finish_reason="stop")
+            yield StreamChunk(content_delta=" end", finish_reason="stop")
 
         # Start stuck generation
         arm_session(session, stuck_stream())
@@ -871,7 +732,9 @@ class TestForceCancelThreaded:
         session.cancel()
 
         # New generation should work
-        arm_session(session, iter([FakeChunk(content_delta="Fresh response")]))
+        arm_session(
+            session, iter([StreamChunk(content_delta="Fresh response", finish_reason="stop")])
+        )
         session.send("new message")
 
         # The new generation should have completed successfully
@@ -1320,3 +1183,28 @@ class TestOrphanArmDutiesGate:
         assert session._last_usage is sentinel
         assert session._assistant_pending_tokens == 42
         tracker.record_success.assert_not_called()
+
+    def test_unscoped_generation_still_runs_arm_duties(self, tmp_db):
+        """Generation 0 means UNSCOPED, the convention ``_check_cancelled``
+        and ``_CancelRef._superseded`` share: the ref fires the hook for a
+        direct seam caller, so the hook's own gate must not refuse it.  A
+        bare ``!=`` compare skips the duties on any session whose
+        generation was ever claimed, silently recycling the previous
+        turn's usage into this turn's estimate and losing the lane's
+        health success."""
+        from turnstone.core.session import _StreamTurnConsumer
+
+        session = _make_session()
+        session._generation = 3  # a prior send claimed generations
+        consumer = _StreamTurnConsumer(session, my_generation=0)
+        tracker = MagicMock()
+        ref = _CancelRef(session, 0, on_first_append=consumer.on_stream_armed)
+        consumer.begin_attempt(ref, tracker, MagicMock())
+
+        session._last_usage = {"prompt_tokens": 99}
+        session._assistant_pending_tokens = 42
+        ref.append(MagicMock())
+
+        assert session._last_usage is None
+        assert session._assistant_pending_tokens == 0
+        tracker.record_success.assert_called_once()

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -405,10 +405,9 @@ class TestStreamFlushBeforeToolCalls:
             )
 
         # Two scripted turns: the tool round-trip makes send() loop, and
-        # the follow-up turn must carry a real finish reason — the old
-        # exhausted-iterator path was silently committed as an empty turn
-        # by the pre-fold lax consumer; the strict finish gate (ruled,
-        # #832) rejects it now.
+        # the follow-up turn must carry a real finish reason — the strict
+        # finish gate (RULED, #832) rejects an exhausted iterator that
+        # used to commit as an empty turn.
         arm_session(
             session,
             stream_content_then_tool(),
@@ -462,8 +461,7 @@ class TestStreamAbort:
         """The per-attempt ref's eager append registers the SDK handle in
         ``_cancel_stream`` before the first chunk is consumed — the handle
         ``cancel()`` closes to unblock a stuck read — and send()'s finally
-        clears it (#832: the shared ref list is gone; the handle slot is
-        the surviving cancel surface)."""
+        clears it."""
         ui = NullUI()
         session = _make_session(ui=ui)
 
@@ -555,13 +553,12 @@ class TestStreamAbort:
     def test_pre_set_cancel_no_mint_no_dispatch(self, tmp_db):
         """A Stop already set when the streaming phase is entered issues NO
         request and — on a dynamically authenticated alias — mints NO
-        credential (#832; the #972 pre-dispatch rule extended to the
-        interactive path).  Pre-fold, ``_try_stream`` resolved the backend
-        token BEFORE its first cancel check, so an abandoned turn still
-        paid a mint (on a cache miss: a network round trip under the
-        cluster-wide advisory lock).  Post-fold the resolver runs inside
-        ``model_turn`` after its entry abort read, and the ladder's own
-        loop-top check precedes even the lane build."""
+        credential (the #972 pre-dispatch rule on the interactive path).
+        A mint on a cache miss is a network round trip under the
+        cluster-wide advisory lock, so an abandoned turn must not pay one:
+        the resolver runs inside ``model_turn`` after its entry abort
+        read, and the ladder's loop-top check precedes even the lane
+        build."""
         session = _make_session()
         session._cancel_event.set()
         resolver = MagicMock(return_value=None)
@@ -624,8 +621,7 @@ class TestCancelRef:
         """The long-lived shared ref is GONE (#832): every model-call site
         builds a fresh per-attempt, generation-scoped _CancelRef, so a
         force-cancelled generation's ref reads aborted via supersession.
-        This pin holds the line against the gen-0 shared instance coming
-        back through a fixture or a convenience refactor."""
+        The pin holds the line against a gen-0 shared instance returning."""
         session = _make_session()
         assert not hasattr(session, "_cancel_ref")
 
@@ -689,10 +685,10 @@ class TestOnFirstAppendHook:
 
 class TestForceCancelOrphanNoReissue:
     """A force-cancelled generation's mid-stream death is never re-issued
-    on the orphan's behalf (#832 regression pin: the old shared gen-0 ref
-    read ``aborted`` False after a force-cancel — the successor installs a
-    fresh unset event and gen 0 never reads superseded — so the retry
-    machinery would have spent tokens for a generation nobody owns)."""
+    on the orphan's behalf.  A gen-0 ref would read ``aborted`` False
+    after a force-cancel (the successor installs a fresh unset event and
+    gen 0 never reads superseded), and the retry machinery would spend
+    tokens for a generation nobody owns."""
 
     def test_orphan_death_not_reissued_no_ui_finalize(self, tmp_db):
         ui = NullUI()
@@ -711,8 +707,7 @@ class TestForceCancelOrphanNoReissue:
         def dying_orphan_stream():
             yield FakeChunk(content_delta="old ")
             # Force-cancel: a successor claims the generation (bumped
-            # counter + fresh UNSET event) while this stream is mid-body —
-            # exactly the state where the old shared ref read aborted=False.
+            # counter + fresh UNSET event) while this stream is mid-body.
             session._claim_generation()
             raise ConnectionError("connection reset")
 
@@ -1269,8 +1264,7 @@ class TestEffectStatusPersistence:
 class TestNeverArmedStopLeavesNoRow:
     def test_stop_during_creation_persists_nothing(self, tmp_db):
         """A Stop landing while creation is still connecting — nothing
-        armed, zero tokens streamed — must not write an assistant row:
-        pre-fold no row existed for a turn that never streamed, and a
+        armed, zero tokens streamed — must not write an assistant row: a
         marker-only row would replay to the model as context on every
         later turn.  (An ARMED zero-token Stop still records its marker
         via record_cancelled_partial — TestCancelDuringStreaming pins

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests._session_helpers import arm_session
 from turnstone.core.session import (
     ChatSession,
     GenerationCancelled,
@@ -23,51 +24,6 @@ from turnstone.core.trajectory import (
     dicts_from_turns,
     turn_from_dict,
 )
-
-
-def _armed_provider(session, *streams, name="openai-compatible"):
-    """Install a provider fake for the post-#832 seam on *session*.
-
-    ``create_streaming`` arms the
-    per-attempt ``cancel_ref`` with a closeable handle (mirroring every
-    real adapter's eager append — the creation-vs-midstream classifier and
-    ``cancel()``'s stream-close path both depend on it) and serves the
-    given *streams* SEQUENTIALLY, one per create call, each consumed once —
-    so side-effectful generator scripts (yield → ``session.cancel()`` →
-    yield) drive the REAL wrapper+consumer+drain path these tests assert
-    against, and a multi-turn send (tool round-trips) scripts one stream
-    per turn.  A create call beyond the script list fails LOUDLY — the
-    old silent-empty-commit that used to absorb it is gone (the strict
-    finish gate, ruled on #832).
-
-    Title generation is quieted on the session: with a provider-LEVEL
-    fake, the best-effort title lane would otherwise consume the one-shot
-    script before the main loop ran (pre-fold, the session-level seam
-    patches hid that lane and its attempt failed silently against the
-    MagicMock client).
-    """
-    from turnstone.core.providers._protocol import ModelCapabilities
-
-    session._generate_title = lambda *a, **kw: None
-    provider = MagicMock()
-    provider.provider_name = name
-    provider.get_capabilities.return_value = ModelCapabilities()
-    provider.retryable_error_names = frozenset({"IncompleteStreamError"})
-    handle = MagicMock()
-    remaining = list(streams)
-
-    def _create(**kwargs):
-        ref = kwargs.get("cancel_ref")
-        if ref is not None:
-            ref.append(handle)
-        assert remaining, "scripted provider exhausted: send looped for more turns than scripted"
-        stream = remaining.pop(0)
-        return iter(stream) if not hasattr(stream, "__next__") else stream
-
-    provider.create_streaming = MagicMock(side_effect=_create)
-    provider._armed_handle = handle
-    session._provider = provider
-    return provider
 
 
 class NullUI:
@@ -201,7 +157,7 @@ class TestCancelEvent:
 
         fake_stream = iter([FakeChunk(content_delta="Hello", finish_reason="stop")])
 
-        _armed_provider(session, fake_stream)
+        arm_session(session, fake_stream)
         session.send("test")
 
         # Should complete normally — cancel flag was cleared
@@ -233,7 +189,7 @@ class TestCancelDuringStreaming:
             session.cancel()
             yield FakeChunk(content_delta=" — this should not appear")
 
-        _armed_provider(session, cancelling_stream())
+        arm_session(session, cancelling_stream())
         session.send("test")
 
         # Session should be idle (not error)
@@ -297,7 +253,7 @@ class TestCancelDuringToolExecution:
             session.cancel()
             raise GenerationCancelled()
 
-        _armed_provider(session, stream_with_tool())
+        arm_session(session, stream_with_tool())
         with patch.object(session, "_execute_tools", side_effect=cancel_before_execute):
             session.send("run something")
 
@@ -337,7 +293,7 @@ class TestCancelWhenIdle:
             provider_blocks: list = field(default_factory=list)
 
         fake_stream = iter([FakeChunk(content_delta="ok", finish_reason="stop")])
-        _armed_provider(session, fake_stream)
+        arm_session(session, fake_stream)
         session.send("hello")
 
         # Should complete normally
@@ -371,23 +327,22 @@ class TestCancelThreadSafety:
             time.sleep(2)  # Simulate slow streaming
             yield FakeChunk(content_delta=" end", finish_reason="stop")
 
-        _armed_provider(session, slow_stream())
-        with contextlib.nullcontext():
-            # Run send() in a thread
-            error = []
+        arm_session(session, slow_stream())
+        # Run send() in a thread
+        error = []
 
-            def run():
-                try:
-                    session.send("test")
-                except Exception as e:
-                    error.append(e)
+        def run():
+            try:
+                session.send("test")
+            except Exception as e:
+                error.append(e)
 
-            t = threading.Thread(target=run)
-            t.start()
-            barrier.wait(timeout=5)
-            # Cancel from main thread
-            session.cancel()
-            t.join(timeout=5)
+        t = threading.Thread(target=run)
+        t.start()
+        barrier.wait(timeout=5)
+        # Cancel from main thread
+        session.cancel()
+        t.join(timeout=5)
 
         assert not error
         assert ui.states[-1] == "idle"
@@ -462,7 +417,7 @@ class TestStreamFlushBeforeToolCalls:
         # exhausted-iterator path was silently committed as an empty turn
         # by the pre-fold lax consumer; the strict finish gate (ruled,
         # #832) rejects it now.
-        _armed_provider(
+        arm_session(
             session,
             stream_content_then_tool(),
             iter([FakeChunk(finish_reason="stop")]),
@@ -539,7 +494,7 @@ class TestStreamAbort:
             seen["handle_at_first_chunk"] = session._cancel_stream
             yield FakeChunk(content_delta="hi", finish_reason="stop")
 
-        provider = _armed_provider(session, observing_stream())
+        provider = arm_session(session, observing_stream())
         session.send("test")
 
         assert seen["handle_at_first_chunk"] is provider._armed_handle
@@ -567,7 +522,7 @@ class TestStreamAbort:
             session._cancel_event.set()
             raise ConnectionError("stream closed")
 
-        _armed_provider(session, stream_that_errors())
+        arm_session(session, stream_that_errors())
         session.send("test")
 
         # Should complete as cancelled, not error
@@ -601,7 +556,7 @@ class TestStreamAbort:
             yield FakeChunk(content_delta="Hello")
             raise ValueError("unexpected error")
 
-        _armed_provider(session, stream_that_errors())
+        arm_session(session, stream_that_errors())
         with pytest.raises(ValueError, match="unexpected error"):
             session.send("test")
 
@@ -618,7 +573,7 @@ class TestStreamAbort:
         session = _make_session()
         session._cancel_event.set()
         resolver = MagicMock(return_value=None)
-        provider = _armed_provider(session, iter(()))
+        provider = arm_session(session, iter(()))
 
         with (
             patch.object(session, "_model_backend_auth_token", resolver),
@@ -700,7 +655,7 @@ class TestCancelRef:
             info_delta: str = ""
             provider_blocks: list = field(default_factory=list)
 
-        _armed_provider(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
+        arm_session(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
         session.send("test")
 
         # During the stream the armed handle was registered; after send()
@@ -769,7 +724,7 @@ class TestForceCancelOrphanNoReissue:
             session._claim_generation()
             raise ConnectionError("connection reset")
 
-        provider = _armed_provider(session, dying_orphan_stream())
+        provider = arm_session(session, dying_orphan_stream())
         my_generation = session._claim_generation()
         ends_before = ui.stream_ends
 
@@ -807,8 +762,8 @@ class TestForceCancelGeneration:
 
         # We can't trivially test the full threading scenario in a unit test,
         # so directly verify that _check_cancelled raises when my_generation
-        # is stale, which is what guards _stream_attempt against orphaned
-        # (force-cancelled) threads continuing to mutate messages.
+        # is stale — the per-chunk check the streaming consumer runs, which
+        # guards orphaned (force-cancelled) threads out of mutating messages.
         session._generation = 5
         with pytest.raises(GenerationCancelled):
             session._check_cancelled(my_generation=4)  # orphaned generation
@@ -830,7 +785,7 @@ class TestForceCancelGeneration:
 
         original_event = session._cancel_event
 
-        _armed_provider(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
+        arm_session(session, iter([FakeChunk(content_delta="hi", finish_reason="stop")]))
         session.send("test")
 
         # After send() completes, _cancel_event should be a NEW Event
@@ -868,7 +823,7 @@ class TestForceCancelThreaded:
             yield FakeChunk(content_delta=" more", finish_reason="stop")
 
         # Start generation 1 (will get stuck)
-        _armed_provider(session, slow_stream())
+        arm_session(session, slow_stream())
         if True:
 
             def run_old():
@@ -920,7 +875,7 @@ class TestForceCancelThreaded:
             yield FakeChunk(content_delta=" end", finish_reason="stop")
 
         # Start stuck generation
-        _armed_provider(session, stuck_stream())
+        arm_session(session, stuck_stream())
         t = threading.Thread(target=lambda: session.send("old"), daemon=True)
         t.start()
         assert barrier.wait(timeout=5), "stream did not start"
@@ -929,7 +884,7 @@ class TestForceCancelThreaded:
         session.cancel()
 
         # New generation should work
-        _armed_provider(session, iter([FakeChunk(content_delta="Fresh response")]))
+        arm_session(session, iter([FakeChunk(content_delta="Fresh response")]))
         session.send("new message")
 
         # The new generation should have completed successfully

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -4,13 +4,12 @@ import contextlib
 import json
 import threading
 import time
-from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests._session_helpers import arm_session, make_session
-from turnstone.core.providers import StreamChunk
+from turnstone.core.providers import StreamChunk, ToolCallDelta
 from turnstone.core.session import (
     GenerationCancelled,
     _CancelRef,
@@ -193,21 +192,13 @@ class TestCancelDuringToolExecution:
         ui = NullUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeToolDelta:
-            index: int = 0
-            id: str = ""
-            name: str = ""
-            arguments_delta: str = ""
-
         # First call: return content with a tool call
         def stream_with_tool():
             yield StreamChunk(
-                tool_call_deltas=[FakeToolDelta(index=0, id="tc_1", name="bash")],
-                finish_reason="",
+                tool_call_deltas=[ToolCallDelta(index=0, id="tc_1", name="bash")],
             )
             yield StreamChunk(
-                tool_call_deltas=[FakeToolDelta(index=0, arguments_delta='{"command":"echo hi"}')],
+                tool_call_deltas=[ToolCallDelta(index=0, arguments_delta='{"command":"echo hi"}')],
                 finish_reason="tool_calls",
             )
 
@@ -325,23 +316,16 @@ class TestStreamFlushBeforeToolCalls:
         ui = TrackingUI()
         session = _make_session(ui=ui)
 
-        @dataclass
-        class FakeToolDelta:
-            index: int = 0
-            id: str = ""
-            name: str = ""
-            arguments_delta: str = ""
-
         def stream_content_then_tool():
             # Content long enough to leave chars in the tag-scan carry
             # buffer (ThinkTagSplitter retains the last MAX_TAG_LEN = 12
             # chars until a flush)
             yield StreamChunk(content_delta="Hello world, this is a test message")
             yield StreamChunk(
-                tool_call_deltas=[FakeToolDelta(index=0, id="tc_1", name="bash")],
+                tool_call_deltas=[ToolCallDelta(index=0, id="tc_1", name="bash")],
             )
             yield StreamChunk(
-                tool_call_deltas=[FakeToolDelta(index=0, arguments_delta='{"command":"echo hi"}')],
+                tool_call_deltas=[ToolCallDelta(index=0, arguments_delta='{"command":"echo hi"}')],
                 finish_reason="tool_calls",
             )
 
@@ -1208,3 +1192,83 @@ class TestOrphanArmDutiesGate:
         assert session._last_usage is None
         assert session._assistant_pending_tokens == 0
         tracker.record_success.assert_called_once()
+
+
+class TestSupersessionVerdictAgreement:
+    """Every arm of one streaming turn must reach the SAME supersession
+    verdict for the same generation shape.  Generation 0 is unscoped, so
+    on a session whose generation was claimed earlier a Stop and a Ctrl-C
+    must both finalize the display — a per-arm spelling once split them,
+    finalizing on one path and not the other."""
+
+    def _session_at_generation(self, gen, ui):
+        session = _make_session(ui=ui)
+        session._generation = gen
+        session.messages.append(Turn.user("hi"))
+        return session
+
+    def _drive(self, gen, kind):
+        ui = NullUI()
+        session = self._session_at_generation(gen, ui)
+
+        def stream():
+            yield StreamChunk(content_delta="partial answer")
+            if kind == "stop":
+                session.cancel()
+                yield StreamChunk(content_delta=" unreachable")
+            else:
+                raise KeyboardInterrupt
+
+        provider = arm_session(session, stream())
+        assert provider is session._provider
+        raised = None
+        try:
+            session._stream_response(0)
+        except BaseException as exc:  # noqa: BLE001 — the class IS the observation
+            raised = type(exc).__name__
+        return raised, ui.stream_ends, session._cancelled_partial_msg
+
+    def test_stop_and_ctrl_c_agree_on_an_unscoped_generation(self, tmp_db):
+        stop_raised, stop_ends, partial = self._drive(3, "stop")
+        kb_raised, kb_ends, _ = self._drive(3, "ctrl_c")
+
+        assert stop_raised == "GenerationCancelled"
+        assert kb_raised == "KeyboardInterrupt"
+        # The verdict is "live" on BOTH arms: each finalizes the display.
+        assert stop_ends == 1
+        assert kb_ends == 1
+        assert partial and partial["content"] == "partial answer"
+
+    def test_superseded_generation_finalizes_on_neither_arm(self, tmp_db):
+        # The scoped counterpart: a real orphan (its generation lost the
+        # claim) must touch the UI on no arm at all.  It never reaches
+        # one: the ref reads superseded, so ``model_turn`` refuses to
+        # dispatch and the ladder converts that to a cancel — an orphan
+        # issues no request and finalizes nothing.
+        ui = NullUI()
+        session = self._session_at_generation(5, ui)
+
+        def stream():
+            raise KeyboardInterrupt
+            yield  # unreachable; makes this a generator
+
+        provider = arm_session(session, stream())
+        with pytest.raises(GenerationCancelled):
+            session._stream_response(2)  # generation 2 lost the claim to 5
+        assert ui.stream_ends == 0
+        provider.create_streaming.assert_not_called()
+
+    def test_unscoped_generation_finalizes_on_the_ctrl_c_arm(self, tmp_db):
+        # Same arm, unscoped generation: the verdict flips to "live", so
+        # the display IS finalized — the agreement this class pins.
+        ui = NullUI()
+        session = self._session_at_generation(5, ui)
+
+        def stream():
+            raise KeyboardInterrupt
+            yield
+
+        arm_session(session, stream())
+        with pytest.raises(KeyboardInterrupt):
+            session._stream_response(0)
+        assert ui.stream_ends == 1

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1272,3 +1272,91 @@ class TestSupersessionVerdictAgreement:
         with pytest.raises(KeyboardInterrupt):
             session._stream_response(0)
         assert ui.stream_ends == 1
+
+
+class TestOrphanGuardsBelowTheLadder:
+    """The two supersession guards in ``_stream_response``'s own arms.
+
+    They fire only when a force-cancel lands in the window BELOW the
+    ladder's conversion: ``_model_turn_with_retry`` re-checks the
+    generation before it classifies a death, so on every deterministic
+    path an orphan's failure has already become ``GenerationCancelled``
+    by the time it leaves the ladder.  These arms cover the sub-statement
+    race where supersession arrives after that check — the same
+    accepted-width window ``_CancelRef`` documents.  Reaching them means
+    simulating the race at the seam directly; a scripted stream cannot,
+    which is why the suite left both branches unexercised.
+
+    What they protect: an orphaned thread must emit NOTHING, because the
+    successor generation is already streaming into the same UI.
+    """
+
+    def _armed_death(self, session, exc):
+        """A death observed as if supersession landed after the ladder's
+        own generation check: the attempt streamed, a newer generation
+        claimed the session, and only then does the failure surface."""
+
+        def _seam(consumer, prepare_wire, my_generation):
+            consumer.begin_attempt(_CancelRef(session, my_generation), None, MagicMock())
+            consumer._saw_chunk = True  # the attempt reached the display
+            session._generation = my_generation + 1  # force-cancel lands
+            raise exc
+
+        return _seam
+
+    def test_superseded_stream_death_emits_nothing(self, tmp_db):
+        from turnstone.core.providers import IncompleteStreamError
+
+        ui = NullUI()
+        session = _make_session(ui=ui)
+        session._generation = 1
+        with (
+            patch.object(
+                session,
+                "_model_turn_with_fallback",
+                side_effect=self._armed_death(session, IncompleteStreamError("wire died")),
+            ),
+            pytest.raises(IncompleteStreamError),
+        ):
+            session._stream_response(1)
+
+        # No retry theater, no finalize, no partial stashed: the live
+        # successor owns the UI now.
+        assert ui.stream_ends == 0
+        assert ui.infos == []
+        assert session._cancelled_partial_msg is None
+
+    def test_superseded_keyboard_interrupt_emits_nothing(self, tmp_db):
+        ui = NullUI()
+        session = _make_session(ui=ui)
+        session._generation = 1
+        with (
+            patch.object(
+                session,
+                "_model_turn_with_fallback",
+                side_effect=self._armed_death(session, KeyboardInterrupt()),
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            session._stream_response(1)
+
+        assert ui.stream_ends == 0
+
+    def test_live_generation_still_finalizes_on_ctrl_c(self, tmp_db):
+        # The other side of the same branch, without the supersession.
+        ui = NullUI()
+        session = _make_session(ui=ui)
+        session._generation = 1
+
+        def _seam(consumer, prepare_wire, my_generation):
+            consumer.begin_attempt(_CancelRef(session, my_generation), None, MagicMock())
+            consumer._saw_chunk = True
+            raise KeyboardInterrupt
+
+        with (
+            patch.object(session, "_model_turn_with_fallback", side_effect=_seam),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            session._stream_response(1)
+
+        assert ui.stream_ends == 1

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -666,16 +666,15 @@ class TestForceCancelThreaded:
 
         # Start generation 1 (will get stuck)
         arm_session(session, slow_stream())
-        if True:
 
-            def run_old():
-                with contextlib.suppress(Exception):
-                    session.send("old message")
-                old_done.set()
+        def run_old():
+            with contextlib.suppress(Exception):
+                session.send("old message")
+            old_done.set()
 
-            t1 = threading.Thread(target=run_old, daemon=True)
-            t1.start()
-            assert barrier.wait(timeout=5), "stream did not start"
+        t1 = threading.Thread(target=run_old, daemon=True)
+        t1.start()
+        assert barrier.wait(timeout=5), "stream did not start"
 
         # Force cancel: simulate what the server does
         session.cancel()

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests._parity_832 import make_result
 from tests._session_helpers import make_session
 from turnstone.core.session import (
     COMPACTION_SOURCE,
@@ -204,10 +205,7 @@ class TestCompactionLatch:
         session._compaction_advised = True  # stale latch from a prior turn
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session, "_stream_response", return_value={"role": "assistant", "content": "done"}
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("done")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -249,11 +247,10 @@ class TestEndOfTurnAutoResume:
             calls["n"] += 1
             if calls["n"] == 1:
                 session._compaction_advised = True  # advisory fired this turn
-                return {"role": "assistant", "content": "paused; plan recorded"}
-            return {"role": "assistant", "content": "done"}
+                return make_result("paused; plan recorded")
+            return make_result("done")
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
@@ -282,10 +279,7 @@ class TestEndOfTurnAutoResume:
         session._compaction_advised = False
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session, "_stream_response", return_value={"role": "assistant", "content": "done"}
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("done")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -321,11 +315,10 @@ class TestEndOfTurnAutoResume:
             calls["n"] += 1
             if calls["n"] == 1:
                 session._compaction_advised = True  # advised stop
-                return {"role": "assistant", "content": "paused"}
-            return {"role": "assistant", "content": "done"}
+                return make_result("paused")
+            return make_result("done")
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
@@ -365,14 +358,13 @@ class TestEndOfTurnAutoResume:
             n["i"] += 1
             if n["i"] == 1:
                 session._compaction_advised = True  # advisory fired this turn
-                return {"role": "assistant", "content": "pausing to compact"}
-            return {"role": "assistant", "content": "all done"}
+                return make_result("pausing to compact")
+            return make_result("all done")
 
         def est(*_a, **_k):
             return 9_999 if n["i"] <= 1 else 10  # over threshold only on the stop turn
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
@@ -454,11 +446,10 @@ class TestCompactBeforeTruncate:
         def stream(*_a, **_k):
             n["i"] += 1
             if n["i"] == 1:
-                return {"role": "assistant", "content": "", "tool_calls": [tc]}
-            return {"role": "assistant", "content": "done"}
+                return make_result("", tool_calls=[tc])
+            return make_result("done")
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_execute_tools", return_value=([("call_1", "out")], "")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -493,11 +484,10 @@ class TestCompactBeforeTruncate:
         def stream(*_a, **_k):
             n["i"] += 1
             if n["i"] == 1:
-                return {"role": "assistant", "content": "", "tool_calls": [tc]}
-            return {"role": "assistant", "content": "done"}
+                return make_result("", tool_calls=[tc])
+            return make_result("done")
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_execute_tools", return_value=([("call_1", "out")], "")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -534,11 +524,10 @@ class TestCompactBeforeTruncate:
         def stream(*_a, **_k):
             n["i"] += 1
             if n["i"] == 1:
-                return {"role": "assistant", "content": "", "tool_calls": [tc]}
-            return {"role": "assistant", "content": "done"}
+                return make_result("", tool_calls=[tc])
+            return make_result("done")
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_execute_tools", return_value=([("call_1", "out")], "")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -1095,7 +1084,7 @@ class TestProactivePreSend:
 
         def fake_stream_response(*_args, **_kwargs):
             order.append("stream")
-            return {"role": "assistant", "content": "done"}
+            return make_result("done")
 
         with (
             # 9999 > hard (9000) → compaction is owed at send time.
@@ -1475,7 +1464,7 @@ class TestChunkerOverflowSplit:
         with (
             patch.object(session, "_estimated_prompt_tokens", return_value=10),  # under hard
             patch.object(session, "_check_metacognitive_nudge", return_value=None),
-            patch.object(session, "_create_stream_with_retry", side_effect=cancel_midstream),
+            patch.object(session, "_stream_response", side_effect=cancel_midstream),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -2330,7 +2319,12 @@ class TestOrphanedCompactionRetirement:
     def test_summary_call_registers_abortable_stream(self, session):
         """Each summary attempt passes a fresh _CancelRef so cancel() can
         close the in-flight summary HTTP stream — Stop during compaction
-        aborts the blocked read instead of waiting out a model call."""
+        aborts the blocked read instead of waiting out a model call.
+
+        Freshness is pinned per CALL rather than against a session-wide
+        register: #832 retired the shared ``_cancel_ref`` slot outright, so
+        "not the shared ref" is no longer a statement anything can violate —
+        "every call mints its own, and no session-wide slot exists" is."""
         from turnstone.core.session import _CancelRef
 
         seen: list[object] = []
@@ -2344,9 +2338,11 @@ class TestOrphanedCompactionRetirement:
 
         with patch.object(session, "_utility_completion", side_effect=fake_uc):
             assert session._summarize_once("sys", "body") == "dense"
-        assert len(seen) == 1
-        assert isinstance(seen[0], _CancelRef)
-        assert seen[0] is not session._cancel_ref  # scoped, never the shared ref
+            assert session._summarize_once("sys", "body") == "dense"
+        assert len(seen) == 2
+        assert all(isinstance(ref, _CancelRef) for ref in seen)
+        assert seen[0] is not seen[1]  # scoped to its call, never reused
+        assert not hasattr(session, "_cancel_ref")  # and no shared register
 
     def test_cancel_ref_aborted_property_tracks_event(self, session):
         """model_turn consults cancel_ref.aborted to suppress drain retries

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -20,8 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests._parity_832 import make_result
-from tests._session_helpers import make_session
+from tests._session_helpers import make_result, make_session
 from turnstone.core.session import (
     COMPACTION_SOURCE,
     COMPACTION_SUMMARY_LABEL,

--- a/tests/test_idle_nudge_wake_integration.py
+++ b/tests/test_idle_nudge_wake_integration.py
@@ -2,8 +2,8 @@
 
 Drives a *real* :class:`SessionManager` + a *real* :class:`ChatSession`
 + a *real* :class:`IdleNudgeWatcher` end-to-end.  The only stub is the
-LLM provider (patched ``_create_stream_with_retry``); every other layer
-is production code:
+model turn (patched ``_stream_response``, returning a canned
+``ModelTurnResult``); every other layer is production code:
 
 * ``SessionManager.set_state`` snapshotting + iterating subscribers
 * ``IdleNudgeWatcher._on_state`` peeking the queue
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._helpers import wait_until as _wait_until
+from tests._parity_832 import make_result
 from tests.test_session_manager import FakeStorage
 from turnstone.core import session_worker
 from turnstone.core.idle_nudge_watcher import IdleNudgeWatcher, wake_workstream_if_pending
@@ -234,12 +235,7 @@ def test_idle_event_through_real_session_manager_drives_wake_send(real_mgr, tmp_
         # without any real provider.  We patch on the just-built ChatSession;
         # the patches are reverted by the `with` block.
         with (
-            patch.object(ws.session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                ws.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(ws.session, "_stream_response", return_value=make_result(content="ok")),
             patch.object(ws.session, "_update_token_table"),
             patch.object(ws.session, "_print_status_line"),
             patch.object(ws.session, "_visible_memory_count", return_value=0),
@@ -341,12 +337,7 @@ def test_watch_fire_on_already_idle_session_drives_wake_send(real_mgr, tmp_db):
     )
 
     with (
-        patch.object(ws.session, "_create_stream_with_retry", return_value=iter([])),
-        patch.object(
-            ws.session,
-            "_stream_response",
-            return_value={"role": "assistant", "content": "ok"},
-        ),
+        patch.object(ws.session, "_stream_response", return_value=make_result(content="ok")),
         patch.object(ws.session, "_update_token_table"),
         patch.object(ws.session, "_print_status_line"),
         patch.object(ws.session, "_visible_memory_count", return_value=0),
@@ -450,11 +441,8 @@ def test_coord_idle_with_active_children_emits_envelope_via_real_managers(coord_
         coord.session.messages.append(turn_from_dict({"role": "assistant", "content": "ok"}))
 
         with (
-            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(
-                coord.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ack"},
+                coord.session, "_stream_response", return_value=make_result(content="ack")
             ),
             patch.object(coord.session, "_full_messages", return_value=[]),
             patch.object(coord.session, "_update_token_table"),
@@ -542,11 +530,8 @@ def test_coord_idle_with_children_and_open_tasks_delivers_both(coord_mgr, tmp_db
         coord.session.messages.append(turn_from_dict({"role": "assistant", "content": "ok"}))
 
         with (
-            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(
-                coord.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ack"},
+                coord.session, "_stream_response", return_value=make_result(content="ack")
             ),
             patch.object(coord.session, "_full_messages", return_value=[]),
             patch.object(coord.session, "_update_token_table"),
@@ -647,11 +632,8 @@ def test_coord_idle_with_open_tasks_and_no_children_omits_children_content(coord
         coord.session.messages.append(turn_from_dict({"role": "assistant", "content": "ok"}))
 
         with (
-            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(
-                coord.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ack"},
+                coord.session, "_stream_response", return_value=make_result(content="ack")
             ),
             patch.object(coord.session, "_full_messages", return_value=[]),
             patch.object(coord.session, "_update_token_table"),
@@ -757,11 +739,8 @@ def test_stop_latch_survives_the_liveness_wake(coord_mgr, tmp_db):
         assert coord.session._metacog_state.get("idle_tasks") is None
 
         with (
-            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(
-                coord.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ack"},
+                coord.session, "_stream_response", return_value=make_result(content="ack")
             ),
             patch.object(coord.session, "_full_messages", return_value=[]),
             patch.object(coord.session, "_update_token_table"),
@@ -860,11 +839,8 @@ def test_coord_idle_emitted_from_worker_thread_still_wakes(coord_mgr, tmp_db):
         coord.session.messages.append(turn_from_dict({"role": "assistant", "content": "ok"}))
 
         with (
-            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(
-                coord.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ack"},
+                coord.session, "_stream_response", return_value=make_result(content="ack")
             ),
             patch.object(coord.session, "_full_messages", return_value=[]),
             patch.object(coord.session, "_update_token_table"),
@@ -943,10 +919,7 @@ def test_wake_delivery_contains_generation_cancelled(tmp_db):
 def _patch_llm_surface(session: Any) -> tuple[Any, ...]:
     """The file's standard LLM-stub patch set, for make_chat_session tests."""
     return (
-        patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-        patch.object(
-            session, "_stream_response", return_value={"role": "assistant", "content": "ok"}
-        ),
+        patch.object(session, "_stream_response", return_value=make_result(content="ok")),
         patch.object(session, "_update_token_table"),
         patch.object(session, "_print_status_line"),
         patch.object(session, "_visible_memory_count", return_value=0),
@@ -967,7 +940,7 @@ def test_wake_channel_survives_real_seam_drains_and_delivers_via_wake(tmp_db):
     session._nudge_queue.enqueue("idle_children", "kids waiting", "wake")
 
     p = _patch_llm_surface(session)
-    with p[0], p[1], p[2], p[3], p[4], p[5]:
+    with p[0], p[1], p[2], p[3], p[4]:
         # Real user-seam drain: appends any drained entry as a system
         # turn — a wake-channel entry must neither drain nor render.
         session._emit_pending_user_nudges()
@@ -1053,7 +1026,7 @@ def test_quiet_ride_along_still_delivers_when_wake_proceeds(tmp_db):
     session._nudge_queue.enqueue("idle_children", "kids waiting", "wake")
 
     p = _patch_llm_surface(session)
-    with p[0], p[1], p[2], p[3], p[4], p[5]:
+    with p[0], p[1], p[2], p[3], p[4]:
         session.deliver_wake_nudge_from_queue()
 
     msgs = dicts_from_turns(session.messages)
@@ -1089,7 +1062,7 @@ def test_interjection_handoff_delivers_externals_and_drops_only_idle_nudges(tmp_
     session.queue_message("pivot: focus on the flaky login test")
 
     p = _patch_llm_surface(session)
-    with p[0], p[1], p[2], p[3], p[4], p[5]:
+    with p[0], p[1], p[2], p[3], p[4]:
         session.deliver_wake_nudge_from_queue()
 
     msgs = dicts_from_turns(session.messages)
@@ -1160,11 +1133,8 @@ def test_queued_interjection_owns_the_idle_seam(coord_mgr, tmp_db):
         coord.session.messages.append(turn_from_dict({"role": "assistant", "content": "ok"}))
 
         with (
-            patch.object(coord.session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(
-                coord.session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ack"},
+                coord.session, "_stream_response", return_value=make_result(content="ack")
             ),
             patch.object(coord.session, "_full_messages", return_value=[]),
             patch.object(coord.session, "_update_token_table"),

--- a/tests/test_idle_nudge_wake_integration.py
+++ b/tests/test_idle_nudge_wake_integration.py
@@ -29,7 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._helpers import wait_until as _wait_until
-from tests._parity_832 import make_result
+from tests._session_helpers import make_result
 from tests.test_session_manager import FakeStorage
 from turnstone.core import session_worker
 from turnstone.core.idle_nudge_watcher import IdleNudgeWatcher, wake_workstream_if_pending

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -771,27 +771,27 @@ class TestSessionIntegration:
         assert "Malformed tool call" in session.ui.on_error.call_args[0][0]
 
     def test_ensure_tool_call_ids_dict(self, tmp_db):
-        """_ensure_tool_call_ids fills empty IDs on streaming-style dict."""
-        from turnstone.core.session import ChatSession
+        """ensure_tool_call_ids fills empty IDs on streaming-style dict."""
+        from turnstone.core.model_turn import ensure_tool_call_ids
 
         tool_calls_acc = {
             0: {"id": "", "function": {"name": "bash", "arguments": "{}"}},
             1: {"id": "", "function": {"name": "read_file", "arguments": "{}"}},
         }
-        ChatSession._ensure_tool_call_ids(tool_calls_acc)
+        ensure_tool_call_ids(tool_calls_acc)
         ids = [tc["id"] for tc in tool_calls_acc.values()]
         assert all(id_.startswith("call_") for id_ in ids)
         assert len(set(ids)) == 2  # unique
 
     def test_ensure_tool_call_ids_list(self, tmp_db):
-        """_ensure_tool_call_ids fills empty IDs on list (agent path)."""
-        from turnstone.core.session import ChatSession
+        """ensure_tool_call_ids fills empty IDs on list (agent path)."""
+        from turnstone.core.model_turn import ensure_tool_call_ids
 
         tool_calls = [
             {"id": None, "function": {"name": "bash", "arguments": "{}"}},
             {"id": "call_existing", "function": {"name": "bash", "arguments": "{}"}},
         ]
-        ChatSession._ensure_tool_call_ids(tool_calls)
+        ensure_tool_call_ids(tool_calls)
         assert tool_calls[0]["id"].startswith("call_")
         assert tool_calls[1]["id"] == "call_existing"  # preserved
 

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -2,7 +2,7 @@
 
 A wire death DURING body iteration surfaces after the request already
 returned its stream handle, so neither the SDK's ``max_retries`` nor the
-creation-time ``_try_stream`` ladder ever sees it.  These tests drive
+creation-time per-lane ladder (``_model_turn_with_retry``) ever sees it.  These tests drive
 ``ChatSession.send()`` with scripted provider streams and pin the retry
 loop's contract: bounded re-issue on the normalized retryable shape, the
 dead attempt finalized client-side before the retry notice
@@ -18,12 +18,12 @@ retry pays real exponential backoff).
 """
 
 import logging
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
+from tests._parity_832 import arm_session
 from tests._session_helpers import NullUI, RecordingUI, make_session
 from turnstone.core.memory import load_last_error
 from turnstone.core.providers import IncompleteStreamError, StreamChunk, UsageInfo
@@ -83,8 +83,8 @@ class TestMidStreamRetry:
             _dying_stream(first_text, exc=httpx.ReadError("[SSL] record layer failure")),
             _good_stream("Hello world"),
         ]
+        create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
             patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
         ):
@@ -135,8 +135,8 @@ class TestMidStreamRetry:
         streams = [
             _dying_stream("a", exc=httpx.ReadError("[SSL] record layer failure")) for _ in range(3)
         ]
+        create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
             patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.INFO, logger="turnstone.core.session"),
             pytest.raises(IncompleteStreamError, match="ReadError"),
@@ -174,12 +174,10 @@ class TestMidStreamRetry:
             session.cancel()
             real_backoff(delay, my_generation)
 
+        create = arm_session(
+            session, _dying_stream("Hel", exc=httpx.ReadError("wire died"))
+        ).create_streaming
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[_dying_stream("Hel", exc=httpx.ReadError("wire died"))],
-            ) as create,
             patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
             patch.object(session, "_full_messages", return_value=[]),
         ):
@@ -210,8 +208,8 @@ class TestMidStreamRetry:
             # object (the identity signal the wrapper keys on).
             session.client = MagicMock()
 
+        create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
             patch.object(session, "_refresh_model_from_registry", side_effect=swap_binding),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(
@@ -234,8 +232,8 @@ class TestMidStreamRetry:
             _dying_stream("y", exc=httpx.ReadError("wire died again")),
             _good_stream("ok"),
         ]
+        create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams) as create,
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(
                 session,
@@ -259,8 +257,8 @@ class TestMidStreamRetry:
             _dying_stream(exc=httpx.ReadError("pre-token wire death")),
             _good_stream("ok"),
         ]
+        arm_session(session, *streams)
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
@@ -284,12 +282,8 @@ class TestMidStreamRetry:
             session.cancel()
             real_backoff(delay, my_generation)
 
+        arm_session(session, _dying_stream(exc=httpx.ReadError("died before first token")))
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[_dying_stream(exc=httpx.ReadError("died before first token"))],
-            ),
             patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
             patch.object(session, "_full_messages", return_value=[]),
         ):
@@ -318,8 +312,8 @@ class TestMidStreamRetry:
             _dying_stream("Hel", exc=httpx.ReadError("wire died")),
             second_stream(),
         ]
+        arm_session(session, *streams)
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
@@ -342,8 +336,8 @@ class TestMidStreamRetry:
             # ends cleanly under transport_guarded's post-finish tolerance.
             session.cancel()
 
+        arm_session(session, gen())
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=[gen()]),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
@@ -360,12 +354,8 @@ class TestMidStreamRetry:
     def test_keyboard_interrupt_finalizes_dead_attempt(self, tmp_db, caplog):
         ui = RecordingUI()
         session = _make_session(ui)
+        arm_session(session, _dying_stream("Hel", exc=KeyboardInterrupt()))
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[_dying_stream("Hel", exc=KeyboardInterrupt())],
-            ),
             patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.INFO, logger="turnstone.core.session"),
             pytest.raises(KeyboardInterrupt),
@@ -378,53 +368,43 @@ class TestMidStreamRetry:
         assert ui.kinds().count("stream_end") == 1
         assert ("state", "error") in ui.events
 
-    def test_gate_consults_live_stream_provider_not_primary(self, tmp_db):
+    def test_gate_consults_serving_lane_provider(self, tmp_db):
         class FlakyError(Exception):
             pass
 
         ui = RecordingUI()
         session = _make_session(ui)
-        live = SimpleNamespace(retryable_error_names=frozenset({"FlakyError"}))
-        calls = {"n": 0}
+        # Post-fold the retry gate reads the SERVING lane's provider off
+        # the frame's consumer (the creation-time handoff register is
+        # gone).  FlakyError is retryable only per THIS provider's set —
+        # the re-issue proves the gate consulted the lane that armed the
+        # stream, not some global default.  (The distinct-fallback-lane
+        # variant of this contract is exercised through the real fallback
+        # walk in test_model_registry's TestSessionFallback.)
+        provider = arm_session(
+            session,
+            _dying_stream("x", exc=FlakyError("in-band transient")),
+            _good_stream("ok"),
+            retryable=frozenset({"FlakyError"}),
+        )
+        session.send("test")
 
-        def create(msgs):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                # What _try_stream records at creation: the provider that
-                # owns the live stream (a fallback here — its retryable
-                # set differs from the primary's).
-                session._active_stream_provider = live
-                return _dying_stream("x", exc=FlakyError("in-band transient"))
-            return _good_stream("ok")
-
-        with (
-            patch.object(session, "_create_stream_with_retry", side_effect=create),
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
-
-        # FlakyError is NOT in the primary provider's retryable set — the
-        # re-issue proves the gate consulted the live stream's provider.
-        assert calls["n"] == 2
+        assert provider.create_streaming.call_count == 2
         assert _assistant_msgs(session)[-1]["content"] == "ok"
 
     def test_recreate_overflow_falls_through_to_compact_retry(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
-        calls = {"n": 0}
-
-        def create(msgs):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                return _dying_stream("x", exc=httpx.ReadError("wire died"))
-            if calls["n"] == 2:
-                # A mid-retry rebind landed on a smaller-window model: the
-                # re-create overflows deterministically.
-                raise RuntimeError("maximum context length exceeded")
-            return _good_stream("recovered")
-
+        provider = arm_session(
+            session,
+            _dying_stream("x", exc=httpx.ReadError("wire died")),
+            # A mid-retry rebind landed on a smaller-window model: the
+            # re-create overflows deterministically (a creation-phase
+            # raise — unarmed).
+            RuntimeError("maximum context length exceeded"),
+            _good_stream("recovered"),
+        )
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=create),
             patch.object(session, "_compact_messages") as compact,
             patch.object(session, "_full_messages", return_value=[]),
         ):
@@ -432,23 +412,19 @@ class TestMidStreamRetry:
 
         # The overflow surfaced as ITSELF (not masked behind the stream
         # death), so send()'s compact-and-retry arm recovered the turn.
-        assert calls["n"] == 3
+        assert provider.create_streaming.call_count == 3
         compact.assert_called_once()
         assert _assistant_msgs(session)[-1]["content"] == "recovered"
 
     def test_postcompaction_failure_surfaces_as_itself(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
-        calls = {"n": 0}
-
-        def create(msgs):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                raise RuntimeError("maximum context length exceeded")
-            raise ValueError("backend exploded")
-
+        arm_session(
+            session,
+            RuntimeError("maximum context length exceeded"),
+            ValueError("backend exploded"),
+        )
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=create),
             patch.object(session, "_compact_messages"),
             patch.object(session, "_full_messages", return_value=[]),
             pytest.raises(ValueError, match="backend exploded"),
@@ -480,8 +456,8 @@ class TestMidStreamRetry:
             if refreshes["n"] == 2:
                 session.model = "swapped-model"
 
+        arm_session(session, *streams)
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams),
             patch.object(session, "_refresh_model_from_registry", side_effect=swap_model),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(
@@ -501,8 +477,9 @@ class TestMidStreamRetry:
             yield StreamChunk(content_delta="orphan text")
             yield StreamChunk(content_delta="more")
 
+        arm_session(session, chunks())
         with pytest.raises(GenerationCancelled):
-            session._stream_attempt(iter(chunks()), my_generation=3)
+            session._stream_response(3)
 
         # The superseded thread's cancel arm must touch neither the UI
         # (its stream_end would reset the successor's inflight buffers)
@@ -518,12 +495,8 @@ class TestMidStreamRetry:
             session._generation += 1  # force-cancel claimed a successor
             raise GenerationCancelled()
 
+        arm_session(session, _dying_stream("Hel", exc=httpx.ReadError("wire died")))
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[_dying_stream("Hel", exc=httpx.ReadError("wire died"))],
-            ),
             patch.object(session, "_backoff_or_cancelled", side_effect=supersede_then_cancel),
             patch.object(session, "_full_messages", return_value=[]),
         ):
@@ -552,8 +525,8 @@ class TestMidStreamRetry:
             ),
             _good_stream("final answer"),
         ]
+        arm_session(session, *streams)
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
@@ -582,12 +555,8 @@ class TestMidStreamRetry:
             real_backoff(delay, my_generation)
 
         dead_text = "a dead attempt long enough to flush past the carry window"
+        arm_session(session, _dying_stream(dead_text, exc=httpx.ReadError("wire died")))
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[_dying_stream(dead_text, exc=httpx.ReadError("wire died"))],
-            ),
             patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
             patch.object(session, "_full_messages", return_value=[]),
         ):
@@ -612,8 +581,8 @@ class TestMidStreamRetry:
             _dying_stream("x", exc=httpx.ReadError("wire died")),
             _good_stream("ok"),
         ]
+        arm_session(session, *streams)
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=streams),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
@@ -632,25 +601,21 @@ class TestMidStreamRetry:
 
         ui = _BufferUI()
         session = _make_session(ui)
-        calls = {"n": 0}
-
-        def create(msgs):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                return _dying_stream(
-                    "dead overflow text",
-                    exc=RuntimeError("maximum context length exceeded"),
-                )
-            return _good_stream("recovered")
-
+        provider = arm_session(
+            session,
+            _dying_stream(
+                "dead overflow text",
+                exc=RuntimeError("maximum context length exceeded"),
+            ),
+            _good_stream("recovered"),
+        )
         with (
-            patch.object(session, "_create_stream_with_retry", side_effect=create),
             patch.object(session, "_compact_messages"),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
 
-        assert calls["n"] == 2
+        assert provider.create_streaming.call_count == 2
         assert "".join(ui._ws_turn_content) == "recovered"
 
     def test_orphan_death_records_no_fatal_over_successor(self, tmp_db):
@@ -665,11 +630,12 @@ class TestMidStreamRetry:
             session._generation += 1
             raise ValueError("orphan death")
 
-        with (
-            patch.object(session, "_create_stream_with_retry", side_effect=[dying_superseded()]),
-            patch.object(session, "_full_messages", return_value=[]),
-            pytest.raises(ValueError, match="orphan death"),
-        ):
+        arm_session(session, dying_superseded())
+        with patch.object(session, "_full_messages", return_value=[]):
+            # Post-fold the orphan's death converts at the ladder's
+            # generation check and send() ends SILENTLY as cancelled — no
+            # arbitrary exception class escapes into the thread runner
+            # (named orphan-exit delta, design D12).
             session.send("test")
 
         # The orphan must not flash an error banner over the live
@@ -677,16 +643,15 @@ class TestMidStreamRetry:
         assert ("state", "error") not in ui.events
         assert not ui.of("error")
         assert not load_last_error(session._ws_id)
+        assert not _assistant_msgs(session)
 
     def test_non_retryable_error_is_immediately_fatal(self, tmp_db):
         ui = RecordingUI()
         session = _make_session(ui)
+        create = arm_session(
+            session, _dying_stream("Hel", exc=ValueError("model exploded"))
+        ).create_streaming
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[_dying_stream("Hel", exc=ValueError("model exploded"))],
-            ) as create,
             patch.object(session, "_full_messages", return_value=[]),
             pytest.raises(ValueError, match="model exploded"),
         ):
@@ -705,15 +670,12 @@ class TestMidStreamRetry:
         replace the operator-actionable stream-death error with its own."""
         ui = RecordingUI()
         session = _make_session(ui)
+        create = arm_session(
+            session,
+            _dying_stream("He", exc=httpx.ReadError("[SSL] record layer failure")),
+            RuntimeError("Cannot send a request, as the client has been closed."),
+        ).create_streaming
         with (
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=[
-                    _dying_stream("He", exc=httpx.ReadError("[SSL] record layer failure")),
-                    RuntimeError("Cannot send a request, as the client has been closed."),
-                ],
-            ) as create,
             patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
             pytest.raises(IncompleteStreamError, match="ReadError"),
@@ -739,8 +701,8 @@ class TestMidStreamRetry:
             yield StreamChunk(finish_reason="stop")
             raise httpx.ReadError("late blip")  # the usage chunk is lost
 
+        arm_session(session, blipping())
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=blipping()),
             patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -2,16 +2,16 @@
 
 A wire death DURING body iteration surfaces after the request already
 returned its stream handle, so neither the SDK's ``max_retries`` nor the
-creation-time per-lane ladder (``_model_turn_with_retry``) ever sees it.  These tests drive
-``ChatSession.send()`` with scripted provider streams and pin the retry
-loop's contract: bounded re-issue on the normalized retryable shape, the
-dead attempt finalized client-side before the retry notice
-(``stream_end``) and discarded from the server buffers once the backoff
-survives the Stop window (``stream_discarded`` — never
-``turn_committed``, whose semantics keep the turn buffer), cancel-in-
-retry-window abort, exhaustion surfacing the stream-death wording, and the
-``_assistant_pending_tokens`` reset that keeps a post-finish blip from
-recycling the prior turn's token count.
+creation-time per-lane ladder (``_model_turn_with_retry``) ever sees it.
+These tests drive ``ChatSession.send()`` with scripted provider streams
+and pin the retry loop's contract: bounded re-issue on the normalized
+retryable shape, the dead attempt finalized client-side before the retry
+notice (``stream_end``) and discarded from the server buffers once the
+backoff survives the Stop window (``stream_discarded`` — never
+``turn_committed``, whose semantics keep the turn buffer),
+cancel-in-retry-window abort, exhaustion surfacing the stream-death
+wording, and the ``_assistant_pending_tokens`` reset that keeps a
+post-finish blip from recycling the prior turn's token count.
 
 Fixture note: tests zero ``_RETRY_BASE_DELAY`` per instance (else each
 retry pays real exponential backoff).
@@ -358,12 +358,10 @@ class TestMidStreamRetry:
 
         ui = RecordingUI()
         session = _make_session(ui)
-        # Post-fold the retry gate reads the SERVING lane's provider off
-        # the frame's consumer (the creation-time handoff register is
-        # gone).  FlakyError is retryable only per THIS provider's set —
-        # the re-issue proves the gate consulted the lane that armed the
-        # stream, not some global default.  (The distinct-fallback-lane
-        # variant of this contract is exercised through the real fallback
+        # The retry gate reads the SERVING lane's provider.  FlakyError is
+        # retryable only per THIS provider's set, so the re-issue proves
+        # the gate consulted the lane that armed the stream, not a global
+        # default.  (The distinct-fallback-lane variant rides the real
         # walk in test_model_registry's TestSessionFallback.)
         provider = arm_session(
             session,
@@ -716,9 +714,8 @@ class TestRecreateWindowClassification:
             session.send("test")
 
         # The dead attempt streamed only its safe-flush prefix ("Ha");
-        # the splitter carry ("lf an answer") must NEVER surface as a
-        # late content token — the stale-armed bug flushed it into the
-        # just-truncated segment behind a duplicate stream_end.
+        # the splitter carry ("lf an answer") must NEVER surface as a late
+        # content token behind a duplicate stream_end.
         assert ui.of("content") == ["Ha"]
         assert ui.kinds().count("stream_end") == 1
         # The full partial (flushed + carry) still reaches history via
@@ -740,9 +737,9 @@ class TestRecreateWindowClassification:
             _good_stream("never reached"),
         )
         # The re-issue walk's PREAMBLE (before any begin_attempt) raises:
-        # with the dead attempt's ref properly retired this classifies as
-        # a creation-phase failure and the ORIGINAL stream death is the
-        # error the operator sees — not the preamble's.
+        # with the dead attempt's ref retired this is a creation-phase
+        # failure, so the ORIGINAL stream death is the error the operator
+        # sees — not the preamble's.
         real_tracker = session._get_health_tracker
         calls: list[int] = []
 
@@ -781,12 +778,11 @@ class TestRecreateWindowClassification:
         assert not any("Backend stream died mid-response" in e for e in errors)
 
     def test_never_arming_adapter_death_classifies_midstream(self, tmp_db):
-        """An adapter that ignores ``cancel_ref`` (the pre-#832 letter of
-        the contract) forfeits the health/usage hook duties, but its
-        mid-stream death must STILL classify as mid-stream: chunks
-        reached the display, so a creation-classified death would
-        silently re-issue the same lane and double-render them.  The
-        consumer's saw-chunk fallback is that tripwire."""
+        """An adapter that ignores ``cancel_ref`` forfeits the
+        health/usage hook duties, but its mid-stream death must STILL
+        classify as mid-stream: chunks reached the display, so a
+        creation-classified death would silently re-issue the same lane
+        and double-render them."""
         ui = RecordingUI()
         session = _make_session(ui)
         provider = arm_session(session)  # install the provider shell only
@@ -817,8 +813,7 @@ class TestRecreateWindowClassification:
         """A deterministic lowering failure is a session-data fault: no
         dispatch, no health record, no fallback walk — the typed
         ``WirePreparationError`` rides to the fatal formatter's dedicated
-        branch.  (Pre-fold parity: wire prep ran in send() outside the
-        streaming try and could reach none of them.)"""
+        branch."""
         ui = RecordingUI()
         session = _make_session(ui)
         provider = arm_session(session, _good_stream("unreached"))
@@ -848,9 +843,9 @@ class TestDebugDumpLatch:
     """The debug request dump prints once per ``_stream_response``
     invocation.  RULED (#832): send()'s overflow-recovery re-invocation
     prints the RE-PREPARED wire — the dump that diagnoses the recovery —
-    where the pre-fold accident (wire prep hoisted outside the streaming
-    try) printed only the first.  Within one invocation, re-issues and
-    fallback lanes re-run the passes but never re-dump."""
+    where the pre-fold behavior printed only the first.  Within one
+    invocation, re-issues and fallback lanes re-run the passes but never
+    re-dump."""
 
     def test_reissue_never_redumps(self, tmp_db):
         session = _make_session(RecordingUI())
@@ -881,7 +876,7 @@ class TestFallbackFailureRedaction:
         """The fallback-failure info line lands in the browser transcript
         and persisted event stream — it carries the exception CLASS, never
         its text (a ConnectError's str can embed a credential-bearing
-        base_url; same rule as the re-issue log arm)."""
+        base_url)."""
         ui = RecordingUI()
         session = _make_session(ui)
         registry = MagicMock()

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -810,10 +810,11 @@ class TestRecreateWindowClassification:
         assert ui.of("content").count(flushed) == 1
 
     def test_wire_preparation_failure_never_touches_backend_health(self, tmp_db):
-        """A deterministic lowering failure is a session-data fault: no
-        dispatch, no health record, no fallback walk — the typed
-        ``WirePreparationError`` rides to the fatal formatter's dedicated
-        branch."""
+        """A lowering failure is a session-data fault: no dispatch and no
+        health record on ANY lane — but it DOES walk the fallbacks, since
+        prepare is lane-variant and another lane's posture may serve the
+        turn.  When none does, the typed ``WirePreparationError`` rides to
+        the fatal formatter's dedicated branch."""
         ui = RecordingUI()
         session = _make_session(ui)
         provider = arm_session(session, _good_stream("unreached"))
@@ -823,7 +824,7 @@ class TestRecreateWindowClassification:
         session._registry = registry
         with (
             patch.object(session, "_get_health_tracker", return_value=tracker),
-            patch.object(session, "_try_fallback_lane") as fb_spy,
+            patch.object(session, "_try_fallback_lane", return_value=None) as fb_spy,
             patch.object(
                 session, "_prepare_wire_messages", side_effect=ValueError("malformed turn 7")
             ),
@@ -832,11 +833,66 @@ class TestRecreateWindowClassification:
             session.send("test")
 
         tracker.record_failure.assert_not_called()
-        fb_spy.assert_not_called()
+        fb_spy.assert_called_once()
         provider.create_streaming.assert_not_called()
         errors = ui.of("error")
         assert errors and "stored history" in errors[-1]
         assert "malformed turn 7" in errors[-1]
+
+    def test_fallback_prep_fault_continues_walk(self, tmp_db):
+        """A prep fault on one lane must not abort the walk: the next
+        alias may still serve the turn (prepare is lane-variant)."""
+        from tests._session_helpers import make_result
+
+        session = _make_session(RecordingUI())
+        registry = MagicMock()
+        registry.fallback = ["a", "b"]
+        session._registry = registry
+        served = make_result(content="ok")
+        tracker = MagicMock()
+        with (
+            patch.object(session, "_get_health_tracker", return_value=tracker),
+            patch.object(
+                session,
+                "_model_turn_with_retry",
+                side_effect=WirePreparationError("primary prep fault"),
+            ),
+            patch.object(session, "_try_fallback_lane", side_effect=[None, served]) as fb,
+        ):
+            from turnstone.core.session import _StreamTurnConsumer
+
+            consumer = _StreamTurnConsumer(session, 0)
+            result = session._model_turn_with_fallback(consumer, lambda w, lane: w, 0)
+
+        assert result is served
+        assert fb.call_count == 2
+        tracker.record_failure.assert_not_called()
+
+    def test_fallback_prep_fault_records_no_health(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        registry = MagicMock()
+        registry.resolve_binding.return_value = (MagicMock(), "m", None, MagicMock(), None)
+        fb_tracker = MagicMock()
+        session._registry = registry
+        session._health_registry = MagicMock()
+        session._health_registry.get_tracker_for_alias.return_value = fb_tracker
+        with (
+            patch.object(session, "_build_main_lane", return_value=MagicMock()),
+            patch.object(
+                session,
+                "_model_turn_with_retry",
+                side_effect=WirePreparationError("fold blew up"),
+            ),
+        ):
+            from turnstone.core.session import _StreamTurnConsumer
+
+            consumer = _StreamTurnConsumer(session, 0)
+            out = session._try_fallback_lane("fb", consumer, lambda w, lane: w, 0)
+
+        assert out is None
+        fb_tracker.record_failure.assert_not_called()
+        assert any("Fallback fb also failed: WirePreparationError" in i for i in ui.of("info"))
 
 
 class TestDebugDumpLatch:

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -874,3 +874,27 @@ class TestDebugDumpLatch:
             session._stream_response(0)
             session._stream_response(0)
         assert dump.call_count == 2
+
+
+class TestFallbackFailureRedaction:
+    def test_fallback_ui_line_carries_class_name_only(self, tmp_db):
+        """The fallback-failure info line lands in the browser transcript
+        and persisted event stream — it carries the exception CLASS, never
+        its text (a ConnectError's str can embed a credential-bearing
+        base_url; same rule as the re-issue log arm)."""
+        ui = RecordingUI()
+        session = _make_session(ui)
+        registry = MagicMock()
+        registry.resolve_binding.side_effect = httpx.ConnectError(
+            "dial http://user:SECRETKEY@gw.example/v1 failed"
+        )
+        session._registry = registry
+        from turnstone.core.session import _StreamTurnConsumer
+
+        consumer = _StreamTurnConsumer(session, 0)
+        result = session._try_fallback_lane("fb", consumer, lambda w: w, 0)
+
+        assert result is None
+        infos = ui.of("info")
+        assert any("Fallback fb also failed: ConnectError" in i for i in infos)
+        assert not any("SECRETKEY" in i for i in infos)

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -887,9 +887,44 @@ class TestFallbackFailureRedaction:
         from turnstone.core.session import _StreamTurnConsumer
 
         consumer = _StreamTurnConsumer(session, 0)
-        result = session._try_fallback_lane("fb", consumer, lambda w: w, 0)
+        result = session._try_fallback_lane("fb", consumer, lambda w, lane: w, 0)
 
         assert result is None
         infos = ui.of("info")
         assert any("Fallback fb also failed: ConnectError" in i for i in infos)
         assert not any("SECRETKEY" in i for i in infos)
+
+
+class TestPrepareWireLaneCaps:
+    """The per-attempt wire prep folds with the SERVING lane's
+    capabilities — a fallback whose template rejects mid-conversation
+    system roles gets the folded shape even when the primary keeps them
+    inline."""
+
+    def test_caps_override_controls_fold_posture(self, tmp_db):
+        from turnstone.core.providers import ModelCapabilities
+
+        session = _make_session(RecordingUI())
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "yo"},
+            {"role": "system", "content": "nudge", "_source": "idle_nudge"},
+            {"role": "user", "content": "next"},
+        ]
+        native = session._prepare_wire_messages(
+            list(msgs), caps=ModelCapabilities(supports_mid_conversation_system=True)
+        )
+        folded = session._prepare_wire_messages(
+            list(msgs), caps=ModelCapabilities(supports_mid_conversation_system=False)
+        )
+        assert any(m["role"] == "system" for m in native[1:])
+        assert not any(m["role"] == "system" for m in folded[1:])
+
+    def test_stream_prepare_passes_serving_lane_caps(self, tmp_db):
+        session = _make_session(RecordingUI())
+        arm_session(session, _good_stream("ok"))
+        with patch.object(
+            session, "_prepare_wire_messages", wraps=session._prepare_wire_messages
+        ) as prep:
+            session.send("test")
+        assert prep.call_args.kwargs["caps"] is session._get_capabilities()

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -23,13 +23,13 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from tests._parity_832 import arm_session
-from tests._session_helpers import NullUI, RecordingUI, make_session
+from tests._session_helpers import NullUI, RecordingUI, arm_session, make_session
 from turnstone.core.memory import load_last_error
+from turnstone.core.model_turn import WirePreparationError
 from turnstone.core.providers import IncompleteStreamError, StreamChunk, UsageInfo
-from turnstone.core.session import GenerationCancelled
+from turnstone.core.session import BackendAuthUnavailableError, GenerationCancelled
 from turnstone.core.streaming_text import ThinkTagSplitter
-from turnstone.core.trajectory import dicts_from_turns
+from turnstone.core.trajectory import Turn, dicts_from_turns
 
 
 def _make_session(ui=None, **kwargs):
@@ -85,7 +85,6 @@ class TestMidStreamRetry:
         ]
         create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
         ):
             session.send("test")
@@ -137,7 +136,6 @@ class TestMidStreamRetry:
         ]
         create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.INFO, logger="turnstone.core.session"),
             pytest.raises(IncompleteStreamError, match="ReadError"),
         ):
@@ -179,7 +177,6 @@ class TestMidStreamRetry:
         ).create_streaming
         with (
             patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
-            patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
 
@@ -211,7 +208,6 @@ class TestMidStreamRetry:
         create = arm_session(session, *streams).create_streaming
         with (
             patch.object(session, "_refresh_model_from_registry", side_effect=swap_binding),
-            patch.object(session, "_full_messages", return_value=[]),
             patch.object(
                 session, "_prepare_wire_messages", wraps=session._prepare_wire_messages
             ) as prep,
@@ -234,7 +230,6 @@ class TestMidStreamRetry:
         ]
         create = arm_session(session, *streams).create_streaming
         with (
-            patch.object(session, "_full_messages", return_value=[]),
             patch.object(
                 session,
                 "_refresh_model_from_registry",
@@ -258,10 +253,7 @@ class TestMidStreamRetry:
             _good_stream("ok"),
         ]
         arm_session(session, *streams)
-        with (
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        session.send("test")
 
         # A pre-first-token death leaves the spinner RUNNING; the CLI's
         # on_thinking_start is idempotent at the callee (it stops a live
@@ -285,7 +277,6 @@ class TestMidStreamRetry:
         arm_session(session, _dying_stream(exc=httpx.ReadError("died before first token")))
         with (
             patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
-            patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
 
@@ -313,10 +304,7 @@ class TestMidStreamRetry:
             second_stream(),
         ]
         arm_session(session, *streams)
-        with (
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        session.send("test")
 
         # The replacement attempt recorded an EMPTY partial; the wrapper
         # backfills it with the previous attempt's text — the user saw it,
@@ -337,10 +325,7 @@ class TestMidStreamRetry:
             session.cancel()
 
         arm_session(session, gen())
-        with (
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        session.send("test")
 
         # The post-loop cancel re-check converts the Stop — the turn must
         # NOT commit as complete (its tool calls would execute despite the
@@ -356,7 +341,6 @@ class TestMidStreamRetry:
         session = _make_session(ui)
         arm_session(session, _dying_stream("Hel", exc=KeyboardInterrupt()))
         with (
-            patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.INFO, logger="turnstone.core.session"),
             pytest.raises(KeyboardInterrupt),
         ):
@@ -406,7 +390,6 @@ class TestMidStreamRetry:
         )
         with (
             patch.object(session, "_compact_messages") as compact,
-            patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
 
@@ -426,7 +409,6 @@ class TestMidStreamRetry:
         )
         with (
             patch.object(session, "_compact_messages"),
-            patch.object(session, "_full_messages", return_value=[]),
             pytest.raises(ValueError, match="backend exploded"),
         ):
             session.send("test")
@@ -459,7 +441,6 @@ class TestMidStreamRetry:
         arm_session(session, *streams)
         with (
             patch.object(session, "_refresh_model_from_registry", side_effect=swap_model),
-            patch.object(session, "_full_messages", return_value=[]),
             patch.object(
                 session, "_prepare_wire_messages", wraps=session._prepare_wire_messages
             ) as prep,
@@ -498,7 +479,6 @@ class TestMidStreamRetry:
         arm_session(session, _dying_stream("Hel", exc=httpx.ReadError("wire died")))
         with (
             patch.object(session, "_backoff_or_cancelled", side_effect=supersede_then_cancel),
-            patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")  # the orphaned turn returns silently
 
@@ -526,10 +506,7 @@ class TestMidStreamRetry:
             _good_stream("final answer"),
         ]
         arm_session(session, *streams)
-        with (
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        session.send("test")
 
         # The dead segment was truncated at the watermark; only the
         # retried attempt's text reaches the IDLE payload.
@@ -558,7 +535,6 @@ class TestMidStreamRetry:
         arm_session(session, _dying_stream(dead_text, exc=httpx.ReadError("wire died")))
         with (
             patch.object(session, "_backoff_or_cancelled", side_effect=cancel_then_backoff),
-            patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
 
@@ -582,10 +558,7 @@ class TestMidStreamRetry:
             _good_stream("ok"),
         ]
         arm_session(session, *streams)
-        with (
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        session.send("test")
 
         assert _assistant_msgs(session)[-1]["content"] == "ok"
         assert ("state", "idle") in ui.events
@@ -611,7 +584,6 @@ class TestMidStreamRetry:
         )
         with (
             patch.object(session, "_compact_messages"),
-            patch.object(session, "_full_messages", return_value=[]),
         ):
             session.send("test")
 
@@ -631,12 +603,11 @@ class TestMidStreamRetry:
             raise ValueError("orphan death")
 
         arm_session(session, dying_superseded())
-        with patch.object(session, "_full_messages", return_value=[]):
-            # Post-fold the orphan's death converts at the ladder's
-            # generation check and send() ends SILENTLY as cancelled — no
-            # arbitrary exception class escapes into the thread runner
-            # (named orphan-exit delta, design D12).
-            session.send("test")
+        # RULED (#832, orphan-exit): a superseded generation's death
+        # converts at the ladder's generation check and send() ends
+        # SILENTLY as cancelled — no arbitrary exception class escapes
+        # into the thread runner.
+        session.send("test")
 
         # The orphan must not flash an error banner over the live
         # successor turn or persist a wrong last_error for the coord.
@@ -652,7 +623,6 @@ class TestMidStreamRetry:
             session, _dying_stream("Hel", exc=ValueError("model exploded"))
         ).create_streaming
         with (
-            patch.object(session, "_full_messages", return_value=[]),
             pytest.raises(ValueError, match="model exploded"),
         ):
             session.send("test")
@@ -676,7 +646,6 @@ class TestMidStreamRetry:
             RuntimeError("Cannot send a request, as the client has been closed."),
         ).create_streaming
         with (
-            patch.object(session, "_full_messages", return_value=[]),
             caplog.at_level(logging.WARNING, logger="turnstone.core.session"),
             pytest.raises(IncompleteStreamError, match="ReadError"),
         ):
@@ -702,10 +671,7 @@ class TestMidStreamRetry:
             raise httpx.ReadError("late blip")  # the usage chunk is lost
 
         arm_session(session, blipping())
-        with (
-            patch.object(session, "_full_messages", return_value=[]),
-        ):
-            session.send("test")
+        session.send("test")
 
         assistant = _assistant_msgs(session)
         assert len(assistant) == 1
@@ -716,3 +682,195 @@ class TestMidStreamRetry:
         expected = max(1, int(session._msg_char_count(assistant[0]) / session._chars_per_token))
         assert session._msg_tokens[-1] == expected
         assert session._msg_tokens[-1] != 777
+
+
+class TestRecreateWindowClassification:
+    """Between a mid-stream death and the next attempt's ``begin_attempt``
+    there is NO live attempt — ``end_attempt`` pronounces the dead one
+    dead the moment its partial is captured.  These pins hold the two
+    failure modes of reading the dead attempt's armed state in that
+    window (a Stop re-finalizing discarded display state; a walk-preamble
+    error replacing the stream death), the two error classes the
+    re-issue mask must forward verbatim, and the saw-chunk classifier
+    fallback for adapters that never arm."""
+
+    def test_stop_in_recreate_window_emits_no_stale_display_state(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        arm_session(
+            session,
+            _dying_stream("Half an answer", exc=httpx.ReadError("wire died")),
+            _good_stream("never reached"),
+        )
+        # The Stop lands AFTER backoff+discard, BEFORE the next attempt
+        # arms: _refresh_model_from_registry is the last step of the
+        # re-create sequence, so a cancel fired there raises at the next
+        # walk's loop-top _check_cancelled — the exact window.
+        real_refresh = session._refresh_model_from_registry
+
+        def cancel_in_window():
+            real_refresh()
+            session._cancel_event.set()
+
+        with patch.object(session, "_refresh_model_from_registry", side_effect=cancel_in_window):
+            session.send("test")
+
+        # The dead attempt streamed only its safe-flush prefix ("Ha");
+        # the splitter carry ("lf an answer") must NEVER surface as a
+        # late content token — the stale-armed bug flushed it into the
+        # just-truncated segment behind a duplicate stream_end.
+        assert ui.of("content") == ["Ha"]
+        assert ui.kinds().count("stream_end") == 1
+        # The full partial (flushed + carry) still reaches history via
+        # the promotion path — display suppression must not cost text.
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert (
+            assistant[0]["content"] == "Half an answer\n\n[generation cancelled before completion]"
+        )
+        assert ("state", "idle") in ui.events
+        assert ("state", "error") not in ui.events
+
+    def test_recreate_preamble_error_surfaces_original_death(self, tmp_db):
+        ui = RecordingUI()
+        session = _make_session(ui)
+        arm_session(
+            session,
+            _dying_stream("text", exc=httpx.ReadError("wire died")),
+            _good_stream("never reached"),
+        )
+        # The re-issue walk's PREAMBLE (before any begin_attempt) raises:
+        # with the dead attempt's ref properly retired this classifies as
+        # a creation-phase failure and the ORIGINAL stream death is the
+        # error the operator sees — not the preamble's.
+        real_tracker = session._get_health_tracker
+        calls: list[int] = []
+
+        def tracker_then_boom():
+            calls.append(1)
+            if len(calls) >= 2:
+                raise RuntimeError("registry blew up mid-rebind")
+            return real_tracker()
+
+        with (
+            patch.object(session, "_get_health_tracker", side_effect=tracker_then_boom),
+            pytest.raises(IncompleteStreamError, match="ReadError"),
+        ):
+            session.send("test")
+
+        errors = ui.of("error")
+        assert errors and "Backend stream died mid-response" in errors[-1]
+        assert not any("registry blew up" in e for e in errors)
+
+    def test_auth_refusal_at_reissue_surfaces_as_itself(self, tmp_db):
+        # An OBO mint refusal during the re-create is a config outage
+        # with its own remediation branch — masking it behind the earlier
+        # transport death would misdiagnose it as a network flap.
+        ui = RecordingUI()
+        session = _make_session(ui)
+        arm_session(
+            session,
+            _dying_stream("text", exc=httpx.ReadError("wire died")),
+            BackendAuthUnavailableError("obo mint refused for alias 'gpt': no cached grant"),
+        )
+        with pytest.raises(BackendAuthUnavailableError):
+            session.send("test")
+
+        errors = ui.of("error")
+        assert errors and "configured to mint a credential per call" in errors[-1]
+        assert not any("Backend stream died mid-response" in e for e in errors)
+
+    def test_never_arming_adapter_death_classifies_midstream(self, tmp_db):
+        """An adapter that ignores ``cancel_ref`` (the pre-#832 letter of
+        the contract) forfeits the health/usage hook duties, but its
+        mid-stream death must STILL classify as mid-stream: chunks
+        reached the display, so a creation-classified death would
+        silently re-issue the same lane and double-render them.  The
+        consumer's saw-chunk fallback is that tripwire."""
+        ui = RecordingUI()
+        session = _make_session(ui)
+        provider = arm_session(session)  # install the provider shell only
+        scripts = [
+            _dying_stream("First words from the dying wire", exc=httpx.ReadError("wire died")),
+            _good_stream("Recovered"),
+        ]
+
+        def create_no_arm(**kwargs):
+            assert scripts, "script exhausted"
+            return scripts.pop(0)
+
+        provider.create_streaming = MagicMock(side_effect=create_no_arm)
+        session.send("test")
+
+        # The mid-stream ladder ran its full theater — finalize, notice,
+        # discard — and the retried attempt committed ALONE.
+        assert any("stream died mid-response" in d for d in ui.of("info"))
+        assert ui.kinds().count("stream_discarded") == 1
+        assistant = _assistant_msgs(session)
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == "Recovered"
+        # The dead attempt's flushed prefix rendered exactly once.
+        flushed = "First words from the dying wire"[: -ThinkTagSplitter.MAX_TAG_LEN]
+        assert ui.of("content").count(flushed) == 1
+
+    def test_wire_preparation_failure_never_touches_backend_health(self, tmp_db):
+        """A deterministic lowering failure is a session-data fault: no
+        dispatch, no health record, no fallback walk — the typed
+        ``WirePreparationError`` rides to the fatal formatter's dedicated
+        branch.  (Pre-fold parity: wire prep ran in send() outside the
+        streaming try and could reach none of them.)"""
+        ui = RecordingUI()
+        session = _make_session(ui)
+        provider = arm_session(session, _good_stream("unreached"))
+        tracker = MagicMock()
+        registry = MagicMock()
+        registry.fallback = ["fb1"]
+        session._registry = registry
+        with (
+            patch.object(session, "_get_health_tracker", return_value=tracker),
+            patch.object(session, "_try_fallback_lane") as fb_spy,
+            patch.object(
+                session, "_prepare_wire_messages", side_effect=ValueError("malformed turn 7")
+            ),
+            pytest.raises(WirePreparationError),
+        ):
+            session.send("test")
+
+        tracker.record_failure.assert_not_called()
+        fb_spy.assert_not_called()
+        provider.create_streaming.assert_not_called()
+        errors = ui.of("error")
+        assert errors and "stored history" in errors[-1]
+        assert "malformed turn 7" in errors[-1]
+
+
+class TestDebugDumpLatch:
+    """The debug request dump prints once per ``_stream_response``
+    invocation.  RULED (#832): send()'s overflow-recovery re-invocation
+    prints the RE-PREPARED wire — the dump that diagnoses the recovery —
+    where the pre-fold accident (wire prep hoisted outside the streaming
+    try) printed only the first.  Within one invocation, re-issues and
+    fallback lanes re-run the passes but never re-dump."""
+
+    def test_reissue_never_redumps(self, tmp_db):
+        session = _make_session(RecordingUI())
+        session.debug = True
+        session.messages.append(Turn.user("hi"))
+        arm_session(
+            session,
+            _dying_stream("x" * 20, exc=httpx.ReadError("wire died")),
+            _good_stream("ok"),
+        )
+        with patch.object(session, "_debug_print_request") as dump:
+            session._stream_response(0)
+        assert dump.call_count == 1
+
+    def test_second_invocation_reprints(self, tmp_db):
+        session = _make_session(RecordingUI())
+        session.debug = True
+        session.messages.append(Turn.user("hi"))
+        arm_session(session, _good_stream("a"), _good_stream("b"))
+        with patch.object(session, "_debug_print_request") as dump:
+            session._stream_response(0)
+            session._stream_response(0)
+        assert dump.call_count == 2

--- a/tests/test_model_provider_obo.py
+++ b/tests/test_model_provider_obo.py
@@ -1577,7 +1577,7 @@ class TestModelOboToken:
         # build is the one place the alias enters.
         sess = MagicMock()
         sess._model_alias = "oboagent"
-        ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire: wire)
+        ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire, lane: wire)
         sess._build_main_lane.assert_called_once()
         assert sess._build_main_lane.call_args.kwargs["alias"] == "oboagent"
 
@@ -1590,7 +1590,7 @@ class TestModelOboToken:
         sess._get_health_tracker.return_value = tracker
 
         with pytest.raises(BackendAuthUnavailableError):
-            ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire: wire)
+            ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire, lane: wire)
 
         sess._try_fallback_lane.assert_not_called()
         # An auth refusal is never reinterpreted as backend health.

--- a/tests/test_model_provider_obo.py
+++ b/tests/test_model_provider_obo.py
@@ -1519,12 +1519,10 @@ class TestModelOboToken:
         session._mcp_mint_client.mint_app_token_sync.assert_not_called()
 
     def test_main_lane_carries_backend_auth_resolver(self) -> None:
-        """The main loop's lane wires the session's mint resolver — the
+        """The main loop's lane wires the session's mint resolver; the
         credential then resolves and binds INSIDE model_turn per attempt,
-        after its entry abort read (the #972/#832 ordering: a pre-set Stop
-        mints nothing, pinned in test_cancel; the with_options SDK binding
-        itself is model_turn's own pinned behavior).  This replaces the
-        retired pin on _try_stream's hoisted once-per-ladder resolve."""
+        after its entry abort read (the #972 ordering — a pre-set Stop
+        mints nothing, pinned in test_cancel)."""
         sess = MagicMock()
         sess._registry = None
         sess._config_store = None
@@ -1543,16 +1541,15 @@ class TestModelOboToken:
         assert lane.backend_auth_resolver is sess._model_backend_auth_token
         assert lane.alias == "tf"
         # The session's own sampling knobs override the lane's operator
-        # rungs (wire parity with the pre-fold loop).
+        # rungs.
         assert lane.temperature == 0.5
         assert lane.reasoning_effort is None
 
     def test_main_lane_never_consults_config_store(self) -> None:
         """The alias/global sampling rungs must not reach the main loop:
-        the session's own knobs replace both values ``config_store``
-        would feed, so ``_build_main_lane`` omits the store entirely —
-        a store with configured rungs contributes nothing to the lane
-        (wire parity with the pre-fold loop, which never consulted it)."""
+        the session's own knobs replace both values ``config_store`` would
+        feed, so ``_build_main_lane`` omits the store entirely and a store
+        with configured rungs contributes nothing to the lane."""
         sess = MagicMock()
         sess._registry = None
         store = MagicMock()
@@ -1576,9 +1573,8 @@ class TestModelOboToken:
     def test_primary_lane_built_with_session_alias_for_obo(self) -> None:
         # Regression: the primary lane must carry the session alias, or the
         # backend-auth resolver can't resolve the OBO token and an
-        # entra_obo main turn goes out on the static client key. (The
-        # pre-fold bug lived in _try_stream's missing model_alias kwarg;
-        # the lane build is the one place the alias enters now.)
+        # entra_obo main turn goes out on the static client key.  The lane
+        # build is the one place the alias enters.
         sess = MagicMock()
         sess._model_alias = "oboagent"
         ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire: wire)

--- a/tests/test_model_provider_obo.py
+++ b/tests/test_model_provider_obo.py
@@ -1518,66 +1518,61 @@ class TestModelOboToken:
         )
         session._mcp_mint_client.mint_app_token_sync.assert_not_called()
 
-    def test_primary_stream_binds_backend_token_once_before_retry_loop(self) -> None:
-        """The main streaming path mirrors model_turn's SDK binding."""
+    def test_main_lane_carries_backend_auth_resolver(self) -> None:
+        """The main loop's lane wires the session's mint resolver — the
+        credential then resolves and binds INSIDE model_turn per attempt,
+        after its entry abort read (the #972/#832 ordering: a pre-set Stop
+        mints nothing, pinned in test_cancel; the with_options SDK binding
+        itself is model_turn's own pinned behavior).  This replaces the
+        retired pin on _try_stream's hoisted once-per-ladder resolve."""
         sess = MagicMock()
-        sess._MAX_RETRIES = 2
-        sess._provider = MagicMock()
-        sess._provider.create_streaming.return_value = iter(())
-        sess._get_capabilities.return_value = SimpleNamespace(default_reasoning_effort=None)
-        sess._maybe_attach_vllm_chat_reasoning.side_effect = lambda messages, _provider, _alias: (
-            messages
-        )
-        sess._model_backend_auth_token.return_value = "minted-jwt"
-        sess._cancel_ref = []
-        sess._get_active_tools.return_value = []
-        sess.max_tokens = 1024
-        sess.temperature = None
+        sess._registry = None
+        sess._config_store = None
+        sess.temperature = 0.5
         sess.reasoning_effort = None
-        sess._provider_extra_params.return_value = None
-        sess._get_deferred_names.return_value = frozenset()
-        sess._resolve_replay_reasoning_to_model.return_value = False
-        base_client = MagicMock()
-        base_client.base_url = "https://gateway.example.com"
-        bound_client = object()
-        base_client.with_options.return_value = bound_client
 
-        stream = ChatSession._try_stream(
+        lane = ChatSession._build_main_lane(
             sess,
-            base_client,
-            "vmg/opus",
-            [{"role": "user", "content": "hi"}],
-            model_alias="tf",
+            provider=MagicMock(provider_name="openai-compatible"),
+            client=MagicMock(),
+            model="vmg/opus",
+            alias="tf",
+            capabilities=SimpleNamespace(),
         )
 
-        assert list(stream) == []
-        sess._model_backend_auth_token.assert_called_once_with("tf")
-        base_client.with_options.assert_called_once_with(api_key="minted-jwt")
-        assert sess._provider.create_streaming.call_args.kwargs["client"] is bound_client
+        assert lane.backend_auth_resolver is sess._model_backend_auth_token
+        assert lane.alias == "tf"
+        # The session's own sampling knobs override the lane's operator
+        # rungs (wire parity with the pre-fold loop).
+        assert lane.temperature == 0.5
+        assert lane.reasoning_effort is None
 
-    def test_primary_stream_forwards_alias_for_obo(self) -> None:
-        # Regression: the primary _create_stream_with_retry call must pass
-        # model_alias, or the backend-auth resolver can't resolve the OBO token and an
-        # entra_obo main turn goes out on the static client key. The fallback
-        # path and utility (title) completions always passed the alias; the
-        # primary path silently didn't.
+    def test_primary_lane_built_with_session_alias_for_obo(self) -> None:
+        # Regression: the primary lane must carry the session alias, or the
+        # backend-auth resolver can't resolve the OBO token and an
+        # entra_obo main turn goes out on the static client key. (The
+        # pre-fold bug lived in _try_stream's missing model_alias kwarg;
+        # the lane build is the one place the alias enters now.)
         sess = MagicMock()
         sess._model_alias = "oboagent"
-        ChatSession._create_stream_with_retry(sess, [{"role": "user", "content": "hi"}])
-        sess._try_stream.assert_called_once()
-        assert sess._try_stream.call_args.kwargs.get("model_alias") == "oboagent"
+        ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire: wire)
+        sess._build_main_lane.assert_called_once()
+        assert sess._build_main_lane.call_args.kwargs["alias"] == "oboagent"
 
     def test_fail_closed_refusal_never_enters_model_fallback_chain(self) -> None:
         sess = MagicMock()
         sess._model_alias = "oboagent"
-        sess._try_stream.side_effect = BackendAuthUnavailableError("mint failed")
+        sess._model_turn_with_retry.side_effect = BackendAuthUnavailableError("mint failed")
         sess._registry.fallback = ["static-backup"]
-        sess._get_health_tracker.return_value = None
+        tracker = MagicMock()
+        sess._get_health_tracker.return_value = tracker
 
         with pytest.raises(BackendAuthUnavailableError):
-            ChatSession._create_stream_with_retry(sess, [{"role": "user", "content": "hi"}])
+            ChatSession._model_turn_with_fallback(sess, MagicMock(), lambda wire: wire)
 
-        sess._try_fallback.assert_not_called()
+        sess._try_fallback_lane.assert_not_called()
+        # An auth refusal is never reinterpreted as backend health.
+        tracker.record_failure.assert_not_called()
 
     def test_static_alias_returns_none_and_never_mints(self) -> None:
         static_cfg = ModelConfig(

--- a/tests/test_model_provider_obo.py
+++ b/tests/test_model_provider_obo.py
@@ -1547,6 +1547,32 @@ class TestModelOboToken:
         assert lane.temperature == 0.5
         assert lane.reasoning_effort is None
 
+    def test_main_lane_never_consults_config_store(self) -> None:
+        """The alias/global sampling rungs must not reach the main loop:
+        the session's own knobs replace both values ``config_store``
+        would feed, so ``_build_main_lane`` omits the store entirely —
+        a store with configured rungs contributes nothing to the lane
+        (wire parity with the pre-fold loop, which never consulted it)."""
+        sess = MagicMock()
+        sess._registry = None
+        store = MagicMock()
+        sess._config_store = store
+        sess.temperature = None
+        sess.reasoning_effort = "high"
+
+        lane = ChatSession._build_main_lane(
+            sess,
+            provider=MagicMock(provider_name="openai-compatible"),
+            client=MagicMock(),
+            model="m",
+            alias="a",
+            capabilities=SimpleNamespace(),
+        )
+
+        assert not store.mock_calls
+        assert lane.temperature is None
+        assert lane.reasoning_effort == "high"
+
     def test_primary_lane_built_with_session_alias_for_obo(self) -> None:
         # Regression: the primary lane must carry the session alias, or the
         # backend-auth resolver can't resolve the OBO token and an

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -2185,41 +2185,44 @@ class TestSessionConstructionFailureLatch:
 
 class TestSessionFallback:
     def test_fallback_on_primary_failure(self) -> None:
+        # provider="openai-compatible" pins the Chat Completions surface, the
+        # one the patched ``chat.completions.create`` stubs below speak (see
+        # TestSessionRemovedAliasDegradedTurns._registry for the precedent).
         reg = ModelRegistry(
             models={
-                "primary": ModelConfig("primary", "http://p/v1", "k", "p-model"),
-                "fallback": ModelConfig("fallback", "http://f/v1", "k", "f-model"),
+                "primary": ModelConfig(
+                    "primary", "http://p/v1", "k", "p-model", provider="openai-compatible"
+                ),
+                "fallback": ModelConfig(
+                    "fallback", "http://f/v1", "k", "f-model", provider="openai-compatible"
+                ),
             },
             default="primary",
             fallback=["fallback"],
         )
         session = _make_session(registry=reg, model_alias="primary")
+        # Primary: an unarmed creation failure (raises before any chunk, so
+        # cancel_ref is never appended) — a non-retryable class, so the
+        # per-lane ladder gives up after one attempt and the fallback walk
+        # takes over.
+        session.client.chat.completions.create = MagicMock(
+            side_effect=ConnectionError("Primary down")
+        )
+        # Fallback: resolved through the REAL registry binding, so the fake
+        # goes on the registry's own client for that alias, not the session's.
+        fb_client = reg.get_client("fallback")
+        fb_client.chat.completions.create = scripted_chat_client({"content": "fallback_response"})
 
-        # _try_stream: first call (primary) raises, second call (fallback) succeeds
-        call_count = 0
+        session.send("hi")
 
-        def fake_try_stream(client: Any, model: str, msgs: Any, **kwargs: Any) -> str:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise ConnectionError("Primary down")
-            return "fallback_response"
-
-        session._try_stream = fake_try_stream  # type: ignore[assignment]
-        result = session._create_stream_with_retry([{"role": "user", "content": "hi"}])
-        assert result == "fallback_response"
-        assert call_count == 2
+        assert session.messages[-1].text == "fallback_response"
         assert any("falling back" in i for i in session.ui.infos)
 
     def test_no_fallback_without_registry(self) -> None:
         session = _make_session()
-
-        def fake_try_stream(client: Any, model: str, msgs: Any, **kwargs: Any) -> str:
-            raise ConnectionError("Down")
-
-        session._try_stream = fake_try_stream  # type: ignore[assignment]
+        session.client.chat.completions.create = MagicMock(side_effect=ConnectionError("Down"))
         with pytest.raises(ConnectionError):
-            session._create_stream_with_retry([{"role": "user", "content": "hi"}])
+            session.send("hi")
 
 
 class TestSessionAgentModel:

--- a/tests/test_persona_guards.py
+++ b/tests/test_persona_guards.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests._parity_832 import make_result
+from tests._session_helpers import make_result
 from turnstone.core.personas import PersonaSnapshot, snapshot_from_persona
 from turnstone.core.session import ChatSession
 from turnstone.core.storage import get_storage

--- a/tests/test_persona_guards.py
+++ b/tests/test_persona_guards.py
@@ -9,17 +9,21 @@ stamped-at-create isolation from later persona edits.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests._parity_832 import make_result
 from turnstone.core.personas import PersonaSnapshot, snapshot_from_persona
 from turnstone.core.session import ChatSession
 from turnstone.core.storage import get_storage
 from turnstone.core.storage._utils import PERSONA_MUTABLE
 from turnstone.core.tools import TASK_AGENT_TOOLS
 from turnstone.core.workstream import WorkstreamKind
+
+if TYPE_CHECKING:
+    from turnstone.core.model_turn import ModelTurnResult
 
 
 def _snap(
@@ -333,18 +337,17 @@ class TestMemoryOff:
         summary = SimpleNamespace(content="## Open tasks\nfinish it", finish_reason="stop")
         n = {"i": 0}
 
-        def stream(*_a: Any, **_k: Any) -> dict[str, str]:
+        def stream(*_a: Any, **_k: Any) -> ModelTurnResult:
             n["i"] += 1
             if n["i"] == 1:
                 session._compaction_advised = True  # advisory fired this turn
-                return {"role": "assistant", "content": "pausing to compact"}
-            return {"role": "assistant", "content": "all done"}
+                return make_result(content="pausing to compact")
+            return make_result(content="all done")
 
         def est(*_a: Any, **_k: Any) -> int:
             return 9_999 if n["i"] <= 1 else 10  # over threshold only on the stop turn
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
             patch.object(session, "_stream_response", side_effect=stream),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),

--- a/tests/test_provider_anthropic_compat.py
+++ b/tests/test_provider_anthropic_compat.py
@@ -493,11 +493,16 @@ class TestCompatSessionPlumbing:
         assert caps.supports_vision is False
 
     def test_session_extra_params_gate(self, tmp_db: Any) -> None:
-        """server_compat extra_body forwards for the compat lane, not real Anthropic."""
+        """server_compat extra_body forwards for the compat lane, not real Anthropic.
+
+        The gate lives in ``model_turn.provider_extra_params`` (the session's
+        delegate wrapper retired with the #832 fold — the lane resolver is the
+        one caller now, so the pin asserts the module function directly).
+        """
         from turnstone.core.model_registry import ModelConfig, ModelRegistry
+        from turnstone.core.model_turn import provider_extra_params
         from turnstone.core.providers import create_provider
 
-        session = _make_session(reasoning_effort="medium")
         cfg = ModelConfig(
             alias="vllm-messages",
             base_url="http://localhost:8000",
@@ -506,14 +511,15 @@ class TestCompatSessionPlumbing:
             provider="anthropic-compatible",
             server_compat={"extra_body": {"chat_template_kwargs": {"thinking": False}}},
         )
-        session._registry = ModelRegistry(models={"vllm-messages": cfg}, default="vllm-messages")
-        session._model_alias = "vllm-messages"
+        registry = ModelRegistry(models={"vllm-messages": cfg}, default="vllm-messages")
 
-        session._provider = create_provider("anthropic-compatible")
-        assert session._provider_extra_params() == {"chat_template_kwargs": {"thinking": False}}
+        compat = create_provider("anthropic-compatible")
+        assert provider_extra_params(compat, registry, "vllm-messages") == {
+            "chat_template_kwargs": {"thinking": False}
+        }
 
-        session._provider = create_provider("anthropic")
-        assert session._provider_extra_params() is None
+        real = create_provider("anthropic")
+        assert provider_extra_params(real, registry, "vllm-messages") is None
 
 
 # ===========================================================================

--- a/tests/test_provider_openai_responses_reasoning.py
+++ b/tests/test_provider_openai_responses_reasoning.py
@@ -187,7 +187,7 @@ class TestReasoningItemForInput:
 class TestBuildKwargsInclude:
     """``_build_kwargs`` adds ``include=["reasoning.encrypted_content"]``
     when the resolved operator flag is True.  The capability AND-gate
-    lives upstream in ``ChatSession._resolve_replay_reasoning_to_model``
+    lives upstream in ``model_turn.resolve_replay_reasoning_to_model``
     (single source of truth across providers); the provider trusts the
     bool it receives.  See
     ``test_session_replay_reasoning.py::TestSessionToOpenAIResponsesBoundaryIntegration``

--- a/tests/test_reasoning_audit_log_discipline.py
+++ b/tests/test_reasoning_audit_log_discipline.py
@@ -27,8 +27,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
-from tests._parity_832 import scripted_provider
-from tests._session_helpers import make_session
+from tests._session_helpers import make_session, scripted_provider
 from turnstone.core.history_decoration import (
     extract_reasoning_for_history,
     extract_reasoning_text_from_provider_content,

--- a/tests/test_reasoning_audit_log_discipline.py
+++ b/tests/test_reasoning_audit_log_discipline.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+from tests._parity_832 import scripted_provider
 from tests._session_helpers import make_session
 from turnstone.core.history_decoration import (
     extract_reasoning_for_history,
@@ -36,6 +37,7 @@ from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
 from turnstone.core.providers._protocol import StreamChunk, UsageInfo
+from turnstone.core.trajectory import Turn
 
 _MARKER = "SECRET_REASONING_MARKER_xyz123_unlikely_collision"
 
@@ -226,30 +228,34 @@ class TestReasoningAuditLogDiscipline:
             f"reasoning text into INFO+ logs: {offending}"
         )
 
-    def test_synth_reasoning_block_via_stream_attempt_does_not_log_reasoning(
+    def test_synth_reasoning_block_via_stream_response_does_not_log_reasoning(
         self,
     ) -> None:
-        """Drives ChatSession._stream_attempt (which invokes
-        model_turn.synth_reasoning_block at end-of-stream via
-        _finalize_provider_blocks) with a fake
-        ``reasoning_delta=_MARKER`` chunk; asserts no log call carried
-        the marker text."""
+        """Drives session._stream_response (the real drain seam —
+        _stream_attempt no longer exists post-#832; invokes
+        model_turn.synth_reasoning_block at end-of-turn via
+        finalize_provider_blocks) with a fake ``reasoning_delta=_MARKER``
+        chunk; asserts no log call carried the marker text."""
         session = make_session()
-        chunks = [
-            StreamChunk(reasoning_delta=_MARKER, is_first=True),
-            StreamChunk(content_delta="answer"),
-            StreamChunk(
-                finish_reason="stop",
-                usage=UsageInfo(prompt_tokens=10, completion_tokens=20, total_tokens=30),
-            ),
-        ]
+        session._provider = scripted_provider(
+            [
+                StreamChunk(reasoning_delta=_MARKER, is_first=True),
+                StreamChunk(content_delta="answer"),
+                StreamChunk(
+                    finish_reason="stop",
+                    usage=UsageInfo(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+                ),
+            ]
+        )
+        session.messages.append(Turn.user("hi"))
         captured, patchers = _capture_log_calls()
         for p in patchers:
             p.start()
         try:
-            msg = session._stream_attempt(iter(chunks))
-            # Synth block stamped onto _provider_content with the marker.
-            assert msg["_provider_content"][0]["text"] == _MARKER
+            result = session._stream_response(0)
+            # Synth block stamped onto the native lane with the marker.
+            assert result.turn.native is not None
+            assert result.turn.native.blocks[0]["text"] == _MARKER
         finally:
             for p in patchers:
                 p.stop()
@@ -259,7 +265,7 @@ class TestReasoningAuditLogDiscipline:
             if _payload_contains_marker(args, kwargs)
         ]
         assert offending == [], (
-            f"_stream_attempt + synth_reasoning_block leaked reasoning "
+            f"_stream_response + synth_reasoning_block leaked reasoning "
             f"text into INFO+ logs: {offending}"
         )
 
@@ -332,31 +338,34 @@ class TestReasoningAuditLogDiscipline:
         )
 
     def test_maybe_attach_vllm_chat_reasoning_does_not_log_reasoning(self) -> None:
-        """Phase 5 gate method on ChatSession — the session-level
-        composite gate calls ``attach_vllm_chat_reasoning_field`` when
-        all 3 conditions pass.  Pin that the gate path itself doesn't
-        log reasoning text (the registry / capability lookups happen
-        adjacent to the reasoning bytes; a defensive ``log.warning``
-        showing the message dict on an error path would silently
-        violate the contract)."""
+        """Phase 5 gate — ``model_turn.maybe_attach_vllm_chat_reasoning``.
+
+        Post-#832 this composite gate is a plain module function (no
+        ``ChatSession`` delegate survives; ``model_turn.model_turn`` calls
+        it directly with the lane's own registry/alias). Pin that the
+        gate path itself doesn't log reasoning text (the registry /
+        capability lookups happen adjacent to the reasoning bytes; a
+        defensive ``log.warning`` showing the message dict on an error
+        path would silently violate the contract)."""
+        from turnstone.core.model_turn import maybe_attach_vllm_chat_reasoning
         from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 
-        session = make_session()
-        session._registry = SimpleNamespace(
+        registry = SimpleNamespace(
             get_config=lambda _alias: SimpleNamespace(
                 replay_reasoning_to_model=True,
                 capabilities={},
                 server_compat={"server_type": "vllm"},
             )
         )
-        session._model_alias = "qwen3"
         provider = OpenAIChatCompletionsProvider()
 
         captured, patchers = _capture_log_calls()
         for p in patchers:
             p.start()
         try:
-            out = session._maybe_attach_vllm_chat_reasoning([self._thinking_msg(_MARKER)], provider)
+            out = maybe_attach_vllm_chat_reasoning(
+                [self._thinking_msg(_MARKER)], provider, registry, "qwen3"
+            )
             assert out[0]["reasoning"] == _MARKER
         finally:
             for p in patchers:
@@ -367,6 +376,6 @@ class TestReasoningAuditLogDiscipline:
             if _payload_contains_marker(args, kwargs)
         ]
         assert offending == [], (
-            f"ChatSession._maybe_attach_vllm_chat_reasoning leaked reasoning "
+            f"model_turn.maybe_attach_vllm_chat_reasoning leaked reasoning "
             f"text into INFO+ logs: {offending}"
         )

--- a/tests/test_sdk_stream_boundary.py
+++ b/tests/test_sdk_stream_boundary.py
@@ -9,9 +9,9 @@ transports (no network, no live backend):
 2. The Anthropic ``messages.stream()`` helper propagates the same shape.
 3. Closing an httpx-backed SDK client from another thread while a read is
    blocked (the ``ModelRegistry.reload()`` shape) surfaces as an
-   ``httpx.TransportError`` on the blocked ``next()`` — which is why the
-   resilient ``_stream_response`` re-resolves the registry binding before
-   re-creating.
+   ``httpx.TransportError`` on the blocked ``next()`` — which is why
+   ``_stream_response``'s mid-stream re-issue ladder re-resolves the
+   registry binding before re-creating.
 
 If an SDK/httpx upgrade changes any of these, the ``transport_guarded``
 conversion (and the retry gate consuming it) must be re-verified — these

--- a/tests/test_sdk_stream_boundary.py
+++ b/tests/test_sdk_stream_boundary.py
@@ -207,3 +207,62 @@ def test_cross_thread_client_close_surfaces_transport_error_to_blocked_read():
             client.close()
     assert not closer_thread.is_alive()
     assert not server_thread.is_alive()
+
+
+class TestEagerAppendContract:
+    """Every adapter arms ``cancel_ref`` INSIDE ``create_streaming``'s body —
+    at HTTP-response time, before the iterator is returned (the Protocol
+    contract, strengthened on #832): the interactive wrapper's
+    creation-vs-midstream classifier and its health recording key on that
+    instant, and a lazily-issued generator adapter would silently move the
+    arming to first ``next()``, misclassifying every pre-first-chunk death
+    as a creation failure.  Real SDK clients over mock transports; the
+    assertion deliberately runs BEFORE any iteration.
+    """
+
+    def _armed_at_return(self, provider, client, **extra):
+        ref: list = []
+        stream = provider.create_streaming(
+            client=client,
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            cancel_ref=ref,
+            **extra,
+        )
+        assert len(ref) == 1, "cancel_ref not armed before create_streaming returned"
+        assert hasattr(ref[0], "close")
+        with contextlib.suppress(Exception):
+            stream.close()
+
+    def test_openai_chat_arms_eagerly(self):
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        requests: list = []
+        client = openai.OpenAI(
+            api_key="probe",
+            http_client=httpx.Client(transport=_dying_transport(CHAT_CHUNK, requests)),
+        )
+        self._armed_at_return(OpenAIChatCompletionsProvider(), client)
+        assert len(requests) == 1  # the HTTP call happened inside create
+
+    def test_openai_responses_arms_eagerly(self):
+        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+
+        requests: list = []
+        client = openai.OpenAI(
+            api_key="probe",
+            http_client=httpx.Client(transport=_dying_transport(CHAT_CHUNK, requests)),
+        )
+        self._armed_at_return(OpenAIResponsesProvider(), client)
+        assert len(requests) == 1
+
+    def test_anthropic_arms_eagerly(self):
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        requests: list = []
+        client = anthropic.Anthropic(
+            api_key="probe",
+            http_client=httpx.Client(transport=_dying_transport(ANTHROPIC_EVENTS, requests)),
+        )
+        self._armed_at_return(AnthropicProvider(), client)
+        assert len(requests) == 1

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._oidc_test_helpers import keyed_app_state
+from tests._parity_832 import make_result
 from tests._session_helpers import (
     FakeAnthropicBlock,
     as_stream,
@@ -20,6 +21,7 @@ from tests._session_helpers import (
     scripted_chat_client,
     seam_provider,
 )
+from turnstone.core.model_turn import ModelTurnResult, provider_extra_params
 from turnstone.core.session import _IMAGE_EXTENSIONS, _IMAGE_SIZE_CAP, ChatSession
 from turnstone.core.trajectory import (
     Turn,
@@ -133,10 +135,17 @@ def _send_with_mocks(session, responses, mock_execute, **extra_patches):
     Extra per-test patches (e.g. wrapping ``_collect_advisories``) ride
     via ``**extra_patches`` — keyword name maps to attribute on the
     session, value is the ``side_effect`` to inject.
+
+    ``responses`` are ``ModelTurnResult``s (build them with
+    ``tests._parity_832.make_result``) — the streaming seam's return
+    type since #832 folded creation and drain into ``model_turn``.  None
+    of these tests care HOW the turn was produced, only that one
+    happened, so they patch the whole ``_stream_response`` seam rather
+    than script a provider.
     """
     from unittest.mock import patch as _patch
 
-    def mock_response(_msgs, _gen):
+    def mock_response(_gen):
         return responses.pop(0)
 
     with contextlib.ExitStack() as stack:
@@ -2050,18 +2059,17 @@ class TestTitleRetry:
         # The assistant's opening turn is ALL tool calls — under the old
         # trigger no title would generate until a later text-only turn.
         responses = [
-            {
-                "role": "assistant",
-                "content": "working",
-                "tool_calls": [
+            make_result(
+                "working",
+                tool_calls=[
                     {
                         "id": "c1",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "done"},
+            ),
+            make_result("done"),
         ]
         capture_cls, started = _capturing_thread_cls()
 
@@ -2091,7 +2099,7 @@ class TestTitleRetry:
         for user_input, kwargs in (("   ", {}), ("a real message", {"from_wake": True})):
             session = _make_session()
             with (
-                _send_with_mocks(session, [{"role": "assistant", "content": "ok"}], mock_execute),
+                _send_with_mocks(session, [make_result("ok")], mock_execute),
                 patch("turnstone.core.session.threading.Thread", capture_cls),
             ):
                 session.send(user_input, **kwargs)
@@ -2923,7 +2931,6 @@ class TestAgentChildRegistration:
         with (
             patch.object(session, "_prepare_tool", side_effect=fake_prepare),
             patch.object(session, "_resolve_capabilities", return_value=OPENAI_COMPAT_DEFAULT),
-            patch.object(session, "_provider_extra_params", return_value={}),
         ):
             session._run_agent(
                 turns,
@@ -2983,7 +2990,6 @@ class TestAgentChildRegistration:
         with (
             patch.object(session, "_prepare_tool", side_effect=fake_prepare),
             patch.object(session, "_resolve_capabilities", return_value=OPENAI_COMPAT_DEFAULT),
-            patch.object(session, "_provider_extra_params", return_value={}),
         ):
             session._run_agent(
                 turns,
@@ -3929,7 +3935,16 @@ class TestTruncateBeforeJudge:
 
 
 class TestProviderExtraParams:
-    """Tests for _provider_extra_params — server_compat passthrough only."""
+    """Tests for the session lane's extra_params resolution — server_compat
+    passthrough only.
+
+    #832 deleted ``ChatSession._provider_extra_params``: it was a thin
+    delegate whose last caller was the retired stream-creation ladder, and
+    the resolution now happens inside ``resolve_lane``.  These pin the
+    module function every lane goes through,
+    :func:`turnstone.core.model_turn.provider_extra_params`, with the
+    session's own binding supplied explicitly.
+    """
 
     def _session_with_provider(self, provider_name: str, tmp_db) -> ChatSession:
         from turnstone.core.providers import create_provider
@@ -3938,19 +3953,29 @@ class TestProviderExtraParams:
         session._provider = create_provider(provider_name)
         return session
 
+    @staticmethod
+    def _extra(session: ChatSession, alias: str | None = None):
+        """The session binding's extra_params, as ``resolve_lane`` resolves
+        them (*alias* overrides the primary — the fallback-lane case)."""
+        return provider_extra_params(
+            session._provider,
+            session._registry,
+            alias if alias is not None else (session._model_alias or ""),
+        )
+
     def test_openai_compatible_no_compat_returns_none(self, tmp_db):
         """No server_compat → no extra_body needed (no auto-injection)."""
         session = self._session_with_provider("openai-compatible", tmp_db)
-        assert session._provider_extra_params() is None
+        assert self._extra(session) is None
 
     def test_openai_commercial_no_compat_returns_none(self, tmp_db):
         """Cloud OpenAI without server_compat → None."""
         session = self._session_with_provider("openai", tmp_db)
-        assert session._provider_extra_params() is None
+        assert self._extra(session) is None
 
     def test_anthropic_returns_none(self, tmp_db):
         session = self._session_with_provider("anthropic", tmp_db)
-        assert session._provider_extra_params() is None
+        assert self._extra(session) is None
 
     def test_no_reasoning_effort_kwarg(self, tmp_db):
         """reasoning_effort is not part of the surface; passing it should TypeError.
@@ -3964,7 +3989,7 @@ class TestProviderExtraParams:
         bad_kwargs = {"reasoning_effort": "high"}
         session = self._session_with_provider("openai-compatible", tmp_db)
         with pytest.raises(TypeError):
-            session._provider_extra_params(**bad_kwargs)
+            provider_extra_params(session._provider, session._registry, "", **bad_kwargs)
 
     def test_server_compat_extra_body_passes_through(self, tmp_db):
         """server_compat.extra_body workarounds forward as extra_params."""
@@ -3980,8 +4005,7 @@ class TestProviderExtraParams:
         )
         session._registry = ModelRegistry(models={"test": cfg}, default="test")
         session._model_alias = "test"
-        result = session._provider_extra_params()
-        assert result == {"skip_special_tokens": False}
+        assert self._extra(session) == {"skip_special_tokens": False}
 
     def test_operator_chat_template_kwargs_pass_through(self, tmp_db):
         """Operator-set chat_template_kwargs (e.g. for gpt-oss) forwards verbatim."""
@@ -3997,11 +4021,11 @@ class TestProviderExtraParams:
         )
         session._registry = ModelRegistry(models={"test": cfg}, default="test")
         session._model_alias = "test"
-        result = session._provider_extra_params()
-        assert result == {"chat_template_kwargs": {"reasoning_effort": "high"}}
+        assert self._extra(session) == {"chat_template_kwargs": {"reasoning_effort": "high"}}
 
     def test_model_alias_resolves_target_compat(self, tmp_db):
-        """model_alias parameter selects compat from the target, not the primary."""
+        """The alias argument selects compat from the target, not the primary
+        — the fallback lane's own extra_params, resolved per lane swap."""
         from turnstone.core.model_registry import ModelConfig, ModelRegistry
 
         session = self._session_with_provider("openai-compatible", tmp_db)
@@ -4027,9 +4051,9 @@ class TestProviderExtraParams:
         session._model_alias = "primary"
 
         # Primary alias → gets Gemma workaround
-        assert session._provider_extra_params() == {"skip_special_tokens": False}
+        assert self._extra(session) == {"skip_special_tokens": False}
         # Fallback alias → no compat at all
-        assert session._provider_extra_params(model_alias="fallback") is None
+        assert self._extra(session, "fallback") is None
 
 
 class TestSafePrepareTool:
@@ -5007,7 +5031,7 @@ class TestMemoryCompositionDeferral:
             seen_queries.append(extract_recent_context(dicts_from_turns(session.messages)))
             real_init()
 
-        responses = [{"role": "assistant", "content": "ok"}]
+        responses = [make_result("ok")]
         with _send_with_mocks(
             session, responses, lambda _tc: ([], None), _init_system_messages=spy_init
         ):
@@ -5030,7 +5054,7 @@ class TestMemoryCompositionDeferral:
             nonlocal init_calls
             init_calls += 1
 
-        responses = [{"role": "assistant", "content": "ok"}]
+        responses = [make_result("ok")]
         with _send_with_mocks(
             session, responses, lambda _tc: ([], None), _init_system_messages=spy_init
         ):
@@ -5601,18 +5625,17 @@ class TestMetacognitiveBuffers:
         full ``send`` loop, not just ``_collect_advisories`` in isolation."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -5703,18 +5726,17 @@ class TestMetacognitiveBuffers:
         """
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -5764,18 +5786,17 @@ class TestMetacognitiveBuffers:
         a prefix-only call."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -5819,18 +5840,17 @@ class TestMetacognitiveBuffers:
         breaks this test."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -5913,18 +5933,17 @@ class TestMetacognitiveBuffers:
         ``system`` DB row appended after the tool row."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -5953,18 +5972,17 @@ class TestMetacognitiveBuffers:
         is never spliced into tool content anymore."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "echo", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -5990,18 +6008,17 @@ class TestMetacognitiveBuffers:
         interjection rides its own ``system`` row."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "view_image", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -6039,18 +6056,17 @@ class TestMetacognitiveBuffers:
         carries the interjection — both replay from their own rows."""
         session = _make_session()
         responses = [
-            {
-                "role": "assistant",
-                "content": "calling",
-                "tool_calls": [
+            make_result(
+                "calling",
+                tool_calls=[
                     {
                         "id": "call_x",
                         "type": "function",
                         "function": {"name": "view_image", "arguments": "{}"},
                     }
                 ],
-            },
-            {"role": "assistant", "content": "ack"},
+            ),
+            make_result("ack"),
         ]
 
         def mock_execute(_tool_calls):
@@ -6103,11 +6119,7 @@ class TestMetacognitiveBuffers:
         # gate passes — content of the memories doesn't matter here.
         with (
             patch.object(session, "_visible_memory_count", return_value=3),
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=GenerationCancelled(),
-            ),
+            patch.object(session, "_stream_response", side_effect=GenerationCancelled()),
         ):
             session.send("first user message")
 
@@ -6191,11 +6203,7 @@ class TestMetacognitiveBuffers:
         session._queue_tool_advisory("tool_error", "leftover")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=GenerationCancelled(),
-            ),
+            patch.object(session, "_stream_response", side_effect=GenerationCancelled()),
         ):
             session.send("user input")
 
@@ -6426,7 +6434,12 @@ class TestUpdateTokenTableMsgsParam:
     """``_update_token_table(msgs=...)`` reuses the wire-bound message
     list already built for the stream call instead of re-folding the
     system turns (perf-2), so the calibration char count matches the
-    bytes the provider counted."""
+    bytes the provider counted.
+
+    Post-#832 the main loop feeds it ``ModelTurnResult.wire_msgs``, and
+    the on-the-fly re-fold fallback survives for callers (fake results,
+    direct calls) that have no wire list.  The old leading
+    ``assistant_msg`` argument is gone — the body never read it."""
 
     def test_uses_provided_msgs_skips_re_application(self, tmp_db):
         session = _make_session()
@@ -6440,13 +6453,15 @@ class TestUpdateTokenTableMsgsParam:
         ) as m_prep:
             pre_built = session._prepare_wire_messages(session._full_messages())
             calls_after_prebuild = m_prep.call_count
-            session._update_token_table({"role": "assistant", "content": "ok"}, msgs=pre_built)
+            session._update_token_table(msgs=pre_built)
             # Calibration must not have re-folded.
             assert m_prep.call_count == calls_after_prebuild
 
     def test_falls_back_to_apply_when_msgs_missing(self, tmp_db):
         """The optional kwarg has a fallback so callers that don't (or
-        can't) pre-build the wire copy still get a sane calibration."""
+        can't) pre-build the wire copy still get a sane calibration —
+        a ``ModelTurnResult`` with ``wire_msgs=None`` (the fake-result
+        shape send() passes straight through) takes this path."""
         session = _make_session()
         session._last_usage = {"prompt_tokens": 100, "completion_tokens": 50}
         session.messages.append(turn_from_dict({"role": "user", "content": "hi"}))
@@ -6455,7 +6470,7 @@ class TestUpdateTokenTableMsgsParam:
             "_prepare_wire_messages",
             wraps=session._prepare_wire_messages,
         ) as m_prep:
-            session._update_token_table({"role": "assistant", "content": "ok"})
+            session._update_token_table(msgs=make_result("ok").wire_msgs)
             # Fallback path folds on the fly.
             assert m_prep.call_count == 1
 
@@ -6475,11 +6490,7 @@ class TestUserAdvisoryCancelClear:
         session._queue_user_advisory("denial", "leftover")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=GenerationCancelled(),
-            ),
+            patch.object(session, "_stream_response", side_effect=GenerationCancelled()),
         ):
             session.send("user input")
         assert _user_pending(session) == []
@@ -6489,11 +6500,7 @@ class TestUserAdvisoryCancelClear:
         session._queue_user_advisory("correction", "leftover")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=KeyboardInterrupt(),
-            ),
+            patch.object(session, "_stream_response", side_effect=KeyboardInterrupt()),
             contextlib.suppress(KeyboardInterrupt),
         ):
             session.send("user input")
@@ -6504,11 +6511,7 @@ class TestUserAdvisoryCancelClear:
         session._queue_user_advisory("resume", "leftover")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=RuntimeError("boom"),
-            ),
+            patch.object(session, "_stream_response", side_effect=RuntimeError("boom")),
             contextlib.suppress(RuntimeError),
         ):
             session.send("user input")
@@ -6535,7 +6538,7 @@ class TestUserAdvisoryCancelClear:
         session._title_generated = True
         stream_calls = 0
 
-        def mock_stream_response(msgs, my_generation=0):
+        def mock_stream_response(my_generation=0):
             nonlocal stream_calls
             stream_calls += 1
             if stream_calls == 1:
@@ -6543,7 +6546,7 @@ class TestUserAdvisoryCancelClear:
                 # time the no-tool branch runs ``_flush_queued_messages``,
                 # this item is in the queue waiting to be drained.
                 session.queue_message("late arrival", queue_msg_id="q-late")
-            return {"role": "assistant", "content": "ok"}
+            return make_result("ok")
 
         with (
             patch.object(session, "_stream_response", side_effect=mock_stream_response),
@@ -6591,11 +6594,11 @@ class TestDeliverWakeNudge:
         # won't match.  Bail before synthesizing an empty user turn.
         session._queue_tool_advisory("tool_error", "stale")
         before_len = len(session.messages)
-        with patch.object(session, "_create_stream_with_retry") as stream:
+        with patch.object(session, "_stream_response") as turn:
             session.deliver_wake_nudge_from_queue()
-        # No send → no message appended → stream untouched.
+        # No send → no message appended → the streaming seam untouched.
         assert len(session.messages) == before_len
-        assert stream.call_count == 0
+        assert turn.call_count == 0
         # Tool entry still queued (would orphan in production today; the
         # bail just protects against the empty-envelope failure mode).
         assert _tool_pending(session) == [("tool_error", "stale")]
@@ -6605,10 +6608,10 @@ class TestDeliverWakeNudge:
     def test_no_op_when_queue_is_empty(self, tmp_db):
         session = _make_session()
         before_len = len(session.messages)
-        with patch.object(session, "_create_stream_with_retry") as stream:
+        with patch.object(session, "_stream_response") as turn:
             session.deliver_wake_nudge_from_queue()
         assert len(session.messages) == before_len
-        assert stream.call_count == 0
+        assert turn.call_count == 0
         assert session._wake_source_tag == ""
 
     def test_drains_any_channel_onto_synthetic_empty_user_turn(self, tmp_db):
@@ -6620,12 +6623,7 @@ class TestDeliverWakeNudge:
         session._title_generated = True  # suppress auto-title thread
         session._nudge_queue.enqueue("idle_children", "your kids", "any")
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -6652,12 +6650,7 @@ class TestDeliverWakeNudge:
         session._title_generated = True
         session._queue_user_advisory("denial", "leftover")
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -6675,12 +6668,7 @@ class TestDeliverWakeNudge:
         session._title_generated = True
         session._queue_user_advisory("denial", "x")
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -6711,12 +6699,7 @@ class TestDeliverWakeNudge:
         # otherwise fire a fresh correction nudge.
         session.messages.append(turn_from_dict({"role": "user", "content": "earlier"}))
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -6758,22 +6741,17 @@ class TestDeliverWakeNudge:
         session._title_generated = True
         session._nudge_queue.enqueue("idle_children", "kids", "any")
 
-        def _queue_then_reply(*_a: Any, **_k: Any) -> dict[str, Any]:
+        def _queue_then_reply(*_a: Any, **_k: Any) -> ModelTurnResult:
             # First stream call: a real user message lands mid-wake-turn.
             # Subsequent calls: plain replies until the flush seam empties.
             if not session._queued_messages and not any(
                 "real user input" in str(m.content) for m in session.messages
             ):
                 session.queue_message("real user input", queue_msg_id="q-1")
-            return {"role": "assistant", "content": "ok"}
+            return make_result("ok")
 
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                side_effect=_queue_then_reply,
-            ),
+            patch.object(session, "_stream_response", side_effect=_queue_then_reply),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -6803,11 +6781,7 @@ class TestDeliverWakeNudge:
         session._queue_user_advisory("denial", "leftover")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
-            patch.object(
-                session,
-                "_create_stream_with_retry",
-                side_effect=RuntimeError("boom"),
-            ),
+            patch.object(session, "_stream_response", side_effect=RuntimeError("boom")),
             contextlib.suppress(RuntimeError),
         ):
             session.deliver_wake_nudge_from_queue()
@@ -6832,12 +6806,7 @@ class TestDeliverWakeNudge:
         session._title_generated = True
         session._queue_user_advisory("denial", "leftover")
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
@@ -6863,12 +6832,7 @@ class TestDeliverWakeNudge:
         session._title_generated = True
         session._queue_user_advisory("denial", "do not do that")
         with (
-            patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-            patch.object(
-                session,
-                "_stream_response",
-                return_value={"role": "assistant", "content": "ok"},
-            ),
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -16,6 +16,7 @@ from tests._session_helpers import (
     FakeAnthropicBlock,
     as_stream,
     make_result,
+    make_session,
     mock_completion_result,
     scripted_anthropic_client,
     scripted_chat_client,
@@ -105,19 +106,14 @@ def _make_session(
     instructions=None,
     **kwargs,
 ):
-    """Helper to construct a ChatSession with minimal setup."""
-    client = mock_openai_client or MagicMock()
-    defaults = dict(
-        client=client,
-        model="test-model",
-        ui=NullUI(),
-        instructions=instructions,
-        temperature=0.5,
-        max_tokens=4096,
-        tool_timeout=30,
+    """Wrap the shared session factory with this suite's conveniences
+    (positional mock client; local recording NullUI default).  The
+    defaults live in tests/_session_helpers.make_session — duplicating
+    them here is exactly the drift its docstring warns about."""
+    kwargs.setdefault("ui", NullUI())
+    return make_session(
+        client=mock_openai_client or MagicMock(), instructions=instructions, **kwargs
     )
-    defaults.update(kwargs)
-    return ChatSession(**defaults)
 
 
 @contextlib.contextmanager
@@ -137,7 +133,7 @@ def _send_with_mocks(session, responses, mock_execute, **extra_patches):
     session, value is the ``side_effect`` to inject.
 
     ``responses`` are ``ModelTurnResult``s (build them with
-    ``tests._parity_832.make_result``) — the streaming seam's return
+    ``tests._session_helpers.make_result``) — the streaming seam's return
     type since #832 folded creation and drain into ``model_turn``.  None
     of these tests care HOW the turn was produced, only that one
     happened, so they patch the whole ``_stream_response`` seam rather

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,10 +12,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._oidc_test_helpers import keyed_app_state
-from tests._parity_832 import make_result
 from tests._session_helpers import (
     FakeAnthropicBlock,
     as_stream,
+    make_result,
     mock_completion_result,
     scripted_anthropic_client,
     scripted_chat_client,

--- a/tests/test_session_chat_reasoning_replay.py
+++ b/tests/test_session_chat_reasoning_replay.py
@@ -32,8 +32,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from tests._parity_832 import ArmedHandle
-from tests._session_helpers import as_stream, mock_completion_result, think_tag_stream
+from tests._session_helpers import ArmedHandle, as_stream, mock_completion_result, think_tag_stream
 from tests._session_helpers import make_session as _make_session
 from turnstone.core.model_turn import maybe_attach_vllm_chat_reasoning
 from turnstone.core.providers._anthropic import AnthropicProvider

--- a/tests/test_session_chat_reasoning_replay.py
+++ b/tests/test_session_chat_reasoning_replay.py
@@ -3,17 +3,23 @@
 
 Phase 5 is the only reasoning-replay path that does NOT use the static
 ``supports_reasoning_replay`` capability gate.  It's a parallel path to
-Paths 1+2, gated entirely at the session level on three conditions:
+Paths 1+2, gated on three conditions and nothing else:
 
 1. Provider is ``OpenAIChatCompletionsProvider``.
 2. ``server_compat.server_type == "vllm"``.
 3. Operator-set ``ModelConfig.replay_reasoning_to_model`` is True.
 
-These tests drive through ``ChatSession._maybe_attach_vllm_chat_reasoning``
+These tests drive through ``model_turn.maybe_attach_vllm_chat_reasoning``
 to pin each gate independently, then one round-trip test through the real
 OpenAI Python SDK + httpx MockTransport confirms the ``reasoning`` field
 actually reaches the wire bytes (the SDK-boundary guarantee that the
-session-level attach approach hinges on).
+attach approach hinges on).
+
+The gate ran behind a ``ChatSession`` wrapper until #832 folded the main
+loop onto ``model_turn``; the attach is now one of the seam's own lowering
+passes, reading the lane's registry + alias.  Same three gates, one
+indirection down — and both session funnels (the streaming turn and
+``_utility_completion``) reach it through that one seam.
 """
 
 from __future__ import annotations
@@ -21,13 +27,15 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
 
-from tests._session_helpers import as_stream, mock_completion_result
+from tests._parity_832 import ArmedHandle
+from tests._session_helpers import as_stream, mock_completion_result, think_tag_stream
 from tests._session_helpers import make_session as _make_session
+from turnstone.core.model_turn import maybe_attach_vllm_chat_reasoning
 from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
@@ -90,34 +98,33 @@ def _assistant_msg_with_thinking(text: str = "let me think") -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Gate tests via ``_maybe_attach_vllm_chat_reasoning`` directly
+# Gate tests via ``maybe_attach_vllm_chat_reasoning`` directly
 # ---------------------------------------------------------------------------
 
 
 class TestMaybeAttachVllmChatReasoningGates:
-    """The session-level method that combines all three Phase 5 gates."""
+    """The seam pass that combines all three Phase 5 gates.
+
+    Reads the registry + alias the LANE carries — what the session
+    wrapper used to hand it, resolved per call inside ``model_turn`` so a
+    mid-session admin toggle keeps applying.
+    """
 
     def test_all_gates_pass_attaches_reasoning(self) -> None:
-        session = _make_session()
-        session._registry = _vllm_registry(replay=True)
-        session._model_alias = "qwen3"
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [{"role": "user", "content": "q"}, _assistant_msg_with_thinking("CoT")]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, _vllm_registry(replay=True), "qwen3")
         assert out[1]["reasoning"] == "CoT"
 
     def test_non_chat_completions_provider_is_no_op(self) -> None:
         # Provider isinstance gate: Anthropic / Responses / Google all
         # have their own reasoning-replay paths (Paths 1 / 2) — Phase 5
         # must not double-attach.
-        session = _make_session()
-        session._registry = _vllm_registry(replay=True)
-        session._model_alias = "qwen3"
         provider = AnthropicProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, _vllm_registry(replay=True), "qwen3")
         assert "reasoning" not in out[0]
         # Same reference — no copy made.
         assert out[0] is msgs[0]
@@ -127,13 +134,10 @@ class TestMaybeAttachVllmChatReasoningGates:
         # OpenAIChatCompletionsProvider) — the isinstance gate rejects
         # it cleanly.  This is the load-bearing distinction; an
         # accidental inheritance refactor would break the gate.
-        session = _make_session()
-        session._registry = _vllm_registry(replay=True)
-        session._model_alias = "qwen3"
         provider = OpenAIResponsesProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, _vllm_registry(replay=True), "qwen3")
         assert "reasoning" not in out[0]
 
     @pytest.mark.parametrize("server_type", ["", "llama.cpp", "sglang", "openai", "unknown"])
@@ -141,43 +145,34 @@ class TestMaybeAttachVllmChatReasoningGates:
         # Server-type pin bounds blast radius — canonical OpenAI Chat
         # Completions, llama.cpp, sglang, and any unrecognised server
         # never receive the non-standard ``reasoning`` field.
-        session = _make_session()
-        session._registry = _registry_with_server_type(server_type, replay=True)
-        session._model_alias = "some-model"
+        registry = _registry_with_server_type(server_type, replay=True)
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, registry, "some-model")
         assert "reasoning" not in out[0]
 
     def test_operator_flag_off_is_no_op(self) -> None:
-        session = _make_session()
-        session._registry = _vllm_registry(replay=False)  # operator flag OFF
-        session._model_alias = "qwen3"
+        registry = _vllm_registry(replay=False)  # operator flag OFF
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, registry, "qwen3")
         assert "reasoning" not in out[0]
 
     def test_missing_registry_is_no_op(self) -> None:
-        session = _make_session()
-        session._registry = None
-        session._model_alias = "qwen3"
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, None, "qwen3")
         assert "reasoning" not in out[0]
 
     def test_missing_alias_is_no_op(self) -> None:
-        session = _make_session()
-        session._registry = _vllm_registry(replay=True)
-        session._model_alias = ""
+        # A lane outside the registry carries ``alias=""``.
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, _vllm_registry(replay=True), "")
         assert "reasoning" not in out[0]
 
     def test_registry_exception_is_no_op(self) -> None:
@@ -187,20 +182,17 @@ class TestMaybeAttachVllmChatReasoningGates:
         def boom(_alias: str) -> Any:
             raise KeyError("missing")
 
-        session = _make_session()
-        session._registry = SimpleNamespace(get_config=boom)
-        session._model_alias = "qwen3"
+        registry = SimpleNamespace(get_config=boom)
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        out = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
+        out = maybe_attach_vllm_chat_reasoning(msgs, provider, registry, "qwen3")
         assert "reasoning" not in out[0]
 
-    def test_explicit_alias_arg_overrides_session_default(self) -> None:
-        # When _try_stream forwards an explicit ``model_alias`` (different
-        # from the session's primary), the helper must read THAT alias'
-        # config — not the session's primary.  Mirrors the per-alias
-        # behaviour pinned for _resolve_replay_reasoning_to_model.
+    def test_alias_selects_its_own_config(self) -> None:
+        # The gate reads the config of the alias the LANE resolved — a
+        # fallback lane's alias, not the session's primary.  Mirrors the
+        # per-alias behaviour pinned for resolve_replay_reasoning_to_model.
         def per_alias(alias: str) -> Any:
             return SimpleNamespace(
                 replay_reasoning_to_model=(alias == "wants-replay"),
@@ -208,18 +200,16 @@ class TestMaybeAttachVllmChatReasoningGates:
                 server_compat={"server_type": "vllm"},
             )
 
-        session = _make_session()
-        session._registry = SimpleNamespace(get_config=per_alias)
-        session._model_alias = "primary"
+        registry = SimpleNamespace(get_config=per_alias)
         provider = OpenAIChatCompletionsProvider()
 
         msgs = [_assistant_msg_with_thinking()]
-        # Default alias → flag off → no attach.
-        out_default = session._maybe_attach_vllm_chat_reasoning(msgs, provider)
-        assert "reasoning" not in out_default[0]
-        # Explicit alias arg → flag on → attached.
-        out_explicit = session._maybe_attach_vllm_chat_reasoning(msgs, provider, "wants-replay")
-        assert out_explicit[0]["reasoning"] == "let me think"
+        # Flag off for this alias → no attach.
+        out_primary = maybe_attach_vllm_chat_reasoning(msgs, provider, registry, "primary")
+        assert "reasoning" not in out_primary[0]
+        # Flag on for this one → attached.
+        out_replay = maybe_attach_vllm_chat_reasoning(msgs, provider, registry, "wants-replay")
+        assert out_replay[0]["reasoning"] == "let me think"
 
 
 # ---------------------------------------------------------------------------
@@ -278,7 +268,7 @@ class TestReasoningFieldReachesWireBytes:
         provider = OpenAIChatCompletionsProvider()
 
         # Mimic the post-attach message shape that
-        # ``_maybe_attach_vllm_chat_reasoning`` produces, then sanitize.
+        # ``maybe_attach_vllm_chat_reasoning`` produces, then sanitize.
         # ``sanitize_messages`` runs inside provider._prepare_messages
         # and must preserve the non-``_``-prefixed ``reasoning`` field.
         messages = [
@@ -348,58 +338,55 @@ class TestReasoningFieldReachesWireBytes:
 
 
 # ---------------------------------------------------------------------------
-# Call-site integration: confirm _try_stream and _utility_completion both
-# invoke the helper.  Pins that the 2 hoist points stay in sync; a missed
-# call site is exactly the kind of regression this catches.  The agent
-# _run_agent path is deliberately NOT a Phase 5 hoist — see the NOTE
-# comment inside _run_agent's nested _api_call closure (grep session.py
-# for "Phase 5 vLLM ``reasoning`` field replay is intentionally NOT
-# wired here"): agent assistant messages don't carry
-# ``_provider_content`` so the helper would no-op every turn anyway.
+# Call-site integration: confirm the streaming turn and _utility_completion
+# both reach the attach.  Post-#832 both funnel through ``model_turn``,
+# which runs the pass itself — so these pin that each funnel still goes
+# through that seam (a call site that grew a private wire path would skip
+# it).  The sub-agent loop rides the same seam via ``_run_agent``'s
+# ``_api_call``; its assistant turns carry no ``_provider_content`` in
+# practice, so the pass no-ops there rather than being wired around.
 # ---------------------------------------------------------------------------
 
 
 class TestCallSitesInvokeMaybeAttach:
-    """The helper does nothing unless one of the 2 call sites calls it.
-    Verify the wiring at each — without this, a refactor that drops a
-    call site would silently regress Phase 5 on that path."""
+    """The pass does nothing for a call site that doesn't reach it.
+    Verify the wiring at each — without this, a refactor that gives one
+    funnel its own wire build would silently regress Phase 5 there."""
 
-    def test_try_stream_call_site_attaches(self) -> None:
+    def test_streaming_call_site_attaches(self) -> None:
         session = _make_session()
         session._registry = _vllm_registry(replay=True)
         session._model_alias = "qwen3"
+        session.model = "qwen3"
 
         captured: dict[str, Any] = {}
 
         def capture_streaming(**kwargs: Any) -> Any:
             captured.update(kwargs)
-            return iter([])
+            # The armed/creation classifier reads the cancel_ref, so the
+            # fake arms it eagerly like every real adapter.
+            ref = kwargs.get("cancel_ref")
+            if ref is not None:
+                ref.append(ArmedHandle())
+            return think_tag_stream("ok")
 
         provider = OpenAIChatCompletionsProvider()
         # Patch only the network-facing method so we don't actually call
         # an LLM, but keep the real provider instance (so the isinstance
         # gate sees the right type).
         provider.create_streaming = capture_streaming  # type: ignore[method-assign]
+        session._provider = provider
+        session.messages = turns_from_dicts([_assistant_msg_with_thinking("from the main loop")])
 
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            session._try_stream(
-                client=MagicMock(),
-                model="qwen3",
-                msgs=[_assistant_msg_with_thinking("from try_stream")],
-                provider=provider,
-                model_alias="qwen3",
-            )
+        session._stream_response(0)
 
         # The messages handed to the provider include the attached
-        # reasoning field — proves _try_stream invoked
-        # _maybe_attach_vllm_chat_reasoning before the call.
+        # reasoning field — proves the streaming turn reached the attach.
+        # The wire list carries the session's system messages now, so the
+        # assistant turn is found by role, not by index.
         msgs_sent = captured["messages"]
-        assert msgs_sent[0]["reasoning"] == "from try_stream"
+        assistant = next(m for m in msgs_sent if m["role"] == "assistant")
+        assert assistant["reasoning"] == "from the main loop"
 
     def test_utility_completion_call_site_attaches(self) -> None:
         session = _make_session()
@@ -416,11 +403,11 @@ class TestCallSitesInvokeMaybeAttach:
         provider.create_streaming = capture_streaming  # type: ignore[method-assign]
         session._provider = provider
 
-        with (
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(
-                session, "_get_capabilities", return_value=provider.get_capabilities("qwen3")
-            ),
+        # No extra_params patch: _utility_completion resolves them inside
+        # resolve_lane (a module seam reading the registry config), which
+        # a session-attribute patch cannot intercept.
+        with patch.object(
+            session, "_get_capabilities", return_value=provider.get_capabilities("qwen3")
         ):
             session._utility_completion(
                 turns_from_dicts([_assistant_msg_with_thinking("from utility")]),

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -5,19 +5,24 @@ Phase 2 of optional reasoning persistence reads the per-model
 site and threads it through ``provider.create_streaming`` (the one
 transport post-#831).  These tests pin:
 
-1. The resolver helper (``ChatSession._resolve_replay_reasoning_to_model``)
-   walks the registry correctly and falls back to ``False`` (the
-   conservative default matching the migration server_default) when
-   the lookup fails.
-2. The streaming wire-build call site at ``session.py:_try_stream``
-   actually passes the resolved flag down — without this, the Phase
-   2 work is dead code (the strip-when-False predicate never fires).
-3. The non-streaming wire-build call site at
-   ``session.py:_utility_completion`` does the same.
+1. The resolver (``model_turn.resolve_replay_reasoning_to_model``) walks
+   the registry correctly and falls back to ``False`` (the conservative
+   default matching the migration server_default) when the lookup fails.
+2. The streaming wire-build call site actually passes the resolved flag
+   down — post-#832 that call site is ``model_turn``, reached through
+   ``session._stream_response`` and its lane-swap fallback walk.  Without
+   this the Phase 2 work is dead code (the strip-when-False predicate
+   never fires).
+3. The non-streaming call site at ``session.py:_utility_completion``
+   does the same, through the same ``model_turn`` seam.
 
-Drives through the real ``ChatSession._resolve_replay_reasoning_to_model``
-with a stub registry, then captures the kwarg passed to a mock provider
-to verify the flow end-to-end.
+Drives the real resolver against a stub registry, then reads the kwarg a
+fake provider captured — the same assertion surface as before the fold,
+one caller down.  The capability half of the resolver's AND-gate now
+reaches it as the LANE's capabilities (provider static table + the
+registry's operator overrides) instead of a ``capabilities=`` argument at
+the call site, so tests that supplied their own ``ModelCapabilities``
+state it through the stub registry's ``capabilities`` dict.
 """
 
 from __future__ import annotations
@@ -26,179 +31,165 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from tests._session_helpers import as_stream, mock_completion_result
+from tests._parity_832 import SCENARIOS, scripted_provider
+from tests._session_helpers import (
+    FakeAnthropicBlock,
+    as_stream,
+    fake_anthropic_stream,
+    mock_completion_result,
+)
 from tests._session_helpers import make_session as _make_session
-from turnstone.core.trajectory import Turn
+from turnstone.core.model_turn import resolve_replay_reasoning_to_model
+from turnstone.core.providers._protocol import ModelCapabilities
+from turnstone.core.trajectory import Turn, turns_from_dicts
 
 
-def _registry_with_flag(persist: bool = True, replay: bool = False) -> Any:
+def _registry_with_flag(
+    persist: bool = True,
+    replay: bool = False,
+    caps_overrides: dict[str, Any] | None = None,
+) -> Any:
     """Stub registry returning a ModelConfig-shaped object with the
-    flags under test."""
+    flags under test.  *caps_overrides* rides the config's
+    ``capabilities`` dict, which is how an operator states a model
+    capability the lane must resolve."""
     return SimpleNamespace(
         get_config=lambda alias: SimpleNamespace(
             surface_persisted_reasoning=persist,
             replay_reasoning_to_model=replay,
+            capabilities=dict(caps_overrides or {}),
         )
     )
 
 
+def _flag_capture_provider(*, supports_replay: bool = True) -> MagicMock:
+    """Provider fake recording the kwargs ``model_turn`` built, then
+    replaying a finished stream.
+
+    The eager ``cancel_ref`` arming is mandatory at this seam (the
+    creation-vs-midstream classifier reads it), so the shape comes from
+    ``tests._parity_832.scripted_provider`` verbatim; only the advertised
+    reasoning-replay capability is per-test.
+    """
+    provider = scripted_provider(SCENARIOS["content_only"])
+    provider.get_capabilities.return_value = ModelCapabilities(
+        supports_reasoning_replay=supports_replay
+    )
+    return provider
+
+
+def _drive_stream(session: Any, provider: MagicMock) -> dict[str, Any]:
+    """Run ONE real streaming turn against *provider* and return the
+    kwargs that reached ``create_streaming``."""
+    session._provider = provider
+    session.messages.append(Turn.user("hi"))
+    session._stream_response(0)
+    kwargs: dict[str, Any] = provider.create_streaming.call_args.kwargs
+    return kwargs
+
+
 class TestResolveReplayReasoningToModel:
-    """Direct unit tests for the resolver."""
+    """Direct unit tests for the resolver.
+
+    The session wrapper this class used to call was deleted with the
+    ``_try_stream`` seam (#832): the lane carries the registry and the
+    alias, and ``model_turn`` reads the flag off them per call.  Same
+    resolver, one indirection down — so the case table is unchanged.
+    """
 
     def test_returns_false_when_no_registry(self) -> None:
-        session = _make_session()
-        session._registry = None
-        session._model_alias = "anything"
-        assert session._resolve_replay_reasoning_to_model() is False
+        assert resolve_replay_reasoning_to_model(None, "anything") is False
 
     def test_returns_false_when_no_alias(self) -> None:
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=True)
-        session._model_alias = ""
-        assert session._resolve_replay_reasoning_to_model() is False
+        # A lane outside the registry carries ``alias=""``.
+        assert resolve_replay_reasoning_to_model(_registry_with_flag(replay=True), "") is False
 
     def test_returns_false_default(self) -> None:
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=False)
-        session._model_alias = "claude-opus-4-7"
-        assert session._resolve_replay_reasoning_to_model() is False
+        registry = _registry_with_flag(replay=False)
+        assert resolve_replay_reasoning_to_model(registry, "claude-opus-4-7") is False
 
     def test_returns_true_when_flag_set(self) -> None:
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=True)
-        session._model_alias = "claude-opus-4-7"
-        assert session._resolve_replay_reasoning_to_model() is True
+        registry = _registry_with_flag(replay=True)
+        assert resolve_replay_reasoning_to_model(registry, "claude-opus-4-7") is True
 
-    def test_explicit_alias_arg_overrides_default(self) -> None:
-        session = _make_session()
-
+    def test_alias_selects_its_own_config(self) -> None:
+        # The flag tracks the alias the LANE resolved, not any session
+        # default — the property the fallback walk depends on (pinned
+        # end-to-end by test_fallback_alias_uses_its_own_flag below).
         def per_alias(alias: str) -> Any:
             return SimpleNamespace(
                 replay_reasoning_to_model=(alias == "needs-replay"),
             )
 
-        session._registry = SimpleNamespace(get_config=per_alias)
-        session._model_alias = "primary"
-        # Default reads session._model_alias → False.
-        assert session._resolve_replay_reasoning_to_model() is False
-        # Explicit alias arg → True for "needs-replay".
-        assert session._resolve_replay_reasoning_to_model("needs-replay") is True
+        registry = SimpleNamespace(get_config=per_alias)
+        assert resolve_replay_reasoning_to_model(registry, "primary") is False
+        assert resolve_replay_reasoning_to_model(registry, "needs-replay") is True
 
     def test_returns_false_on_registry_exception(self) -> None:
-        session = _make_session()
-
         def boom(alias: str) -> Any:
             raise KeyError(alias)
 
-        session._registry = SimpleNamespace(get_config=boom)
-        session._model_alias = "missing"
+        registry = SimpleNamespace(get_config=boom)
         # Conservative fallback — losing the strip is a UX nuisance,
         # but accepting wire-side reasoning replay against an unknown
         # operator preference is a worse default.
-        assert session._resolve_replay_reasoning_to_model() is False
+        assert resolve_replay_reasoning_to_model(registry, "missing") is False
 
     def test_caps_none_preserves_back_compat(self) -> None:
         # When ``caps`` is omitted, the resolver returns the operator
         # flag unchanged — matching pre-PR behaviour for any caller
         # that hasn't been updated to thread caps yet.
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=True)
-        session._model_alias = "claude-opus-4-7"
-        assert session._resolve_replay_reasoning_to_model() is True
-        assert session._resolve_replay_reasoning_to_model(caps=None) is True
+        registry = _registry_with_flag(replay=True)
+        assert resolve_replay_reasoning_to_model(registry, "claude-opus-4-7") is True
+        assert resolve_replay_reasoning_to_model(registry, "claude-opus-4-7", caps=None) is True
 
     def test_caps_supports_replay_true_passes_through(self) -> None:
-        from turnstone.core.providers._protocol import ModelCapabilities
-
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=True)
-        session._model_alias = "claude-opus-4-7"
+        registry = _registry_with_flag(replay=True)
         caps = ModelCapabilities(supports_reasoning_replay=True)
-        assert session._resolve_replay_reasoning_to_model(caps=caps) is True
+        assert resolve_replay_reasoning_to_model(registry, "claude-opus-4-7", caps=caps) is True
 
     def test_caps_supports_replay_false_blocks_replay(self) -> None:
-        from turnstone.core.providers._protocol import ModelCapabilities
-
         # Operator flipped replay=True but the model's capability
         # advertises supports_reasoning_replay=False — AND-gate blocks
         # replay so the strip predicate runs at the wire build.
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=True)
-        session._model_alias = "hypothetical-no-replay-claude"
+        registry = _registry_with_flag(replay=True)
         caps = ModelCapabilities(supports_reasoning_replay=False)
-        assert session._resolve_replay_reasoning_to_model(caps=caps) is False
+        alias = "hypothetical-no-replay-claude"
+        assert resolve_replay_reasoning_to_model(registry, alias, caps=caps) is False
 
     def test_caps_supports_replay_true_does_not_force_replay(self) -> None:
-        from turnstone.core.providers._protocol import ModelCapabilities
-
         # Capability True but operator flag False — result must be
         # False (the AND has to be False on either side).
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=False)
-        session._model_alias = "claude-opus-4-7"
+        registry = _registry_with_flag(replay=False)
         caps = ModelCapabilities(supports_reasoning_replay=True)
-        assert session._resolve_replay_reasoning_to_model(caps=caps) is False
+        assert resolve_replay_reasoning_to_model(registry, "claude-opus-4-7", caps=caps) is False
 
 
 class TestStreamingCallSitePassesFlag:
-    """Pin that ``_try_stream`` actually passes the resolved flag to
+    """Pin that the streaming turn actually passes the resolved flag to
     ``provider.create_streaming`` — without this the Phase 2 work is
-    dead code at the call site."""
+    dead code at the call site.
+
+    The call site is ``model_turn`` now, driven through the real
+    ``_stream_response`` wrapper (creation walk → drain → finalize), so
+    the flag rides the lane the walk actually served the turn on.
+    """
 
     def test_replay_true_propagates_to_provider(self) -> None:
         session = _make_session()
         session._registry = _registry_with_flag(replay=True)
         session._model_alias = "claude-opus-4-7"
-        # Stub provider: capture the kwargs passed to create_streaming.
-        captured: dict[str, Any] = {}
-
-        def capture_streaming(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return iter([])
-
-        mock_provider = MagicMock()
-        mock_provider.create_streaming = capture_streaming
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            session._try_stream(
-                client=MagicMock(),
-                model="claude-opus-4-7",
-                msgs=[{"role": "user", "content": "hi"}],
-                provider=mock_provider,
-                model_alias="claude-opus-4-7",
-            )
-        assert captured["replay_reasoning_to_model"] is True
+        kwargs = _drive_stream(session, _flag_capture_provider(supports_replay=True))
+        assert kwargs["replay_reasoning_to_model"] is True
 
     def test_replay_false_propagates_to_provider(self) -> None:
         session = _make_session()
         session._registry = _registry_with_flag(replay=False)
         session._model_alias = "claude-opus-4-7"
-        captured: dict[str, Any] = {}
-
-        def capture_streaming(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return iter([])
-
-        mock_provider = MagicMock()
-        mock_provider.create_streaming = capture_streaming
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            session._try_stream(
-                client=MagicMock(),
-                model="claude-opus-4-7",
-                msgs=[{"role": "user", "content": "hi"}],
-                provider=mock_provider,
-                model_alias="claude-opus-4-7",
-            )
-        assert captured["replay_reasoning_to_model"] is False
+        # Capability advertises replay support: the False comes from the
+        # operator flag alone, not from the AND-gate's other half.
+        kwargs = _drive_stream(session, _flag_capture_provider(supports_replay=True))
+        assert kwargs["replay_reasoning_to_model"] is False
 
     def test_fallback_alias_uses_its_own_flag(self) -> None:
         # When the primary fails and we fall back to an alias with a
@@ -209,52 +200,45 @@ class TestStreamingCallSitePassesFlag:
         def per_alias(alias: str) -> Any:
             return SimpleNamespace(
                 replay_reasoning_to_model=(alias == "fallback-with-replay"),
+                capabilities={},
             )
 
-        session._registry = SimpleNamespace(get_config=per_alias)
+        fb_provider = _flag_capture_provider(supports_replay=True)
+        session._registry = SimpleNamespace(
+            get_config=per_alias,
+            fallback=["fallback-with-replay"],
+            resolve_binding=lambda alias: (MagicMock(), "fallback-model", None, fb_provider, None),
+        )
         session._model_alias = "primary"  # primary has replay=False
-        captured: dict[str, Any] = {}
-
-        def capture_streaming(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return iter([])
-
-        mock_provider = MagicMock()
-        mock_provider.create_streaming = capture_streaming
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            session._try_stream(
-                client=MagicMock(),
-                model="fallback-model",
-                msgs=[{"role": "user", "content": "hi"}],
-                provider=mock_provider,
-                model_alias="fallback-with-replay",
-            )
+        # The primary lane dies at CREATION (raises without arming its
+        # cancel_ref), which is what sends the walk to the next alias; a
+        # non-retryable class keeps the ladder from burning backoff.
+        primary = _flag_capture_provider(supports_replay=True)
+        primary.create_streaming = MagicMock(side_effect=RuntimeError("primary is down"))
+        _drive_stream(session, primary)
         # Resolved against the FALLBACK alias, not the session's primary.
-        assert captured["replay_reasoning_to_model"] is True
+        assert fb_provider.create_streaming.call_args.kwargs["replay_reasoning_to_model"] is True
+        # ...and the primary's own attempt resolved its own alias' flag.
+        assert primary.create_streaming.call_args.kwargs["replay_reasoning_to_model"] is False
 
 
 class TestSessionToWireBoundaryIntegration:
-    """End-to-end integration: session._try_stream -> real
-    AnthropicProvider.create_streaming -> captured Anthropic SDK
+    """End-to-end integration: session._stream_response -> model_turn ->
+    real AnthropicProvider.create_streaming -> captured Anthropic SDK
     boundary call.  Verifies the strip-when-False predicate actually
     fires at the wire payload, not just at the captured kwarg.
 
-    The bare-function-stub tests above (TestStreamingCallSitePassesFlag)
-    pin that ``_try_stream`` PASSES the flag; this test pins that the
-    real provider USES it.  Together they catch:
-      - kwarg renamed at provider boundary -> stub-tests still pass,
-        this one fails on its real-provider assertion.
-      - _convert_messages stops reading the kwarg -> stub-tests still
-        pass, this one fails because the wire payload still carries
+    The provider-fake tests above (TestStreamingCallSitePassesFlag) pin
+    that the streaming turn PASSES the flag; this test pins that the real
+    provider USES it.  Together they catch:
+      - kwarg renamed at provider boundary -> fake-provider tests still
+        pass, this one fails on its real-provider assertion.
+      - _convert_messages stops reading the kwarg -> fake-provider tests
+        still pass, this one fails because the wire payload still carries
         the thinking block.
-      - _try_stream stops calling create_streaming -> stub-tests fail
-        on the captured kwarg, this one fails because the SDK boundary
-        was never reached.
+      - the streaming turn stops calling create_streaming -> fake-provider
+        tests fail on the captured kwarg, this one fails because the SDK
+        boundary was never reached.
 
     Drives through the real ``AnthropicProvider`` with a mock client
     whose ``client.messages.stream`` is captured — the smallest possible
@@ -273,19 +257,16 @@ class TestSessionToWireBoundaryIntegration:
     def _stub_anthropic_client(self) -> tuple[MagicMock, dict[str, object]]:
         """Build a mock Anthropic client + captured-kwargs dict.
 
-        ``client.messages.stream(**kwargs)`` returns a context manager
-        whose ``__enter__`` yields an iterable of zero events — enough
-        to satisfy the ``_iter_with_cleanup`` shape without exercising
-        actual streaming protocol.
+        ``client.messages.stream(**kwargs)`` returns the real event
+        grammar for a one-block reply, so the fused create+drain reaches
+        a finish reason instead of exhausting finish-less (which the
+        post-#832 seam re-issues as an ``IncompleteStreamError``).
         """
         captured: dict[str, object] = {}
 
         def stream(**kwargs: object) -> object:
             captured.update(kwargs)
-            cm = MagicMock()
-            cm.__enter__ = MagicMock(return_value=iter([]))
-            cm.__exit__ = MagicMock(return_value=False)
-            return cm
+            return fake_anthropic_stream([FakeAnthropicBlock(type="text", text="ok")])
 
         client = MagicMock()
         client.messages.stream = stream
@@ -295,38 +276,31 @@ class TestSessionToWireBoundaryIntegration:
         self,
         replay_flag: bool,
         msgs: list[dict[str, object]],
+        caps_overrides: dict[str, Any] | None = None,
     ) -> dict[str, object]:
-        """Run session._try_stream against a real AnthropicProvider with
-        the resolver pre-set to *replay_flag*.  Returns the kwargs
+        """Run one real streaming turn against a real AnthropicProvider
+        with the resolver pre-set to *replay_flag*.  Returns the kwargs
         dict that reached the (mocked) Anthropic SDK boundary.
+
+        *msgs* seeds the session trajectory (the wire list is built from
+        it inside ``model_turn`` now — lowering plus the session's own
+        ``prepare_wire`` passes — instead of being handed to the seam).
         """
         from turnstone.core.providers._anthropic import AnthropicProvider
 
         session = _make_session()
-        session._registry = _registry_with_flag(replay=replay_flag)
+        session._registry = _registry_with_flag(replay=replay_flag, caps_overrides=caps_overrides)
         session._model_alias = "claude-opus-4-7"
+        session.model = "claude-opus-4-7"
         client, captured = self._stub_anthropic_client()
-        real_provider = AnthropicProvider()
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            stream = session._try_stream(
-                client=client,
-                model="claude-opus-4-7",
-                msgs=msgs,
-                provider=real_provider,
-                model_alias="claude-opus-4-7",
-            )
-            # Iterate the stream to drain the (empty) generator and ensure
-            # convert / build_kwargs all ran.
-            list(stream)
+        session.client = client
+        session._provider = AnthropicProvider()
+        session.messages = turns_from_dicts(msgs)
+        session._stream_response(0)
         return captured
 
     def test_replay_false_strips_thinking_at_wire(self) -> None:
-        msgs: list[dict[str, object]] = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "hello"},
             {
                 "role": "assistant",
@@ -357,7 +331,7 @@ class TestSessionToWireBoundaryIntegration:
         assert "secret reasoning" not in flat, "Reasoning text leaked into the SDK boundary payload"
 
     def test_replay_true_preserves_thinking_at_wire(self) -> None:
-        msgs: list[dict[str, object]] = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "hello"},
             {
                 "role": "assistant",
@@ -384,11 +358,11 @@ class TestSessionToWireBoundaryIntegration:
         # replay=True but the model's capability advertises
         # supports_reasoning_replay=False.  AND-gate at the resolver
         # blocks replay, so the strip predicate fires at the wire and
-        # the thinking block does NOT reach the SDK boundary.
-        from turnstone.core.providers._anthropic import AnthropicProvider
-        from turnstone.core.providers._protocol import ModelCapabilities
-
-        msgs: list[dict[str, object]] = [
+        # the thinking block does NOT reach the SDK boundary.  The
+        # capability reaches the resolver as the LANE's — an operator
+        # override on the alias, since the lane resolves its own caps
+        # rather than taking them from the caller.
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "hello"},
             {
                 "role": "assistant",
@@ -401,27 +375,11 @@ class TestSessionToWireBoundaryIntegration:
             {"role": "user", "content": "ack"},
         ]
 
-        session = _make_session()
-        session._registry = _registry_with_flag(replay=True)  # operator opted in
-        session._model_alias = "hypothetical-no-replay-claude"
-        caps = ModelCapabilities(supports_reasoning_replay=False)
-        client, captured = self._stub_anthropic_client()
-        real_provider = AnthropicProvider()
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            stream = session._try_stream(
-                client=client,
-                model="hypothetical-no-replay-claude",
-                msgs=msgs,
-                provider=real_provider,
-                capabilities=caps,
-                model_alias="hypothetical-no-replay-claude",
-            )
-            list(stream)
+        captured = self._drive_session_through_anthropic(
+            True,  # operator opted in
+            msgs,
+            caps_overrides={"supports_reasoning_replay": False},
+        )
 
         wire_msgs = captured.get("messages")
         assert isinstance(wire_msgs, list), (
@@ -440,8 +398,8 @@ class TestSessionToWireBoundaryIntegration:
 
 
 class TestSessionToOpenAIResponsesBoundaryIntegration:
-    """End-to-end integration: session._try_stream -> real
-    OpenAIResponsesProvider.create_streaming -> captured Responses
+    """End-to-end integration: session._stream_response -> model_turn ->
+    real OpenAIResponsesProvider.create_streaming -> captured Responses
     SDK boundary call.  Mirrors the AnthropicProvider test above
     but for the path-2 (Responses API) replay flow.
 
@@ -452,12 +410,14 @@ class TestSessionToOpenAIResponsesBoundaryIntegration:
 
     def _stub_responses_client(self) -> tuple[MagicMock, dict[str, object]]:
         """Mock OpenAI Responses client.  ``client.responses.create``
-        captures kwargs and returns an empty stream iterator."""
+        captures kwargs and returns a stream carrying only the terminal
+        event — the fused create+drain needs a finish reason (a
+        finish-less exhaust is an ``IncompleteStreamError`` post-#832)."""
         captured: dict[str, object] = {}
 
         def create(**kwargs: object) -> object:
             captured.update(kwargs)
-            return iter([])
+            return iter([SimpleNamespace(type="response.completed", response=None)])
 
         client = MagicMock()
         client.responses.create = create
@@ -466,114 +426,71 @@ class TestSessionToOpenAIResponsesBoundaryIntegration:
     def _registry_with_reasoning_capability(
         self, replay: bool = True, supports_replay: bool = True
     ) -> Any:
-        from turnstone.core.providers._protocol import ModelCapabilities
-
+        """Stub registry stating both halves of the gate: the operator
+        flag and — as an alias capability override, the operator's way to
+        state one — the model's reasoning-replay support.  The lane
+        resolves its own capabilities now, so this is where a test says
+        what the model can do."""
         return SimpleNamespace(
             get_config=lambda alias: SimpleNamespace(
                 replay_reasoning_to_model=replay,
-                capabilities={},  # no overrides
-            ),
-            _caps=ModelCapabilities(
-                context_window=400000,
-                supports_temperature=False,
-                reasoning_effort_values=("low", "medium", "high"),
-                default_reasoning_effort="medium",
-                supports_reasoning_replay=supports_replay,
+                capabilities={"supports_reasoning_replay": supports_replay},
             ),
         )
 
-    def test_replay_true_adds_include_to_responses_request(self) -> None:
+    def _drive(self, session: Any, msgs: list[dict[str, Any]]) -> dict[str, object]:
+        """One real streaming turn through the real Responses provider."""
         from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
 
-        registry = self._registry_with_reasoning_capability(replay=True, supports_replay=True)
-        session = _make_session()
-        session._registry = registry
-        session._model_alias = "gpt-5"
         client, captured = self._stub_responses_client()
-        real_provider = OpenAIResponsesProvider()
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            stream = session._try_stream(
-                client=client,
-                model="gpt-5",
-                msgs=[{"role": "user", "content": "hi"}],
-                provider=real_provider,
-                capabilities=registry._caps,
-                model_alias="gpt-5",
-            )
-            list(stream)
+        session.client = client
+        session._provider = OpenAIResponsesProvider()
+        session.messages = turns_from_dicts(msgs)
+        session._stream_response(0)
+        return captured
+
+    def test_replay_true_adds_include_to_responses_request(self) -> None:
+        session = _make_session()
+        session._registry = self._registry_with_reasoning_capability(
+            replay=True, supports_replay=True
+        )
+        session._model_alias = "gpt-5"
+        session.model = "gpt-5"
+        captured = self._drive(session, [{"role": "user", "content": "hi"}])
         assert captured.get("include") == ["reasoning.encrypted_content"]
 
     def test_replay_false_omits_include(self) -> None:
-        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
-
-        registry = self._registry_with_reasoning_capability(replay=False, supports_replay=True)
         session = _make_session()
-        session._registry = registry
+        session._registry = self._registry_with_reasoning_capability(
+            replay=False, supports_replay=True
+        )
         session._model_alias = "gpt-5"
-        client, captured = self._stub_responses_client()
-        real_provider = OpenAIResponsesProvider()
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            stream = session._try_stream(
-                client=client,
-                model="gpt-5",
-                msgs=[{"role": "user", "content": "hi"}],
-                provider=real_provider,
-                capabilities=registry._caps,
-                model_alias="gpt-5",
-            )
-            list(stream)
+        session.model = "gpt-5"
+        captured = self._drive(session, [{"role": "user", "content": "hi"}])
         assert "include" not in captured
 
     def test_capability_false_omits_include_even_when_flag_true(self) -> None:
-        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
-
         # Operator flips replay=True but the model has
         # supports_reasoning_replay=False (e.g. gpt-4o via Responses).
         # Capability gate prevents the include= from being sent.
-        registry = self._registry_with_reasoning_capability(replay=True, supports_replay=False)
         session = _make_session()
-        session._registry = registry
+        session._registry = self._registry_with_reasoning_capability(
+            replay=True, supports_replay=False
+        )
         session._model_alias = "gpt-4o"
-        client, captured = self._stub_responses_client()
-        real_provider = OpenAIResponsesProvider()
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            stream = session._try_stream(
-                client=client,
-                model="gpt-4o",
-                msgs=[{"role": "user", "content": "hi"}],
-                provider=real_provider,
-                capabilities=registry._caps,
-                model_alias="gpt-4o",
-            )
-            list(stream)
+        session.model = "gpt-4o"
+        captured = self._drive(session, [{"role": "user", "content": "hi"}])
         assert "include" not in captured
 
     def test_replay_true_emits_reasoning_input_item(self) -> None:
-        from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
-
-        registry = self._registry_with_reasoning_capability(replay=True, supports_replay=True)
         session = _make_session()
-        session._registry = registry
+        session._registry = self._registry_with_reasoning_capability(
+            replay=True, supports_replay=True
+        )
         session._model_alias = "gpt-5"
-        client, captured = self._stub_responses_client()
-        real_provider = OpenAIResponsesProvider()
+        session.model = "gpt-5"
         # Multi-turn conversation with stored reasoning on assistant turn.
-        msgs: list[dict[str, object]] = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "explain"},
             {
                 "role": "assistant",
@@ -589,21 +506,7 @@ class TestSessionToOpenAIResponsesBoundaryIntegration:
             },
             {"role": "user", "content": "follow-up"},
         ]
-        with (
-            patch.object(session, "_get_active_tools", return_value=None),
-            patch.object(session, "_provider_extra_params", return_value=None),
-            patch.object(session, "_get_deferred_names", return_value=frozenset()),
-            patch.object(session, "_check_cancelled"),
-        ):
-            stream = session._try_stream(
-                client=client,
-                model="gpt-5",
-                msgs=msgs,
-                provider=real_provider,
-                capabilities=registry._caps,
-                model_alias="gpt-5",
-            )
-            list(stream)
+        captured = self._drive(session, msgs)
         # Walk the wire input items — one of them must be the reasoning
         # round-trip (id matches what we stored).
         wire_input = captured.get("input")
@@ -619,8 +522,6 @@ class TestUtilityCompletionPassesFlag:
     same plumbing requirement as streaming."""
 
     def test_utility_completion_passes_resolved_flag(self) -> None:
-        from turnstone.core.providers._protocol import ModelCapabilities
-
         session = _make_session()
         session._registry = _registry_with_flag(replay=True)
         session._model_alias = "claude-opus-4-7"
@@ -634,9 +535,9 @@ class TestUtilityCompletionPassesFlag:
         mock_provider.create_streaming = capture_streaming
         session._provider = mock_provider
         caps = ModelCapabilities(max_output_tokens=0, supports_reasoning_replay=True)
-        # No _provider_extra_params patch: _utility_completion resolves
-        # extra_params inside resolve_lane (module seam), which a
-        # session-attribute patch cannot intercept.
+        # No extra_params patch: _utility_completion resolves them inside
+        # resolve_lane (a module seam reading the registry config), which
+        # a session-attribute patch cannot intercept.
         with patch.object(session, "_get_capabilities", return_value=caps):
             session._utility_completion(
                 [Turn.user("summarize")],

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -31,12 +31,13 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from tests._parity_832 import SCENARIOS, scripted_provider
+from tests._parity_832 import SCENARIOS
 from tests._session_helpers import (
     FakeAnthropicBlock,
     as_stream,
     fake_anthropic_stream,
     mock_completion_result,
+    scripted_provider,
 )
 from tests._session_helpers import make_session as _make_session
 from turnstone.core.model_turn import resolve_replay_reasoning_to_model

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -28,9 +28,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-from tests._parity_832 import scripted_provider
 from tests._session_helpers import make_session as _make_session
-from turnstone.core.model_turn import _server_type_of, synth_reasoning_block
+from tests._session_helpers import scripted_provider
+from turnstone.core.model_turn import (
+    _server_type_of,
+    finalize_provider_blocks,
+    synth_reasoning_block,
+)
 from turnstone.core.providers._anthropic import (
     ANTHROPIC_VALID_BLOCK_TYPES,
     AnthropicProvider,
@@ -339,7 +343,9 @@ class TestServerTypeOf:
 
 class TestFinalizeProviderBlocks:
     """Direct unit tests for the shared native-lane builder
-    ``ChatSession._finalize_provider_blocks`` — in particular the
+    ``model_turn.finalize_provider_blocks`` (the session's streaming
+    wrapper calls it with the session registry/alias, which these tests
+    pass explicitly) — in particular the
     ``had_blank_ids`` gate (a uuid back-fill reaches only the tool_calls
     mirror, so blocks that would replay the blank id must be dropped while
     the reasoning lane survives)."""
@@ -350,7 +356,13 @@ class TestFinalizeProviderBlocks:
             {"type": "thinking", "thinking": "x", "signature": "s"},
             {"type": "tool_use", "id": "toolu_1", "name": "f", "input": {}},
         ]
-        out = session._finalize_provider_blocks(blocks, [], has_tool_calls=True)
+        out = finalize_provider_blocks(
+            blocks,
+            [],
+            has_tool_calls=True,
+            registry=session._registry,
+            alias=session._model_alias or "",
+        )
         assert out is blocks
 
     def test_no_tool_calls_strips_orphan_client_blocks(self) -> None:
@@ -359,7 +371,13 @@ class TestFinalizeProviderBlocks:
             {"type": "thinking", "thinking": "x", "signature": "s"},
             {"type": "tool_use", "id": "toolu_1", "name": "f", "input": {}},
         ]
-        out = session._finalize_provider_blocks(blocks, [], has_tool_calls=False)
+        out = finalize_provider_blocks(
+            blocks,
+            [],
+            has_tool_calls=False,
+            registry=session._registry,
+            alias=session._model_alias or "",
+        )
         assert [b["type"] for b in out] == ["thinking"]
 
     def test_blank_ids_drop_messages_shaped_lane_entirely(self) -> None:
@@ -374,7 +392,14 @@ class TestFinalizeProviderBlocks:
             {"type": "text", "text": "using f"},
             {"type": "tool_use", "id": "", "name": "f", "input": {}},
         ]
-        out = session._finalize_provider_blocks(blocks, [], has_tool_calls=True, had_blank_ids=True)
+        out = finalize_provider_blocks(
+            blocks,
+            [],
+            has_tool_calls=True,
+            had_blank_ids=True,
+            registry=session._registry,
+            alias=session._model_alias or "",
+        )
         assert out == []
 
     def test_blank_ids_drop_asymmetric_thinking_lane_without_tool_blocks(self) -> None:
@@ -386,7 +411,14 @@ class TestFinalizeProviderBlocks:
             {"type": "thinking", "thinking": "x", "signature": "s"},
             {"type": "text", "text": "t"},
         ]
-        out = session._finalize_provider_blocks(blocks, [], has_tool_calls=True, had_blank_ids=True)
+        out = finalize_provider_blocks(
+            blocks,
+            [],
+            has_tool_calls=True,
+            had_blank_ids=True,
+            registry=session._registry,
+            alias=session._model_alias or "",
+        )
         assert out == []
 
     def test_blank_ids_drop_responses_reasoning_items(self) -> None:
@@ -398,7 +430,14 @@ class TestFinalizeProviderBlocks:
             {"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": "enc"},
             {"type": "function_call", "call_id": "", "name": "f", "arguments": "{}"},
         ]
-        out = session._finalize_provider_blocks(blocks, [], has_tool_calls=True, had_blank_ids=True)
+        out = finalize_provider_blocks(
+            blocks,
+            [],
+            has_tool_calls=True,
+            had_blank_ids=True,
+            registry=session._registry,
+            alias=session._model_alias or "",
+        )
         assert out == []
 
     def test_blank_ids_keep_only_reasoning_text(self) -> None:
@@ -411,8 +450,13 @@ class TestFinalizeProviderBlocks:
         blocks = [
             {"id": "", "type": "function", "function": {"name": "f", "arguments": "{}"}},
         ]
-        out = session._finalize_provider_blocks(
-            blocks, ["thinking text"], has_tool_calls=True, had_blank_ids=True
+        out = finalize_provider_blocks(
+            blocks,
+            ["thinking text"],
+            has_tool_calls=True,
+            had_blank_ids=True,
+            registry=session._registry,
+            alias=session._model_alias or "",
         )
         assert [b["type"] for b in out] == ["reasoning_text"]
         assert out[0]["text"] == "thinking text"
@@ -422,7 +466,12 @@ class TestFinalizeProviderBlocks:
         # but no client tool blocks at all — nothing can desync, so the
         # synthesized reasoning lane must be kept (the over-drop case).
         session = _make_session()
-        out = session._finalize_provider_blocks(
-            [], ["step by step"], has_tool_calls=True, had_blank_ids=True
+        out = finalize_provider_blocks(
+            [],
+            ["step by step"],
+            has_tool_calls=True,
+            had_blank_ids=True,
+            registry=session._registry,
+            alias=session._model_alias or "",
         )
         assert [b["type"] for b in out] == ["reasoning_text"]

--- a/tests/test_session_synth_reasoning_block.py
+++ b/tests/test_session_synth_reasoning_block.py
@@ -8,9 +8,8 @@ provider_blocks shape on the wire, so the captured reasoning text is
 stamped onto ``_provider_content`` as a synthetic
 ``{type: "reasoning_text"}`` block at the end of the turn by
 ``model_turn.synth_reasoning_block`` — the one synthesizer every lane
-runs (the main loop reaches it through ``ChatSession._stream_attempt``
-→ ``_finalize_provider_blocks``; agents and judges through
-``model_turn``).
+runs (every lane — main loop, agents, judges — reaches it through
+``model_turn.model_turn``'s ``finalize_provider_blocks`` call).
 
 These tests pin:
 1. The synthesizer fires only when no native blocks were emitted AND
@@ -29,6 +28,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from tests._parity_832 import scripted_provider
 from tests._session_helpers import make_session as _make_session
 from turnstone.core.model_turn import _server_type_of, synth_reasoning_block
 from turnstone.core.providers._anthropic import (
@@ -36,6 +36,8 @@ from turnstone.core.providers._anthropic import (
     AnthropicProvider,
 )
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+from turnstone.core.providers._protocol import StreamChunk, UsageInfo
+from turnstone.core.trajectory import Turn
 
 
 class TestSynthReasoningBlock:
@@ -210,25 +212,24 @@ class TestOpenAIChatExtractReasoningText:
         assert provider.extract_reasoning_text(blocks) == ""
 
 
-class TestStreamAttemptSynthBlockIntegration:
+class TestStreamResponseSynthBlockIntegration:
     """Integration test: drives a fake reasoning-emitting stream
-    through ``ChatSession._stream_attempt`` and asserts the
-    synthesizer wires up correctly.  Pins the call site at
-    ``session.py`` (where ``model_turn.synth_reasoning_block`` is
-    invoked — via ``_finalize_provider_blocks`` — on the assembled
-    provider_blocks before stamping ``_provider_content``) — without
+    through ``session._stream_response`` (the real drain seam —
+    ``_stream_attempt`` no longer exists post-#832) and asserts the
+    synthesizer wires up correctly.  Pins the call site inside
+    ``model_turn.model_turn`` (where ``model_turn.synth_reasoning_block``
+    is invoked — via ``finalize_provider_blocks`` — on the assembled
+    provider_blocks before the result's native lane is built) — without
     this, a future refactor that drops the synthesizer call would
     silently break path-3 capture (vLLM/llama.cpp/Gemini-compat
     reasoning would be visible live but invisible on history reload).
     """
 
-    def _make_stream(self, content: str, reasoning: str) -> Any:
-        """Build an iterator of StreamChunks that mimic a path-3
-        capture (reasoning_delta chunks, content chunks, no
-        provider_blocks emitted).
+    def _make_chunks(self, content: str, reasoning: str) -> list[StreamChunk]:
+        """Build a chunk script that mimics a path-3 capture
+        (reasoning_delta chunks, content chunks, no provider_blocks
+        emitted).
         """
-        from turnstone.core.providers._protocol import StreamChunk, UsageInfo
-
         chunks = []
         # Reasoning first (matches live SSE order).
         if reasoning:
@@ -248,39 +249,44 @@ class TestStreamAttemptSynthBlockIntegration:
                 usage=UsageInfo(prompt_tokens=10, completion_tokens=20, total_tokens=30),
             )
         )
-        return iter(chunks)
+        return chunks
 
-    def test_stream_attempt_stamps_synth_block_when_path3_reasoning_captured(
+    def test_stream_response_stamps_synth_block_when_path3_reasoning_captured(
         self,
     ) -> None:
         """Drive a fake stream emitting reasoning_delta chunks (no
-        native provider_blocks) through ``_stream_attempt``; assert
-        the resulting assistant_msg carries a synthetic reasoning_text
-        block stamped onto ``_provider_content``."""
+        native provider_blocks) through ``_stream_response``; assert
+        the resulting turn carries a synthetic reasoning_text block on
+        its native lane."""
         session = _make_session()
         # No registry → source field omitted from synth block.
-        stream = self._make_stream(content="Final answer.", reasoning="path-3 reasoning")
-        msg = session._stream_attempt(stream)
-        assert msg["role"] == "assistant"
-        assert msg["content"] == "Final answer."
-        # Synthetic block should be stamped onto _provider_content.
-        provider_content = msg.get("_provider_content")
-        assert isinstance(provider_content, list)
-        assert len(provider_content) == 1
-        assert provider_content[0]["type"] == "reasoning_text"
-        assert provider_content[0]["text"] == "path-3 reasoning"
+        session._provider = scripted_provider(
+            self._make_chunks(content="Final answer.", reasoning="path-3 reasoning")
+        )
+        session.messages.append(Turn.user("hi"))
+        result = session._stream_response(0)
+        assert result.content == "Final answer."
+        # Synthetic block should be stamped onto the native lane.
+        assert result.turn.native is not None
+        blocks = list(result.turn.native.blocks)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "reasoning_text"
+        assert blocks[0]["text"] == "path-3 reasoning"
 
-    def test_stream_attempt_no_synth_when_no_reasoning_captured(self) -> None:
+    def test_stream_response_no_synth_when_no_reasoning_captured(self) -> None:
         """Stream emits only content (no reasoning_delta).  No synth
-        block stamped — _provider_content key absent on assistant_msg."""
+        block stamped — the result's native lane is absent."""
         session = _make_session()
-        stream = self._make_stream(content="just content", reasoning="")
-        msg = session._stream_attempt(stream)
-        assert msg["content"] == "just content"
-        # No synth block (and no native blocks either) → key absent.
-        assert "_provider_content" not in msg
+        session._provider = scripted_provider(
+            self._make_chunks(content="just content", reasoning="")
+        )
+        session.messages.append(Turn.user("hi"))
+        result = session._stream_response(0)
+        assert result.content == "just content"
+        # No synth block (and no native blocks either) → native absent.
+        assert result.turn.native is None
 
-    def test_stream_attempt_synth_block_carries_source_when_server_type_resolvable(
+    def test_stream_response_synth_block_carries_source_when_server_type_resolvable(
         self,
     ) -> None:
         """When the active model has server_compat.server_type set,
@@ -293,11 +299,14 @@ class TestStreamAttemptSynthBlockIntegration:
             )
         )
         session._model_alias = "qwen3-32b"
-        stream = self._make_stream(content="answer", reasoning="reasoning text")
-        msg = session._stream_attempt(stream)
-        provider_content = msg.get("_provider_content")
-        assert isinstance(provider_content, list)
-        assert provider_content[0]["source"] == "vllm"
+        session._provider = scripted_provider(
+            self._make_chunks(content="answer", reasoning="reasoning text")
+        )
+        session.messages.append(Turn.user("hi"))
+        result = session._stream_response(0)
+        assert result.turn.native is not None
+        blocks = list(result.turn.native.blocks)
+        assert blocks[0]["source"] == "vllm"
 
 
 class TestServerTypeOf:

--- a/tests/test_think_tag_split.py
+++ b/tests/test_think_tag_split.py
@@ -391,26 +391,30 @@ class TestCloseRun:
     def test_plain_tail_emits_as_content(self):
         sp, events = self._splitter()
         sp.feed("Short")
-        sp.close_run()
+        assert sp.close_run() == ""
         assert events == [("Short", False)]
         assert sp.pending == ""
 
-    def test_partial_tag_tail_is_held(self):
+    def test_partial_tag_tail_is_returned_not_held(self):
+        # The carry's lifetime belongs to the RUN OWNER: the splitter's
+        # own pending would be re-read under a flipped in_think (the
+        # round-2 relabel defect), so close_run hands the tail back and
+        # clears its buffer.
         sp, events = self._splitter()
         sp.feed("Ans<thi")
-        sp.close_run()
+        assert sp.close_run() == "<thi"
         assert events == [("Ans", False)]
-        assert sp.pending == "<thi"
+        assert sp.pending == ""
 
     def test_reasoning_state_tail_emits_as_reasoning(self):
         sp, events = self._splitter()
         sp.in_think = True
         sp.feed("held thought")
-        sp.close_run()
+        assert sp.close_run() == ""
         assert events == [("held thought", True)]
         assert sp.pending == ""
 
     def test_empty_pending_is_noop(self):
         sp, events = self._splitter()
-        sp.close_run()
+        assert sp.close_run() == ""
         assert events == []

--- a/tests/test_think_tag_split.py
+++ b/tests/test_think_tag_split.py
@@ -1,10 +1,12 @@
 """Behavior pins for the interactive think-tag splitting layer.
 
-``ChatSession._stream_attempt`` splits streamed content into content vs
-reasoning around ``<think>``/``<reasoning>`` tags, buffering potential
-partial tags across chunk boundaries.  These tables pin the CURRENT
-emission behavior — exact UI token sequence and final message content —
-so the logic can move into a standalone ``ThinkTagSplitter`` class with
+``turnstone.core.session._StreamTurnConsumer`` (the main loop's
+chunk→UI translation, ``model_turn``'s ``on_chunk`` body post-#832)
+splits streamed content into content vs reasoning around
+``<think>``/``<reasoning>`` tags, buffering potential partial tags
+across chunk boundaries.  These tables pin the CURRENT emission
+behavior — exact UI token sequence and final displayed content — so
+the logic can move into a standalone ``ThinkTagSplitter`` class with
 byte-identical output.  Every case drives the real chunk consumer end to
 end; none reaches into the implementation, so the same rows must stay
 green across the extraction.
@@ -23,18 +25,23 @@ Pinned rules:
 """
 
 import random
+from unittest.mock import MagicMock
 
 import pytest
 
+from tests._parity_832 import scripted_provider
 from tests._reasoning_dialect import CASES as DIALECT_CASES
 from tests._session_helpers import make_session
+from turnstone.core.model_turn import ModelLane
 from turnstone.core.providers import StreamChunk, ToolCallDelta
+from turnstone.core.session import _StreamTurnConsumer
 from turnstone.core.streaming_text import ThinkTagSplitter, split_inline_reasoning
+from turnstone.core.trajectory import Turn
 
 
 class _TokenRecorderUI:
     """Records dispatched token events; stubs the rest of the surface
-    ``_stream_attempt`` touches."""
+    ``_StreamTurnConsumer`` touches."""
 
     def __init__(self):
         self.tokens = []
@@ -58,13 +65,24 @@ class _TokenRecorderUI:
         pass
 
 
-def _drive(chunks, *, show_reasoning=True):
+def _drive(chunks, *, show_reasoning=True, capabilities=None):
+    """Drive *chunks* through a bare ``_StreamTurnConsumer`` — the
+    display-grid seam post-#832 (``_stream_attempt`` is gone; tool_calls
+    assembly is the drain's job now, so this helper is for display-only
+    pins — content emission order plus the accumulated displayed text).
+    """
     session = make_session()
     session.show_reasoning = show_reasoning
     ui = _TokenRecorderUI()
     session.ui = ui
-    msg = session._stream_attempt(iter(chunks))
-    return msg, ui.tokens
+    lane = ModelLane(
+        provider=MagicMock(), client=MagicMock(), model="test-model", capabilities=capabilities
+    )
+    consumer = _StreamTurnConsumer(session, lane, 0)
+    for chunk in chunks:
+        consumer(chunk)
+    consumer.finish_stream()
+    return "".join(consumer._content_parts), ui.tokens
 
 
 def _c(text):
@@ -150,15 +168,15 @@ CASES = [
     ids=[c[0] for c in CASES],
 )
 def test_tag_splitting_emissions(chunks, expected_events, expected_content):
-    msg, tokens = _drive(chunks)
+    content, tokens = _drive(chunks)
     assert tokens == expected_events
-    assert msg["content"] == expected_content
+    assert content == expected_content
 
 
 def test_show_reasoning_off_suppresses_reasoning_dispatch_only():
-    msg, tokens = _drive([_c("<think>deep</think>answer"), _FINISH], show_reasoning=False)
+    content, tokens = _drive([_c("<think>deep</think>answer"), _FINISH], show_reasoning=False)
     assert tokens == [("content", "answer")]
-    assert msg["content"] == "answer"
+    assert content == "answer"
 
 
 def test_splitter_standalone_contract():
@@ -213,19 +231,19 @@ def test_scan_tags_off_returns_every_utterance_byte_identical(case):
 
 def test_session_consumer_scan_follows_server_parses_reasoning():
     """The interactive consumer wires ``scan_tags`` from the SAME capability
-    the drain seam reads (``server_parses_reasoning``), so the two lanes
-    cannot disagree.  With the flag declared, streamed tag text reaches the
-    UI verbatim as content — it is prose on such a backend, not a
-    boundary."""
+    the drain seam reads (``server_parses_reasoning``), taken off the
+    ACTIVE lane post-#832 (no more session-level ``_cached_capabilities``
+    read at the consumer).  With the flag declared, streamed tag text
+    reaches the UI verbatim as content — it is prose on such a backend,
+    not a boundary."""
     from turnstone.core.providers._protocol import ModelCapabilities
 
-    session = make_session()
-    session._cached_capabilities = ModelCapabilities(server_parses_reasoning=True)
-    ui = _TokenRecorderUI()
-    session.ui = ui
-    msg = session._stream_attempt(iter([_c("<think>quoted</think>answer"), _FINISH]))
-    assert msg["content"] == "<think>quoted</think>answer"
-    assert all(kind == "content" for kind, _ in ui.tokens)
+    content, tokens = _drive(
+        [_c("<think>quoted</think>answer"), _FINISH],
+        capabilities=ModelCapabilities(server_parses_reasoning=True),
+    )
+    assert content == "<think>quoted</think>answer"
+    assert all(kind == "content" for kind, _ in tokens)
 
 
 def test_scan_tags_off_holds_no_carry_and_honors_out_of_band_state():
@@ -268,7 +286,12 @@ def test_one_shot_equivalent_to_streaming_over_random_chunkings(case):
 
 def test_tool_calls_flush_pending_raw_at_current_state():
     # Once tool calls begin, buffered text cannot be a partial tag: it
-    # flushes RAW (no tag scan) at the current in_think state.
+    # flushes RAW (no tag scan) at the current in_think state.  Tool_calls
+    # assembly is the drain's job post-#832 (the display consumer only
+    # flushes the splitter at the boundary), so this one needs the real
+    # seam — session._stream_response over scripted_provider — to pin the
+    # display order and the assembled call together, as the fused
+    # pre-fold consumer did.
     chunks = [
         _c("part<thi"),
         StreamChunk(tool_call_deltas=[ToolCallDelta(index=0, id="tc1", name="bash")]),
@@ -277,9 +300,14 @@ def test_tool_calls_flush_pending_raw_at_current_state():
             finish_reason="tool_calls",
         ),
     ]
-    msg, tokens = _drive(chunks)
-    assert tokens == [("content", "part<thi")]
-    assert msg["content"] == "part<thi"
-    assert msg["tool_calls"] == [
+    session = make_session()
+    ui = _TokenRecorderUI()
+    session.ui = ui
+    session._provider = scripted_provider(chunks)
+    session.messages.append(Turn.user("hi"))
+    result = session._stream_response(0)
+    assert ui.tokens == [("content", "part<thi")]
+    assert result.content == "part<thi"
+    assert result.tool_calls == [
         {"id": "tc1", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
     ]

--- a/tests/test_think_tag_split.py
+++ b/tests/test_think_tag_split.py
@@ -29,12 +29,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tests._parity_832 import scripted_provider
 from tests._reasoning_dialect import CASES as DIALECT_CASES
-from tests._session_helpers import make_session
+from tests._session_helpers import make_session, scripted_provider
 from turnstone.core.model_turn import ModelLane
 from turnstone.core.providers import StreamChunk, ToolCallDelta
-from turnstone.core.session import _StreamTurnConsumer
+from turnstone.core.session import _CancelRef, _StreamTurnConsumer
 from turnstone.core.streaming_text import ThinkTagSplitter, split_inline_reasoning
 from turnstone.core.trajectory import Turn
 
@@ -78,7 +77,10 @@ def _drive(chunks, *, show_reasoning=True, capabilities=None):
     lane = ModelLane(
         provider=MagicMock(), client=MagicMock(), model="test-model", capabilities=capabilities
     )
-    consumer = _StreamTurnConsumer(session, lane, 0)
+    consumer = _StreamTurnConsumer(session, 0)
+    # begin_attempt is the consumer's SOLE per-attempt initializer (the
+    # lane-free constructor carries no display state of its own).
+    consumer.begin_attempt(_CancelRef(session, 0), None, lane)
     for chunk in chunks:
         consumer(chunk)
     consumer.finish_stream()

--- a/tests/test_think_tag_split.py
+++ b/tests/test_think_tag_split.py
@@ -1,15 +1,14 @@
 """Behavior pins for the interactive think-tag splitting layer.
 
-``turnstone.core.session._StreamTurnConsumer`` (the main loop's
-chunk→UI translation, ``model_turn``'s ``on_chunk`` body post-#832)
-splits streamed content into content vs reasoning around
-``<think>``/``<reasoning>`` tags, buffering potential partial tags
-across chunk boundaries.  These tables pin the CURRENT emission
-behavior — exact UI token sequence and final displayed content — so
-the logic can move into a standalone ``ThinkTagSplitter`` class with
-byte-identical output.  Every case drives the real chunk consumer end to
-end; none reaches into the implementation, so the same rows must stay
-green across the extraction.
+``turnstone.core.session._StreamTurnConsumer`` (the main loop's chunk→UI
+translation, ``model_turn``'s ``on_chunk`` body) splits streamed content
+into content vs reasoning around ``<think>``/``<reasoning>`` tags,
+buffering potential partial tags across chunk boundaries.  These tables
+pin the CURRENT emission behavior — exact UI token sequence and final
+displayed content — so the logic can move into a standalone
+``ThinkTagSplitter`` class with byte-identical output.  Every case drives
+the real chunk consumer end to end; none reaches into the
+implementation, so the same rows must stay green across the extraction.
 
 Pinned rules:
 
@@ -70,9 +69,9 @@ class _TokenRecorderUI:
 
 def _drive(chunks, *, show_reasoning=True, capabilities=None):
     """Drive *chunks* through a bare ``_StreamTurnConsumer`` — the
-    display-grid seam post-#832 (``_stream_attempt`` is gone; tool_calls
-    assembly is the drain's job now, so this helper is for display-only
-    pins — content emission order plus the accumulated displayed text).
+    display-grid seam.  Tool-call assembly is the drain's job, so this
+    helper serves display-only pins: content emission order plus the
+    accumulated displayed text.
     """
     session = make_session()
     session.show_reasoning = show_reasoning
@@ -165,9 +164,9 @@ CASES = [
         [("reasoning", "y" * 8), ("reasoning", "y" * 12), ("content", "ok")],
         "ok",
     ),
-    # Reasoning-boundary run close (live-caught #832 divergence): a
-    # buffered content tail must emit as CONTENT when a reasoning_delta
-    # arrives, exactly as the drain closes its per-run split there.
+    # Reasoning-boundary run close: a buffered content tail must emit as
+    # CONTENT when a reasoning_delta arrives, exactly as the drain closes
+    # its per-run split there.
     (
         "reasoning_boundary_closes_short_content_run",
         [_c("Short"), StreamChunk(reasoning_delta="(r)"), _FINISH],
@@ -273,10 +272,9 @@ def test_scan_tags_off_returns_every_utterance_byte_identical(case):
 def test_session_consumer_scan_follows_server_parses_reasoning():
     """The interactive consumer wires ``scan_tags`` from the SAME capability
     the drain seam reads (``server_parses_reasoning``), taken off the
-    ACTIVE lane post-#832 (no more session-level ``_cached_capabilities``
-    read at the consumer).  With the flag declared, streamed tag text
-    reaches the UI verbatim as content — it is prose on such a backend,
-    not a boundary."""
+    ACTIVE lane.  With the flag declared, streamed tag text reaches the UI
+    verbatim as content — it is prose on such a backend, not a
+    boundary."""
     from turnstone.core.providers._protocol import ModelCapabilities
 
     content, tokens = _drive(
@@ -327,12 +325,10 @@ def test_one_shot_equivalent_to_streaming_over_random_chunkings(case):
 
 def test_tool_calls_flush_pending_raw_at_current_state():
     # Once tool calls begin, buffered text cannot be a partial tag: it
-    # flushes RAW (no tag scan) at the current in_think state.  Tool_calls
-    # assembly is the drain's job post-#832 (the display consumer only
-    # flushes the splitter at the boundary), so this one needs the real
-    # seam — session._stream_response over scripted_provider — to pin the
-    # display order and the assembled call together, as the fused
-    # pre-fold consumer did.
+    # flushes RAW (no tag scan) at the current in_think state.  Assembly
+    # is the drain's job while the consumer only flushes the splitter, so
+    # this pin drives the real seam to hold the display order and the
+    # assembled call together.
     chunks = [
         _c("part<thi"),
         StreamChunk(tool_call_deltas=[ToolCallDelta(index=0, id="tc1", name="bash")]),
@@ -357,9 +353,8 @@ def test_tool_calls_flush_pending_raw_at_current_state():
 class TestPartialTagTail:
     """Boundary-contract rows for ``partial_tag_tail``: only a PROPER
     prefix of a tag is a partial tag.  A complete tag self-matching via
-    ``startswith`` was the live-caught latent bug — the drain then
-    carried a finished ``<reasoning>`` across a run boundary as if it
-    might still grow, relabeling the next run."""
+    ``startswith`` makes the drain carry a finished ``<reasoning>`` across
+    a run boundary as if it might still grow, relabeling the next run."""
 
     @pytest.mark.parametrize(
         ("text", "tail"),
@@ -397,9 +392,9 @@ class TestCloseRun:
 
     def test_partial_tag_tail_is_returned_not_held(self):
         # The carry's lifetime belongs to the RUN OWNER: the splitter's
-        # own pending would be re-read under a flipped in_think (the
-        # round-2 relabel defect), so close_run hands the tail back and
-        # clears its buffer.
+        # own pending would be re-read under a flipped in_think and
+        # relabeled, so close_run hands the tail back and clears its
+        # buffer.
         sp, events = self._splitter()
         sp.feed("Ans<thi")
         assert sp.close_run() == "<thi"

--- a/tests/test_think_tag_split.py
+++ b/tests/test_think_tag_split.py
@@ -34,7 +34,11 @@ from tests._session_helpers import make_session, scripted_provider
 from turnstone.core.model_turn import ModelLane
 from turnstone.core.providers import StreamChunk, ToolCallDelta
 from turnstone.core.session import _CancelRef, _StreamTurnConsumer
-from turnstone.core.streaming_text import ThinkTagSplitter, split_inline_reasoning
+from turnstone.core.streaming_text import (
+    ThinkTagSplitter,
+    partial_tag_tail,
+    split_inline_reasoning,
+)
 from turnstone.core.trajectory import Turn
 
 
@@ -160,6 +164,41 @@ CASES = [
         [_c("<think>" + "y" * 20), _c("</think>ok"), _FINISH],
         [("reasoning", "y" * 8), ("reasoning", "y" * 12), ("content", "ok")],
         "ok",
+    ),
+    # Reasoning-boundary run close (live-caught #832 divergence): a
+    # buffered content tail must emit as CONTENT when a reasoning_delta
+    # arrives, exactly as the drain closes its per-run split there.
+    (
+        "reasoning_boundary_closes_short_content_run",
+        [_c("Short"), StreamChunk(reasoning_delta="(r)"), _FINISH],
+        [("content", "Short"), ("reasoning", "(r)")],
+        "Short",
+    ),
+    (
+        "reasoning_boundary_closes_long_run_tail",
+        [_c("A much longer content run here"), StreamChunk(reasoning_delta="(r)"), _FINISH],
+        [
+            ("content", "A much longer cont"),
+            ("content", "ent run here"),
+            ("reasoning", "(r)"),
+        ],
+        "A much longer content run here",
+    ),
+    (
+        "partial_tag_carries_across_reasoning_boundary",
+        [
+            _c("Ans<thi"),
+            StreamChunk(reasoning_delta="(r)"),
+            _c("nk>hidden</think>done"),
+            _FINISH,
+        ],
+        [
+            ("content", "Ans"),
+            ("reasoning", "(r)"),
+            ("reasoning", "hidden"),
+            ("content", "done"),
+        ],
+        "Ansdone",
     ),
 ]
 
@@ -313,3 +352,65 @@ def test_tool_calls_flush_pending_raw_at_current_state():
     assert result.tool_calls == [
         {"id": "tc1", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
     ]
+
+
+class TestPartialTagTail:
+    """Boundary-contract rows for ``partial_tag_tail``: only a PROPER
+    prefix of a tag is a partial tag.  A complete tag self-matching via
+    ``startswith`` was the live-caught latent bug — the drain then
+    carried a finished ``<reasoning>`` across a run boundary as if it
+    might still grow, relabeling the next run."""
+
+    @pytest.mark.parametrize(
+        ("text", "tail"),
+        [
+            ("Answer<reasoning>", ""),  # complete tag is NOT partial
+            ("Answer<think>", ""),
+            ("orphan</think>", ""),
+            ("Answer</reasoning>", ""),
+            ("Answer<reasonin", "<reasonin"),
+            ("Ans<thi", "<thi"),
+            ("trailing<", "<"),
+            ("no tags here", ""),
+            ("", ""),
+        ],
+    )
+    def test_contract(self, text, tail):
+        assert partial_tag_tail(text) == tail
+
+
+class TestCloseRun:
+    """``close_run`` — the reasoning-boundary run close, mirroring the
+    drain's per-run rule: decided text emits at the current state, only
+    a partial tag prefix carries."""
+
+    def _splitter(self):
+        events = []
+        return ThinkTagSplitter(lambda t, r: events.append((t, r))), events
+
+    def test_plain_tail_emits_as_content(self):
+        sp, events = self._splitter()
+        sp.feed("Short")
+        sp.close_run()
+        assert events == [("Short", False)]
+        assert sp.pending == ""
+
+    def test_partial_tag_tail_is_held(self):
+        sp, events = self._splitter()
+        sp.feed("Ans<thi")
+        sp.close_run()
+        assert events == [("Ans", False)]
+        assert sp.pending == "<thi"
+
+    def test_reasoning_state_tail_emits_as_reasoning(self):
+        sp, events = self._splitter()
+        sp.in_think = True
+        sp.feed("held thought")
+        sp.close_run()
+        assert events == [("held thought", True)]
+        assert sp.pending == ""
+
+    def test_empty_pending_is_noop(self):
+        sp, events = self._splitter()
+        sp.close_run()
+        assert events == []

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests._parity_832 import make_result
 from turnstone.core.session import ChatSession
 from turnstone.core.trajectory import Role, turns_from_dicts
 
@@ -205,12 +206,12 @@ class TestContextOverflowRecovery:
 
         call_count = 0
 
-        def mock_stream_response(msgs, my_generation=0):
+        def mock_stream_response(my_generation=0):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise Exception("maximum context length exceeded")
-            return {"role": "assistant", "content": "ok"}
+            return make_result(content="ok")
 
         compact_mock = MagicMock()
         with (
@@ -235,12 +236,12 @@ class TestContextOverflowRecovery:
 
         call_count = 0
 
-        def mock_stream_response(msgs, my_generation=0):
+        def mock_stream_response(my_generation=0):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise Exception("prompt is too long: 250000 tokens > 200000 maximum")
-            return {"role": "assistant", "content": "ok"}
+            return make_result(content="ok")
 
         compact_mock = MagicMock()
         with (
@@ -263,7 +264,7 @@ class TestContextOverflowRecovery:
         with (
             patch.object(
                 session,
-                "_create_stream_with_retry",
+                "_stream_response",
                 side_effect=Exception("authentication failed"),
             ),
             patch.object(session, "_full_messages", return_value=[]),
@@ -280,7 +281,7 @@ class TestContextOverflowRecovery:
         with (
             patch.object(
                 session,
-                "_create_stream_with_retry",
+                "_stream_response",
                 side_effect=Exception("maximum context length exceeded"),
             ),
             patch.object(session, "_compact_messages", side_effect=RuntimeError("compact failed")),
@@ -302,13 +303,13 @@ def _send_with_tool_batches(session, batches, **extra_patches):
     """Drive one ``send()`` through the tool-execution drain with canned results.
 
     *batches* is a list of ``(tool_calls, results)`` pairs, one send-loop
-    iteration each: ``_stream_response`` returns an assistant turn carrying
-    each batch's *tool_calls* in order, then a plain reply ends the loop.
-    Each *results* is what ``_execute_tools`` hands the drain — the
-    truncation/floor/compact path under test runs REAL code between the
-    mocked boundaries.  Mirrors ``tests/test_session.py::_send_with_mocks``;
-    kept local because these tests patch the budget/compaction seam
-    differently per scenario.
+    iteration each: ``_stream_response`` returns a ``ModelTurnResult`` whose
+    ``.tool_calls`` carries each batch's *tool_calls* in order, then a plain
+    reply ends the loop.  Each *results* is what ``_execute_tools`` hands the
+    drain — the truncation/floor/compact path under test runs REAL code
+    between the mocked boundaries.  Mirrors
+    ``tests/test_session.py::_send_with_mocks``; kept local because these
+    tests patch the budget/compaction seam differently per scenario.
 
     ``_estimated_prompt_tokens`` is pinned LOW so the end-of-turn/owed
     compaction paths stay quiet — every compaction observed by these tests
@@ -317,12 +318,12 @@ def _send_with_tool_batches(session, batches, **extra_patches):
     no background utility-completion thread churns against the mock client.
     """
     session._title_generated = True
-    responses = [
-        {"role": "assistant", "content": "", "tool_calls": tool_calls} for tool_calls, _ in batches
-    ] + [{"role": "assistant", "content": "done"}]
+    responses = [make_result(content="", tool_calls=tool_calls) for tool_calls, _ in batches] + [
+        make_result(content="done")
+    ]
     exec_results = [(results, []) for _, results in batches]
 
-    def mock_response(_msgs, _gen):
+    def mock_response(_gen):
         return responses.pop(0)
 
     with contextlib.ExitStack() as stack:

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -200,7 +200,14 @@ class TestRemainingTokenBudget:
 class TestContextOverflowRecovery:
     """Test that context-length errors trigger compact-and-retry."""
 
-    def test_openai_context_length_error_triggers_compact(self, session):
+    @pytest.mark.parametrize(
+        "overflow_text",
+        [
+            pytest.param("maximum context length exceeded", id="openai"),
+            pytest.param("prompt is too long: 250000 tokens > 200000 maximum", id="anthropic"),
+        ],
+    )
+    def test_context_overflow_triggers_compact(self, session, overflow_text):
         session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])
         session._msg_tokens = [1]
 
@@ -210,7 +217,7 @@ class TestContextOverflowRecovery:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise Exception("maximum context length exceeded")
+                raise Exception(overflow_text)
             return make_result(content="ok")
 
         compact_mock = MagicMock()
@@ -229,33 +236,6 @@ class TestContextOverflowRecovery:
         # hits overflow must not compact-and-swap a newer generation's history.
         compact_mock.assert_called_once_with(auto=True, my_generation=session._generation)
         assert call_count == 2
-
-    def test_anthropic_prompt_too_long_triggers_compact(self, session):
-        session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])
-        session._msg_tokens = [1]
-
-        call_count = 0
-
-        def mock_stream_response(my_generation=0):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise Exception("prompt is too long: 250000 tokens > 200000 maximum")
-            return make_result(content="ok")
-
-        compact_mock = MagicMock()
-        with (
-            patch.object(session, "_stream_response", side_effect=mock_stream_response),
-            patch.object(session, "_compact_messages", compact_mock),
-            patch.object(session, "_full_messages", return_value=[]),
-            patch.object(session, "_update_token_table"),
-            patch.object(session, "_print_status_line"),
-            patch.object(session, "_emit_state"),
-            patch("turnstone.core.session.save_message"),
-        ):
-            session.send("hello")
-
-        compact_mock.assert_called_once_with(auto=True, my_generation=session._generation)
 
     def test_non_context_error_propagates(self, session):
         session.messages = turns_from_dicts([{"role": "user", "content": "hi"}])

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests._parity_832 import make_result
+from tests._session_helpers import make_result
 from turnstone.core.session import ChatSession
 from turnstone.core.trajectory import Role, turns_from_dicts
 

--- a/tests/test_watch_integration.py
+++ b/tests/test_watch_integration.py
@@ -30,7 +30,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._helpers import patch_session_storage
-from tests._parity_832 import make_result
+from tests._session_helpers import make_result
 from turnstone.core.session import ChatSession
 from turnstone.core.storage import get_storage
 from turnstone.core.trajectory import dicts_from_turns

--- a/tests/test_watch_integration.py
+++ b/tests/test_watch_integration.py
@@ -3,8 +3,9 @@
 Drives a real :class:`ChatSession` + a real :class:`WatchRunner` (with
 its daemon thread skipped — we call ``_dispatch_result`` directly to
 avoid the timer dependency) end-to-end through the chat-loop drain
-seam.  The only stub is the LLM provider (patched
-``_create_stream_with_retry``); every other layer is production code:
+seam.  The only stub is the model turn (patched ``_stream_response``,
+returning a canned ``ModelTurnResult``); every other layer is
+production code:
 
 * ``WatchRunner._dispatch_result`` releasing the dispatch lock before
   fan-out
@@ -29,6 +30,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._helpers import patch_session_storage
+from tests._parity_832 import make_result
 from turnstone.core.session import ChatSession
 from turnstone.core.storage import get_storage
 from turnstone.core.trajectory import dicts_from_turns
@@ -117,16 +119,11 @@ def test_watch_fires_then_user_send_drains_envelope(tmp_db, monkeypatch):
     pending = session._nudge_queue.pending(channel="any")
     assert pending == [("watch_triggered", "watch payload body")]
 
-    # 3. Run the chat loop with the LLM patched.  We don't care about
-    # the assistant turn's content; only the wire payload sent to the
-    # provider matters.
+    # 3. Run the chat loop with the model turn patched.  We don't care
+    # about the assistant turn's content; only what the drain seam put
+    # into history alongside it matters.
     with (
-        patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-        patch.object(
-            session,
-            "_stream_response",
-            return_value={"role": "assistant", "content": "ok"},
-        ),
+        patch.object(session, "_stream_response", return_value=make_result(content="ok")),
         patch.object(session, "_update_token_table"),
         patch.object(session, "_print_status_line"),
         patch.object(session, "_visible_memory_count", return_value=0),
@@ -182,12 +179,7 @@ def test_three_back_to_back_watch_fires_drain_into_one_turn(tmp_db, monkeypatch)
     assert len(session._nudge_queue) == 3
 
     with (
-        patch.object(session, "_create_stream_with_retry", return_value=iter([])),
-        patch.object(
-            session,
-            "_stream_response",
-            return_value={"role": "assistant", "content": "got it"},
-        ),
+        patch.object(session, "_stream_response", return_value=make_result(content="got it")),
         patch.object(session, "_update_token_table"),
         patch.object(session, "_print_status_line"),
         patch.object(session, "_visible_memory_count", return_value=0),

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -284,7 +284,7 @@ def sanitize_tool_call_arguments(messages: list[dict[str, Any]]) -> list[dict[st
 
     The stream accumulator commits ``arguments`` verbatim, and the only guard that
     drops a malformed tool call is ``finish_reason == "length"``
-    (``ChatSession._stream_attempt``); a model that emits invalid JSON with a
+    (``ChatSession._finalize_stream_result``); a model that emits invalid JSON with a
     ``stop`` / ``tool_calls`` finish reason slips through, and one such turn then
     poison-pills every later request that replays it on a strict renderer.  This
     legalizes each offending ``arguments`` to a JSON-object string.

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -968,9 +968,9 @@ def model_turn(
     *prepare_wire* is the caller's OWN deterministic lowering, called
     with the serving lane so per-lane capability posture is available,
     composed after the seam passes and before the Phase-5 attach: the
-    main loop's
-    system-message prepend, sender labels, capability-sensitive
-    system-turn fold, empty-user drop, and orphan repair live here, each
+    main loop's system-message prepend, sender labels,
+    capability-sensitive system-turn fold, empty-user drop, and orphan
+    repair live here, each
     a ``lowering.py``-composed pass.  It must be pure lowering — no
     learned selection, no provider calls, no side effects (the session's
     debug request dump, a read-only latch, is the tolerated exception).

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -15,12 +15,15 @@ Contract, held deliberately narrow:
 * **Policy-free.**  No retry, no deadline, no tool execution, no usage
   recording inside — those belong to each caller.  The callers are
   different organs (a judge is not a sub-agent is not a title generator);
-  the plant call is the one thing they share.  Two carve-outs, both about
-  a call that is already dead rather than about policy: the drain-retry
-  loop re-issues a mid-stream death, and an aborted ``cancel_ref`` raises
-  ``DeadlineCancelledError`` rather than dispatch — the caller still owns
-  the deadline, this only refuses to spend on a call already abandoned
-  (see ``Raises`` on :func:`model_turn`).
+  the plant call is the one thing they share.  Three carve-outs, each
+  about a call that is already dead rather than about policy: the
+  drain-retry loop re-issues a mid-stream death; an aborted ``cancel_ref``
+  raises ``DeadlineCancelledError`` rather than dispatch — the caller
+  still owns the deadline, this only refuses to spend on a call already
+  abandoned; and ``on_chunk`` DISABLES that drain retry — a
+  partially-surfaced stream is dead to silent re-issue, because a UI
+  already rendered its tokens and only the streaming caller can finalize
+  a display per attempt (see ``Raises`` on :func:`model_turn`).
 * **Providers stay codegen.**  The provider boundary keeps taking lowered
   wire dicts; Turn IR does not enter the provider Protocol, and
   ``lowering.py`` remains the only wire-mutation owner.  This module
@@ -43,15 +46,10 @@ from dataclasses import dataclass, fields, replace
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterator, Sequence
     from types import EllipsisType
 
     from turnstone.core.model_registry import ModelRegistry
-    from turnstone.core.providers._protocol import (
-        LLMProvider,
-        ModelCapabilities,
-        UsageInfo,
-    )
 
 from turnstone.core.deadline import DeadlineCancelledError
 from turnstone.core.history_decoration import attach_vllm_chat_reasoning_field
@@ -60,10 +58,30 @@ from turnstone.core.lowering import (
     restore_provider_tool_ids,
     sanitize_tool_call_arguments,
 )
+
+# Protocol names imported at runtime (not TYPE_CHECKING) and re-exported with
+# the explicit ``as`` idiom: post-#832 ``ChatSession`` types its provider
+# handles, chunk callback, and capabilities against THIS module, so the
+# provider package stays a single-import-site dependency of the plant layer.
+from turnstone.core.providers._protocol import (
+    LLMProvider as LLMProvider,
+)
+from turnstone.core.providers._protocol import (
+    ModelCapabilities as ModelCapabilities,
+)
+from turnstone.core.providers._protocol import (
+    StreamChunk as StreamChunk,
+)
+from turnstone.core.providers._protocol import (
+    UsageInfo as UsageInfo,
+)
 from turnstone.core.providers._protocol import (
     drain_stream,
     has_reasoning_bearing_block,
     thinking_off_template_kwargs,
+)
+from turnstone.core.providers._protocol import (
+    merge_usage as merge_usage,
 )
 from turnstone.core.storage._utils import (
     _CLIENT_TOOL_CALL_BLOCK_TYPES,
@@ -734,12 +752,20 @@ class ModelTurnResult:
     ``function.name`` / ``function.arguments`` dicts everywhere today.
     *finish_reason* / *usage* are transport facts, not trajectory content
     — which is why they ride the result, not the Turn.
+
+    *wire_msgs* is the exact lowered list handed to ``create_streaming``
+    (post every pass, including the caller's ``prepare_wire``) — the
+    main loop's token-table calibration reads it so the chars-per-token
+    estimate is computed against what the provider actually counted,
+    surviving lowerings the caller cannot see (#832; the successor of
+    the session's ``_wire_msgs`` message-dict carrier).
     """
 
     turn: Turn
     finish_reason: str
     usage: UsageInfo | None
     tool_calls: list[dict[str, Any]]
+    wire_msgs: list[dict[str, Any]] | None = None
 
     @property
     def content(self) -> str:
@@ -760,6 +786,26 @@ def cap_tool_calls(result: ModelTurnResult, max_calls: int) -> tuple[list[dict[s
     if len(result.tool_calls) > len(capped):
         turn = Turn.assistant(result.content, tool_calls=turn.tool_calls[: len(capped)])
     return capped, turn
+
+
+def _tee_chunks(
+    chunks: Iterator[StreamChunk],
+    on_chunk: Callable[[StreamChunk], None],
+) -> Iterator[StreamChunk]:
+    """Surface each chunk to *on_chunk* before the drain accumulates it.
+
+    Sits UPSTREAM of ``drain_stream``'s own ``transport_guarded`` wrapper, so
+    the callback observes exactly the chunk sequence the assembler consumes —
+    no more (transport deaths raise at ``next()`` and never reach the
+    callback) and no fewer (a callback raise at chunk N, the cancellation
+    path, discards N from display and assembly alike, matching the
+    interactive loop's check-before-dispatch ordering).  The callback's
+    exceptions propagate untouched: ``GenerationCancelled`` is a
+    ``BaseException``, invisible to the drain-retry arm by design.
+    """
+    for sc in chunks:
+        on_chunk(sc)
+        yield sc
 
 
 def _raise_if_aborted(cancel_ref: Any, lane: ModelLane) -> None:
@@ -798,6 +844,9 @@ def model_turn(
     resolve_attachments: Callable[[list[str]], dict[str, Any]] | None = None,
     cancel_ref: list[Any] | None = None,
     backend_auth_token: str | None = None,
+    deferred_names: frozenset[str] | None = None,
+    prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]] | None = None,
+    on_chunk: Callable[[StreamChunk], None] | None = None,
 ) -> ModelTurnResult:
     """Advance a trajectory by one model turn: lower, sample, re-ingest.
 
@@ -872,11 +921,41 @@ def model_turn(
     reads the error at all, which is what keeps a Stop mid-summary off
     the red-error path.
 
+    *prepare_wire* is the caller's OWN deterministic lowering, composed
+    after the seam passes and before the Phase-5 attach — the main loop's
+    system-message prepend, sender labels, capability-sensitive system-turn
+    fold, empty-user drop, and orphan repair live here (#832), each a
+    ``lowering.py``-composed pass.  It must be pure lowering: no learned
+    selection, no provider calls, no side effects (the session's debug
+    request dump, a read-only latch, is the tolerated exception).  The
+    exact post-``prepare_wire``, post-attach list that went to the wire is
+    returned as ``ModelTurnResult.wire_msgs`` for caller-side calibration.
+
+    *deferred_names* passes through to ``create_streaming`` — the
+    tool-search deferred-loading set is per-call state (it grows as the
+    session discovers tools), which is why it is a parameter here and not
+    a ``ModelLane`` field.
+
+    *on_chunk* is the streaming surface (#832): each normalized
+    :class:`StreamChunk` is surfaced to the caller as it arrives — via a
+    tee UPSTREAM of the drain, so the callback sees exactly the sequence
+    the assembler consumes — and the fully assembled result is returned as
+    usual.  Chunk→UI translation is entirely the caller's business; the
+    canonical Turn always comes from the drain's assembly, never from
+    anything the callback accumulated.  A callback raise aborts the call
+    with that exception (the interactive cancellation path rides this:
+    ``GenerationCancelled`` is a ``BaseException`` and passes the retry
+    arm untouched).  **With *on_chunk* present the mid-stream drain retry
+    below is DISABLED** — the third and final policy carve-out: a
+    partially-surfaced stream must never be silently re-issued behind a
+    UI that already rendered its tokens; the streaming caller owns
+    re-issue, finalizing its display per attempt.
+
     Raises whatever the provider raises — retry/deadline/fallback policy
     is the caller's — EXCEPT transient mid-stream deaths: a failure the
     provider's own ``retryable_error_names`` recognizes, raised while
     DRAINING (``IncompleteStreamError`` and friends), is re-issued in
-    place up to ``_DRAIN_RETRIES`` times.  The retired non-streaming
+    place up to ``_DRAIN_RETRIES`` times (zero with *on_chunk*, above).  The retired non-streaming
     transport read the whole body inside the SDK's retried request, so
     single-shot callers never saw a mid-body wire blip; this loop is
     that retry's new home (request-time failures still get the SDK's own
@@ -913,6 +992,8 @@ def model_turn(
         sanitize_tool_call_arguments(dicts_from_turns(list(turns))),
         wire_id_map if wire_id_map is not None else {},
     )
+    if prepare_wire is not None:
+        wire = prepare_wire(wire)
     wire = maybe_attach_vllm_chat_reasoning(wire, lane.provider, lane.registry, lane.alias, cfg=cfg)
     # The effort assignment scheme's lower rungs: explicit relay → lane
     # (operator) → in-code model definition → None.  None/unset knobs are
@@ -936,6 +1017,9 @@ def model_turn(
         if resolved_backend_auth
         else lane.client
     )
+    # A partially-surfaced stream is never silently re-issued (see the
+    # on_chunk docstring section) — the streaming caller owns re-issue.
+    drain_retries = 0 if on_chunk is not None else _DRAIN_RETRIES
     attempt = 0
     while True:
         # Last read before the wire — it covers everything the entry read is
@@ -959,6 +1043,7 @@ def model_turn(
             temperature=temperature if temperature is not None else lane.temperature,
             reasoning_effort=effective_effort,
             extra_params=lane.extra_params,
+            deferred_names=deferred_names,
             cancel_ref=cancel_ref,
             capabilities=lane.capabilities,
             replay_reasoning_to_model=resolve_replay_reasoning_to_model(
@@ -968,7 +1053,7 @@ def model_turn(
         )
         try:
             result = drain_stream(
-                chunks,
+                _tee_chunks(chunks, on_chunk) if on_chunk else chunks,
                 # A lane with no declared capabilities keeps the
                 # passthrough-server default: scan.
                 scan_inline_reasoning=not (
@@ -979,7 +1064,7 @@ def model_turn(
         except Exception as exc:
             attempt += 1
             if (
-                attempt > _DRAIN_RETRIES
+                attempt > drain_retries
                 or bool(getattr(cancel_ref, "aborted", False))
                 or type(exc).__name__ not in lane.provider.retryable_error_names
             ):
@@ -1058,4 +1143,5 @@ def model_turn(
         finish_reason=result.finish_reason,
         usage=result.usage,
         tool_calls=raw_calls,
+        wire_msgs=wire,
     )

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -886,7 +886,7 @@ def model_turn(
     cancel_ref: list[Any] | None = None,
     backend_auth_token: str | None = None,
     deferred_names: frozenset[str] | None = None,
-    prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]] | None = None,
+    prepare_wire: Callable[[list[dict[str, Any]], ModelLane], list[dict[str, Any]]] | None = None,
     on_chunk: Callable[[StreamChunk], None] | None = None,
 ) -> ModelTurnResult:
     """Advance a trajectory by one model turn: lower, sample, re-ingest.
@@ -962,7 +962,9 @@ def model_turn(
     reads the error at all, which is what keeps a Stop mid-summary off
     the red-error path.
 
-    *prepare_wire* is the caller's OWN deterministic lowering, composed
+    *prepare_wire* is the caller's OWN deterministic lowering (called
+    with the serving lane, so per-lane capability posture is available),
+    composed
     after the seam passes and before the Phase-5 attach: the main loop's
     system-message prepend, sender labels, capability-sensitive
     system-turn fold, empty-user drop, and orphan repair live here, each
@@ -1036,7 +1038,10 @@ def model_turn(
     )
     if prepare_wire is not None:
         try:
-            wire = prepare_wire(wire)
+            # The serving lane rides along so caller lowering can be
+            # capability-correct per attempt — a fallback's fold posture
+            # is its own, not the primary's.
+            wire = prepare_wire(wire, lane)
         except Exception as prep_err:
             # A caller-data fault, never a backend signal — typed so the
             # retry and fallback ladders cannot treat it as one.

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -59,6 +59,12 @@ from turnstone.core.lowering import (
     sanitize_tool_call_arguments,
 )
 
+# The provider FACTORY rides the same re-export seam: the session's
+# no-registry default construction is the one provider-construction site
+# left outside the registry, and routing it through here keeps the
+# provider package a plant-layer-only import.
+from turnstone.core.providers import create_provider as create_provider
+
 # Protocol names imported at runtime (not TYPE_CHECKING) and re-exported with
 # the explicit ``as`` idiom: post-#832 ``ChatSession`` types its provider
 # handles, chunk callback, and capabilities against THIS module, so the
@@ -759,6 +765,12 @@ class ModelTurnResult:
     estimate is computed against what the provider actually counted,
     surviving lowerings the caller cannot see (#832; the successor of
     the session's ``_wire_msgs`` message-dict carrier).
+
+    *producer* is the SERVING lane's provider name — the same identity
+    stamped on ``turn.native`` when a native lane exists, carried
+    separately so a native-less turn still records who produced it (the
+    storage row's ``producer`` column; pre-fold this read the session's
+    PRIMARY binding and mislabeled fallback-served turns).
     """
 
     turn: Turn
@@ -766,6 +778,7 @@ class ModelTurnResult:
     usage: UsageInfo | None
     tool_calls: list[dict[str, Any]]
     wire_msgs: list[dict[str, Any]] | None = None
+    producer: str = ""
 
     @property
     def content(self) -> str:
@@ -1144,4 +1157,5 @@ def model_turn(
         usage=result.usage,
         tool_calls=raw_calls,
         wire_msgs=wire,
+        producer=lane.provider.provider_name,
     )

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -17,13 +17,12 @@ Contract, held deliberately narrow:
   different organs (a judge is not a sub-agent is not a title generator);
   the plant call is the one thing they share.  Three carve-outs, each
   about a call that is already dead rather than about policy: the
-  drain-retry loop re-issues a mid-stream death; an aborted ``cancel_ref``
-  raises ``DeadlineCancelledError`` rather than dispatch — the caller
-  still owns the deadline, this only refuses to spend on a call already
-  abandoned; and ``on_chunk`` DISABLES that drain retry — a
-  partially-surfaced stream is dead to silent re-issue, because a UI
-  already rendered its tokens and only the streaming caller can finalize
-  a display per attempt (see ``Raises`` on :func:`model_turn`).
+  drain-retry loop re-issues a mid-stream death; an aborted
+  ``cancel_ref`` raises ``DeadlineCancelledError`` rather than dispatch,
+  refusing to spend on an abandoned call while the caller keeps the
+  deadline; and ``on_chunk`` DISABLES that drain retry, because only the
+  streaming caller can finalize a display per attempt (see ``Raises`` on
+  :func:`model_turn`).
 * **Providers stay codegen.**  The provider boundary keeps taking lowered
   wire dicts; Turn IR does not enter the provider Protocol, and
   ``lowering.py`` remains the only wire-mutation owner.  This module
@@ -59,19 +58,18 @@ from turnstone.core.lowering import (
     sanitize_tool_call_arguments,
 )
 
-# The provider FACTORY rides the same re-export seam: the session's
-# no-registry default construction is the one provider-construction site
-# left outside the registry, and routing it through here keeps the
-# provider package a plant-layer-only import.
+# The provider FACTORY rides the same seam — the session's no-registry
+# default construction is the only provider-construction site outside the
+# registry — so the provider package stays a plant-layer-only import.
 from turnstone.core.providers import create_provider as create_provider
 from turnstone.core.providers._protocol import (
     TRAILING_INFO_SEPARATOR as TRAILING_INFO_SEPARATOR,
 )
 
-# Protocol names imported at runtime (not TYPE_CHECKING) and re-exported with
-# the explicit ``as`` idiom: post-#832 ``ChatSession`` types its provider
-# handles, chunk callback, and capabilities against THIS module, so the
-# provider package stays a single-import-site dependency of the plant layer.
+# Runtime (not TYPE_CHECKING) re-exports via the explicit ``as`` idiom —
+# ``ChatSession`` types its provider handles, chunk callback, and
+# capabilities against THIS module, so the provider package has one
+# import site.
 from turnstone.core.providers._protocol import (
     LLMProvider as LLMProvider,
 )
@@ -125,11 +123,10 @@ class WirePreparationError(RuntimeError):
     """The caller's ``prepare_wire`` hook raised — a session-data fault.
 
     ``prepare_wire`` is deterministic caller-supplied lowering over the
-    caller's own history; its failure says nothing about the backend, so
-    ``model_turn`` types it here to keep retry/fallback ladders from
-    classifying it as one (recording backend-health failures and walking
-    every fallback alias over a bug that will fail identically on each).
-    The original exception rides ``__cause__``.
+    caller's own history, so its failure says nothing about the backend.
+    Typing it here keeps retry/fallback ladders from recording backend
+    health or walking every alias over a bug that fails identically on
+    each.  The original exception rides ``__cause__``.
     """
 
 
@@ -499,11 +496,11 @@ def lane_scans_inline_reasoning(lane: ModelLane | None) -> bool:
     """THE inline tag-scan gate — the single spelling of the #978 rule.
 
     Scan ``<think>`` tags out of the content stream unless the lane's
-    capabilities declare the server already segregates reasoning
-    (``server_parses_reasoning``).  A lane with no declared capabilities —
-    or no lane yet — keeps the passthrough-server default: scan.  Shared
-    by the drain seam and the interactive display splitter so the two
-    interpretations of one stream cannot disagree.
+    capabilities declare that the server segregates reasoning itself
+    (``server_parses_reasoning``); no capabilities, or no lane yet, keeps
+    the passthrough-server default: scan.  Shared by the drain seam and
+    the interactive display splitter so the two readings of one stream
+    cannot disagree.
     """
     return (
         lane is None or lane.capabilities is None or not lane.capabilities.server_parses_reasoning
@@ -792,18 +789,17 @@ class ModelTurnResult:
     *finish_reason* / *usage* are transport facts, not trajectory content
     — which is why they ride the result, not the Turn.
 
-    *wire_msgs* is the exact lowered list handed to ``create_streaming``
-    (post every pass, including the caller's ``prepare_wire``) — the
-    main loop's token-table calibration reads it so the chars-per-token
-    estimate is computed against what the provider actually counted,
-    surviving lowerings the caller cannot see (#832; the successor of
-    the session's ``_wire_msgs`` message-dict carrier).
+    *wire_msgs* is the exact lowered list handed to ``create_streaming``,
+    after every pass including the caller's ``prepare_wire`` — the main
+    loop's token-table calibration reads it so chars-per-token is
+    computed against what the provider actually counted, lowerings the
+    caller cannot see included.
 
-    *producer* is the SERVING lane's provider name — the same identity
-    stamped on ``turn.native`` when a native lane exists, carried
-    separately so a native-less turn still records who produced it (the
-    storage row's ``producer`` column; pre-fold this read the session's
-    PRIMARY binding and mislabeled fallback-served turns).
+    *producer* is the SERVING lane's provider name (the storage row's
+    ``producer`` column) — the identity stamped on ``turn.native`` when a
+    native lane exists, carried separately so a native-less turn still
+    records who produced it and a fallback-served turn is not labeled
+    with the primary binding.
     """
 
     turn: Turn
@@ -840,14 +836,13 @@ def _tee_chunks(
 ) -> Iterator[StreamChunk]:
     """Surface each chunk to *on_chunk* before the drain accumulates it.
 
-    Sits UPSTREAM of ``drain_stream``'s own ``transport_guarded`` wrapper, so
-    the callback observes exactly the chunk sequence the assembler consumes —
-    no more (transport deaths raise at ``next()`` and never reach the
-    callback) and no fewer (a callback raise at chunk N, the cancellation
-    path, discards N from display and assembly alike, matching the
-    interactive loop's check-before-dispatch ordering).  The callback's
-    exceptions propagate untouched: ``GenerationCancelled`` is a
-    ``BaseException``, invisible to the drain-retry arm by design.
+    Sits UPSTREAM of ``drain_stream``'s ``transport_guarded`` wrapper, so
+    the callback sees exactly the sequence the assembler consumes: no
+    more (a transport death raises at ``next()`` and never reaches the
+    callback) and no fewer (a callback raise at chunk N — the
+    cancellation path — discards N from display and assembly alike).
+    Callback exceptions propagate untouched; ``GenerationCancelled`` is a
+    ``BaseException`` and so invisible to the drain-retry arm.
     """
     for sc in chunks:
         on_chunk(sc)
@@ -968,34 +963,33 @@ def model_turn(
     the red-error path.
 
     *prepare_wire* is the caller's OWN deterministic lowering, composed
-    after the seam passes and before the Phase-5 attach — the main loop's
-    system-message prepend, sender labels, capability-sensitive system-turn
-    fold, empty-user drop, and orphan repair live here (#832), each a
-    ``lowering.py``-composed pass.  It must be pure lowering: no learned
-    selection, no provider calls, no side effects (the session's debug
-    request dump, a read-only latch, is the tolerated exception).  The
-    exact post-``prepare_wire``, post-attach list that went to the wire is
-    returned as ``ModelTurnResult.wire_msgs`` for caller-side calibration.
+    after the seam passes and before the Phase-5 attach: the main loop's
+    system-message prepend, sender labels, capability-sensitive
+    system-turn fold, empty-user drop, and orphan repair live here, each
+    a ``lowering.py``-composed pass.  It must be pure lowering — no
+    learned selection, no provider calls, no side effects (the session's
+    debug request dump, a read-only latch, is the tolerated exception).
+    The list that went to the wire comes back as
+    ``ModelTurnResult.wire_msgs``.
 
-    *deferred_names* passes through to ``create_streaming`` — the
+    *deferred_names* passes through to ``create_streaming``: the
     tool-search deferred-loading set is per-call state (it grows as the
-    session discovers tools), which is why it is a parameter here and not
-    a ``ModelLane`` field.
+    session discovers tools), so it is a parameter and not a
+    ``ModelLane`` field.
 
     *on_chunk* is the streaming surface (#832): each normalized
-    :class:`StreamChunk` is surfaced to the caller as it arrives — via a
-    tee UPSTREAM of the drain, so the callback sees exactly the sequence
-    the assembler consumes — and the fully assembled result is returned as
-    usual.  Chunk→UI translation is entirely the caller's business; the
-    canonical Turn always comes from the drain's assembly, never from
-    anything the callback accumulated.  A callback raise aborts the call
-    with that exception (the interactive cancellation path rides this:
-    ``GenerationCancelled`` is a ``BaseException`` and passes the retry
-    arm untouched).  **With *on_chunk* present the mid-stream drain retry
-    below is DISABLED** — the third and final policy carve-out: a
-    partially-surfaced stream must never be silently re-issued behind a
-    UI that already rendered its tokens; the streaming caller owns
-    re-issue, finalizing its display per attempt.
+    :class:`StreamChunk` reaches the caller as it arrives — via a tee
+    UPSTREAM of the drain, so the callback sees exactly the sequence the
+    assembler consumes — and the assembled result is returned as usual.
+    Chunk→UI translation is the caller's business; the canonical Turn
+    always comes from the drain's assembly, never from anything the
+    callback accumulated.  A callback raise aborts the call with that
+    exception; ``GenerationCancelled``, being a ``BaseException``, passes
+    the retry arm untouched.  **With *on_chunk* present the mid-stream
+    drain retry below is DISABLED** — the third policy carve-out: a
+    partially-surfaced stream must not be silently re-issued behind a UI
+    that already rendered its tokens, so the streaming caller owns
+    re-issue.
 
     Raises whatever the provider raises — retry/deadline/fallback policy
     is the caller's — EXCEPT transient mid-stream deaths: a failure the
@@ -1007,12 +1001,10 @@ def model_turn(
     wire blip; this loop is that retry's new home (request-time failures
     still get the SDK's own policy inside ``create_streaming`` and
     propagate unchanged).  A *prepare_wire* raise is the one re-typed
-    exception: it surfaces as :class:`WirePreparationError` (original as
-    ``__cause__``) so ladders can keep a caller-data fault out of backend
-    health and fallback walks.  An
-    aborted *cancel_ref* suppresses retries — a deadline that closed the
-    stream must not have the request resurrected behind its back — and,
-    read before each dispatch, raises
+    exception, surfacing as :class:`WirePreparationError` with the
+    original as ``__cause__``.  An aborted *cancel_ref* suppresses
+    retries — a deadline that closed the stream must not have the request
+    resurrected behind its back — and, read before each dispatch, raises
     :class:`~turnstone.core.deadline.DeadlineCancelledError` instead of
     issuing the request at all (see *cancel_ref* above).
 
@@ -1046,10 +1038,8 @@ def model_turn(
         try:
             wire = prepare_wire(wire)
         except Exception as prep_err:
-            # Deterministic caller-side lowering over the caller's own
-            # history — never a backend signal.  Typed so the retry and
-            # fallback ladders can refuse to record health or walk aliases
-            # over it (each lane would re-run the same failing passes).
+            # A caller-data fault, never a backend signal — typed so the
+            # retry and fallback ladders cannot treat it as one.
             raise WirePreparationError(str(prep_err)) from prep_err
     wire = maybe_attach_vllm_chat_reasoning(wire, lane.provider, lane.registry, lane.alias, cfg=cfg)
     # The effort assignment scheme's lower rungs: explicit relay → lane
@@ -1074,8 +1064,8 @@ def model_turn(
         if resolved_backend_auth
         else lane.client
     )
-    # A partially-surfaced stream is never silently re-issued (see the
-    # on_chunk docstring section) — the streaming caller owns re-issue.
+    # A partially-surfaced stream is never silently re-issued — the
+    # streaming caller owns re-issue.
     drain_retries = 0 if on_chunk is not None else _DRAIN_RETRIES
     attempt = 0
     while True:

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -965,16 +965,15 @@ def model_turn(
     reads the error at all, which is what keeps a Stop mid-summary off
     the red-error path.
 
-    *prepare_wire* is the caller's OWN deterministic lowering, called
-    with the serving lane so per-lane capability posture is available,
-    composed after the seam passes and before the Phase-5 attach: the
-    main loop's system-message prepend, sender labels,
-    capability-sensitive system-turn fold, empty-user drop, and orphan
-    repair live here, each
-    a ``lowering.py``-composed pass.  It must be pure lowering — no
-    learned selection, no provider calls, no side effects (the session's
-    debug request dump, a read-only latch, is the tolerated exception).
-    The list that went to the wire comes back as
+    *prepare_wire* is the caller's OWN deterministic lowering, called with
+    the serving lane so per-lane capability posture is available, composed
+    after the seam passes and before the Phase-5 attach: the main loop's
+    system-message prepend, sender labels, capability-sensitive
+    system-turn fold, empty-user drop, and orphan repair live here, each a
+    ``lowering.py``-composed pass.  It must be pure lowering — no learned
+    selection, no provider calls, no side effects (the session's debug
+    request dump, a read-only latch, is the tolerated exception).  The
+    list that went to the wire comes back as
     ``ModelTurnResult.wire_msgs``.
 
     *deferred_names* passes through to ``create_streaming``: the

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -64,6 +64,9 @@ from turnstone.core.lowering import (
 # left outside the registry, and routing it through here keeps the
 # provider package a plant-layer-only import.
 from turnstone.core.providers import create_provider as create_provider
+from turnstone.core.providers._protocol import (
+    TRAILING_INFO_SEPARATOR as TRAILING_INFO_SEPARATOR,
+)
 
 # Protocol names imported at runtime (not TYPE_CHECKING) and re-exported with
 # the explicit ``as`` idiom: post-#832 ``ChatSession`` types its provider
@@ -85,6 +88,9 @@ from turnstone.core.providers._protocol import (
     drain_stream,
     has_reasoning_bearing_block,
     thinking_off_template_kwargs,
+)
+from turnstone.core.providers._protocol import (
+    folds_trailing_info as folds_trailing_info,
 )
 from turnstone.core.providers._protocol import (
     merge_usage as merge_usage,
@@ -113,6 +119,18 @@ _DRAIN_RETRY_BASE_DELAY = 0.5
 # (REASONING_BEARING_BLOCK_TYPES + has_reasoning_bearing_block, beside the
 # drain's double-reasoning check); this layer consumes the shared
 # predicate in :func:`synth_reasoning_block`.
+
+
+class WirePreparationError(RuntimeError):
+    """The caller's ``prepare_wire`` hook raised — a session-data fault.
+
+    ``prepare_wire`` is deterministic caller-supplied lowering over the
+    caller's own history; its failure says nothing about the backend, so
+    ``model_turn`` types it here to keep retry/fallback ladders from
+    classifying it as one (recording backend-health failures and walking
+    every fallback alias over a bug that will fail identically on each).
+    The original exception rides ``__cause__``.
+    """
 
 
 # --------------------------------------------------------------------------- #
@@ -474,6 +492,21 @@ def lane_thinking_suppressed(lane: ModelLane) -> bool:
         caps is not None
         and not caps.server_parses_reasoning
         and lane.provider.provider_name in EXTRA_BODY_PROVIDERS
+    )
+
+
+def lane_scans_inline_reasoning(lane: ModelLane | None) -> bool:
+    """THE inline tag-scan gate — the single spelling of the #978 rule.
+
+    Scan ``<think>`` tags out of the content stream unless the lane's
+    capabilities declare the server already segregates reasoning
+    (``server_parses_reasoning``).  A lane with no declared capabilities —
+    or no lane yet — keeps the passthrough-server default: scan.  Shared
+    by the drain seam and the interactive display splitter so the two
+    interpretations of one stream cannot disagree.
+    """
+    return (
+        lane is None or lane.capabilities is None or not lane.capabilities.server_parses_reasoning
     )
 
 
@@ -968,11 +1001,15 @@ def model_turn(
     is the caller's — EXCEPT transient mid-stream deaths: a failure the
     provider's own ``retryable_error_names`` recognizes, raised while
     DRAINING (``IncompleteStreamError`` and friends), is re-issued in
-    place up to ``_DRAIN_RETRIES`` times (zero with *on_chunk*, above).  The retired non-streaming
-    transport read the whole body inside the SDK's retried request, so
-    single-shot callers never saw a mid-body wire blip; this loop is
-    that retry's new home (request-time failures still get the SDK's own
-    policy inside ``create_streaming`` and propagate unchanged).  An
+    place up to ``_DRAIN_RETRIES`` times (zero with *on_chunk*, above).
+    The retired non-streaming transport read the whole body inside the
+    SDK's retried request, so single-shot callers never saw a mid-body
+    wire blip; this loop is that retry's new home (request-time failures
+    still get the SDK's own policy inside ``create_streaming`` and
+    propagate unchanged).  A *prepare_wire* raise is the one re-typed
+    exception: it surfaces as :class:`WirePreparationError` (original as
+    ``__cause__``) so ladders can keep a caller-data fault out of backend
+    health and fallback walks.  An
     aborted *cancel_ref* suppresses retries — a deadline that closed the
     stream must not have the request resurrected behind its back — and,
     read before each dispatch, raises
@@ -1006,7 +1043,14 @@ def model_turn(
         wire_id_map if wire_id_map is not None else {},
     )
     if prepare_wire is not None:
-        wire = prepare_wire(wire)
+        try:
+            wire = prepare_wire(wire)
+        except Exception as prep_err:
+            # Deterministic caller-side lowering over the caller's own
+            # history — never a backend signal.  Typed so the retry and
+            # fallback ladders can refuse to record health or walk aliases
+            # over it (each lane would re-run the same failing passes).
+            raise WirePreparationError(str(prep_err)) from prep_err
     wire = maybe_attach_vllm_chat_reasoning(wire, lane.provider, lane.registry, lane.alias, cfg=cfg)
     # The effort assignment scheme's lower rungs: explicit relay → lane
     # (operator) → in-code model definition → None.  None/unset knobs are
@@ -1067,11 +1111,7 @@ def model_turn(
         try:
             result = drain_stream(
                 _tee_chunks(chunks, on_chunk) if on_chunk else chunks,
-                # A lane with no declared capabilities keeps the
-                # passthrough-server default: scan.
-                scan_inline_reasoning=not (
-                    lane.capabilities.server_parses_reasoning if lane.capabilities else False
-                ),
+                scan_inline_reasoning=lane_scans_inline_reasoning(lane),
             )
             break
         except Exception as exc:

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -492,19 +492,22 @@ def lane_thinking_suppressed(lane: ModelLane) -> bool:
     )
 
 
-def lane_scans_inline_reasoning(lane: ModelLane | None) -> bool:
+def caps_scan_inline_reasoning(caps: ModelCapabilities | None) -> bool:
     """THE inline tag-scan gate — the single spelling of the #978 rule.
 
-    Scan ``<think>`` tags out of the content stream unless the lane's
+    Scan ``<think>`` tags out of the content stream unless the
     capabilities declare that the server segregates reasoning itself
-    (``server_parses_reasoning``); no capabilities, or no lane yet, keeps
-    the passthrough-server default: scan.  Shared by the drain seam and
-    the interactive display splitter so the two readings of one stream
-    cannot disagree.
+    (``server_parses_reasoning``); no declaration keeps the
+    passthrough-server default: scan.  Shared by the drain seam, the
+    interactive display splitter, and the title peel, so no two
+    consumers can read one stream differently.
     """
-    return (
-        lane is None or lane.capabilities is None or not lane.capabilities.server_parses_reasoning
-    )
+    return caps is None or not caps.server_parses_reasoning
+
+
+def lane_scans_inline_reasoning(lane: ModelLane | None) -> bool:
+    """:func:`caps_scan_inline_reasoning` over a lane (no lane yet = scan)."""
+    return caps_scan_inline_reasoning(lane.capabilities if lane is not None else None)
 
 
 def lane_without_thinking(lane: ModelLane) -> ModelLane:
@@ -962,10 +965,10 @@ def model_turn(
     reads the error at all, which is what keeps a Stop mid-summary off
     the red-error path.
 
-    *prepare_wire* is the caller's OWN deterministic lowering (called
-    with the serving lane, so per-lane capability posture is available),
-    composed
-    after the seam passes and before the Phase-5 attach: the main loop's
+    *prepare_wire* is the caller's OWN deterministic lowering, called
+    with the serving lane so per-lane capability posture is available,
+    composed after the seam passes and before the Phase-5 attach: the
+    main loop's
     system-message prepend, sender labels, capability-sensitive
     system-turn fold, empty-user drop, and orphan repair live here, each
     a ``lowering.py``-composed pass.  It must be pure lowering — no

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -1301,15 +1301,15 @@ def _normalize_finish_reason(reason: str) -> str:
         return "stop"
     if reason == "refusal":
         # A safety classifier declined the request.  This arrives as a
-        # SUCCESSFUL HTTP 200 with content empty (declined before any output)
-        # or partial (declined mid-stream), so nothing upstream raises — the
-        # drain gate only errors on an ABSENT finish reason.  "content_filter"
-        # is the
-        # OpenAI-vocabulary equivalent this function normalizes onto, and both
-        # consumers already handle it: the interactive wrapper's
-        # _finalize_stream_result warns the user, and the sub-agent loop
-        # stops early instead of flailing on an empty turn.  Falling through to the raw "refusal" string instead
-        # would land a truncated answer as a complete result.
+        # SUCCESSFUL HTTP 200 with content empty (declined before any
+        # output) or partial (declined mid-stream), so nothing upstream
+        # raises — the drain gate only errors on an ABSENT finish reason.
+        # "content_filter" is the OpenAI-vocabulary equivalent this
+        # function normalizes onto, and both consumers already handle it:
+        # the interactive wrapper's _finalize_stream_result warns the
+        # user, and the sub-agent loop stops early instead of flailing on
+        # an empty turn.  Falling through to the raw "refusal" string
+        # instead would land a truncated answer as a complete result.
         return "content_filter"
     return reason
 

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -554,8 +554,8 @@ class AnthropicProvider:
         intentionally preserved.  The kwarg defaults to ``True`` here
         purely for back-compat with any direct caller that hasn't been
         updated to thread the resolver — production call sites
-        (``ChatSession._try_stream`` / ``_utility_completion``) always
-        pass the resolved flag explicitly.
+        (``model_turn`` — every lane, the interactive loop included)
+        always pass the resolved flag explicitly.
 
         ``supports_mid_conversation_system`` (claude-opus-4-8,
         claude-fable-5) makes the
@@ -1306,9 +1306,9 @@ def _normalize_finish_reason(reason: str) -> str:
         # drain gate only errors on an ABSENT finish reason.  "content_filter"
         # is the
         # OpenAI-vocabulary equivalent this function normalizes onto, and both
-        # consumers already handle it: ChatSession._stream_attempt warns the
-        # user, and the sub-agent loop stops early instead of flailing on an
-        # empty turn.  Falling through to the raw "refusal" string instead
+        # consumers already handle it: the interactive wrapper's
+        # _finalize_stream_result warns the user, and the sub-agent loop
+        # stops early instead of flailing on an empty turn.  Falling through to the raw "refusal" string instead
         # would land a truncated answer as a complete result.
         return "content_filter"
     return reason

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -253,6 +253,20 @@ def transport_guarded(chunks: Iterator[StreamChunk]) -> Iterator[StreamChunk]:
         yield sc
 
 
+# The trailing-citations fold rule, shared spelling: post-finish info
+# (web-search source footers) folds into committed content only onto a
+# non-blank answer, joined by this separator.  The interactive display
+# consumer mirrors the drain's fold with these same two pieces — one
+# constant and one predicate — so the streamed and committed renderings
+# of a footer cannot drift.
+TRAILING_INFO_SEPARATOR = "\n\n"
+
+
+def folds_trailing_info(content: str) -> bool:
+    """Whether a trailing info footer folds onto *content* (non-blank)."""
+    return bool(content.strip())
+
+
 def drain_stream(
     chunks: Iterator[StreamChunk], *, scan_inline_reasoning: bool = True
 ) -> CompletionResult:
@@ -423,10 +437,12 @@ def drain_stream(
     # not exist, folded on, would hand every downstream emptiness check a
     # truthy footer-only "answer".  Blankness, not truthiness; checked
     # only when a footer exists (footers ride web-search turns only, and
-    # the strip scan shouldn't tax every drained completion).
-    if trailing_info_parts and content.strip():
+    # the strip scan shouldn't tax every drained completion).  The gate
+    # and separator are the shared module-level pair above — the display
+    # consumer's mirror uses the same two.
+    if trailing_info_parts and folds_trailing_info(content):
         for info in trailing_info_parts:
-            content += "\n\n" + info
+            content += TRAILING_INFO_SEPARATOR + info
 
     tool_calls = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
     return CompletionResult(
@@ -875,14 +891,15 @@ class LLMProvider(Protocol):
         the model registry (e.g. ``thinking_mode``, ``token_param``)
         are respected.
 
-        If *cancel_ref* is provided the provider appends the underlying SDK
-        stream object (which has a ``.close()`` method) EAGERLY — inside
-        this call's body, at HTTP-response time, before the iterator is
-        even returned (not merely before the first chunk; a lazily-issued
-        generator adapter would violate this).  The append instant is
-        load-bearing: the caller's creation-vs-midstream classifier and
-        health recording key on it (#832), and the eager-append tripwires
-        in ``test_sdk_stream_boundary`` pin it per adapter.  The caller can then close it from another thread to
+        If *cancel_ref* is provided the provider appends the underlying
+        SDK stream object (which has a ``.close()`` method) EAGERLY —
+        inside this call's body, at HTTP-response time, before the
+        iterator is even returned (not merely before the first chunk; a
+        lazily-issued generator adapter would violate this).  The append
+        instant is load-bearing: the caller's creation-vs-midstream
+        classifier and health recording key on it (#832), and the
+        eager-append tripwires in ``test_sdk_stream_boundary`` pin it per
+        adapter.  The caller can then close it from another thread to
         abort a blocked HTTP read immediately.
 
         This is the ONLY transport — single-shot callers drain it through

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -98,10 +98,11 @@ def merge_usage(acc: UsageInfo | None, new: UsageInfo) -> UsageInfo:
     recomputed from the merged parts.  Returns a fresh ``UsageInfo`` and
     never mutates ``new`` (the provider's object).
 
-    Serves :func:`drain_stream` and ``ChatSession``'s inline chunk
-    consumer alike — the interactive loop re-projects the merged
-    accumulator into its ``_last_usage`` dict on every usage chunk (that
-    dict has mid-stream readers), so the two lanes cannot drift on the
+    Serves :func:`drain_stream` (the one assembler) and the interactive
+    ``on_chunk`` consumer's live re-projection alike — the streaming
+    callback re-projects the merged accumulator into the session's
+    ``_last_usage`` dict on every usage chunk (that dict has mid-stream
+    readers), so the display lane cannot drift from the assembly on the
     merge rule.
     """
     if acc is None:
@@ -146,8 +147,9 @@ def accumulate_tool_call_delta(
     fragment), ``arguments_delta`` concatenates.  Returns the (possibly
     fresh) accumulator entry so callers can hang provider extras off it.
 
-    Serves :func:`drain_stream`, ``GoogleProvider``'s raw-fidelity
-    capture, and ``ChatSession``'s inline chunk consumer — every
+    Serves :func:`drain_stream` (the one assembler — post-#832 the
+    interactive loop assembles here too) and ``GoogleProvider``'s
+    raw-fidelity capture — every
     accumulator in the tree, so the chat loop and the drained lanes
     cannot assemble different calls from the same wire stream.
     """
@@ -874,8 +876,13 @@ class LLMProvider(Protocol):
         are respected.
 
         If *cancel_ref* is provided the provider appends the underlying SDK
-        stream object (which has a ``.close()`` method) before yielding the
-        first chunk.  The caller can then close it from another thread to
+        stream object (which has a ``.close()`` method) EAGERLY — inside
+        this call's body, at HTTP-response time, before the iterator is
+        even returned (not merely before the first chunk; a lazily-issued
+        generator adapter would violate this).  The append instant is
+        load-bearing: the caller's creation-vs-midstream classifier and
+        health recording key on it (#832), and the eager-append tripwires
+        in ``test_sdk_stream_boundary`` pin it per adapter.  The caller can then close it from another thread to
         abort a blocked HTTP read immediately.
 
         This is the ONLY transport — single-shot callers drain it through

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -99,11 +99,9 @@ def merge_usage(acc: UsageInfo | None, new: UsageInfo) -> UsageInfo:
     never mutates ``new`` (the provider's object).
 
     Serves :func:`drain_stream` (the one assembler) and the interactive
-    ``on_chunk`` consumer's live re-projection alike — the streaming
-    callback re-projects the merged accumulator into the session's
-    ``_last_usage`` dict on every usage chunk (that dict has mid-stream
-    readers), so the display lane cannot drift from the assembly on the
-    merge rule.
+    ``on_chunk`` consumer, which re-projects the merged accumulator into
+    the session's ``_last_usage`` dict (read mid-stream) on every usage
+    chunk — so the display lane cannot drift from the assembly.
     """
     if acc is None:
         return replace(new)
@@ -147,11 +145,10 @@ def accumulate_tool_call_delta(
     fragment), ``arguments_delta`` concatenates.  Returns the (possibly
     fresh) accumulator entry so callers can hang provider extras off it.
 
-    Serves :func:`drain_stream` (the one assembler — post-#832 the
-    interactive loop assembles here too) and ``GoogleProvider``'s
-    raw-fidelity capture — every
-    accumulator in the tree, so the chat loop and the drained lanes
-    cannot assemble different calls from the same wire stream.
+    Serves :func:`drain_stream` — the one assembler since #832 folded the
+    interactive loop into it — and ``GoogleProvider``'s raw-fidelity
+    capture: every accumulator in the tree, so no two lanes can assemble
+    different calls from the same wire stream.
     """
     tc = acc.setdefault(
         tcd.index,
@@ -253,12 +250,10 @@ def transport_guarded(chunks: Iterator[StreamChunk]) -> Iterator[StreamChunk]:
         yield sc
 
 
-# The trailing-citations fold rule, shared spelling: post-finish info
-# (web-search source footers) folds into committed content only onto a
-# non-blank answer, joined by this separator.  The interactive display
-# consumer mirrors the drain's fold with these same two pieces — one
-# constant and one predicate — so the streamed and committed renderings
-# of a footer cannot drift.
+# The trailing-citations fold rule in one place: post-finish info
+# (web-search source footers) folds onto a non-blank answer only, joined
+# by this separator.  The interactive display consumer and the drain
+# share both pieces, so a footer cannot render two ways.
 TRAILING_INFO_SEPARATOR = "\n\n"
 
 
@@ -437,9 +432,7 @@ def drain_stream(
     # not exist, folded on, would hand every downstream emptiness check a
     # truthy footer-only "answer".  Blankness, not truthiness; checked
     # only when a footer exists (footers ride web-search turns only, and
-    # the strip scan shouldn't tax every drained completion).  The gate
-    # and separator are the shared module-level pair above — the display
-    # consumer's mirror uses the same two.
+    # the strip scan shouldn't tax every drained completion).
     if trailing_info_parts and folds_trailing_info(content):
         for info in trailing_info_parts:
             content += TRAILING_INFO_SEPARATOR + info
@@ -892,15 +885,14 @@ class LLMProvider(Protocol):
         are respected.
 
         If *cancel_ref* is provided the provider appends the underlying
-        SDK stream object (which has a ``.close()`` method) EAGERLY —
+        SDK stream object (which has a ``.close()`` method) EAGERLY:
         inside this call's body, at HTTP-response time, before the
-        iterator is even returned (not merely before the first chunk; a
-        lazily-issued generator adapter would violate this).  The append
-        instant is load-bearing: the caller's creation-vs-midstream
-        classifier and health recording key on it (#832), and the
-        eager-append tripwires in ``test_sdk_stream_boundary`` pin it per
-        adapter.  The caller can then close it from another thread to
-        abort a blocked HTTP read immediately.
+        iterator is returned — not merely before the first chunk (a
+        lazily-issued generator adapter would violate this).  The
+        caller's creation-vs-midstream classifier and health recording
+        key on that instant (#832); ``test_sdk_stream_boundary`` pins it
+        per adapter.  The caller can then close the stream from another
+        thread to abort a blocked HTTP read immediately.
 
         This is the ONLY transport — single-shot callers drain it through
         :func:`drain_stream` instead of a separate non-streaming entry

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -330,8 +330,7 @@ class _CancelRef(list[Any]):
     """List proxy handed to ``create_streaming`` as its ``cancel_ref``.
 
     One FRESH instance per attempt, frame-local to the model-call wrapper
-    that built it — #832 retired the session-level shared slot
-    (``test_cancel`` pins ``not hasattr(session, "_cancel_ref")``).
+    that built it: #832 retired the session-level shared slot.
     Providers call ``cancel_ref.append(stream_handle)`` eagerly — the HTTP
     call and registration happen before the iterator is returned to the
     caller.  By overriding ``append`` we update ``ChatSession._cancel_stream``
@@ -339,31 +338,27 @@ class _CancelRef(list[Any]):
     was created (e.g. cancel during retry backoff), the stream is closed
     on arrival so the blocked iteration is unblocked.
 
-    ``my_generation`` scopes a ref to one generation.  EVERY model-call
-    site now passes its own per-attempt, generation-scoped ref (the main
-    loop and compaction alike — #832 retired the main loop's long-lived
-    gen-0 shared instance, whose ``aborted`` was force-cancel-blind: a
-    successor generation installs a fresh unset event, and gen 0 never
-    reads superseded).  A superseded ref's late-arriving stream — an
-    abandoned call that passed its boundary check just before a
-    force-cancel and opened one final zombie call — must neither hijack
-    ``_cancel_stream`` from the successor generation's live stream nor
-    keep burning tokens, so the append skips the registration and closes
-    the stream on arrival.  The generation check and the register are two
-    lockless statements; the residual bytecode-width TOCTOU (successor
-    claims AND registers between them) is accepted — its harm is one
-    delayed Stop (closes a dead handle; the event arm still cancels at the
-    next chunk), not corruption — versus the model-call-width window this
-    closes.
+    ``my_generation`` scopes a ref to one generation, and EVERY model-call
+    site passes its own per-attempt one (main loop and compaction alike).
+    A long-lived gen-0 ref would be force-cancel-blind: a successor
+    generation installs a fresh unset event, and gen 0 never reads
+    superseded.  A superseded ref's late-arriving stream — an abandoned
+    call that passed its boundary check just before a force-cancel and
+    opened one final zombie call — must neither hijack ``_cancel_stream``
+    from the successor generation's live stream nor keep burning tokens,
+    so the append skips the registration and closes the stream on
+    arrival.  The generation check and the register are two lockless
+    statements; the residual bytecode-width TOCTOU (successor claims AND
+    registers between them) is accepted — its harm is one delayed Stop
+    (closes a dead handle; the event arm still cancels at the next chunk),
+    not corruption — versus the model-call-width window this closes.
 
     ``on_first_append`` fires once, on the first non-superseded append —
-    i.e. at the adapters' eager HTTP-response-time registration, before
-    the iterator is returned (the eager-append tripwire in
-    ``test_sdk_stream_boundary`` pins that timing).  It is the main-loop
-    wrapper's observation point for "the request was accepted": the
-    health tracker's success record, the creation-vs-midstream retry
-    classifier, and the per-turn usage-slot resets all key on it (#832).
-    A superseded arrival does not fire it — an orphan must not record
+    the adapters' eager HTTP-response-time registration, before the
+    iterator is returned.  It is the wrapper's "request was accepted"
+    instant: the health success record, the creation-vs-midstream retry
+    classifier, and the per-turn usage-slot resets all key on it.  A
+    superseded arrival does not fire it — an orphan must not record
     health or reset the successor's usage slots.
     """
 
@@ -422,19 +417,17 @@ class _CancelRef(list[Any]):
         that Stop; the failure surfaces and the caller's own cancel check
         turns it into ``GenerationCancelled``.
 
-        Deliberately the same two conditions as :meth:`_check_cancelled`
-        — provided both are asked about the same generation, which every
-        model-call lane now guarantees by construction: compaction and the
-        main loop alike build a fresh ref per attempt carrying the very
-        ``my_generation`` their surrounding checks use (#832 closed the
-        main loop's gen-0 exception).  The pairing is load-bearing twice:
-        compaction's ``_summarize_once`` handler calls ``_check_cancelled``
-        before it reads the error, converting ``model_turn``'s pre-dispatch
-        raise into a cancelled compaction instead of a red failure row, and
-        the main-loop wrapper's except arms do the same before classifying
-        a death.  Widening this predicate without widening that one, or
-        pairing a ref with a check on a different generation, breaks the
-        translation.
+        Deliberately the same two conditions as :meth:`_check_cancelled`,
+        provided both are asked about the same generation — which every
+        model-call lane guarantees by construction, building a fresh ref
+        per attempt that carries the ``my_generation`` its surrounding
+        checks use.  The pairing is load-bearing twice: compaction's
+        ``_summarize_once`` handler and the main-loop wrapper's except
+        arms both call ``_check_cancelled`` before reading the error,
+        which is what turns ``model_turn``'s pre-dispatch raise into a
+        cancellation rather than a red failure row.  Widening this
+        predicate without widening that one, or pairing a ref with a check
+        on a different generation, breaks the translation.
         """
         return self._session._cancel_event.is_set() or self._superseded()
 
@@ -444,38 +437,35 @@ class _StreamTurnConsumer:
 
     One instance per streaming TURN, reset per attempt: display state
     (splitter carry, spinner latch) is attempt-local, while the instance
-    itself outlives attempts so the re-issue ladder can read the dead
-    attempt's partial without riding it on the exception (the old
-    ``_dead_partial`` hitch-hike — the consumer is frame-local to the
-    wrapper, so an orphaned generation still cannot poison a successor).
+    outlives attempts so the re-issue ladder can read the dead attempt's
+    partial without riding it on the exception.  It is frame-local to the
+    wrapper, so an orphaned generation cannot poison a successor.
 
     Deliberately display-side ONLY: the canonical turn is assembled by
-    ``drain_stream`` inside ``model_turn`` — this class accumulates just
-    enough to serve the partial-preservation rules (flushed content plus
-    the splitter's non-think carry) and the live UI grid.  Reasoning is
-    emitted, never accumulated; tool-call deltas only flush the splitter;
-    ``provider_blocks`` are ignored (assembly owns them).
+    ``drain_stream`` inside ``model_turn``, and this class accumulates
+    just enough to serve the partial-preservation rules (flushed content
+    plus the splitter's non-think carry) and the live UI grid.  Reasoning
+    is emitted, never accumulated; tool-call deltas only flush the
+    splitter; ``provider_blocks`` are ignored (assembly owns them).
 
     The tag-scan posture follows the SAME capability the drain seam reads
     (``server_parses_reasoning``), taken from the ACTIVE lane — primary or
-    fallback — so the interactive and drained interpretations of one
-    stream cannot disagree (the #978 gate, re-homed from the creation-time
-    handoff register onto the lane).
+    fallback — so the interactive and drained readings of one stream
+    cannot disagree.
 
     The trailing citations footer is emitted as CONTENT, mirroring the
     drain's conditional fold (only when the accumulated post-split content
     is non-blank; ``\\n\\n``-joined) — the #832 ruling that citations
-    survive into the committed turn; pre-finish info stays an ephemeral
-    info line exactly as before.
+    survive into the committed turn.  Pre-finish info stays an ephemeral
+    info line.
     """
 
     def __init__(self, session: ChatSession, my_generation: int) -> None:
         self._session = session
         self._my_generation = my_generation
-        # No lane until the walk's first begin_attempt resolves one — the
-        # per-attempt state has exactly ONE initializer (``_reset_attempt``),
-        # so a first attempt and a re-issue cannot drift, and construction
-        # costs no resolve_lane walk.
+        # No lane until the walk's first begin_attempt resolves one:
+        # per-attempt state has exactly ONE initializer, so a first
+        # attempt and a re-issue cannot drift.
         self.lane: ModelLane | None = None
         self.ref: _CancelRef | None = None
         self.tracker: BackendHealthTracker | None = None
@@ -490,15 +480,13 @@ class _StreamTurnConsumer:
         self._path1_reasoning = False
         self._finish_seen = False
         self._saw_chunk = False
-        # Content-state text held across a reasoning block (the run-close
-        # carry) and post-finish footer parts held for the end-of-stream
-        # fold — both owned HERE, outside the splitter, so in_think flips
-        # cannot relabel them (mirrors the drain's separate carry).
+        # The run-close carry and the held footer parts are owned HERE,
+        # outside the splitter, so an ``in_think`` flip cannot relabel
+        # them.
         self._boundary_carry = ""
         self._trailing_info: list[str] = []
         # Per-attempt: a re-issued attempt's usage must never max-merge
-        # onto the dead attempt's (the accumulator was attempt-local in
-        # the pre-fold consumer too).
+        # onto the dead attempt's.
         self._usage_acc: UsageInfo | None = None
         self._splitter = ThinkTagSplitter(
             self._flush_text, scan_tags=lane_scans_inline_reasoning(self.lane)
@@ -512,10 +500,9 @@ class _StreamTurnConsumer:
     ) -> None:
         """Arm display state for one creation attempt on *lane*.
 
-        The usage-slot resets do NOT happen here — they ride
-        :meth:`on_stream_armed` (the request-accepted instant), so a long
-        creation ladder or fallback walk never blanks the reconnecting
-        tab's status bar mid-window.
+        The usage-slot resets ride :meth:`on_stream_armed` (the
+        request-accepted instant) instead, so a long creation ladder or
+        fallback walk never blanks the reconnecting tab's status bar.
         """
         self.ref = ref
         self.tracker = tracker
@@ -526,17 +513,14 @@ class _StreamTurnConsumer:
         """Pronounce the current attempt dead: nothing about it may leak.
 
         The re-issue ladder calls this once a mid-stream death's partial
-        is captured — from here until the next ``begin_attempt`` there is
-        NO live attempt, so ``attempt_armed`` reads False.  Without it, a
-        Stop (or a walk-preamble failure) landing in the re-create window
-        would read the DEAD attempt's armed ref: the cancel arm would
-        re-finalize discarded display state — the stale splitter carry
-        emitted as a fresh content token into the just-truncated segment,
-        with a duplicate ``stream_end`` behind it — and a preamble error
-        would be classified as another armed death, replacing the
-        operator-actionable stream-death error.  The lane survives: the
-        ladder's terminal predicate is judged by the lane that actually
-        armed the dead stream.
+        is captured: from here until the next ``begin_attempt`` there is
+        NO live attempt, so ``attempt_armed`` reads False.  Otherwise a
+        Stop or a walk-preamble failure landing in the re-create window
+        reads the DEAD attempt's armed ref — re-finalizing discarded
+        display state, or classifying a preamble error as another armed
+        death and replacing the operator-actionable stream-death error.
+        The lane survives: the ladder's terminal predicate is judged by
+        the lane that actually armed the dead stream.
         """
         self.ref = None
         self._reset_attempt()
@@ -544,26 +528,22 @@ class _StreamTurnConsumer:
     @property
     def attempt_armed(self) -> bool:
         """Whether this attempt streamed: handle registered, or any chunk
-        actually surfaced.  The chunk fallback is the tripwire for an
-        adapter that skips the eager ``cancel_ref`` append (an out-of-tree
-        adapter written to the pre-#832 letter of the contract): its
-        mid-stream death must still classify as mid-stream — a
-        creation-classified death would silently re-issue the same lane
-        and double-render everything already on screen.  Such an adapter
-        still forfeits ``on_stream_armed``'s duties (health success,
-        usage-slot resets); the in-tree tripwires pin eager arming."""
+        surfaced.  The chunk fallback covers an adapter that skips the
+        eager ``cancel_ref`` append — its mid-stream death must still
+        classify as mid-stream, since a creation-classified death would
+        silently re-issue the same lane and double-render what is already
+        on screen.  Such an adapter still forfeits ``on_stream_armed``'s
+        duties (health success, usage-slot resets)."""
         return (self.ref is not None and self.ref.armed) or self._saw_chunk
 
     def on_stream_armed(self) -> None:
         """`_CancelRef.on_first_append` — the request-accepted instant.
 
-        Carries three duties at exactly the old create-return timing:
-        the health success record for the serving lane, and the two
-        per-turn usage-slot resets whose placement guards both the
+        Three duties: the health success record for the serving lane, and
+        the two per-turn usage-slot resets, placed here to guard both the
         stale-usage leak (a post-finish blip can lose the trailing usage
         chunk, and a stale completion count would be recycled as the next
-        turn's estimate) and
-        the reconnect status-bar blackout.
+        turn's estimate) and the reconnect status-bar blackout.
         """
         s = self._session
         s._last_usage = None
@@ -589,17 +569,15 @@ class _StreamTurnConsumer:
             self._first_token = False
 
     def __call__(self, chunk: StreamChunk) -> None:
-        # Before the cancel check: the chunk DID arrive, so the attempt
-        # streamed — the classifier fallback must see that even when this
-        # very chunk's cancel check aborts the turn.
+        # Set before the cancel check: the chunk arrived, so the attempt
+        # streamed even when this very chunk's check aborts the turn.
         self._saw_chunk = True
         s = self._session
         s._check_cancelled(self._my_generation)
         if chunk.finish_reason:
             self._finish_seen = True
 
-        # Usage re-projects on EVERY usage chunk via THE shared max-merge
-        # rule — one atomic dict rebind, because the SSE replay preamble
+        # One atomic dict rebind per usage chunk: the SSE replay preamble
         # reads this slot from the connection thread mid-stream.
         if chunk.usage:
             self._usage_acc = merge_usage(self._usage_acc, chunk.usage)
@@ -620,17 +598,12 @@ class _StreamTurnConsumer:
         if chunk.reasoning_delta:
             self._stop_spinner_once()
             # Entering the native-reasoning phase closes the current run
-            # UNCONDITIONALLY, exactly as the drain does: decided text
-            # emits at its own state (content-state tail as content,
-            # in-think tail as reasoning — gating this on in_think left
-            # an open inline think block's carry to be relabeled as
-            # displayed ANSWER text by the later state flip, the CoT-leak
-            # half of the round-2 findings), and only a partial tag
-            # prefix carries across the block.  The carry lives on the
-            # CONSUMER, not in the splitter's pending — pending is read
-            # under whatever state later flushes hit, and the in_think
-            # flip below would relabel a content-state carry as
-            # reasoning (the other half).
+            # UNCONDITIONALLY, as the drain does: an open inline think
+            # block's carry must close at its own state or the later
+            # state flip relabels it, and only a partial tag prefix
+            # carries across the block.  The carry lives on the CONSUMER,
+            # not in the splitter's pending, which is read under whatever
+            # state later flushes hit.
             self._boundary_carry += self._splitter.close_run()
             self._splitter.in_think = True
             self._path1_reasoning = True
@@ -644,10 +617,9 @@ class _StreamTurnConsumer:
                 self._path1_reasoning = False
                 self._splitter.in_think = False
             if self._boundary_carry:
-                # Content resumed after the reasoning block: the carry
-                # prefixes the new text so a tag the server split across
-                # the block reassembles (the drain prefixes its carried
-                # tail onto the next run the same way).
+                # The carry prefixes the resumed text so a tag the server
+                # split across the reasoning block reassembles — the
+                # drain prefixes its carried tail the same way.
                 self._splitter.feed(self._boundary_carry)
                 self._boundary_carry = ""
             self._splitter.feed(chunk.content_delta)
@@ -658,8 +630,8 @@ class _StreamTurnConsumer:
             self._stop_spinner_once()
             if self._boundary_carry:
                 # A partial tag never spans a TOOL boundary (the drain's
-                # rule): the carry is content-state text — flush it as
-                # content, whatever in_think says now.
+                # rule), and the carry is content-state text: flush it as
+                # content whatever ``in_think`` says now.
                 self._flush_text(self._boundary_carry, False)
                 self._boundary_carry = ""
             self._splitter.flush_pending()
@@ -668,13 +640,11 @@ class _StreamTurnConsumer:
         if chunk.info_delta:
             self._stop_spinner_once()
             if self._finish_seen:
-                # Post-finish info is the trailing citations footer: HELD
-                # and folded once at stream end after ALL content
-                # (:meth:`finish_stream`), exactly the drain's post-loop
-                # fold.  Folding at arrival diverges from the commit when
-                # a lax gateway emits content after finish — the fold
-                # gate must judge the FULL answer, and the footer must
-                # follow it.
+                # The trailing citations footer is HELD and folded once
+                # at stream end (:meth:`finish_stream`), like the drain's
+                # post-loop fold: a lax gateway can emit content after
+                # finish, and the fold gate must judge the FULL answer
+                # with the footer behind it.
                 self._trailing_info.append(chunk.info_delta)
             else:
                 s.ui.on_info(f"{GRAY}{chunk.info_delta}{RESET}")
@@ -682,11 +652,11 @@ class _StreamTurnConsumer:
     # -- partial preservation --------------------------------------------------
 
     def partial_content(self) -> str:
-        """THE partial-content rule: flushed content, plus the boundary
-        carry (content-state by construction), plus the splitter's carry
-        tail when it is content-state (an in-think tail is reasoning and
-        stays out) — one closure serving the cancel arms and the re-issue
-        ladder's dead-partial promotion alike."""
+        """THE partial-content rule: flushed content, the boundary carry
+        (content-state by construction), and the splitter's tail only
+        when it is content-state — an in-think tail is reasoning and
+        stays out.  Serves the cancel arms and the re-issue ladder's
+        dead-partial promotion alike."""
         return (
             "".join(self._content_parts)
             + self._boundary_carry
@@ -695,9 +665,9 @@ class _StreamTurnConsumer:
 
     def _flush_terminal_carries(self) -> None:
         """Terminal display flush shared by the finish and cancel arms:
-        the boundary carry emits as CONTENT (its state was fixed when the
-        run closed — the drain appends its dangling carry to content the
-        same way), then the splitter's own pending at the current state."""
+        the boundary carry emits as CONTENT — its state was fixed when
+        the run closed — then the splitter's pending at the current
+        state."""
         if self._boundary_carry:
             self._flush_text(self._boundary_carry, False)
             self._boundary_carry = ""
@@ -707,15 +677,13 @@ class _StreamTurnConsumer:
         """End-of-stream display flush: the held carries, then the
         trailing citations footer.
 
-        The drain assembled the canonical content already; without this
-        the DISPLAYED stream is missing its last ≤MAX_TAG_LEN characters
-        (the carries), and the footer fold must run AFTER them — once,
-        over the full answer, with the shared gate and separator — or
-        the displayed fold diverges from the drain's post-loop fold.
-        Success-path only, after the trailing Stop re-check — the cancel
-        arms flush via :meth:`record_cancelled_partial` and drop the
-        footer (a cancelled turn commits no drained content to fold
-        onto)."""
+        Without this the DISPLAYED stream is missing its last
+        ≤MAX_TAG_LEN characters, and the footer fold must run AFTER them
+        — once, over the full answer — or it diverges from the drain's
+        post-loop fold.  Success-path only, after the trailing Stop
+        re-check: the cancel arms flush via
+        :meth:`record_cancelled_partial` and drop the footer, since a
+        cancelled turn commits no drained content to fold onto."""
         self._flush_terminal_carries()
         if self._trailing_info and folds_trailing_info("".join(self._content_parts)):
             for info in self._trailing_info:
@@ -727,8 +695,8 @@ class _StreamTurnConsumer:
         send()'s cancel handler.  No-op for a SUPERSEDED generation: an
         orphan must touch neither the UI nor the shared partial slot.
         ``tool_calls`` and the native lane are DELIBERATELY omitted —
-        incomplete calls would orphan their results, and the marker-as-
-        message contract needs plain content (same rules as ever)."""
+        incomplete calls would orphan their results, and the
+        marker-as-message contract needs plain content."""
         if self._session._generation != self._my_generation:
             return
         content = self.partial_content()
@@ -2283,8 +2251,8 @@ class ChatSession:
         # content-addressed against the turn; same lifecycle as the two above.
         self._tool_previews: dict[str, tuple[dict[str, Any], Attachment]] = {}
         # Cooperative cancellation: set from outside to stop generation.
-        # No long-lived cancel REF: every model-call site builds a fresh
-        # per-attempt, generation-scoped _CancelRef (#832) — this slot is
+        # No long-lived cancel REF: every model-call site builds its own
+        # per-attempt, generation-scoped _CancelRef, and this slot is only
         # the closeable handle those refs register for cancel().
         self._cancel_event = threading.Event()
         self._cancel_stream: Any = None  # closeable SDK stream handle
@@ -2296,11 +2264,6 @@ class ChatSession:
         # the model detached on purpose.  close() reaps everything.
         self._background_shells = BackgroundShellRegistry(on_exit=self._on_background_shell_exit)
         self._cancelled_partial_msg: dict[str, Any] | None = None
-        # (The creation-time handoff register — _active_stream_provider /
-        # _active_stream_caps — is gone: the streaming wrapper's frame
-        # holds the ACTIVE ModelLane itself, so the retry gate's
-        # retryable set and the consumer's tag-scan posture read the
-        # serving lane by construction, fallback walk included. #832)
         self._pending_retry: str | None = None
         # True when a fatal exception's text has been persisted to
         # workstream_config["last_error"] for the coord's inspect/wait
@@ -5766,11 +5729,9 @@ class ChatSession:
 
         name = type(exc).__name__
 
-        # A wire-preparation failure is the session's own data at fault —
-        # ``model_turn`` typed it so no ladder recorded health or walked
-        # fallbacks.  Checked FIRST: it is the most specific classification,
-        # and the overflow text-match below must not claim a lowering error
-        # whose message happens to mention token limits.
+        # A wire-preparation failure is the session's own data at fault, not
+        # the backend's.  Checked FIRST: the overflow text-match below must
+        # not claim a lowering error whose message mentions token limits.
         if isinstance(exc, WirePreparationError):
             prep_cause = exc.__cause__
             detail = f"{type(prep_cause).__name__}: {prep_cause}" if prep_cause else raw_msg
@@ -6226,16 +6187,12 @@ class ChatSession:
 
         The session's OWN sampling knobs override the lane's
         operator-resolved rungs (``dataclasses.replace`` on the frozen
-        lane): the pre-fold loop passed ``self.temperature`` /
-        ``self.reasoning_effort`` to the wire verbatim and never consulted
-        the per-alias config rungs, and a resumed workstream with unset
-        knobs must keep OMITTING rather than newly picking up alias
-        config.  ``config_store`` is deliberately NOT passed: its only
-        consumers inside ``resolve_lane`` are the two sampling-knob
-        resolvers this method overrides, and a dead store read per lane
-        build would misread as the rungs reaching the main loop.  Whether
-        they SHOULD is a live question — but not this fold's (wire parity
-        first).
+        lane): a resumed workstream with unset knobs must keep OMITTING
+        them rather than picking up per-alias config.  ``config_store``
+        is deliberately NOT passed — its only consumers inside
+        ``resolve_lane`` are the two sampling-knob resolvers this method
+        overrides, so a dead store read per lane build would misread as
+        those rungs reaching the main loop.
         """
         lane = resolve_lane(
             provider,
@@ -6258,17 +6215,16 @@ class ChatSession:
         prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
         my_generation: int = 0,
     ) -> ModelTurnResult:
-        """Run one plant call with lane-swap fallback — the successor of the
-        stream-creation walk, one ``model_turn`` ladder per lane.
+        """Run one plant call with lane-swap fallback: one ``model_turn``
+        ladder per lane.
 
-        Health semantics preserved exactly: success records at the
-        request-accepted instant (the consumer's ``on_stream_armed`` hook),
-        failure records HERE, once per lane's whole ladder — and an ARMED
-        death records neither, because a mid-stream death was never a
-        creation-health signal (it re-raises straight to the re-issue
-        ladder in ``_stream_response``; a fallback lane whose stream died
-        after tokens reached the UI must never be swallowed into
-        try-the-next-alias, or the turn double-renders).
+        Success records at the request-accepted instant (the consumer's
+        ``on_stream_armed`` hook), failure records HERE once per lane's
+        whole ladder, and an ARMED death records neither — a mid-stream
+        death is not a creation-health signal, and it re-raises to the
+        re-issue ladder in ``_stream_response`` rather than being
+        swallowed into try-the-next-alias, which would double-render the
+        turn.
         """
         tracker = self._get_health_tracker()
         primary_lane = self._build_main_lane(
@@ -6287,11 +6243,10 @@ class ChatSession:
             # refusal as backend health and never route it to a static fallback.
             raise
         except WirePreparationError:
-            # Session-data fault, typed by ``model_turn``: the caller's own
-            # lowering raised.  No health record and no fallback walk —
-            # every lane would re-run the same deterministic passes, and
-            # N recorded failures would paint a cluster-wide outage over
-            # a malformed turn in ONE session's history.
+            # No health record and no fallback walk: every lane would
+            # re-run the same deterministic passes, and N recorded
+            # failures would paint a cluster-wide outage over one
+            # session's malformed history.
             raise
         except Exception as primary_err:
             if consumer.attempt_armed:
@@ -6366,21 +6321,18 @@ class ChatSession:
                 fb_lane, fb_tracker, consumer, prepare_wire, my_generation
             )
         except (BackendAuthUnavailableError, WirePreparationError):
-            # Same two verbatim-forward classes as the primary walk: an
-            # auth refusal is fail-closed policy, a wire-preparation
-            # failure is the caller's data bug — neither is this
-            # fallback's health signal.
+            # An auth refusal is fail-closed policy and a wire-preparation
+            # failure is the caller's data bug: neither is this fallback's
+            # health signal.
             raise
         except Exception as fb_err:
             if consumer.attempt_armed:
                 raise
             if fb_tracker:
                 fb_tracker.record_failure()
-            # Class name only in the UI line — the same rule as the
-            # re-issue log arm: a ConnectError's text can carry a
-            # credential-bearing base_url verbatim, and this string lands
-            # in the browser transcript and persisted event stream.  The
-            # full detail goes to the server log.
+            # Class name only in the UI line: a ConnectError's text can
+            # carry a credential-bearing base_url, and this string lands in
+            # the browser transcript and the persisted event stream.
             log.warning(
                 "fallback.failed",
                 alias=alias,
@@ -6421,20 +6373,18 @@ class ChatSession:
         """One lane's creation ladder around ``model_turn``.
 
         Per-attempt state is a FRESH generation-scoped ``_CancelRef`` whose
-        ``on_first_append`` hook marks the request-accepted instant — the
-        creation-vs-midstream classifier: an ARMED attempt's death re-raises
-        immediately to the re-issue ladder (its tokens may be on screen; a
-        silent same-lane retry would double-render), while an unarmed
-        failure is a creation failure and retries here.  The old shared
-        gen-0 ref is gone — a force-cancelled generation's ref now reads
-        ``aborted`` via supersession, so ``model_turn`` refuses dispatch for
-        orphans by construction.
+        ``on_first_append`` hook marks the request-accepted instant, which
+        classifies creation vs mid-stream: an ARMED attempt's death
+        re-raises to the re-issue ladder (its tokens may be on screen, and
+        a silent same-lane retry would double-render), while an unarmed
+        failure is a creation failure and retries here.  Generation-scoping
+        makes an orphan's ref read ``aborted`` via supersession, so
+        ``model_turn`` refuses dispatch for it.
 
         Sampling knobs ride the lane (see ``_build_main_lane``); the
         credential resolves INSIDE ``model_turn`` per attempt, after its
-        entry abort read — a Stop set before the turn no longer mints a
-        token on a dynamically authenticated alias (#832; the #972 rule
-        extended to the interactive path).
+        entry abort read, so a Stop set before the turn mints no token on
+        a dynamically authenticated alias (#972).
         """
         raw_url = str(getattr(lane.client, "base_url", getattr(lane.client, "_base_url", "?")))
         safe_url = raw_url.split("?")[0]  # strip query params (may contain keys)
@@ -6464,17 +6414,15 @@ class ChatSession:
                     on_chunk=consumer,
                 )
             except Exception as e:
-                # A Stop — or supersession — is never a backend failure:
-                # convert BEFORE any classification, the same pre-read
-                # translation compaction's handler performs.  This one line
-                # turns ``model_turn``'s pre-dispatch DeadlineCancelledError,
-                # a post-``cancel()`` transport death, and an orphaned
-                # generation's error into ``GenerationCancelled``.
+                # A Stop — or supersession — is never a backend failure, so
+                # convert BEFORE any classification: this turns a
+                # pre-dispatch DeadlineCancelledError, a post-``cancel()``
+                # transport death, and an orphan's error into
+                # ``GenerationCancelled``.
                 self._check_cancelled(my_generation)
                 if consumer.attempt_armed:
-                    # Mid-stream death — the re-issue ladder owns armed
-                    # deaths (UI finalize → notice → backoff → discard →
-                    # full re-create), on every lane.
+                    # The re-issue ladder owns armed deaths (UI finalize →
+                    # notice → backoff → discard → full re-create).
                     raise
                 ename = type(e).__name__
                 cause_name = (
@@ -7339,11 +7287,9 @@ class ChatSession:
             zero_budget_compact_attempts = 0
             while True:
                 self._check_cancelled(my_generation)
-                # Wire preparation (and the debug request dump) live in the
-                # streaming wrapper's ``prepare_wire`` closure now — run
-                # inside ``model_turn`` per attempt, so a mid-retry rebind
-                # re-prepares by construction and this frame never holds a
-                # wire copy.
+                # Wire preparation and the debug dump live in the streaming
+                # wrapper's ``prepare_wire`` closure — this frame holds no
+                # wire copy, so a mid-retry rebind re-prepares by itself.
 
                 # Reset the per-turn inflight buffers BEFORE entering
                 # the streaming phase so the SSE refresh-resume snapshot
@@ -7409,10 +7355,9 @@ class ChatSession:
                 finally:
                     # Only clear if this generation is still active —
                     # an orphaned thread must not clobber a newer stream.
-                    # (The per-attempt cancel refs die with their frames —
-                    # #832 — but this slot is the handle cancel() closes,
-                    # and a completed turn's dead handle must not linger
-                    # into tool execution.)
+                    # This slot is the handle cancel() closes: a completed
+                    # turn's dead handle must not linger into tool
+                    # execution.
                     if self._generation == my_generation:
                         self._cancel_stream = None
                     self.ui.on_thinking_stop()
@@ -7422,19 +7367,14 @@ class ChatSession:
                     return
 
                 # The wire fold the provider ACTUALLY counted rides the
-                # result (``wire_msgs`` — a mid-retry rebind re-prepared it
-                # inside the streaming wrapper, invisibly to this frame),
-                # keeping the calibration char count aligned with what the
-                # provider counted.  Frame-owned, so a superseding
-                # generation cannot alias it; a fake result without it
-                # falls through to the on-the-fly re-fold inside
-                # ``_update_token_table``.
+                # result: a mid-retry rebind re-prepared it inside the
+                # streaming wrapper, invisibly to this frame.  A fake
+                # result without it re-folds inside _update_token_table.
                 self._update_token_table(msgs=result.wire_msgs)
                 self._print_status_line()  # Report usage for EVERY API call
-                # The canonical Turn — minted tool ids, finalized native
-                # lane, and an ACCURATE producer (the serving lane's, so a
-                # fallback-served turn no longer wears the primary's name
-                # and an in-memory fork no longer decodes producer="").
+                # The canonical Turn: minted tool ids, finalized native
+                # lane, and the SERVING lane's producer, so a
+                # fallback-served turn is not labeled with the primary's.
                 self.messages.append(result.turn)
                 # Clear per-turn inflight buffers — the assistant
                 # message is now in the history list a refresh would
@@ -7452,8 +7392,7 @@ class ChatSession:
 
                 # Log assistant message to conversation history.  ONE
                 # binding for the call list: the persisted mirror and the
-                # executed set below must be the same value by
-                # construction, not by coincidence.
+                # executed set below must be the same value.
                 content = result.content
                 tool_calls = result.tool_calls or None
                 native = result.turn.native
@@ -8253,20 +8192,17 @@ class ChatSession:
         The plant call is ONE ``model_turn`` invocation per attempt
         (creation + drain fused), reached through the lane-swap fallback
         walk; chunk→UI translation lives in the frame's
-        :class:`_StreamTurnConsumer`, handed to ``model_turn`` as
-        ``on_chunk``.  Wire preparation is the ``prepare_wire`` closure —
-        the session's own lowering composed after the seam passes — so a
-        mid-retry registry rebind needs no explicit re-prepare: the next
-        attempt re-runs the closure against the refreshed binding by
-        construction.
+        :class:`_StreamTurnConsumer`, handed over as ``on_chunk``.  Wire
+        preparation is the ``prepare_wire`` closure, so a mid-retry
+        registry rebind needs no explicit re-prepare: the next attempt
+        re-runs the closure against the refreshed binding.
 
         A wire death DURING body iteration surfaces after the request was
-        accepted (the attempt's ``_CancelRef`` armed), so neither the
-        SDK's ``max_retries`` nor the per-lane creation ladder ever sees
-        it; ``model_turn``'s own drain retry is DISABLED on this path (a
-        partially-surfaced stream is never silently re-issued).  This loop
-        finalizes the dead attempt in every UI consumer, then re-issues
-        the whole turn (the APIs cannot resume a generation) up to
+        accepted (the attempt's ``_CancelRef`` armed), so neither the SDK's
+        ``max_retries`` nor the per-lane creation ladder ever sees it, and
+        ``model_turn``'s own drain retry is DISABLED here.  This loop
+        finalizes the dead attempt in every UI consumer, then re-issues the
+        whole turn (the APIs cannot resume a generation) up to
         ``_MID_STREAM_RETRIES`` times.
 
         Ladder stacking: a 3-way stack — each re-issue runs the full
@@ -8274,15 +8210,14 @@ class ChatSession:
         fallback-chain passes, so a persistently transient-shaped failure
         burns (_MID_STREAM_RETRIES + 1) x ((_MAX_RETRIES + 1) + fallback
         passes) calls before the terminal error surfaces.  Both inner
-        layers are the pre-fold creation path (task_agent's ``_api_call``
-        documents the equivalent 2-way stack); every layer stops
-        immediately on a non-retryable class.
+        layers are the creation path's own ladders (task_agent's
+        ``_api_call`` documents the equivalent 2-way stack); every layer
+        stops immediately on a non-retryable class.
         """
         attempt = 0
         # The latest non-empty dead attempt's flushed text.  Wrapper-LOCAL
         # (read off the frame's consumer, never a session slot), so an
-        # orphaned superseded generation cannot poison a live generation's
-        # preservation.
+        # orphaned generation cannot poison a live one's preservation.
         dead_partial = ""
         # The armed death whose re-issue is in progress; when the RE-CREATE
         # phase fails with an unarmed error, the original death is the one
@@ -8295,13 +8230,11 @@ class ChatSession:
         def _prepare(lowered: list[dict[str, Any]]) -> list[dict[str, Any]]:
             """The main loop's ``prepare_wire``: system prepend + the
             session lowering passes, plus the debug request dump behind a
-            once-per-invocation latch — re-issues and fallback lanes
+            once-per-invocation latch, so re-issues and fallback lanes
             re-run the passes but not the dump.  send()'s overflow
-            recovery calls ``_stream_response`` again and prints again:
+            recovery calls ``_stream_response`` again and prints again —
             post-compaction the wire CHANGED, and the re-prepared dump is
-            the one that diagnoses the recovery (a named #832 delta — the
-            pre-fold print-once-per-send was an accident of wire prep
-            living outside the streaming try)."""
+            the one that diagnoses the recovery (a named #832 delta)."""
             nonlocal debug_printed
             wire = self._prepare_wire_messages([*self.system_messages, *lowered])
             if self.debug and not debug_printed:
@@ -8331,13 +8264,11 @@ class ChatSession:
                 and not dead_partial
             ):
                 # Nothing ever streamed this send: a Stop in the
-                # creation/walk window with no prior armed death.
-                # Pre-fold, the first creation ran OUTSIDE the promote
-                # arm and no assistant row was written for a turn that
-                # never streamed — keep that: a marker-only row would
-                # replay to the model as context on every later turn
-                # (round-2 finding; an ARMED zero-token Stop still
-                # records its marker via record_cancelled_partial).
+                # creation/walk window with no prior armed death.  A turn
+                # that never streamed writes no assistant row — a
+                # marker-only row would replay to the model as context on
+                # every later turn.  (An ARMED zero-token Stop still
+                # records its marker via record_cancelled_partial.)
                 return
             cur = self._cancelled_partial_msg
             if cur is None or (not cur.get("content") and dead_partial):
@@ -8351,9 +8282,8 @@ class ChatSession:
                 result = self._model_turn_with_fallback(consumer, _prepare, my_generation)
                 # A Stop that raced the trailing-metadata window: cancel()
                 # closed the stream and the drain's post-finish tolerance
-                # ended it CLEANLY — without this re-check the turn would
-                # commit as complete and its tool calls would execute
-                # despite the Stop.
+                # ended it CLEANLY, so without this re-check the turn
+                # commits as complete and its tool calls execute.
                 self._check_cancelled(my_generation)
                 consumer.finish_stream()
                 return self._finalize_stream_result(result)
@@ -8379,12 +8309,11 @@ class ChatSession:
                 new_dead = consumer.partial_content() if armed else ""
                 dead_partial = new_dead or dead_partial
                 if armed:
-                    # The attempt is dead and its partial captured — from
-                    # here until the next ``begin_attempt`` there is no
-                    # live attempt.  Without this, a Stop or a
-                    # walk-preamble failure landing in the re-create
-                    # window reads the DEAD attempt's armed state (see
-                    # ``end_attempt``).
+                    # The partial is captured, so there is no live attempt
+                    # until the next ``begin_attempt``: without this, a
+                    # Stop or a walk-preamble failure landing in the
+                    # re-create window reads the DEAD attempt's armed
+                    # state (see ``end_attempt``).
                     consumer.end_attempt()
                 if self._generation != my_generation:
                     # Superseded (force-cancel started a newer generation):
@@ -8394,20 +8323,18 @@ class ChatSession:
                     raise
                 if not armed:
                     # Creation-phase failure: the walk already ran its full
-                    # ladder + fallbacks.  Mid re-issue it must not MASK the
-                    # original stream death (a closed-client re-create
+                    # ladder + fallbacks.  Mid re-issue it must not MASK
+                    # the original stream death (a closed-client re-create
                     # surfaces as a retryable APIConnectionError and would
-                    # replace the operator-actionable wording) — EXCEPT the
-                    # classes that carry their own remediation: a
-                    # deterministic overflow surfaces as ITSELF so send()'s
+                    # replace the operator-actionable wording) — EXCEPT
+                    # the classes carrying their own remediation: an
+                    # overflow surfaces as ITSELF so send()'s
                     # compact-and-retry arm can recover the turn, and an
-                    # auth refusal / wire-preparation fault surfaces as
+                    # auth refusal or wire-preparation fault surfaces as
                     # ITSELF so the fatal formatter's dedicated branch
-                    # renders (an OBO mint dying mid-turn is a config
-                    # outage, not a network flap — the walk forwards both
-                    # verbatim for exactly that reason).
-                    # Class name only in the log — a ConnectError's text can
-                    # carry a credential-bearing base_url verbatim.
+                    # renders.  Class name only in the log — a
+                    # ConnectError's text can carry a credential-bearing
+                    # base_url verbatim.
                     if (
                         last_stream_death is None
                         or isinstance(e, (BackendAuthUnavailableError, WirePreparationError))
@@ -8502,10 +8429,9 @@ class ChatSession:
                     # clients whose connection config changed — the
                     # in-flight read then dies with a ReadError and
                     # self.client is CLOSED.  Generation-gated (two compares
-                    # when nothing changed) and cheap; the re-prepare the
-                    # old path ran on a changed binding is now implicit —
-                    # the next attempt's ``prepare_wire`` closure runs
-                    # against whatever binding the walk resolves.
+                    # when nothing changed); the next attempt's
+                    # ``prepare_wire`` closure re-prepares against whatever
+                    # binding the walk resolves.
                     self._refresh_model_from_registry()
                 except GenerationCancelled:
                     # A Stop landing in the backoff window aborts the turn
@@ -8518,13 +8444,12 @@ class ChatSession:
         """Post-drain policies for a COMPLETED interactive turn.
 
         The ``length`` partial-tool-call drop is harness policy, not
-        assembly: the drain keeps everything it accumulated, and this is
-        where the interactive lane discards calls whose JSON arguments a
-        truncation cut mid-string — executing them would dispatch garbage
-        (the sub-agent loop's policy differs: it stops the run instead).
-        The rebuilt turn keeps its reasoning synth but drops the orphan
-        native client tool blocks, via the SAME shared finalize the
-        assembly used (``has_tool_calls=False`` arm) — no private strip.
+        assembly: the drain keeps what it accumulated, and the interactive
+        lane discards calls whose JSON arguments a truncation cut
+        mid-string, since executing them would dispatch garbage (the
+        sub-agent loop stops the run instead).  The rebuilt turn keeps its
+        reasoning synth but drops the orphan native client tool blocks via
+        the SAME shared finalize the assembly used — no private strip.
         """
         finish_reason = result.finish_reason
         if finish_reason == "length":
@@ -8567,13 +8492,11 @@ class ChatSession:
             self.ui.on_error("Warning: response blocked by content filter.")
 
         # Non-destructive integrity signal: the length-guard above drops
-        # tool calls only on ``finish_reason == "length"``, so a model that
-        # emits invalid-JSON arguments with a ``stop``/``tool_calls``
-        # finish reason commits them verbatim.  The canonical Turn stays a
-        # faithful record (the wire copy is legalized by
-        # ``lowering.sanitize_tool_call_arguments``); this only flags the
-        # model-quality problem at the moment it happens, not merely as a
-        # downstream wire legalization on every replay.
+        # tool calls only on ``finish_reason == "length"``, so invalid-JSON
+        # arguments with a ``stop``/``tool_calls`` finish reason commit
+        # verbatim.  The canonical Turn stays a faithful record (the wire
+        # copy is legalized by ``lowering.sanitize_tool_call_arguments``);
+        # this flags the model-quality problem where it happens.
         for tc in result.tool_calls:
             raw_args = tc["function"].get("arguments")
             if not wire_valid_arguments(raw_args):
@@ -8763,9 +8686,7 @@ class ChatSession:
         redundant ``_prepare_wire_messages`` walk and ensures the char
         count matches the bytes the provider counted.  When *msgs* is
         None the caller didn't have one (fake results, direct calls) —
-        fall back to folding on the fly.  (The old leading
-        ``assistant_msg`` parameter was never read by the body and is
-        gone — #832.)
+        fall back to folding on the fly.
         """
         if not self._last_usage:
             return
@@ -9146,11 +9067,10 @@ class ChatSession:
                     # landed), so cancel() aborts the blocked read instead
                     # of waiting out a whole model call — the force-stop
                     # orphan window collapses from one summary call to the
-                    # next checkpoint.  The same fresh-per-attempt,
-                    # generation-scoped discipline the main loop now uses
-                    # (#832); the boundary checks in
+                    # next checkpoint.  A fresh generation-scoped ref per
+                    # attempt; the boundary checks in
                     # _summarize_batch/_backoff guarantee a superseded
-                    # compaction makes no further calls — so it can never
+                    # compaction makes no further calls, so it can never
                     # clobber a successor's registration.
                     cancel_ref=_CancelRef(self, my_generation),
                 )

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -537,6 +537,15 @@ class _StreamTurnConsumer:
         duties (health success, usage-slot resets)."""
         return (self.ref is not None and self.ref.armed) or self._saw_chunk
 
+    def _superseded(self) -> bool:
+        """Whether a newer generation has claimed this session — the
+        consumer's copy of :meth:`_CancelRef._superseded`, scoped the same
+        way (generation 0 is unscoped, so a direct seam caller is never
+        superseded).  The two must agree: the ref decides whether to fire
+        the arm hook, and the hook's own gate decides whether to act."""
+        gen = self._my_generation
+        return bool(gen and self._session._generation != gen)
+
     def on_stream_armed(self) -> None:
         """`_CancelRef.on_first_append` — the request-accepted instant.
 
@@ -550,10 +559,13 @@ class _StreamTurnConsumer:
         two lockless steps, so a force-cancel can claim a new generation
         between them — an orphan's late-arriving registration must not
         null the SUCCESSOR's usage slots or record health for an
-        abandoned lane.
+        abandoned lane.  Scoping matches the ref's own ``_superseded``
+        and ``_check_cancelled``: generation 0 is UNSCOPED (a direct
+        seam caller), and the ref fires the hook for it, so the gate
+        must not refuse it.
         """
         s = self._session
-        if s._generation != self._my_generation:
+        if self._superseded():
             return
         s._last_usage = None
         s._assistant_pending_tokens = 0
@@ -706,7 +718,7 @@ class _StreamTurnConsumer:
         ``tool_calls`` and the native lane are DELIBERATELY omitted —
         incomplete calls would orphan their results, and the
         marker-as-message contract needs plain content."""
-        if self._session._generation != self._my_generation:
+        if self._superseded():
             return
         content = self.partial_content()
         self._flush_terminal_carries()
@@ -1826,6 +1838,18 @@ _SELF_SURFACING_ERRORS: tuple[type[Exception], ...] = (
     BackendAuthUnavailableError,
     WirePreparationError,
 )
+
+# Creation failures that say nothing about the BACKEND: the caller's own
+# lowering raised.  Recording them would paint a cluster-wide outage over
+# one session's malformed history.
+_NON_BACKEND_ERRORS: tuple[type[Exception], ...] = (WirePreparationError,)
+
+
+def _speaks_for_backend(err: BaseException) -> bool:
+    """Whether a creation failure is a health signal for its lane — THE
+    predicate both walk arms use, so primary and fallback can never
+    classify the same error differently."""
+    return not isinstance(err, _NON_BACKEND_ERRORS)
 
 
 def _mint_refusal_cause(
@@ -6276,7 +6300,7 @@ class ChatSession:
             # health — but it DOES enter the walk: prepare runs per lane
             # (fold posture follows lane.capabilities), so another lane's
             # posture may serve a turn the primary's could not.
-            if tracker and not isinstance(primary_err, WirePreparationError):
+            if tracker and _speaks_for_backend(primary_err):
                 tracker.record_failure()
             if not self._registry or not self._registry.fallback:
                 raise
@@ -6352,7 +6376,7 @@ class ChatSession:
             # This lane's wire-preparation fault is not its health signal,
             # and it must not abort the walk: prepare is lane-variant, so
             # the next alias may still serve the turn.
-            if fb_tracker and not isinstance(fb_err, WirePreparationError):
+            if fb_tracker and _speaks_for_backend(fb_err):
                 fb_tracker.record_failure()
             # Class name only in the UI line: a ConnectError's text can
             # carry a credential-bearing base_url, and this string lands in
@@ -8499,16 +8523,13 @@ class ChatSession:
                     count=len(dropped),
                 )
                 old_native = result.turn.native
-                blocks = finalize_provider_blocks(
-                    list(old_native.blocks) if old_native else [],
-                    [],
-                    has_tool_calls=False,
-                )
-                native = (
-                    ProviderNative(producer=old_native.producer, blocks=tuple(blocks))
-                    if blocks and old_native
-                    else None
-                )
+                native = None
+                if old_native:
+                    blocks = finalize_provider_blocks(
+                        list(old_native.blocks), [], has_tool_calls=False
+                    )
+                    if blocks:
+                        native = ProviderNative(producer=old_native.producer, blocks=tuple(blocks))
                 result = dataclasses.replace(
                     result,
                     turn=Turn.assistant(result.turn.text, native=native),

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -327,6 +327,20 @@ class _CompactionIrreducibleError(Exception):
     """
 
 
+def _generation_superseded(session: ChatSession, my_generation: int) -> bool:
+    """Whether a newer generation has claimed *session* — THE supersession
+    predicate, one spelling for every site that asks.
+
+    Generation 0 is UNSCOPED (a direct seam caller, no ``send()`` above
+    it): it is never superseded, matching :meth:`ChatSession._check_cancelled`.
+    Callers read through this rather than sharing a cached answer — each
+    read is its own, which is what makes the streaming consumer's read a
+    real second look after the cancel ref's (the two-step supersession
+    window a force-cancel can land inside).
+    """
+    return bool(my_generation and session._generation != my_generation)
+
+
 class _CancelRef(list[Any]):
     """List proxy handed to ``create_streaming`` as its ``cancel_ref``.
 
@@ -379,8 +393,7 @@ class _CancelRef(list[Any]):
         self._armed = False
 
     def _superseded(self) -> bool:
-        gen = self._my_generation
-        return bool(gen and self._session._generation != gen)
+        return _generation_superseded(self._session, self._my_generation)
 
     @property
     def armed(self) -> bool:
@@ -543,8 +556,7 @@ class _StreamTurnConsumer:
         way (generation 0 is unscoped, so a direct seam caller is never
         superseded).  The two must agree: the ref decides whether to fire
         the arm hook, and the hook's own gate decides whether to act."""
-        gen = self._my_generation
-        return bool(gen and self._session._generation != gen)
+        return _generation_superseded(self._session, self._my_generation)
 
     def on_stream_armed(self) -> None:
         """`_CancelRef.on_first_append` — the request-accepted instant.
@@ -8306,7 +8318,7 @@ class ChatSession:
             text the user actually saw.  Never writes for a superseded
             generation — an orphan must not touch the successor's slot.
             """
-            if self._generation != my_generation:
+            if _generation_superseded(self, my_generation):
                 return
             if (
                 self._cancelled_partial_msg is None
@@ -8351,7 +8363,7 @@ class ChatSession:
                 # but send() treats Ctrl-C as a survivable, recorded path,
                 # so the dead attempt still needs its client-side finalize
                 # (the CLI's markdown fence resets only in on_stream_end).
-                if self._generation == my_generation:
+                if not _generation_superseded(self, my_generation):
                     self.ui.on_stream_end()
                 raise
             except Exception as e:
@@ -8365,7 +8377,7 @@ class ChatSession:
                     # re-create window reads the DEAD attempt's armed
                     # state (see ``end_attempt``).
                     consumer.end_attempt()
-                if self._generation != my_generation:
+                if _generation_superseded(self, my_generation):
                     # Superseded (force-cancel started a newer generation):
                     # an orphaned thread must not touch the UI — a finalize
                     # emitted here would clobber the NEW generation's

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -544,8 +544,16 @@ class _StreamTurnConsumer:
         stale-usage leak (a post-finish blip can lose the trailing usage
         chunk, and a stale completion count would be recycled as the next
         turn's estimate) and the reconnect status-bar blackout.
+
+        Generation-gated: the ref's supersession read and this hook are
+        two lockless steps, so a force-cancel can claim a new generation
+        between them — an orphan's late-arriving registration must not
+        null the SUCCESSOR's usage slots or record health for an
+        abandoned lane.
         """
         s = self._session
+        if s._generation != self._my_generation:
+            return
         s._last_usage = None
         s._assistant_pending_tokens = 0
         if self.tracker:
@@ -5492,6 +5500,8 @@ class ChatSession:
     def _prepare_wire_messages(
         self,
         messages: list[dict[str, Any]],
+        *,
+        caps: ModelCapabilities | None = None,
     ) -> list[dict[str, Any]]:
         """Return a transient copy of *messages* prepared for the provider wire.
 
@@ -5543,11 +5553,16 @@ class ChatSession:
         messages = self._inject_sender_labels(messages)
         folded = messages
         if self._provider is not None:
+            # *caps* is the SERVING lane's capabilities when the streaming
+            # wrapper prepares per attempt — a fallback whose template
+            # rejects mid-conversation system roles must get the folded
+            # shape even when the primary keeps them inline.  Callers
+            # without a lane in hand (the token-table re-fold) default to
+            # the primary binding.
+            fold_caps = caps if caps is not None else self._get_capabilities()
             folded = fold_system_turns(
                 messages,
-                supports_mid_conversation_system=(
-                    self._get_capabilities().supports_mid_conversation_system
-                ),
+                supports_mid_conversation_system=fold_caps.supports_mid_conversation_system,
                 nonce=self._envelope_nonce,
             )
         dropped = drop_empty_user_turns(folded)
@@ -6212,7 +6227,7 @@ class ChatSession:
     def _model_turn_with_fallback(
         self,
         consumer: _StreamTurnConsumer,
-        prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+        prepare_wire: Callable[[list[dict[str, Any]], ModelLane], list[dict[str, Any]]],
         my_generation: int = 0,
     ) -> ModelTurnResult:
         """Run one plant call with lane-swap fallback: one ``model_turn``
@@ -6284,7 +6299,7 @@ class ChatSession:
         self,
         alias: str,
         consumer: _StreamTurnConsumer,
-        prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+        prepare_wire: Callable[[list[dict[str, Any]], ModelLane], list[dict[str, Any]]],
         my_generation: int,
     ) -> ModelTurnResult | None:
         """Attempt a single fallback lane.  Returns the result or ``None``.
@@ -6367,7 +6382,7 @@ class ChatSession:
         lane: ModelLane,
         tracker: BackendHealthTracker | None,
         consumer: _StreamTurnConsumer,
-        prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+        prepare_wire: Callable[[list[dict[str, Any]], ModelLane], list[dict[str, Any]]],
         my_generation: int = 0,
     ) -> ModelTurnResult:
         """One lane's creation ladder around ``model_turn``.
@@ -8227,7 +8242,7 @@ class ChatSession:
 
         debug_printed = False
 
-        def _prepare(lowered: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        def _prepare(lowered: list[dict[str, Any]], lane: ModelLane) -> list[dict[str, Any]]:
             """The main loop's ``prepare_wire``: system prepend + the
             session lowering passes, plus the debug request dump behind a
             once-per-invocation latch, so re-issues and fallback lanes
@@ -8236,7 +8251,9 @@ class ChatSession:
             post-compaction the wire CHANGED, and the re-prepared dump is
             the one that diagnoses the recovery (a named #832 delta)."""
             nonlocal debug_printed
-            wire = self._prepare_wire_messages([*self.system_messages, *lowered])
+            wire = self._prepare_wire_messages(
+                [*self.system_messages, *lowered], caps=lane.capabilities
+            )
             if self.debug and not debug_printed:
                 debug_printed = True
                 self._debug_print_request(wire)

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -613,6 +613,17 @@ class _StreamTurnConsumer:
         # Path 1: provider-normalized reasoning_delta.
         if chunk.reasoning_delta:
             self._stop_spinner_once()
+            if not self._splitter.in_think:
+                # Entering the native-reasoning phase closes the content
+                # run EXACTLY as the drain does: the non-tag tail is
+                # content, and only a partial tag prefix carries across
+                # the reasoning block.  Flipping in_think with the tail
+                # still pending relabels buffered content as reasoning at
+                # the next flush — the displayed stream then loses text
+                # the committed turn keeps (live-caught fold divergence;
+                # worst case a short answer displays as NOTHING while the
+                # commit carries it plus a citations footer).
+                self._splitter.close_run()
             self._splitter.in_think = True
             self._path1_reasoning = True
             if s.show_reasoning:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -143,6 +143,7 @@ from turnstone.core.model_turn import (
     ModelLane,
     ModelTurnResult,
     WirePreparationError,
+    caps_scan_inline_reasoning,
     create_provider,
     finalize_provider_blocks,
     folds_trailing_info,
@@ -1815,6 +1816,16 @@ def _tool_turn_meta(
 
 class BackendAuthUnavailableError(RuntimeError):
     """A fail-closed dynamic model credential could not be resolved."""
+
+
+# Errors that carry their own remediation and must surface AS THEMSELVES:
+# the re-issue ladder never masks them behind an earlier stream death.
+# (Walk policy stays per-class — an auth refusal aborts the walk, a
+# wire-preparation fault continues it — only the mask reads this set.)
+_SELF_SURFACING_ERRORS: tuple[type[Exception], ...] = (
+    BackendAuthUnavailableError,
+    WirePreparationError,
+)
 
 
 def _mint_refusal_cause(
@@ -4258,7 +4269,7 @@ class ChatSession:
             # (``server_parses_reasoning``): there a close tag in content
             # IS quoted prose, and cutting would eat a title that mentions
             # it.  See ``_TITLE_*``.
-            if not self._get_capabilities().server_parses_reasoning:
+            if caps_scan_inline_reasoning(self._get_capabilities()):
                 _cut = max(
                     (raw.rfind(_t) + len(_t) for _t in ThinkTagSplitter.CLOSE_TAGS if _t in raw),
                     default=0,
@@ -5753,9 +5764,8 @@ class ChatSession:
             return (
                 f"Preparing the request from this conversation's history failed: "
                 f"{detail}. This is a fault in the session's stored history, not "
-                f"in the {model_label} backend (no fallback was tried and backend "
-                f"health is unaffected). /compact may clear a malformed turn; "
-                f"please report this."
+                f"in the {model_label} backend (backend health is unaffected). "
+                f"/compact may clear a malformed turn; please report this."
             )
 
         # Context overflow — matched by text, because it arrives as BadRequestError
@@ -6257,18 +6267,16 @@ class ChatSession:
             # Explicit fail-closed policy: never reinterpret an authentication
             # refusal as backend health and never route it to a static fallback.
             raise
-        except WirePreparationError:
-            # No health record and no fallback walk: every lane would
-            # re-run the same deterministic passes, and N recorded
-            # failures would paint a cluster-wide outage over one
-            # session's malformed history.
-            raise
         except Exception as primary_err:
             if consumer.attempt_armed:
                 # Mid-stream death: the re-issue ladder owns it (UI finalize,
                 # backoff, discard, full re-create) — not the fallback walk.
                 raise
-            if tracker:
+            # A wire-preparation fault is the session's data, never backend
+            # health — but it DOES enter the walk: prepare runs per lane
+            # (fold posture follows lane.capabilities), so another lane's
+            # posture may serve a turn the primary's could not.
+            if tracker and not isinstance(primary_err, WirePreparationError):
                 tracker.record_failure()
             if not self._registry or not self._registry.fallback:
                 raise
@@ -6335,15 +6343,16 @@ class ChatSession:
             return self._model_turn_with_retry(
                 fb_lane, fb_tracker, consumer, prepare_wire, my_generation
             )
-        except (BackendAuthUnavailableError, WirePreparationError):
-            # An auth refusal is fail-closed policy and a wire-preparation
-            # failure is the caller's data bug: neither is this fallback's
-            # health signal.
+        except BackendAuthUnavailableError:
+            # Fail-closed policy — never another lane's business.
             raise
         except Exception as fb_err:
             if consumer.attempt_armed:
                 raise
-            if fb_tracker:
+            # This lane's wire-preparation fault is not its health signal,
+            # and it must not abort the walk: prepare is lane-variant, so
+            # the next alias may still serve the turn.
+            if fb_tracker and not isinstance(fb_err, WirePreparationError):
                 fb_tracker.record_failure()
             # Class name only in the UI line: a ConnectError's text can
             # carry a credential-bearing base_url, and this string lands in
@@ -8354,7 +8363,7 @@ class ChatSession:
                     # base_url verbatim.
                     if (
                         last_stream_death is None
-                        or isinstance(e, (BackendAuthUnavailableError, WirePreparationError))
+                        or isinstance(e, _SELF_SURFACING_ERRORS)
                         or _is_ctx_overflow(e)
                     ):
                         raise

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -490,6 +490,12 @@ class _StreamTurnConsumer:
         self._path1_reasoning = False
         self._finish_seen = False
         self._saw_chunk = False
+        # Content-state text held across a reasoning block (the run-close
+        # carry) and post-finish footer parts held for the end-of-stream
+        # fold — both owned HERE, outside the splitter, so in_think flips
+        # cannot relabel them (mirrors the drain's separate carry).
+        self._boundary_carry = ""
+        self._trailing_info: list[str] = []
         # Per-attempt: a re-issued attempt's usage must never max-merge
         # onto the dead attempt's (the accumulator was attempt-local in
         # the pre-fold consumer too).
@@ -613,17 +619,19 @@ class _StreamTurnConsumer:
         # Path 1: provider-normalized reasoning_delta.
         if chunk.reasoning_delta:
             self._stop_spinner_once()
-            if not self._splitter.in_think:
-                # Entering the native-reasoning phase closes the content
-                # run EXACTLY as the drain does: the non-tag tail is
-                # content, and only a partial tag prefix carries across
-                # the reasoning block.  Flipping in_think with the tail
-                # still pending relabels buffered content as reasoning at
-                # the next flush — the displayed stream then loses text
-                # the committed turn keeps (live-caught fold divergence;
-                # worst case a short answer displays as NOTHING while the
-                # commit carries it plus a citations footer).
-                self._splitter.close_run()
+            # Entering the native-reasoning phase closes the current run
+            # UNCONDITIONALLY, exactly as the drain does: decided text
+            # emits at its own state (content-state tail as content,
+            # in-think tail as reasoning — gating this on in_think left
+            # an open inline think block's carry to be relabeled as
+            # displayed ANSWER text by the later state flip, the CoT-leak
+            # half of the round-2 findings), and only a partial tag
+            # prefix carries across the block.  The carry lives on the
+            # CONSUMER, not in the splitter's pending — pending is read
+            # under whatever state later flushes hit, and the in_think
+            # flip below would relabel a content-state carry as
+            # reasoning (the other half).
+            self._boundary_carry += self._splitter.close_run()
             self._splitter.in_think = True
             self._path1_reasoning = True
             if s.show_reasoning:
@@ -635,55 +643,84 @@ class _StreamTurnConsumer:
             if self._path1_reasoning:
                 self._path1_reasoning = False
                 self._splitter.in_think = False
+            if self._boundary_carry:
+                # Content resumed after the reasoning block: the carry
+                # prefixes the new text so a tag the server split across
+                # the block reassembles (the drain prefixes its carried
+                # tail onto the next run the same way).
+                self._splitter.feed(self._boundary_carry)
+                self._boundary_carry = ""
             self._splitter.feed(chunk.content_delta)
 
         # Tool-call deltas: display-side this is only a run boundary —
         # accumulation lives in the drain.
         if chunk.tool_call_deltas:
             self._stop_spinner_once()
+            if self._boundary_carry:
+                # A partial tag never spans a TOOL boundary (the drain's
+                # rule): the carry is content-state text — flush it as
+                # content, whatever in_think says now.
+                self._flush_text(self._boundary_carry, False)
+                self._boundary_carry = ""
             self._splitter.flush_pending()
             self._splitter.in_think = False
 
         if chunk.info_delta:
             self._stop_spinner_once()
             if self._finish_seen:
-                # Trailing citations footer → CONTENT, per the drain's
-                # conditional fold — gate and separator are the SHARED
-                # module-level pair beside ``drain_stream``, so the two
-                # mirrors cannot drift.  The generation is over (finish
-                # seen), so the splitter's carry is final answer text,
-                # never a partial tag — flush it FIRST or the footer
-                # renders spliced into the middle of the answer's last
-                # characters.  Appended via the accumulator too, so the
-                # partial rule and the blankness test stay consistent
-                # with the committed content.
-                self._splitter.flush_pending()
-                if folds_trailing_info("".join(self._content_parts)):
-                    self._flush_text(TRAILING_INFO_SEPARATOR + chunk.info_delta, False)
+                # Post-finish info is the trailing citations footer: HELD
+                # and folded once at stream end after ALL content
+                # (:meth:`finish_stream`), exactly the drain's post-loop
+                # fold.  Folding at arrival diverges from the commit when
+                # a lax gateway emits content after finish — the fold
+                # gate must judge the FULL answer, and the footer must
+                # follow it.
+                self._trailing_info.append(chunk.info_delta)
             else:
                 s.ui.on_info(f"{GRAY}{chunk.info_delta}{RESET}")
 
     # -- partial preservation --------------------------------------------------
 
     def partial_content(self) -> str:
-        """THE partial-content rule: flushed content plus the splitter's
-        carry tail when it is content-state (an in-think tail is reasoning
-        and stays out) — one closure serving the cancel arms and the
-        re-issue ladder's dead-partial promotion alike."""
-        return "".join(self._content_parts) + (
-            self._splitter.pending if not self._splitter.in_think else ""
+        """THE partial-content rule: flushed content, plus the boundary
+        carry (content-state by construction), plus the splitter's carry
+        tail when it is content-state (an in-think tail is reasoning and
+        stays out) — one closure serving the cancel arms and the re-issue
+        ladder's dead-partial promotion alike."""
+        return (
+            "".join(self._content_parts)
+            + self._boundary_carry
+            + (self._splitter.pending if not self._splitter.in_think else "")
         )
 
+    def _flush_terminal_carries(self) -> None:
+        """Terminal display flush shared by the finish and cancel arms:
+        the boundary carry emits as CONTENT (its state was fixed when the
+        run closed — the drain appends its dangling carry to content the
+        same way), then the splitter's own pending at the current state."""
+        if self._boundary_carry:
+            self._flush_text(self._boundary_carry, False)
+            self._boundary_carry = ""
+        self._splitter.flush_pending()
+
     def finish_stream(self) -> None:
-        """End-of-stream display flush: emit the splitter's held carry.
+        """End-of-stream display flush: the held carries, then the
+        trailing citations footer.
 
         The drain assembled the canonical content already; without this
         the DISPLAYED stream is missing its last ≤MAX_TAG_LEN characters
-        (the partial-tag carry).  Success-path only, after the trailing
-        Stop re-check — the cancel arms flush via
-        :meth:`record_cancelled_partial`, and a dead attempt deliberately
-        does not flush (the partial rule reads the carry directly)."""
-        self._splitter.flush_pending()
+        (the carries), and the footer fold must run AFTER them — once,
+        over the full answer, with the shared gate and separator — or
+        the displayed fold diverges from the drain's post-loop fold.
+        Success-path only, after the trailing Stop re-check — the cancel
+        arms flush via :meth:`record_cancelled_partial` and drop the
+        footer (a cancelled turn commits no drained content to fold
+        onto)."""
+        self._flush_terminal_carries()
+        if self._trailing_info and folds_trailing_info("".join(self._content_parts)):
+            for info in self._trailing_info:
+                self._flush_text(TRAILING_INFO_SEPARATOR + info, False)
+        self._trailing_info = []
 
     def record_cancelled_partial(self) -> None:
         """Flush, finalize the stream in the UI, and stash the partial for
@@ -695,7 +732,7 @@ class _StreamTurnConsumer:
         if self._session._generation != self._my_generation:
             return
         content = self.partial_content()
-        self._splitter.flush_pending()
+        self._flush_terminal_carries()
         self._session.ui.on_stream_end()
         self._session._cancelled_partial_msg = {"role": "assistant", "content": content}
 
@@ -6339,7 +6376,18 @@ class ChatSession:
                 raise
             if fb_tracker:
                 fb_tracker.record_failure()
-            self.ui.on_info(f"[Fallback {alias} also failed: {fb_err}]")
+            # Class name only in the UI line — the same rule as the
+            # re-issue log arm: a ConnectError's text can carry a
+            # credential-bearing base_url verbatim, and this string lands
+            # in the browser transcript and persisted event stream.  The
+            # full detail goes to the server log.
+            log.warning(
+                "fallback.failed",
+                alias=alias,
+                error_type=type(fb_err).__name__,
+            )
+            log.debug("fallback failure detail", exc_info=True)
+            self.ui.on_info(f"[Fallback {alias} also failed: {type(fb_err).__name__}]")
             return None
 
     def _stop_retrying(
@@ -7402,13 +7450,16 @@ class ChatSession:
                     )
                 )
 
-                # Log assistant message to conversation history
+                # Log assistant message to conversation history.  ONE
+                # binding for the call list: the persisted mirror and the
+                # executed set below must be the same value by
+                # construction, not by coincidence.
                 content = result.content
-                tc = result.tool_calls or None
+                tool_calls = result.tool_calls or None
                 native = result.turn.native
                 provider_data = json.dumps(list(native.blocks)) if native else None
 
-                tool_calls_json: str | None = json.dumps(tc) if tc else None
+                tool_calls_json: str | None = json.dumps(tool_calls) if tool_calls else None
 
                 # Save assistant message atomically (content + tool_calls in one row)
                 if content or provider_data is not None or tool_calls_json:
@@ -7422,7 +7473,6 @@ class ChatSession:
                         producer=result.producer or None,
                     )
 
-                tool_calls = result.tool_calls or None
                 if not tool_calls:
                     # Did the model stop because we asked it to wind down for a
                     # compaction (cooperative), or because the task is actually
@@ -8274,6 +8324,20 @@ class ChatSession:
             generation — an orphan must not touch the successor's slot.
             """
             if self._generation != my_generation:
+                return
+            if (
+                self._cancelled_partial_msg is None
+                and last_stream_death is None
+                and not dead_partial
+            ):
+                # Nothing ever streamed this send: a Stop in the
+                # creation/walk window with no prior armed death.
+                # Pre-fold, the first creation ran OUTSIDE the promote
+                # arm and no assistant row was written for a turn that
+                # never streamed — keep that: a marker-only row would
+                # replay to the model as context on every later turn
+                # (round-2 finding; an ARMED zero-token Stop still
+                # records its marker via record_cancelled_partial).
                 return
             cur = self._cancelled_partial_msg
             if cur is None or (not cur.get("content") and dead_partial):

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -139,18 +139,18 @@ from turnstone.core.model_registry import (
     ModelClientConstructionError,
 )
 from turnstone.core.model_turn import (
+    ModelLane,
     ModelTurnResult,
+    create_provider,
     ensure_tool_call_ids,
     finalize_provider_blocks,
     lane_thinking_suppressed,
     lane_without_thinking,
-    maybe_attach_vllm_chat_reasoning,
+    merge_usage,
     model_turn,
-    provider_extra_params,
     resolve_capabilities,
     resolve_effort_setting,
     resolve_lane,
-    resolve_replay_reasoning_to_model,
     resolve_temperature_setting,
 )
 from turnstone.core.nudge_queue import (
@@ -178,12 +178,6 @@ from turnstone.core.preview import (
     page_title,
     resolve_preview_kind,
     transcode_text,
-)
-from turnstone.core.providers import (
-    accumulate_tool_call_delta,
-    create_provider,
-    merge_usage,
-    transport_guarded,
 )
 from turnstone.core.ratelimit import TokenBucket
 from turnstone.core.safety import is_command_blocked, sanitize_command
@@ -217,6 +211,7 @@ from turnstone.core.tools import (
 )
 from turnstone.core.trajectory import (
     EffectStatus,
+    ProviderNative,
     Role,
     TextBlock,
     ToolCall,
@@ -254,14 +249,14 @@ if TYPE_CHECKING:
     from turnstone.core.judge import IntentJudge, JudgeConfig
     from turnstone.core.mcp_client import MCPClientManager
     from turnstone.core.model_registry import ModelConfig, ModelRegistry
-    from turnstone.core.output_guard import OutputAssessment
-    from turnstone.core.output_guard_judge import OutputGuardJudge, OutputJudgeVerdict
-    from turnstone.core.providers import (
+    from turnstone.core.model_turn import (
         LLMProvider,
         ModelCapabilities,
         StreamChunk,
         UsageInfo,
     )
+    from turnstone.core.output_guard import OutputAssessment
+    from turnstone.core.output_guard_judge import OutputGuardJudge, OutputJudgeVerdict
     from turnstone.core.rerank import RerankClient, Reranker
     from turnstone.core.web_search import WebSearchClient
 
@@ -338,10 +333,13 @@ class _CancelRef(list[Any]):
     was created (e.g. cancel during retry backoff), the stream is closed
     on arrival so the blocked iteration is unblocked.
 
-    ``my_generation`` scopes a ref to one generation (compaction's summary
-    calls pass theirs; the main loop's long-lived shared ref keeps the
-    default 0 = unconditional).  A superseded ref's late-arriving stream —
-    an abandoned compaction that passed its boundary check just before a
+    ``my_generation`` scopes a ref to one generation.  EVERY model-call
+    site now passes its own per-attempt, generation-scoped ref (the main
+    loop and compaction alike — #832 retired the main loop's long-lived
+    gen-0 shared instance, whose ``aborted`` was force-cancel-blind: a
+    successor generation installs a fresh unset event, and gen 0 never
+    reads superseded).  A superseded ref's late-arriving stream — an
+    abandoned call that passed its boundary check just before a
     force-cancel and opened one final zombie call — must neither hijack
     ``_cancel_stream`` from the successor generation's live stream nor
     keep burning tokens, so the append skips the registration and closes
@@ -351,24 +349,51 @@ class _CancelRef(list[Any]):
     delayed Stop (closes a dead handle; the event arm still cancels at the
     next chunk), not corruption — versus the model-call-width window this
     closes.
+
+    ``on_first_append`` fires once, on the first non-superseded append —
+    i.e. at the adapters' eager HTTP-response-time registration, before
+    the iterator is returned (the eager-append tripwire in
+    ``test_sdk_stream_boundary`` pins that timing).  It is the main-loop
+    wrapper's observation point for "the request was accepted": the
+    health tracker's success record, the creation-vs-midstream retry
+    classifier, and the per-turn usage-slot resets all key on it (#832).
+    A superseded arrival does not fire it — an orphan must not record
+    health or reset the successor's usage slots.
     """
 
-    __slots__ = ("_session", "_my_generation")
+    __slots__ = ("_session", "_my_generation", "_on_first_append", "_armed")
 
-    def __init__(self, session: ChatSession, my_generation: int = 0) -> None:
+    def __init__(
+        self,
+        session: ChatSession,
+        my_generation: int = 0,
+        *,
+        on_first_append: Callable[[], None] | None = None,
+    ) -> None:
         super().__init__()
         self._session = session
         self._my_generation = my_generation
+        self._on_first_append = on_first_append
+        self._armed = False
 
     def _superseded(self) -> bool:
         gen = self._my_generation
         return bool(gen and self._session._generation != gen)
+
+    @property
+    def armed(self) -> bool:
+        """Whether a stream handle has registered (request accepted)."""
+        return self._armed
 
     def append(self, stream: Any) -> None:
         super().append(stream)
         superseded = self._superseded()
         if not superseded:
             self._session._cancel_stream = stream
+            if not self._armed:
+                self._armed = True
+                if self._on_first_append is not None:
+                    self._on_first_append()
         # If cancel was requested before the first chunk arrived (the worker
         # thread is blocked inside the provider generator waiting for the HTTP
         # response), close the stream immediately to unblock it.  Same for a
@@ -392,17 +417,240 @@ class _CancelRef(list[Any]):
         turns it into ``GenerationCancelled``.
 
         Deliberately the same two conditions as :meth:`_check_cancelled`
-        — provided both are asked about the same generation, which on the
-        compaction lane they are (this ref and that call carry the same
-        ``my_generation``).  Compaction depends on the pairing:
-        ``_summarize_once``'s handler calls ``_check_cancelled`` before it
-        reads the error, which is what converts ``model_turn``'s
-        pre-dispatch raise into a cancelled compaction instead of a red
-        failure row.  Widening this predicate without widening that one,
-        or pairing a ref with a check on a different generation, breaks
-        the translation.
+        — provided both are asked about the same generation, which every
+        model-call lane now guarantees by construction: compaction and the
+        main loop alike build a fresh ref per attempt carrying the very
+        ``my_generation`` their surrounding checks use (#832 closed the
+        main loop's gen-0 exception).  The pairing is load-bearing twice:
+        compaction's ``_summarize_once`` handler calls ``_check_cancelled``
+        before it reads the error, converting ``model_turn``'s pre-dispatch
+        raise into a cancelled compaction instead of a red failure row, and
+        the main-loop wrapper's except arms do the same before classifying
+        a death.  Widening this predicate without widening that one, or
+        pairing a ref with a check on a different generation, breaks the
+        translation.
         """
         return self._session._cancel_event.is_set() or self._superseded()
+
+
+class _StreamTurnConsumer:
+    """The main loop's chunk→UI translation — ``model_turn``'s ``on_chunk`` body.
+
+    One instance per streaming TURN, reset per attempt: display state
+    (splitter carry, spinner latch) is attempt-local, while the instance
+    itself outlives attempts so the re-issue ladder can read the dead
+    attempt's partial without riding it on the exception (the old
+    ``_dead_partial`` hitch-hike — the consumer is frame-local to the
+    wrapper, so an orphaned generation still cannot poison a successor).
+
+    Deliberately display-side ONLY: the canonical turn is assembled by
+    ``drain_stream`` inside ``model_turn`` — this class accumulates just
+    enough to serve the partial-preservation rules (flushed content plus
+    the splitter's non-think carry) and the live UI grid.  Reasoning is
+    emitted, never accumulated; tool-call deltas only flush the splitter;
+    ``provider_blocks`` are ignored (assembly owns them).
+
+    The tag-scan posture follows the SAME capability the drain seam reads
+    (``server_parses_reasoning``), taken from the ACTIVE lane — primary or
+    fallback — so the interactive and drained interpretations of one
+    stream cannot disagree (the #978 gate, re-homed from the creation-time
+    handoff register onto the lane).
+
+    The trailing citations footer is emitted as CONTENT, mirroring the
+    drain's conditional fold (only when the accumulated post-split content
+    is non-blank; ``\\n\\n``-joined) — the #832 ruling that citations
+    survive into the committed turn; pre-finish info stays an ephemeral
+    info line exactly as before.
+    """
+
+    def __init__(self, session: ChatSession, lane: ModelLane, my_generation: int) -> None:
+        self._session = session
+        self._my_generation = my_generation
+        self.lane = lane
+        self.ref: _CancelRef | None = None
+        self.tracker: BackendHealthTracker | None = None
+        self._content_parts: list[str] = []
+        self._first_token = True
+        self._path1_reasoning = False
+        self._finish_seen = False
+        self._usage_acc: UsageInfo | None = None
+        self._splitter = ThinkTagSplitter(
+            self._flush_text,
+            scan_tags=not (
+                lane.capabilities.server_parses_reasoning if lane.capabilities else False
+            ),
+        )
+
+    # -- attempt lifecycle ---------------------------------------------------
+
+    def begin_attempt(
+        self,
+        ref: _CancelRef,
+        tracker: BackendHealthTracker | None,
+        lane: ModelLane,
+    ) -> None:
+        """Reset display state for one creation attempt on *lane*.
+
+        The usage-slot resets do NOT happen here — they ride
+        :meth:`on_stream_armed` (the request-accepted instant), so a long
+        creation ladder or fallback walk never blanks the reconnecting
+        tab's status bar mid-window.
+        """
+        self.ref = ref
+        self.tracker = tracker
+        self.lane = lane
+        self._content_parts = []
+        self._first_token = True
+        self._path1_reasoning = False
+        self._finish_seen = False
+        # Per-attempt: a re-issued attempt's usage must never max-merge
+        # onto the dead attempt's (the accumulator was attempt-local in
+        # the pre-fold consumer too).
+        self._usage_acc = None
+        self._splitter = ThinkTagSplitter(
+            self._flush_text,
+            scan_tags=not (
+                lane.capabilities.server_parses_reasoning if lane.capabilities else False
+            ),
+        )
+
+    @property
+    def attempt_armed(self) -> bool:
+        """Whether this attempt's request was accepted (handle registered)."""
+        return self.ref is not None and self.ref.armed
+
+    def on_stream_armed(self) -> None:
+        """`_CancelRef.on_first_append` — the request-accepted instant.
+
+        Carries three duties at exactly the old create-return timing:
+        the health success record for the serving lane, and the two
+        per-turn usage-slot resets whose placement guards both the
+        stale-usage leak (the old ``_stream_attempt``-entry comment) and
+        the reconnect status-bar blackout.
+        """
+        s = self._session
+        s._last_usage = None
+        s._assistant_pending_tokens = 0
+        if self.tracker:
+            self.tracker.record_success()
+
+    # -- the chunk grid --------------------------------------------------------
+
+    def _flush_text(self, text: str, is_reasoning: bool) -> None:
+        if not text:
+            return
+        if is_reasoning:
+            if self._session.show_reasoning:
+                self._session.ui.on_reasoning_token(text)
+        else:
+            self._content_parts.append(text)
+            self._session.ui.on_content_token(text)
+
+    def _stop_spinner_once(self) -> None:
+        if self._first_token:
+            self._session.ui.on_thinking_stop()
+            self._first_token = False
+
+    def __call__(self, chunk: StreamChunk) -> None:
+        s = self._session
+        s._check_cancelled(self._my_generation)
+        if chunk.finish_reason:
+            self._finish_seen = True
+
+        # Usage re-projects on EVERY usage chunk via THE shared max-merge
+        # rule — one atomic dict rebind, because the SSE replay preamble
+        # reads this slot from the connection thread mid-stream.
+        if chunk.usage:
+            self._usage_acc = merge_usage(self._usage_acc, chunk.usage)
+            s._last_usage = dataclasses.asdict(self._usage_acc)
+
+        if s.debug:
+            parts = []
+            if chunk.content_delta:
+                parts.append(f"content={chunk.content_delta!r}")
+            if chunk.reasoning_delta:
+                parts.append(f"reasoning={chunk.reasoning_delta!r}")
+            if chunk.tool_call_deltas:
+                parts.append("tool_calls=...")
+            if parts:
+                s.ui.on_info(f"{GRAY}[delta: {', '.join(parts)}]{RESET}")
+
+        # Path 1: provider-normalized reasoning_delta.
+        if chunk.reasoning_delta:
+            self._stop_spinner_once()
+            self._splitter.in_think = True
+            self._path1_reasoning = True
+            if s.show_reasoning:
+                s.ui.on_reasoning_token(chunk.reasoning_delta)
+
+        # Path 2: content (may carry inline tags when the scan is on).
+        if chunk.content_delta:
+            self._stop_spinner_once()
+            if self._path1_reasoning:
+                self._path1_reasoning = False
+                self._splitter.in_think = False
+            self._splitter.feed(chunk.content_delta)
+
+        # Tool-call deltas: display-side this is only a run boundary —
+        # accumulation lives in the drain.
+        if chunk.tool_call_deltas:
+            self._stop_spinner_once()
+            self._splitter.flush_pending()
+            self._splitter.in_think = False
+
+        if chunk.info_delta:
+            self._stop_spinner_once()
+            if self._finish_seen:
+                # Trailing citations footer → CONTENT, per the drain's
+                # conditional fold: only onto a non-blank answer, with the
+                # same separator.  The generation is over (finish seen), so
+                # the splitter's carry is final answer text, never a
+                # partial tag — flush it FIRST or the footer renders
+                # spliced into the middle of the answer's last characters.
+                # Appended via the accumulator too, so the partial rule and
+                # the blankness test stay consistent with the committed
+                # content.
+                self._splitter.flush_pending()
+                if "".join(self._content_parts).strip():
+                    self._flush_text("\n\n" + chunk.info_delta, False)
+            else:
+                s.ui.on_info(f"{GRAY}{chunk.info_delta}{RESET}")
+
+    # -- partial preservation --------------------------------------------------
+
+    def partial_content(self) -> str:
+        """THE partial-content rule: flushed content plus the splitter's
+        carry tail when it is content-state (an in-think tail is reasoning
+        and stays out) — one closure serving the cancel arms and the
+        re-issue ladder's dead-partial promotion alike."""
+        return "".join(self._content_parts) + (
+            self._splitter.pending if not self._splitter.in_think else ""
+        )
+
+    def finish_stream(self) -> None:
+        """End-of-stream display flush: emit the splitter's held carry.
+
+        The drain assembled the canonical content already; without this
+        the DISPLAYED stream is missing its last ≤MAX_TAG_LEN characters
+        (the partial-tag carry).  Success-path only, after the trailing
+        Stop re-check — the cancel arms flush via
+        :meth:`record_cancelled_partial`, and a dead attempt deliberately
+        does not flush (the partial rule reads the carry directly)."""
+        self._splitter.flush_pending()
+
+    def record_cancelled_partial(self) -> None:
+        """Flush, finalize the stream in the UI, and stash the partial for
+        send()'s cancel handler.  No-op for a SUPERSEDED generation: an
+        orphan must touch neither the UI nor the shared partial slot.
+        ``tool_calls`` and the native lane are DELIBERATELY omitted —
+        incomplete calls would orphan their results, and the marker-as-
+        message contract needs plain content (same rules as ever)."""
+        if self._session._generation != self._my_generation:
+            return
+        content = self.partial_content()
+        self._splitter.flush_pending()
+        self._session.ui.on_stream_end()
+        self._session._cancelled_partial_msg = {"role": "assistant", "content": content}
 
 
 # Image extensions handled as vision content (SVG excluded — it's XML text)
@@ -1950,9 +2198,11 @@ class ChatSession:
         # descriptor lands on the tool turn's meta and the blob persists
         # content-addressed against the turn; same lifecycle as the two above.
         self._tool_previews: dict[str, tuple[dict[str, Any], Attachment]] = {}
-        # Cooperative cancellation: set from outside to stop generation
+        # Cooperative cancellation: set from outside to stop generation.
+        # No long-lived cancel REF: every model-call site builds a fresh
+        # per-attempt, generation-scoped _CancelRef (#832) — this slot is
+        # the closeable handle those refs register for cancel().
         self._cancel_event = threading.Event()
-        self._cancel_ref: _CancelRef = _CancelRef(self)  # provider appends SDK stream here
         self._cancel_stream: Any = None  # closeable SDK stream handle
         self._generation: int = 0  # monotonic counter; orphaned threads skip cleanup
         self._active_procs: set[subprocess.Popen[str]] = set()  # for force-kill
@@ -1962,18 +2212,11 @@ class ChatSession:
         # the model detached on purpose.  close() reaps everything.
         self._background_shells = BackgroundShellRegistry(on_exit=self._on_background_shell_exit)
         self._cancelled_partial_msg: dict[str, Any] | None = None
-        # Creation-time HANDOFF REGISTER: _try_stream stamps the provider
-        # AND resolved capabilities that own the stream it is about to
-        # return (fallback walk included), and _stream_response copies
-        # them into frame locals immediately after each create returns.
-        # Nothing else reads them — a late read would race a superseding
-        # generation's creation — and they are deliberately never cleared
-        # (stale values are unreachable by construction).  The caps ride
-        # beside the provider so the consumer's tag-scan posture
-        # (``server_parses_reasoning``) follows the ACTIVE lane, never
-        # the primary's, exactly like the retry gate's retryable set.
-        self._active_stream_provider: LLMProvider | None = None
-        self._active_stream_caps: ModelCapabilities | None = None
+        # (The creation-time handoff register — _active_stream_provider /
+        # _active_stream_caps — is gone: the streaming wrapper's frame
+        # holds the ACTIVE ModelLane itself, so the retry gate's
+        # retryable set and the consumer's tag-scan posture read the
+        # serving lane by construction, fallback walk included. #832)
         self._pending_retry: str | None = None
         # True when a fatal exception's text has been persisted to
         # workstream_config["last_error"] for the coord's inspect/wait
@@ -2475,41 +2718,6 @@ class ChatSession:
             had_blank_ids=had_blank_ids,
             registry=self._registry,
             alias=alias or self._model_alias or "",
-        )
-
-    def _resolve_replay_reasoning_to_model(
-        self,
-        alias: str | None = None,
-        *,
-        caps: ModelCapabilities | None = None,
-    ) -> bool:
-        """Delegate to
-        :func:`turnstone.core.model_turn.resolve_replay_reasoning_to_model`.
-
-        ``None`` *alias* (the main-loop caller) resolves to the session's
-        primary alias; False-on-miss and the caps AND-gate are documented on
-        the module function.
-        """
-        return resolve_replay_reasoning_to_model(
-            self._registry, alias or self._model_alias or "", caps=caps
-        )
-
-    def _maybe_attach_vllm_chat_reasoning(
-        self,
-        messages: list[dict[str, Any]],
-        provider: LLMProvider,
-        alias: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """Delegate to
-        :func:`turnstone.core.model_turn.maybe_attach_vllm_chat_reasoning`
-        (Phase 5 of reasoning persistence).
-
-        ``None`` *alias* (the main-loop caller) resolves to the session's
-        primary alias; the three gates and the deliberate absence of the
-        static capability gate are documented on the module function.
-        """
-        return maybe_attach_vllm_chat_reasoning(
-            messages, provider, self._registry, alias or self._model_alias or ""
         )
 
     def _save_config(self) -> None:
@@ -5630,20 +5838,6 @@ class ChatSession:
             )
         return None  # unreachable — `name` is in _BACKEND_KNOWN_EXC_NAMES by construction
 
-    def _provider_extra_params(
-        self,
-        provider: LLMProvider | None = None,
-        model_alias: str | None = None,
-    ) -> dict[str, Any] | None:
-        """Delegate to :func:`turnstone.core.model_turn.provider_extra_params`.
-
-        ``None`` *provider* / *model_alias* resolve to the session's primary
-        provider and alias; which lanes consume ``extra_body`` is documented
-        on the module function.
-        """
-        prov = provider or self._provider
-        return provider_extra_params(prov, self._registry, model_alias or self._model_alias or "")
-
     def _utility_completion(
         self,
         turns: list[Turn],
@@ -5945,25 +6139,81 @@ class ChatSession:
             return None
         return self._health_registry.get_tracker_for_alias(self._registry, self._model_alias)
 
-    def _create_stream_with_retry(self, msgs: list[dict[str, Any]]) -> Iterator[StreamChunk]:
-        """Create a streaming request with retry on transient errors.
+    def _build_main_lane(
+        self,
+        *,
+        provider: LLMProvider,
+        client: Any,
+        model: str,
+        alias: str | None,
+        capabilities: ModelCapabilities,
+    ) -> ModelLane:
+        """Resolve the main loop's :class:`ModelLane` for one binding.
 
-        If all retries fail and a fallback chain is configured, tries each
-        fallback model in order before giving up.  Records success/failure
-        on the per-backend health tracker for observability.
+        The session's OWN sampling knobs override the lane's
+        operator-resolved rungs (``dataclasses.replace`` on the frozen
+        lane): the pre-fold loop passed ``self.temperature`` /
+        ``self.reasoning_effort`` to the wire verbatim and never consulted
+        the per-alias config rungs, and a resumed workstream with unset
+        knobs must keep OMITTING rather than newly picking up alias
+        config.  Whether the lane rungs should apply to the main loop is a
+        live question — but not this fold's (wire parity first).
+        """
+        lane = resolve_lane(
+            provider,
+            client,
+            model,
+            alias=alias or "",
+            registry=self._registry,
+            capabilities=capabilities,
+            config_store=self._config_store,
+            backend_auth_resolver=self._model_backend_auth_token,
+        )
+        return dataclasses.replace(
+            lane,
+            temperature=self.temperature,
+            reasoning_effort=self.reasoning_effort or None,
+        )
+
+    def _model_turn_with_fallback(
+        self,
+        consumer: _StreamTurnConsumer,
+        prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+        my_generation: int = 0,
+    ) -> ModelTurnResult:
+        """Run one plant call with lane-swap fallback — the successor of the
+        stream-creation walk, one ``model_turn`` ladder per lane.
+
+        Health semantics preserved exactly: success records at the
+        request-accepted instant (the consumer's ``on_stream_armed`` hook),
+        failure records HERE, once per lane's whole ladder — and an ARMED
+        death records neither, because a mid-stream death was never a
+        creation-health signal (it re-raises straight to the re-issue
+        ladder in ``_stream_response``; a fallback lane whose stream died
+        after tokens reached the UI must never be swallowed into
+        try-the-next-alias, or the turn double-renders).
         """
         tracker = self._get_health_tracker()
-
+        primary_lane = self._build_main_lane(
+            provider=self._provider,
+            client=self.client,
+            model=self.model,
+            alias=self._model_alias,
+            capabilities=self._get_capabilities(),
+        )
         try:
-            result = self._try_stream(self.client, self.model, msgs, model_alias=self._model_alias)
-            if tracker:
-                tracker.record_success()
-            return result
+            return self._model_turn_with_retry(
+                primary_lane, tracker, consumer, prepare_wire, my_generation
+            )
         except BackendAuthUnavailableError:
             # Explicit fail-closed policy: never reinterpret an authentication
             # refusal as backend health and never route it to a static fallback.
             raise
         except Exception as primary_err:
+            if consumer.attempt_armed:
+                # Mid-stream death: the re-issue ladder owns it (UI finalize,
+                # backoff, discard, full re-create) — not the fallback walk.
+                raise
             if tracker:
                 tracker.record_failure()
             if not self._registry or not self._registry.fallback:
@@ -5980,23 +6230,30 @@ class ChatSession:
                     if fb_tracker and fb_tracker.is_degraded:
                         degraded_fallbacks.append(alias)
                         continue
-                stream = self._try_fallback(alias, msgs)
-                if stream is not None:
-                    return stream
+                result = self._try_fallback_lane(alias, consumer, prepare_wire, my_generation)
+                if result is not None:
+                    return result
             # Second pass: try degraded backends as last resort
             for alias in degraded_fallbacks:
                 self.ui.on_info(f"[Fallback {alias} is degraded, trying anyway]")
-                stream = self._try_fallback(alias, msgs)
-                if stream is not None:
-                    return stream
+                result = self._try_fallback_lane(alias, consumer, prepare_wire, my_generation)
+                if result is not None:
+                    return result
             raise primary_err
 
-    def _try_fallback(self, alias: str, msgs: list[dict[str, Any]]) -> Iterator[StreamChunk] | None:
-        """Attempt a single fallback model. Returns stream or None.
+    def _try_fallback_lane(
+        self,
+        alias: str,
+        consumer: _StreamTurnConsumer,
+        prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+        my_generation: int,
+    ) -> ModelTurnResult | None:
+        """Attempt a single fallback lane.  Returns the result or ``None``.
 
-        Records success/failure on the fallback's health tracker so
-        the two-pass ordering (healthy-first, then degraded) learns
-        across request cycles.
+        Records failure on the fallback's health tracker (success records
+        via the armed hook) so the two-pass ordering learns across request
+        cycles.  An ARMED death re-raises rather than returning ``None`` —
+        its tokens are on screen; the next alias must not stream over them.
 
         Caller must ensure ``self._registry`` is not ``None``.
         """
@@ -6013,21 +6270,22 @@ class ChatSession:
             # self-inflicted wrong-dialect failure.
             fb_client, fb_model, _, fb_provider, _ = self._registry.resolve_binding(alias)
             fb_caps = self._resolve_capabilities(fb_provider, fb_model, alias)
-            self.ui.on_info(f"[Primary model failed, falling back to {alias}]")
-            result = self._try_stream(
-                fb_client,
-                fb_model,
-                msgs,
+            fb_lane = self._build_main_lane(
                 provider=fb_provider,
+                client=fb_client,
+                model=fb_model,
+                alias=alias,
                 capabilities=fb_caps,
-                model_alias=alias,
             )
-            if fb_tracker:
-                fb_tracker.record_success()
-            return result
+            self.ui.on_info(f"[Primary model failed, falling back to {alias}]")
+            return self._model_turn_with_retry(
+                fb_lane, fb_tracker, consumer, prepare_wire, my_generation
+            )
         except BackendAuthUnavailableError:
             raise
         except Exception as fb_err:
+            if consumer.attempt_armed:
+                raise
             if fb_tracker:
                 fb_tracker.record_failure()
             self.ui.on_info(f"[Fallback {alias} also failed: {fb_err}]")
@@ -6053,86 +6311,72 @@ class ChatSession:
             or attempt == cap
         )
 
-    def _try_stream(
+    def _model_turn_with_retry(
         self,
-        client: Any,
-        model: str,
-        msgs: list[dict[str, Any]],
-        provider: LLMProvider | None = None,
-        capabilities: ModelCapabilities | None = None,
-        model_alias: str | None = None,
-    ) -> Iterator[StreamChunk]:
-        """Attempt a streaming API call with retries on transient errors."""
-        prov = provider or self._provider
-        # Resolve once outside the retry loop — caps don't change per
-        # attempt, and the resolver below threads them into the
-        # ``replay_reasoning_to_model`` AND-gate.
-        resolved_caps = capabilities or self._get_capabilities(prov, model)
-        raw_url = str(getattr(client, "base_url", getattr(client, "_base_url", "?")))
+        lane: ModelLane,
+        tracker: BackendHealthTracker | None,
+        consumer: _StreamTurnConsumer,
+        prepare_wire: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+        my_generation: int = 0,
+    ) -> ModelTurnResult:
+        """One lane's creation ladder around ``model_turn``.
+
+        Per-attempt state is a FRESH generation-scoped ``_CancelRef`` whose
+        ``on_first_append`` hook marks the request-accepted instant — the
+        creation-vs-midstream classifier: an ARMED attempt's death re-raises
+        immediately to the re-issue ladder (its tokens may be on screen; a
+        silent same-lane retry would double-render), while an unarmed
+        failure is a creation failure and retries here.  The old shared
+        gen-0 ref is gone — a force-cancelled generation's ref now reads
+        ``aborted`` via supersession, so ``model_turn`` refuses dispatch for
+        orphans by construction.
+
+        Sampling knobs ride the lane (see ``_build_main_lane``); the
+        credential resolves INSIDE ``model_turn`` per attempt, after its
+        entry abort read — a Stop set before the turn no longer mints a
+        token on a dynamically authenticated alias (#832; the #972 rule
+        extended to the interactive path).
+        """
+        raw_url = str(getattr(lane.client, "base_url", getattr(lane.client, "_base_url", "?")))
         safe_url = raw_url.split("?")[0]  # strip query params (may contain keys)
-        msg_count = len(msgs)
-        role_counts: dict[str, int] = {}
-        for m in msgs:
-            r = m.get("role", "?")
-            role_counts[r] = role_counts.get(r, 0) + 1
         log.debug(
-            "API call: provider=%s model=%s base_url=%s msgs=%d roles=%s",
-            type(prov).__name__,
-            model,
+            "API call: provider=%s model=%s base_url=%s",
+            type(lane.provider).__name__,
+            lane.model,
             safe_url,
-            msg_count,
-            role_counts,
         )
-        msgs = self._maybe_attach_vllm_chat_reasoning(msgs, prov, model_alias)
-        # Dynamic backend auth: bind the minted token as the SDK client's
-        # api_key (with_options reuses the connection pool) so it becomes the
-        # provider's own credential header — extra_headers can't override the
-        # Anthropic SDK's x-api-key. None → the backend's static key stands.
-        # Resolved once, outside the retry loop.
-        backend_auth_token = self._model_backend_auth_token(model_alias or "")
-        if backend_auth_token:
-            client = client.with_options(api_key=backend_auth_token)
         last_err: Exception | None = None
         for attempt in range(self._MAX_RETRIES + 1):
-            self._check_cancelled()
-            self._cancel_ref.clear()  # discard stale handle from prior attempt
-            # The provider (and its resolved caps) about to own the live
-            # stream — read by the mid-stream retry gate (retryable-set
-            # membership), the fatal formatter's label, and the consumer's
-            # tag-scan posture.  Written here so the fallback walk (which
-            # routes through this method with provider=fb_provider) is
-            # covered by construction.
-            self._active_stream_provider = prov
-            self._active_stream_caps = resolved_caps
+            self._check_cancelled(my_generation)
+            ref = _CancelRef(self, my_generation, on_first_append=consumer.on_stream_armed)
+            consumer.begin_attempt(ref, tracker, lane)
             try:
-                return prov.create_streaming(
-                    client=client,
-                    model=model,
-                    messages=msgs,
+                return model_turn(
+                    lane,
+                    self.messages,
                     tools=self._get_active_tools(),
                     max_tokens=self.max_tokens,
-                    temperature=self.temperature,
-                    # The in-code model-definition rung applies here exactly as
-                    # it does in model_turn's effective computation — the main
-                    # loop must sample identically to every auxiliary lane on
-                    # the same alias (resolve_lane's stated contract).  Session
-                    # effort (operator/user rungs) wins; unset falls to the
-                    # caps declaration; None omits the param.
-                    reasoning_effort=(
-                        self.reasoning_effort or resolved_caps.default_reasoning_effort or None
-                    ),
-                    extra_params=self._provider_extra_params(
-                        provider=prov, model_alias=model_alias
-                    ),
                     deferred_names=self._get_deferred_names(),
-                    cancel_ref=self._cancel_ref,
-                    capabilities=resolved_caps,
-                    replay_reasoning_to_model=self._resolve_replay_reasoning_to_model(
-                        model_alias, caps=resolved_caps
+                    prepare_wire=prepare_wire,
+                    resolve_attachments=lambda ids: self._resolve_attachments(
+                        ids, lane.capabilities
                     ),
-                    resolve_attachments=lambda ids: self._resolve_attachments(ids, resolved_caps),
+                    cancel_ref=ref,
+                    on_chunk=consumer,
                 )
             except Exception as e:
+                # A Stop — or supersession — is never a backend failure:
+                # convert BEFORE any classification, the same pre-read
+                # translation compaction's handler performs.  This one line
+                # turns ``model_turn``'s pre-dispatch DeadlineCancelledError,
+                # a post-``cancel()`` transport death, and an orphaned
+                # generation's error into ``GenerationCancelled``.
+                self._check_cancelled(my_generation)
+                if consumer.attempt_armed:
+                    # Mid-stream death — the re-issue ladder owns armed
+                    # deaths (UI finalize → notice → backoff → discard →
+                    # full re-create), on every lane.
+                    raise
                 ename = type(e).__name__
                 cause_name = (
                     type(e.__cause__).__name__
@@ -6140,16 +6384,14 @@ class ChatSession:
                     else (type(e.__context__).__name__ if e.__context__ else "None")
                 )
                 log.warning(
-                    "API error (attempt %d/%d): %s (cause=%s) "
-                    "provider=%s model=%s base_url=%s msgs=%d",
+                    "API error (attempt %d/%d): %s (cause=%s) provider=%s model=%s base_url=%s",
                     attempt + 1,
                     self._MAX_RETRIES + 1,
                     ename,
                     cause_name,
-                    type(prov).__name__,
-                    model,
+                    type(lane.provider).__name__,
+                    lane.model,
                     safe_url,
-                    msg_count,
                 )
                 log.debug(
                     "API error details (attempt %d/%d)",
@@ -6157,7 +6399,7 @@ class ChatSession:
                     self._MAX_RETRIES + 1,
                     exc_info=True,
                 )
-                if self._stop_retrying(e, attempt, prov):
+                if self._stop_retrying(e, attempt, lane.provider):
                     # Non-retryable class, deterministic overflow (the send-loop
                     # compact-and-retry handles it), or retries exhausted — raise
                     # immediately rather than burn backoff sleeps.
@@ -6165,9 +6407,7 @@ class ChatSession:
                 last_err = e
                 delay = self._RETRY_BASE_DELAY * (2**attempt)
                 self.ui.on_info(f"[Retrying in {delay:.0f}s: {ename}]")
-                # Cancel-aware backoff (event arm only — no generation in
-                # scope here, matching the loop-top _check_cancelled()).
-                self._backoff_or_cancelled(delay)
+                self._backoff_or_cancelled(delay, my_generation)
         assert last_err is not None  # unreachable, but satisfies type checker
         raise last_err
 
@@ -7000,10 +7240,11 @@ class ChatSession:
             zero_budget_compact_attempts = 0
             while True:
                 self._check_cancelled(my_generation)
-                msgs = self._prepare_wire_messages(self._full_messages())
-
-                if self.debug:
-                    self._debug_print_request(msgs)
+                # Wire preparation (and the debug request dump) live in the
+                # streaming wrapper's ``prepare_wire`` closure now — run
+                # inside ``model_turn`` per attempt, so a mid-retry rebind
+                # re-prepares by construction and this frame never holds a
+                # wire copy.
 
                 # Reset the per-turn inflight buffers BEFORE entering
                 # the streaming phase so the SSE refresh-resume snapshot
@@ -7016,7 +7257,7 @@ class ChatSession:
                 self.ui.on_thinking_start()
                 try:
                     try:
-                        assistant_msg = self._stream_response(msgs, my_generation)
+                        result = self._stream_response(my_generation)
                     except Exception as ctx_err:
                         # Context overflow recovery: if the API rejects the
                         # request due to exceeding the context window, compact
@@ -7038,7 +7279,6 @@ class ChatSession:
                             # a newer one — the same race every other compaction
                             # site already guards.
                             self._compact_messages(auto=True, my_generation=my_generation)
-                            msgs = self._prepare_wire_messages(self._full_messages())
                         except Exception:
                             # RECOVERY-machinery failure: the overflow error
                             # is still the actionable one, and its wording
@@ -7051,7 +7291,7 @@ class ChatSession:
                             raise ctx_err from None
                         self.ui.on_thinking_start()
                         try:
-                            assistant_msg = self._stream_response(msgs, my_generation)
+                            result = self._stream_response(my_generation)
                         except Exception as retry_err:
                             if not _is_ctx_overflow(retry_err):
                                 # A post-compaction failure that is NOT a
@@ -7070,32 +7310,33 @@ class ChatSession:
                 finally:
                     # Only clear if this generation is still active —
                     # an orphaned thread must not clobber a newer stream.
+                    # (The per-attempt cancel refs die with their frames —
+                    # #832 — but this slot is the handle cancel() closes,
+                    # and a completed turn's dead handle must not linger
+                    # into tool execution.)
                     if self._generation == my_generation:
                         self._cancel_stream = None
-                        self._cancel_ref.clear()
                     self.ui.on_thinking_stop()
 
                 # Bail if this generation was superseded (force cancel).
                 if self._generation != my_generation:
                     return
 
-                # Reuse the wire-bound ``msgs`` we already built for the
-                # stream call instead of re-folding the system turns
-                # (perf-2); passing the already-prepared list keeps the
-                # calibration char count aligned with what the provider
-                # actually counted.
                 # The wire fold the provider ACTUALLY counted rides the
-                # returned message (a mid-retry rebind re-prepares it
-                # inside _stream_response, invisibly to this frame's msgs
-                # local) — popped BEFORE the message is committed so the
-                # carrier key never persists.  Frame-owned, so a
-                # superseding generation cannot alias it; plain-dict fakes
-                # without the key fall through to the frame-local fold.
-                self._update_token_table(
-                    assistant_msg, msgs=assistant_msg.pop("_wire_msgs", None) or msgs
-                )
+                # result (``wire_msgs`` — a mid-retry rebind re-prepared it
+                # inside the streaming wrapper, invisibly to this frame),
+                # keeping the calibration char count aligned with what the
+                # provider counted.  Frame-owned, so a superseding
+                # generation cannot alias it; a fake result without it
+                # falls through to the on-the-fly re-fold inside
+                # ``_update_token_table``.
+                self._update_token_table(msgs=result.wire_msgs)
                 self._print_status_line()  # Report usage for EVERY API call
-                self.messages.append(turn_from_dict(assistant_msg))
+                # The canonical Turn — minted tool ids, finalized native
+                # lane, and an ACCURATE producer (the serving lane's, so a
+                # fallback-served turn no longer wears the primary's name
+                # and an in-memory fork no longer decodes producer="").
+                self.messages.append(result.turn)
                 # Clear per-turn inflight buffers — the assistant
                 # message is now in the history list a refresh would
                 # replay, so the in_progress_snapshot shouldn't re-
@@ -7106,16 +7347,15 @@ class ChatSession:
                     self._assistant_pending_tokens
                     or max(
                         1,
-                        int(self._msg_char_count(assistant_msg) / self._chars_per_token),
+                        int(self._msg_char_count(result.turn) / self._chars_per_token),
                     )
                 )
 
                 # Log assistant message to conversation history
-                content = assistant_msg.get("content", "")
-                tc = assistant_msg.get("tool_calls")
-                provider_data = None
-                if assistant_msg.get("_provider_content"):
-                    provider_data = json.dumps(assistant_msg["_provider_content"])
+                content = result.content
+                tc = result.tool_calls or None
+                native = result.turn.native
+                provider_data = json.dumps(list(native.blocks)) if native else None
 
                 tool_calls_json: str | None = json.dumps(tc) if tc else None
 
@@ -7128,10 +7368,10 @@ class ChatSession:
                         provider_data=provider_data,
                         tool_calls=tool_calls_json,
                         event_id=self._ui_event_id(),
-                        producer=self._provider.provider_name if self._provider else None,
+                        producer=result.producer or None,
                     )
 
-                tool_calls = assistant_msg.get("tool_calls")
+                tool_calls = result.tool_calls or None
                 if not tool_calls:
                     # Did the model stop because we asked it to wind down for a
                     # compaction (cooperative), or because the task is actually
@@ -7906,40 +8146,73 @@ class ChatSession:
         if discard is not None:
             discard()
 
-    def _stream_response(
-        self, msgs: list[dict[str, Any]], my_generation: int = 0
-    ) -> dict[str, Any]:
-        """Run one resilient streaming turn: acquire, consume, re-issue on death.
+    def _stream_response(self, my_generation: int = 0) -> ModelTurnResult:
+        """Run one resilient streaming turn: sample, surface, re-issue on death.
 
-        The single-pass consumer is :meth:`_stream_attempt`; this wrapper
-        owns ALL stream acquisition — first attempt included — so every
-        attempt's stream comes from the same seam and callers hand over
-        wire-ready *msgs*, never a stream.  A wire death DURING body
-        iteration surfaces after the request already returned its stream
-        handle, so neither the SDK's ``max_retries`` nor the creation-time
-        ``_try_stream`` ladder ever sees it.  ``transport_guarded``
-        normalizes those deaths to the retryable ``IncompleteStreamError``;
-        this loop finalizes the dead attempt in every UI consumer, then
-        re-issues the whole turn (the APIs cannot resume a generation) up
-        to ``_MID_STREAM_RETRIES`` times.
+        The plant call is ONE ``model_turn`` invocation per attempt
+        (creation + drain fused), reached through the lane-swap fallback
+        walk; chunk→UI translation lives in the frame's
+        :class:`_StreamTurnConsumer`, handed to ``model_turn`` as
+        ``on_chunk``.  Wire preparation is the ``prepare_wire`` closure —
+        the session's own lowering composed after the seam passes — so a
+        mid-retry registry rebind needs no explicit re-prepare: the next
+        attempt re-runs the closure against the refreshed binding by
+        construction.
+
+        A wire death DURING body iteration surfaces after the request was
+        accepted (the attempt's ``_CancelRef`` armed), so neither the
+        SDK's ``max_retries`` nor the per-lane creation ladder ever sees
+        it; ``model_turn``'s own drain retry is DISABLED on this path (a
+        partially-surfaced stream is never silently re-issued).  This loop
+        finalizes the dead attempt in every UI consumer, then re-issues
+        the whole turn (the APIs cannot resume a generation) up to
+        ``_MID_STREAM_RETRIES`` times.
 
         Ladder stacking: a 3-way stack — each re-issue runs the full
-        creation ladder, itself the ``_MAX_RETRIES`` loop times the
-        fallback-chain walk, so a persistently transient-shaped failure
+        creation walk, itself the ``_MAX_RETRIES`` loop times the
+        fallback-chain passes, so a persistently transient-shaped failure
         burns (_MID_STREAM_RETRIES + 1) x ((_MAX_RETRIES + 1) + fallback
         passes) calls before the terminal error surfaces.  Both inner
-        layers are the pre-existing creation path (task_agent's
-        ``_api_call`` documents the equivalent 2-way stack); only the
-        outer factor is new, and every layer stops immediately on a
-        non-retryable class.
+        layers are the pre-fold creation path (task_agent's ``_api_call``
+        documents the equivalent 2-way stack); every layer stops
+        immediately on a non-retryable class.
         """
         attempt = 0
-        # The latest non-empty dead attempt's flushed text.  Wrapper-LOCAL:
-        # each death carries its partial on the raised exception (thread-
-        # private), so an orphaned superseded generation cannot poison a
-        # live generation's preservation the way a shared session slot
-        # could.
+        # The latest non-empty dead attempt's flushed text.  Wrapper-LOCAL
+        # (read off the frame's consumer, never a session slot), so an
+        # orphaned superseded generation cannot poison a live generation's
+        # preservation.
         dead_partial = ""
+        # The armed death whose re-issue is in progress; when the RE-CREATE
+        # phase fails with an unarmed error, the original death is the one
+        # the operator needs to see, not the re-create's.
+        last_stream_death: Exception | None = None
+        consumer = _StreamTurnConsumer(
+            self,
+            self._build_main_lane(
+                provider=self._provider,
+                client=self.client,
+                model=self.model,
+                alias=self._model_alias,
+                capabilities=self._get_capabilities(),
+            ),
+            my_generation,
+        )
+
+        debug_printed = False
+
+        def _prepare(lowered: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            """The main loop's ``prepare_wire``: system prepend + the
+            session lowering passes, plus the debug request dump behind a
+            once-per-turn latch (matching the old once-per-send-iteration
+            print; re-issues and fallback lanes re-run the passes but not
+            the dump)."""
+            nonlocal debug_printed
+            wire = self._prepare_wire_messages([*self.system_messages, *lowered])
+            if self.debug and not debug_printed:
+                debug_printed = True
+                self._debug_print_request(wire)
+            return wire
 
         def _promote_dead_partial() -> None:
             """Hand send()'s cancel handler the retry window's partial.
@@ -7964,33 +8237,24 @@ class ChatSession:
                     "content": dead_partial,
                 }
 
-        stream = self._create_stream_with_retry(msgs)
-        # FRAME-LOCAL copy of the creation-time handoff register, taken
-        # immediately after the create returns: the retry gate must judge a
-        # death by the provider that owns THIS stream (a fallback's set can
-        # differ), the consumer must scan tags by THIS stream's caps (a
-        # fallback's ``server_parses_reasoning`` can differ), and reading
-        # the shared register later would race a superseding generation's
-        # own creation.
-        live_provider = self._active_stream_provider or self._provider
-        live_caps = self._active_stream_caps or self._get_capabilities()
         while True:
             try:
-                result = self._stream_attempt(
-                    transport_guarded(stream), my_generation, caps=live_caps
-                )
-                # The fold this turn was ACTUALLY created from rides the
-                # returned message (popped by send() at calibration, before
-                # commit — the message-dict underscore lane, like
-                # _provider_content): a mid-retry rebind re-prepares msgs,
-                # and send()'s frame-local copy cannot see that.  Carried on
-                # the frame-owned dict rather than a session slot so a
-                # superseding generation can never alias it.
-                result["_wire_msgs"] = msgs
-                return result
+                result = self._model_turn_with_fallback(consumer, _prepare, my_generation)
+                # A Stop that raced the trailing-metadata window: cancel()
+                # closed the stream and the drain's post-finish tolerance
+                # ended it CLEANLY — without this re-check the turn would
+                # commit as complete and its tool calls would execute
+                # despite the Stop.
+                self._check_cancelled(my_generation)
+                consumer.finish_stream()
+                return self._finalize_stream_result(result)
             except GenerationCancelled:
                 # A Stop during an attempt (incl. the re-create/TTFT window
-                # after a death) — preserve the window's best partial.
+                # after a death) — finalize the streamed display if the
+                # attempt got a stream, then preserve the window's best
+                # partial.
+                if consumer.attempt_armed:
+                    consumer.record_cancelled_partial()
                 _promote_dead_partial()
                 raise
             except KeyboardInterrupt:
@@ -8002,11 +8266,8 @@ class ChatSession:
                     self.ui.on_stream_end()
                 raise
             except Exception as e:
-                # The death carries the attempt's flushed text (attached by
-                # _stream_attempt's death arm).  Keep the previous
-                # attempt's text when the new death had none — the user
-                # saw it, and a later Stop must preserve it.
-                new_dead = getattr(e, "_dead_partial", "")
+                armed = consumer.attempt_armed
+                new_dead = consumer.partial_content() if armed else ""
                 dead_partial = new_dead or dead_partial
                 if self._generation != my_generation:
                     # Superseded (force-cancel started a newer generation):
@@ -8014,17 +8275,33 @@ class ChatSession:
                     # emitted here would clobber the NEW generation's
                     # in-flight stream state.
                     raise
+                if not armed:
+                    # Creation-phase failure: the walk already ran its full
+                    # ladder + fallbacks.  Mid re-issue it must not MASK the
+                    # original stream death (a closed-client re-create
+                    # surfaces as a retryable APIConnectionError and would
+                    # replace the operator-actionable wording) — except a
+                    # deterministic overflow, which surfaces as ITSELF so
+                    # send()'s compact-and-retry arm can recover the turn.
+                    # Class name only in the log — a ConnectError's text can
+                    # carry a credential-bearing base_url verbatim.
+                    if last_stream_death is None or _is_ctx_overflow(e):
+                        raise
+                    log.warning(
+                        "stream.retry.recreate_failed",
+                        error_type=type(e).__name__,
+                    )
+                    raise last_stream_death from None
                 # The terminal predicate is the SHARED _stop_retrying,
-                # capped at _MID_STREAM_RETRIES, judged by the FRAME-LOCAL
-                # live_provider (the provider that owns this stream — a
-                # fallback's retryable set can differ, e.g.
-                # ResponsesStreamFailedError).  The overflow arm applies
-                # here too — an overflow can surface mid-consumption
-                # (error-frame lanes), and it must fall through to send()'s
-                # compact-and-retry arm rather than burn re-issues on a
-                # deterministic failure.
+                # capped at _MID_STREAM_RETRIES, judged by the lane that
+                # ACTUALLY armed this stream (a fallback's retryable set
+                # can differ, e.g. ResponsesStreamFailedError).  The
+                # overflow arm applies here too — an overflow can surface
+                # mid-consumption (error-frame lanes), and it must fall
+                # through to send()'s compact-and-retry arm rather than
+                # burn re-issues on a deterministic failure.
                 if self._stop_retrying(
-                    e, attempt, live_provider, max_retries=self._MID_STREAM_RETRIES
+                    e, attempt, consumer.lane.provider, max_retries=self._MID_STREAM_RETRIES
                 ):
                     # Terminal: finalize AND discard, exactly like the
                     # retry arm.  Keeping the buffers bought nothing — the
@@ -8037,8 +8314,9 @@ class ChatSession:
                     self.ui.on_stream_end()
                     self._ui_stream_discarded()
                     raise  # fatal path otherwise unchanged
+                last_stream_death = e
                 # Delay from the PRE-increment attempt index — the same
-                # convention as the three sibling ladders' range loops.
+                # convention as the sibling ladders' range loops.
                 delay = self._RETRY_BASE_DELAY * (2**attempt)
                 attempt += 1
                 cause = type(e.__cause__).__name__ if e.__cause__ else type(e).__name__
@@ -8046,7 +8324,7 @@ class ChatSession:
                     "stream.retry",
                     error_type=cause,
                     attempt=attempt,
-                    model=self.model,
+                    model=consumer.lane.model,
                     retry_in=delay,
                     # Spend trace for the abandoned generation: the wire
                     # reports usage only at stream end, so a dead attempt's
@@ -8063,13 +8341,13 @@ class ChatSession:
                 )
                 # Finalize the dead attempt client-side, then WAIT before
                 # discarding: stream_end (browser bubble, CLI markdown
-                # flush/fence reset, Slack/Discord StreamingMessage) ->
-                # notice -> backoff.  The server-buffer discard runs only
-                # AFTER the backoff survives the Stop window — a Stop
-                # during backoff persists the promoted partial to history,
-                # and the idle payload (drained from the turn buffer)
-                # must carry the same text, or the dashboard renders the
-                # cancelled turn empty while the transcript has it.
+                # flush/fence reset) -> notice -> backoff.  The
+                # server-buffer discard runs only AFTER the backoff
+                # survives the Stop window — a Stop during backoff persists
+                # the promoted partial to history, and the idle payload
+                # (drained from the turn buffer) must carry the same text,
+                # or the dashboard renders the cancelled turn empty while
+                # the transcript has it.
                 self.ui.on_stream_end()
                 self.ui.on_info(
                     f"[stream died mid-response ({cause}) — retrying in "
@@ -8094,279 +8372,32 @@ class ChatSession:
                     # A concurrent ModelRegistry.reload() closes cached
                     # clients whose connection config changed — the
                     # in-flight read then dies with a ReadError and
-                    # self.client is CLOSED.  The refresh is
-                    # generation-gated (two compares when nothing changed),
-                    # so this is free in the common case and re-binds
-                    # exactly when reload made the old client unusable.
-                    binding_before = (self.client, self.model, self._provider)
+                    # self.client is CLOSED.  Generation-gated (two compares
+                    # when nothing changed) and cheap; the re-prepare the
+                    # old path ran on a changed binding is now implicit —
+                    # the next attempt's ``prepare_wire`` closure runs
+                    # against whatever binding the walk resolves.
                     self._refresh_model_from_registry()
-                    if (self.client, self.model, self._provider) != binding_before:
-                        # The rebind may have changed the model family, and
-                        # the wire fold is capability-sensitive
-                        # (fold_system_turns) — re-prepare against the new
-                        # binding, the same pass the overflow arm runs
-                        # mid-send.  Compared as the full binding triple:
-                        # reload() deliberately KEEPS the pooled client
-                        # when only the alias's model id changed, so a
-                        # client-identity check alone would re-issue the
-                        # old model's fold against the new model.
-                        msgs = self._prepare_wire_messages(self._full_messages())
-                    try:
-                        stream = self._create_stream_with_retry(msgs)
-                        # Refresh the frame-local gate identities: the
-                        # re-create may have walked to a different
-                        # provider (fallback, rebind) with different caps.
-                        live_provider = self._active_stream_provider or self._provider
-                        live_caps = self._active_stream_caps or self._get_capabilities()
-                    except Exception as recreate_exc:
-                        if _is_ctx_overflow(recreate_exc):
-                            # Deterministic — surface as ITSELF so send()'s
-                            # compact-and-retry arm can recover the turn; a
-                            # rebind can land on a smaller-window model
-                            # mid-retry.
-                            raise
-                        # Otherwise the re-create's failure must not mask
-                        # the true stream-death error: a closed-client
-                        # recreate surfaces as a retryable
-                        # APIConnectionError and would replace the
-                        # operator-actionable wording after burning its own
-                        # ladder.  Class name only — a ConnectError's text
-                        # can carry a credential-bearing base_url verbatim.
-                        log.warning(
-                            "stream.retry.recreate_failed",
-                            error_type=type(recreate_exc).__name__,
-                        )
-                        raise e from None
                 except GenerationCancelled:
-                    # A Stop landing in the backoff/re-create window aborts
-                    # the turn with the dead attempt's partial preserved —
-                    # the same disposition a cancel DURING the attempt gets.
+                    # A Stop landing in the backoff window aborts the turn
+                    # with the dead attempt's partial preserved — the same
+                    # disposition a cancel DURING the attempt gets.
                     _promote_dead_partial()
                     raise
 
-    def _stream_attempt(
-        self,
-        stream: Iterator[StreamChunk],
-        my_generation: int = 0,
-        *,
-        caps: ModelCapabilities | None = None,
-    ) -> dict[str, Any]:
-        """Consume ONE streaming attempt, dispatching tokens to the UI live.
+    def _finalize_stream_result(self, result: ModelTurnResult) -> ModelTurnResult:
+        """Post-drain policies for a COMPLETED interactive turn.
 
-        Handles two reasoning delivery mechanisms:
-        1. The `reasoning_delta` field (e.g. vLLM with --reasoning-parser)
-        2. <think>...</think> tags in regular content (common default)
-
-        Calls self.ui.on_thinking_stop() on the first received delta.
-
-        Returns the complete assistant message as a dict suitable for
-        appending to self.messages.  Single-pass by contract: the
-        acquisition + mid-stream-retry wrapper is :meth:`_stream_response`,
-        which hands this method a ``transport_guarded`` iterator per
-        attempt — along with *caps*, the ACTIVE lane's capabilities from
-        the creation-time handoff register, so the tag-scan posture
-        follows the stream actually being consumed (a fallback's
-        ``server_parses_reasoning`` can differ from the primary's).
-        ``None`` (direct callers, tests) resolves the primary's.
+        The ``length`` partial-tool-call drop is harness policy, not
+        assembly: the drain keeps everything it accumulated, and this is
+        where the interactive lane discards calls whose JSON arguments a
+        truncation cut mid-string — executing them would dispatch garbage
+        (the sub-agent loop's policy differs: it stops the run instead).
+        The rebuilt turn keeps its reasoning synth but drops the orphan
+        native client tool blocks, via the SAME shared finalize the
+        assembly used (``has_tool_calls=False`` arm) — no private strip.
         """
-        caps = caps or self._get_capabilities()
-        # Reset so this API call captures fresh usage — prevents stale
-        # completion_tokens from a prior tool-chain iteration leaking
-        # through the max() accumulator.  _assistant_pending_tokens is the
-        # same staleness one hop later: a post-finish transport blip
-        # (transport_guarded's tolerance) can end this stream with the
-        # trailing usage chunk lost, and _update_token_table's falsy-usage
-        # early-return would then leave the PREVIOUS turn's completion
-        # count to be appended as this turn's estimate by send()'s
-        # `_assistant_pending_tokens or ...` fallback.
-        self._last_usage = None
-        self._assistant_pending_tokens = 0
-
-        content_parts: list[str] = []
-        reasoning_parts: list[str] = []
-        tool_calls_acc: dict[int, dict[str, Any]] = {}
-        provider_blocks: list[dict[str, Any]] = []
-        usage_acc: UsageInfo | None = None
-        first_token = True
-        path1_reasoning = False  # last reasoning came via reasoning_delta field
-
-        def _flush_text(text: str, is_reasoning: bool) -> None:
-            """Dispatch text to the appropriate UI callback."""
-            if not text:
-                return
-            if is_reasoning:
-                reasoning_parts.append(text)
-                if self.show_reasoning:
-                    self.ui.on_reasoning_token(text)
-            else:
-                content_parts.append(text)
-                self.ui.on_content_token(text)
-
-        # Owns the partial-tag carry buffer and the in-think state;
-        # dispatch stays here in _flush_text.  The tag scan follows the
-        # SAME capability the drain seam reads
-        # (``server_parses_reasoning``) so the interactive and drained
-        # lanes cannot disagree about whether a backend's content may
-        # contain inline reasoning — read from the ACTIVE lane's caps
-        # (the *caps* parameter), never the primary's.
-        splitter = ThinkTagSplitter(
-            _flush_text,
-            scan_tags=not caps.server_parses_reasoning,
-        )
-
-        def _stop_spinner_once() -> None:
-            """Stop the spinner on first real content. Call is idempotent."""
-            nonlocal first_token
-            if first_token:
-                self.ui.on_thinking_stop()
-                first_token = False
-
-        def _partial_content() -> str:
-            """THE partial-content rule, in one form: flushed content plus
-            the splitter's carry tail when it is content-state (an in-think
-            tail is reasoning and stays out).  Both preservation paths —
-            the cancel arms' record below and the death arm's exception
-            payload — derive from this single closure so a Stop landing in
-            the retry window persists the same text as a Stop during the
-            attempt."""
-            return "".join(content_parts) + (splitter.pending if not splitter.in_think else "")
-
-        def _record_cancelled_partial() -> None:
-            """Flush buffered text, finalize the stream in the UI, and stash
-            the partial for send()'s cancel handler — the one sequence both
-            cancel arms (cooperative and stream-close-converted) must run.
-            No-op for a SUPERSEDED generation: an orphaned thread must
-            touch neither the UI (its stream_end would reset the successor
-            generation's inflight buffers mid-stream) nor the shared
-            partial slot the successor's cancel handler consumes.
-            ``tool_calls`` and ``_provider_content`` are DELIBERATELY
-            OMITTED from the partial:
-
-            * ``tool_calls`` — incomplete, no matching tool_result;
-              re-emitting on the next turn would orphan them.
-            * ``_provider_content`` — the Anthropic provider reads this
-              lane verbatim ahead of plain ``content`` (see
-              ``providers/_anthropic.py``), and a cancellation can leave
-              partial tool_use blocks here too.  Keeping it would also
-              cause the next-turn replay to bypass the ``[generation
-              cancelled before completion]`` marker the cancel handler
-              appends to ``content``, hiding the partial-output signal
-              from the model.
-            """
-            if self._generation != my_generation:
-                return
-            content = _partial_content()
-            splitter.flush_pending()
-            self.ui.on_stream_end()
-            self._cancelled_partial_msg = {"role": "assistant", "content": content}
-
-        finish_reason = None
-        try:
-            for chunk in stream:
-                # _cancel_stream is set eagerly by _CancelRef.append() when the
-                # provider creates the SDK stream handle (before the first chunk
-                # is returned).  This fallback handles providers that use a
-                # plain list for cancel_ref (e.g. some test fakes).
-                if self._cancel_ref and self._cancel_stream is None:
-                    self._cancel_stream = self._cancel_ref[0]
-                self._check_cancelled(my_generation)
-                # Track finish_reason (e.g. "stop", "length", "tool_calls")
-                if chunk.finish_reason:
-                    finish_reason = chunk.finish_reason
-
-                # Accumulate usage (Anthropic sends prompt tokens in message_start
-                # and completion tokens in message_delta as separate events) via
-                # THE shared max-merge rule (merge_usage, drain_stream's twin).
-                # self._last_usage is re-written on EVERY usage chunk: it is
-                # read mid-stream (_estimated_prompt_tokens, the status line),
-                # so the dict write cannot defer to stream end.
-                if chunk.usage:
-                    usage_acc = merge_usage(usage_acc, chunk.usage)
-                    self._last_usage = dataclasses.asdict(usage_acc)
-
-                if self.debug:
-                    parts = []
-                    if chunk.content_delta:
-                        parts.append(f"content={chunk.content_delta!r}")
-                    if chunk.reasoning_delta:
-                        parts.append(f"reasoning={chunk.reasoning_delta!r}")
-                    if chunk.tool_call_deltas:
-                        parts.append("tool_calls=...")
-                    if parts:
-                        self.ui.on_info(f"{GRAY}[delta: {', '.join(parts)}]{RESET}")
-
-                # Path 1: reasoning field (provider-normalized reasoning_delta)
-                if chunk.reasoning_delta:
-                    _stop_spinner_once()
-                    reasoning_parts.append(chunk.reasoning_delta)
-                    splitter.in_think = True
-                    path1_reasoning = True
-                    if self.show_reasoning:
-                        self.ui.on_reasoning_token(chunk.reasoning_delta)
-
-                # Path 2: regular content (may contain <think> tags)
-                if chunk.content_delta:
-                    _stop_spinner_once()
-                    # Close reasoning if transitioning from Path 1 reasoning
-                    if path1_reasoning:
-                        path1_reasoning = False
-                        splitter.in_think = False
-                    splitter.feed(chunk.content_delta)
-
-                # Handle tool call deltas
-                if chunk.tool_call_deltas:
-                    _stop_spinner_once()
-                    # Flush any buffered content — model has moved to tool calls,
-                    # so pending text cannot be a partial <think> tag.
-                    splitter.flush_pending()
-                    # Close reasoning if transitioning from reasoning
-                    if splitter.in_think:
-                        splitter.in_think = False
-                    for tcd in chunk.tool_call_deltas:
-                        # THE tool-call merge rule, shared with drain_stream
-                        # and the Google raw-fidelity capture — the chat
-                        # loop and every drained lane assemble identical
-                        # calls from identical wire streams.
-                        accumulate_tool_call_delta(tool_calls_acc, tcd)
-
-                # Informational messages (e.g. server-side web search status)
-                if chunk.info_delta:
-                    _stop_spinner_once()
-                    self.ui.on_info(f"{GRAY}{chunk.info_delta}{RESET}")
-
-                # Raw provider content blocks (for multi-turn preservation)
-                if chunk.provider_blocks:
-                    provider_blocks = chunk.provider_blocks
-            # A Stop that raced the trailing-metadata window: cancel()
-            # closed the stream, and transport_guarded's post-finish
-            # tolerance ended it CLEANLY instead of letting the closed-
-            # stream raise reach the conversion arm below — without this
-            # re-check the turn would commit as complete and its tool
-            # calls would execute despite the Stop.
-            self._check_cancelled(my_generation)
-        except GenerationCancelled:
-            _record_cancelled_partial()
-            raise
-        except Exception as death_exc:
-            # cancel() closed the underlying SDK stream, aborting the HTTP
-            # connection.  The blocked next() call on the iterator raises a
-            # transport-level error (httpx, httpcore, etc.).  Convert to
-            # GenerationCancelled if a cancel was requested.
-            if self._cancel_event.is_set():
-                _record_cancelled_partial()
-                raise GenerationCancelled() from None
-            # A non-cancel death: the attempt's flushed text rides the
-            # EXCEPTION (thread-private, so an orphaned generation's death
-            # can never poison a live generation's preservation) for the
-            # resilient wrapper's Stop-in-retry-window promotion.  No UI
-            # emission here — the wrapper finalizes the dead attempt.
-            death_exc._dead_partial = _partial_content()  # type: ignore[attr-defined]
-            raise
-
-        # Flush any remaining buffered text
-        splitter.flush_pending()
-
-        # Warn on non-standard finish reasons
+        finish_reason = result.finish_reason
         if finish_reason == "length":
             self.ui.on_error(
                 f"Warning: response truncated (hit {self.max_tokens} token limit). "
@@ -8376,11 +8407,10 @@ class ChatSession:
                 "stream.truncated",
                 finish_reason=finish_reason,
                 max_tokens=self.max_tokens,
-                had_tool_calls=bool(tool_calls_acc),
+                had_tool_calls=bool(result.tool_calls),
             )
-            # Drop partial tool calls — they'll have malformed JSON
-            if tool_calls_acc:
-                dropped = [tool_calls_acc[i]["function"]["name"] for i in sorted(tool_calls_acc)]
+            if result.tool_calls:
+                dropped = [tc["function"]["name"] for tc in result.tool_calls]
                 self.ui.on_error("Discarding partial tool calls from truncated response.")
                 log.warning(
                     "stream.tool_calls_discarded",
@@ -8388,76 +8418,58 @@ class ChatSession:
                     dropped_tools=dropped,
                     count=len(dropped),
                 )
-                tool_calls_acc.clear()
+                old_native = result.turn.native
+                blocks = finalize_provider_blocks(
+                    list(old_native.blocks) if old_native else [],
+                    [],
+                    has_tool_calls=False,
+                )
+                native = (
+                    ProviderNative(producer=old_native.producer, blocks=tuple(blocks))
+                    if blocks and old_native
+                    else None
+                )
+                result = dataclasses.replace(
+                    result,
+                    turn=Turn.assistant(result.turn.text, native=native),
+                    tool_calls=[],
+                )
         elif finish_reason == "content_filter":
             self.ui.on_error("Warning: response blocked by content filter.")
 
-        # Log stream completion for diagnostics
+        # Non-destructive integrity signal: the length-guard above drops
+        # tool calls only on ``finish_reason == "length"``, so a model that
+        # emits invalid-JSON arguments with a ``stop``/``tool_calls``
+        # finish reason commits them verbatim.  The canonical Turn stays a
+        # faithful record (the wire copy is legalized by
+        # ``lowering.sanitize_tool_call_arguments``); this only flags the
+        # model-quality problem at the moment it happens, not merely as a
+        # downstream wire legalization on every replay.
+        for tc in result.tool_calls:
+            raw_args = tc["function"].get("arguments")
+            if not wire_valid_arguments(raw_args):
+                log.warning(
+                    "stream.tool_args_malformed",
+                    tool=tc["function"].get("name", "?"),
+                    call_id=tc.get("id", ""),
+                    raw_preview=tool_args_preview(raw_args),
+                )
+        if result.tool_calls:
+            log.info(
+                "stream.tool_calls",
+                count=len(result.tool_calls),
+                tools=[tc["function"]["name"] for tc in result.tool_calls],
+            )
+
         log.debug(
             "stream.finished",
             finish_reason=finish_reason,
-            has_content=bool(content_parts),
-            tool_call_count=len(tool_calls_acc),
-            content_length=sum(len(p) for p in content_parts),
+            has_content=bool(result.content),
+            tool_call_count=len(result.tool_calls),
+            content_length=len(result.content),
         )
-
-        # Signal end of stream to the UI
         self.ui.on_stream_end()
-
-        # Build assistant message dict
-        msg: dict[str, Any] = {"role": "assistant"}
-
-        content = "".join(content_parts)
-        msg["content"] = content or ""
-
-        had_blank_ids = False
-        if tool_calls_acc:
-            # Record blanks BEFORE the uuid back-fill (the back-fill reaches
-            # only this mirror; the native blocks keep the blank id verbatim)
-            # — threaded to _finalize_provider_blocks, which drops the blocks
-            # a back-filled id would desync.
-            had_blank_ids = any(not tc.get("id") for tc in tool_calls_acc.values())
-            self._ensure_tool_call_ids(tool_calls_acc)
-            ordered = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
-            msg["tool_calls"] = ordered
-            # Non-destructive integrity signal: the length-guard above drops tool
-            # calls only on ``finish_reason == "length"``, so a model that emits
-            # invalid-JSON arguments with a ``stop`` / ``tool_calls`` finish reason
-            # commits them verbatim.  We keep the raw output (the canonical Turn
-            # stays a faithful record; the wire copy is legalized by
-            # ``lowering.sanitize_tool_call_arguments``) and only flag it here — so a
-            # model-quality problem is visible at the moment it happens, not merely
-            # as a downstream wire legalization on every replay.
-            for tc in ordered:
-                raw_args = tc["function"].get("arguments")
-                if not wire_valid_arguments(raw_args):
-                    log.warning(
-                        "stream.tool_args_malformed",
-                        tool=tc["function"].get("name", "?"),
-                        call_id=tc.get("id", ""),
-                        raw_preview=tool_args_preview(raw_args),
-                    )
-            log.info(
-                "stream.tool_calls",
-                count=len(ordered),
-                tools=[tc["function"]["name"] for tc in ordered],
-            )
-
-        # Store raw provider content blocks for multi-turn preservation
-        # (e.g. Anthropic web_search_tool_result with encrypted_content).
-        # Finalization (path-3 reasoning synthesis + the in-memory
-        # native↔tool_calls mirror gate) is shared with the sub-agent loop —
-        # see _finalize_provider_blocks.
-        provider_blocks = self._finalize_provider_blocks(
-            provider_blocks,
-            reasoning_parts,
-            has_tool_calls=bool(msg.get("tool_calls")),
-            had_blank_ids=had_blank_ids,
-        )
-        if provider_blocks:
-            msg["_provider_content"] = provider_blocks
-
-        return msg
+        return result
 
     _print_lock = threading.Lock()
 
@@ -8612,17 +8624,19 @@ class ChatSession:
 
     def _update_token_table(
         self,
-        assistant_msg: dict[str, Any],
         *,
         msgs: list[dict[str, Any]] | None = None,
     ) -> None:
         """Update per-message token estimates using API usage data.
 
-        *msgs* (optional) is the wire-bound message list already built
-        for the stream call — passing it avoids a redundant
-        ``_prepare_wire_messages`` walk and ensures the char count matches
-        the bytes the provider counted.  When *msgs* is None the caller
-        didn't pre-build (rare path) — fall back to folding on the fly.
+        *msgs* (optional) is the as-sent wire list off the streaming
+        result (``ModelTurnResult.wire_msgs``) — passing it avoids a
+        redundant ``_prepare_wire_messages`` walk and ensures the char
+        count matches the bytes the provider counted.  When *msgs* is
+        None the caller didn't have one (fake results, direct calls) —
+        fall back to folding on the fly.  (The old leading
+        ``assistant_msg`` parameter was never read by the body and is
+        gone — #832.)
         """
         if not self._last_usage:
             return
@@ -9003,12 +9017,12 @@ class ChatSession:
                     # landed), so cancel() aborts the blocked read instead
                     # of waiting out a whole model call — the force-stop
                     # orphan window collapses from one summary call to the
-                    # next checkpoint.  A fresh instance (never the shared
-                    # self._cancel_ref) keeps the main loop's per-attempt
-                    # clear and [0]-fallback semantics untouched, and the
-                    # boundary checks in _summarize_batch/_backoff guarantee
-                    # a superseded compaction makes no further calls — so
-                    # it can never clobber a successor's registration.
+                    # next checkpoint.  The same fresh-per-attempt,
+                    # generation-scoped discipline the main loop now uses
+                    # (#832); the boundary checks in
+                    # _summarize_batch/_backoff guarantee a superseded
+                    # compaction makes no further calls — so it can never
+                    # clobber a successor's registration.
                     cancel_ref=_CancelRef(self, my_generation),
                 )
                 break

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -139,11 +139,14 @@ from turnstone.core.model_registry import (
     ModelClientConstructionError,
 )
 from turnstone.core.model_turn import (
+    TRAILING_INFO_SEPARATOR,
     ModelLane,
     ModelTurnResult,
+    WirePreparationError,
     create_provider,
-    ensure_tool_call_ids,
     finalize_provider_blocks,
+    folds_trailing_info,
+    lane_scans_inline_reasoning,
     lane_thinking_suppressed,
     lane_without_thinking,
     merge_usage,
@@ -324,8 +327,11 @@ class _CompactionIrreducibleError(Exception):
 
 
 class _CancelRef(list[Any]):
-    """List proxy used for ``ChatSession._cancel_ref``.
+    """List proxy handed to ``create_streaming`` as its ``cancel_ref``.
 
+    One FRESH instance per attempt, frame-local to the model-call wrapper
+    that built it — #832 retired the session-level shared slot
+    (``test_cancel`` pins ``not hasattr(session, "_cancel_ref")``).
     Providers call ``cancel_ref.append(stream_handle)`` eagerly — the HTTP
     call and registration happen before the iterator is returned to the
     caller.  By overriding ``append`` we update ``ChatSession._cancel_stream``
@@ -463,25 +469,34 @@ class _StreamTurnConsumer:
     info line exactly as before.
     """
 
-    def __init__(self, session: ChatSession, lane: ModelLane, my_generation: int) -> None:
+    def __init__(self, session: ChatSession, my_generation: int) -> None:
         self._session = session
         self._my_generation = my_generation
-        self.lane = lane
+        # No lane until the walk's first begin_attempt resolves one — the
+        # per-attempt state has exactly ONE initializer (``_reset_attempt``),
+        # so a first attempt and a re-issue cannot drift, and construction
+        # costs no resolve_lane walk.
+        self.lane: ModelLane | None = None
         self.ref: _CancelRef | None = None
         self.tracker: BackendHealthTracker | None = None
+        self._reset_attempt()
+
+    # -- attempt lifecycle ---------------------------------------------------
+
+    def _reset_attempt(self) -> None:
+        """THE per-attempt display reset — sole initializer of this state."""
         self._content_parts: list[str] = []
         self._first_token = True
         self._path1_reasoning = False
         self._finish_seen = False
+        self._saw_chunk = False
+        # Per-attempt: a re-issued attempt's usage must never max-merge
+        # onto the dead attempt's (the accumulator was attempt-local in
+        # the pre-fold consumer too).
         self._usage_acc: UsageInfo | None = None
         self._splitter = ThinkTagSplitter(
-            self._flush_text,
-            scan_tags=not (
-                lane.capabilities.server_parses_reasoning if lane.capabilities else False
-            ),
+            self._flush_text, scan_tags=lane_scans_inline_reasoning(self.lane)
         )
-
-    # -- attempt lifecycle ---------------------------------------------------
 
     def begin_attempt(
         self,
@@ -489,7 +504,7 @@ class _StreamTurnConsumer:
         tracker: BackendHealthTracker | None,
         lane: ModelLane,
     ) -> None:
-        """Reset display state for one creation attempt on *lane*.
+        """Arm display state for one creation attempt on *lane*.
 
         The usage-slot resets do NOT happen here — they ride
         :meth:`on_stream_armed` (the request-accepted instant), so a long
@@ -499,25 +514,39 @@ class _StreamTurnConsumer:
         self.ref = ref
         self.tracker = tracker
         self.lane = lane
-        self._content_parts = []
-        self._first_token = True
-        self._path1_reasoning = False
-        self._finish_seen = False
-        # Per-attempt: a re-issued attempt's usage must never max-merge
-        # onto the dead attempt's (the accumulator was attempt-local in
-        # the pre-fold consumer too).
-        self._usage_acc = None
-        self._splitter = ThinkTagSplitter(
-            self._flush_text,
-            scan_tags=not (
-                lane.capabilities.server_parses_reasoning if lane.capabilities else False
-            ),
-        )
+        self._reset_attempt()
+
+    def end_attempt(self) -> None:
+        """Pronounce the current attempt dead: nothing about it may leak.
+
+        The re-issue ladder calls this once a mid-stream death's partial
+        is captured — from here until the next ``begin_attempt`` there is
+        NO live attempt, so ``attempt_armed`` reads False.  Without it, a
+        Stop (or a walk-preamble failure) landing in the re-create window
+        would read the DEAD attempt's armed ref: the cancel arm would
+        re-finalize discarded display state — the stale splitter carry
+        emitted as a fresh content token into the just-truncated segment,
+        with a duplicate ``stream_end`` behind it — and a preamble error
+        would be classified as another armed death, replacing the
+        operator-actionable stream-death error.  The lane survives: the
+        ladder's terminal predicate is judged by the lane that actually
+        armed the dead stream.
+        """
+        self.ref = None
+        self._reset_attempt()
 
     @property
     def attempt_armed(self) -> bool:
-        """Whether this attempt's request was accepted (handle registered)."""
-        return self.ref is not None and self.ref.armed
+        """Whether this attempt streamed: handle registered, or any chunk
+        actually surfaced.  The chunk fallback is the tripwire for an
+        adapter that skips the eager ``cancel_ref`` append (an out-of-tree
+        adapter written to the pre-#832 letter of the contract): its
+        mid-stream death must still classify as mid-stream — a
+        creation-classified death would silently re-issue the same lane
+        and double-render everything already on screen.  Such an adapter
+        still forfeits ``on_stream_armed``'s duties (health success,
+        usage-slot resets); the in-tree tripwires pin eager arming."""
+        return (self.ref is not None and self.ref.armed) or self._saw_chunk
 
     def on_stream_armed(self) -> None:
         """`_CancelRef.on_first_append` — the request-accepted instant.
@@ -554,6 +583,10 @@ class _StreamTurnConsumer:
             self._first_token = False
 
     def __call__(self, chunk: StreamChunk) -> None:
+        # Before the cancel check: the chunk DID arrive, so the attempt
+        # streamed — the classifier fallback must see that even when this
+        # very chunk's cancel check aborts the turn.
+        self._saw_chunk = True
         s = self._session
         s._check_cancelled(self._my_generation)
         if chunk.finish_reason:
@@ -604,17 +637,18 @@ class _StreamTurnConsumer:
             self._stop_spinner_once()
             if self._finish_seen:
                 # Trailing citations footer → CONTENT, per the drain's
-                # conditional fold: only onto a non-blank answer, with the
-                # same separator.  The generation is over (finish seen), so
-                # the splitter's carry is final answer text, never a
-                # partial tag — flush it FIRST or the footer renders
-                # spliced into the middle of the answer's last characters.
-                # Appended via the accumulator too, so the partial rule and
-                # the blankness test stay consistent with the committed
-                # content.
+                # conditional fold — gate and separator are the SHARED
+                # module-level pair beside ``drain_stream``, so the two
+                # mirrors cannot drift.  The generation is over (finish
+                # seen), so the splitter's carry is final answer text,
+                # never a partial tag — flush it FIRST or the footer
+                # renders spliced into the middle of the answer's last
+                # characters.  Appended via the accumulator too, so the
+                # partial rule and the blankness test stay consistent
+                # with the committed content.
                 self._splitter.flush_pending()
-                if "".join(self._content_parts).strip():
-                    self._flush_text("\n\n" + chunk.info_delta, False)
+                if folds_trailing_info("".join(self._content_parts)):
+                    self._flush_text(TRAILING_INFO_SEPARATOR + chunk.info_delta, False)
             else:
                 s.ui.on_info(f"{GRAY}{chunk.info_delta}{RESET}")
 
@@ -2695,32 +2729,6 @@ class ChatSession:
                 self._cached_capabilities = self._resolve_capabilities(p, m, self._model_alias)
             return self._cached_capabilities
         return self._resolve_capabilities(p, m, "")
-
-    def _finalize_provider_blocks(
-        self,
-        provider_blocks: list[dict[str, Any]],
-        reasoning_parts: list[str],
-        *,
-        has_tool_calls: bool,
-        had_blank_ids: bool = False,
-        alias: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """Delegate to :func:`turnstone.core.model_turn.finalize_provider_blocks`
-        — the ONE native-lane builder every harness shares (main-loop stream
-        accumulator here; sub-agent loop and judges via ``model_turn``).
-
-        ``None`` *alias* (the main-loop caller) resolves to the session's
-        primary alias; the blank-id mirror gate and orphan-strip semantics
-        are documented on the module function.
-        """
-        return finalize_provider_blocks(
-            provider_blocks,
-            reasoning_parts,
-            has_tool_calls=has_tool_calls,
-            had_blank_ids=had_blank_ids,
-            registry=self._registry,
-            alias=alias or self._model_alias or "",
-        )
 
     def _save_config(self) -> None:
         """Persist LLM-affecting config so resumed workstreams behave identically."""
@@ -5710,6 +5718,22 @@ class ChatSession:
 
         name = type(exc).__name__
 
+        # A wire-preparation failure is the session's own data at fault —
+        # ``model_turn`` typed it so no ladder recorded health or walked
+        # fallbacks.  Checked FIRST: it is the most specific classification,
+        # and the overflow text-match below must not claim a lowering error
+        # whose message happens to mention token limits.
+        if isinstance(exc, WirePreparationError):
+            prep_cause = exc.__cause__
+            detail = f"{type(prep_cause).__name__}: {prep_cause}" if prep_cause else raw_msg
+            return (
+                f"Preparing the request from this conversation's history failed: "
+                f"{detail}. This is a fault in the session's stored history, not "
+                f"in the {model_label} backend (no fallback was tried and backend "
+                f"health is unaffected). /compact may clear a malformed turn; "
+                f"please report this."
+            )
+
         # Context overflow — matched by text, because it arrives as BadRequestError
         # (OpenAI 400) OR InternalServerError (Anthropic-compat 500), which would
         # otherwise render as an opaque class name with no hint that the prompt was
@@ -6158,8 +6182,12 @@ class ChatSession:
         ``self.reasoning_effort`` to the wire verbatim and never consulted
         the per-alias config rungs, and a resumed workstream with unset
         knobs must keep OMITTING rather than newly picking up alias
-        config.  Whether the lane rungs should apply to the main loop is a
-        live question — but not this fold's (wire parity first).
+        config.  ``config_store`` is deliberately NOT passed: its only
+        consumers inside ``resolve_lane`` are the two sampling-knob
+        resolvers this method overrides, and a dead store read per lane
+        build would misread as the rungs reaching the main loop.  Whether
+        they SHOULD is a live question — but not this fold's (wire parity
+        first).
         """
         lane = resolve_lane(
             provider,
@@ -6168,7 +6196,6 @@ class ChatSession:
             alias=alias or "",
             registry=self._registry,
             capabilities=capabilities,
-            config_store=self._config_store,
             backend_auth_resolver=self._model_backend_auth_token,
         )
         return dataclasses.replace(
@@ -6210,6 +6237,13 @@ class ChatSession:
         except BackendAuthUnavailableError:
             # Explicit fail-closed policy: never reinterpret an authentication
             # refusal as backend health and never route it to a static fallback.
+            raise
+        except WirePreparationError:
+            # Session-data fault, typed by ``model_turn``: the caller's own
+            # lowering raised.  No health record and no fallback walk —
+            # every lane would re-run the same deterministic passes, and
+            # N recorded failures would paint a cluster-wide outage over
+            # a malformed turn in ONE session's history.
             raise
         except Exception as primary_err:
             if consumer.attempt_armed:
@@ -6283,7 +6317,11 @@ class ChatSession:
             return self._model_turn_with_retry(
                 fb_lane, fb_tracker, consumer, prepare_wire, my_generation
             )
-        except BackendAuthUnavailableError:
+        except (BackendAuthUnavailableError, WirePreparationError):
+            # Same two verbatim-forward classes as the primary walk: an
+            # auth refusal is fail-closed policy, a wire-preparation
+            # failure is the caller's data bug — neither is this
+            # fallback's health signal.
             raise
         except Exception as fb_err:
             if consumer.attempt_armed:
@@ -8189,26 +8227,20 @@ class ChatSession:
         # phase fails with an unarmed error, the original death is the one
         # the operator needs to see, not the re-create's.
         last_stream_death: Exception | None = None
-        consumer = _StreamTurnConsumer(
-            self,
-            self._build_main_lane(
-                provider=self._provider,
-                client=self.client,
-                model=self.model,
-                alias=self._model_alias,
-                capabilities=self._get_capabilities(),
-            ),
-            my_generation,
-        )
+        consumer = _StreamTurnConsumer(self, my_generation)
 
         debug_printed = False
 
         def _prepare(lowered: list[dict[str, Any]]) -> list[dict[str, Any]]:
             """The main loop's ``prepare_wire``: system prepend + the
             session lowering passes, plus the debug request dump behind a
-            once-per-turn latch (matching the old once-per-send-iteration
-            print; re-issues and fallback lanes re-run the passes but not
-            the dump)."""
+            once-per-invocation latch — re-issues and fallback lanes
+            re-run the passes but not the dump.  send()'s overflow
+            recovery calls ``_stream_response`` again and prints again:
+            post-compaction the wire CHANGED, and the re-prepared dump is
+            the one that diagnoses the recovery (a named #832 delta — the
+            pre-fold print-once-per-send was an accident of wire prep
+            living outside the streaming try)."""
             nonlocal debug_printed
             wire = self._prepare_wire_messages([*self.system_messages, *lowered])
             if self.debug and not debug_printed:
@@ -8271,6 +8303,14 @@ class ChatSession:
                 armed = consumer.attempt_armed
                 new_dead = consumer.partial_content() if armed else ""
                 dead_partial = new_dead or dead_partial
+                if armed:
+                    # The attempt is dead and its partial captured — from
+                    # here until the next ``begin_attempt`` there is no
+                    # live attempt.  Without this, a Stop or a
+                    # walk-preamble failure landing in the re-create
+                    # window reads the DEAD attempt's armed state (see
+                    # ``end_attempt``).
+                    consumer.end_attempt()
                 if self._generation != my_generation:
                     # Superseded (force-cancel started a newer generation):
                     # an orphaned thread must not touch the UI — a finalize
@@ -8282,12 +8322,22 @@ class ChatSession:
                     # ladder + fallbacks.  Mid re-issue it must not MASK the
                     # original stream death (a closed-client re-create
                     # surfaces as a retryable APIConnectionError and would
-                    # replace the operator-actionable wording) — except a
-                    # deterministic overflow, which surfaces as ITSELF so
-                    # send()'s compact-and-retry arm can recover the turn.
+                    # replace the operator-actionable wording) — EXCEPT the
+                    # classes that carry their own remediation: a
+                    # deterministic overflow surfaces as ITSELF so send()'s
+                    # compact-and-retry arm can recover the turn, and an
+                    # auth refusal / wire-preparation fault surfaces as
+                    # ITSELF so the fatal formatter's dedicated branch
+                    # renders (an OBO mint dying mid-turn is a config
+                    # outage, not a network flap — the walk forwards both
+                    # verbatim for exactly that reason).
                     # Class name only in the log — a ConnectError's text can
                     # carry a credential-bearing base_url verbatim.
-                    if last_stream_death is None or _is_ctx_overflow(e):
+                    if (
+                        last_stream_death is None
+                        or isinstance(e, (BackendAuthUnavailableError, WirePreparationError))
+                        or _is_ctx_overflow(e)
+                    ):
                         raise
                     log.warning(
                         "stream.retry.recreate_failed",
@@ -8302,8 +8352,10 @@ class ChatSession:
                 # mid-consumption (error-frame lanes), and it must fall
                 # through to send()'s compact-and-retry arm rather than
                 # burn re-issues on a deterministic failure.
+                serving_lane = consumer.lane
+                assert serving_lane is not None  # an armed death implies begin_attempt ran
                 if self._stop_retrying(
-                    e, attempt, consumer.lane.provider, max_retries=self._MID_STREAM_RETRIES
+                    e, attempt, serving_lane.provider, max_retries=self._MID_STREAM_RETRIES
                 ):
                     # Terminal: finalize AND discard, exactly like the
                     # retry arm.  Keeping the buffers bought nothing — the
@@ -8326,7 +8378,7 @@ class ChatSession:
                     "stream.retry",
                     error_type=cause,
                     attempt=attempt,
-                    model=consumer.lane.model,
+                    model=serving_lane.model,
                     retry_in=delay,
                     # Spend trace for the abandoned generation: the wire
                     # reports usage only at stream end, so a dead attempt's
@@ -11289,15 +11341,6 @@ class ChatSession:
                     results = list(pool.map(run_one, items))
 
         return results, user_feedback
-
-    @staticmethod
-    def _ensure_tool_call_ids(tool_calls: list[dict[str, Any]] | dict[int, dict[str, Any]]) -> None:
-        """Fill in missing tool call IDs with synthetic UUIDs.
-
-        Delegates to :func:`turnstone.core.model_turn.ensure_tool_call_ids`
-        (the re-ingest half of the shared plant-call seam).
-        """
-        ensure_tool_call_ids(tool_calls)
 
     def _safe_prepare_tool(self, tc: dict[str, Any]) -> dict[str, Any]:
         """Wrap :meth:`_prepare_tool` so a single failing preparer is

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -525,7 +525,9 @@ class _StreamTurnConsumer:
         Carries three duties at exactly the old create-return timing:
         the health success record for the serving lane, and the two
         per-turn usage-slot resets whose placement guards both the
-        stale-usage leak (the old ``_stream_attempt``-entry comment) and
+        stale-usage leak (a post-finish blip can lose the trailing usage
+        chunk, and a stale completion count would be recycled as the next
+        turn's estimate) and
         the reconnect status-bar blackout.
         """
         s = self._session
@@ -3046,7 +3048,7 @@ class ChatSession:
 
         Thread safety: each assignment creates a new object (copy-on-write).
         Under CPython's GIL, individual reference assignments are atomic.
-        ``_try_stream`` captures tools at call time, so a concurrent refresh
+        Each attempt captures tools at call time, so a concurrent refresh
         between turns is safe; mid-stream the LLM request already holds
         the old snapshot.
         """
@@ -4941,7 +4943,7 @@ class ChatSession:
         fires on a history render."""
         if not ids:
             return {}
-        # caps is the ACTIVE attempt's capabilities, threaded from _try_stream so
+        # caps is the ACTIVE attempt's capabilities, threaded from its lane so
         # a fallback to a model with different media support converts on the
         # right caps; default to the primary only when called without one.
         if caps is None:
@@ -7787,7 +7789,7 @@ class ChatSession:
             # flagged ("…cannot simultaneously guarantee Consistency,"
             # surfaced as if it were a complete sentence).
             if self._cancelled_partial_msg:
-                # _stream_attempt was interrupted — save partial
+                # the streaming attempt was interrupted — save partial
                 # assistant msg.  Two shapes:
                 #
                 # - Some text streamed before cancel: append the

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -2122,7 +2122,7 @@ class SessionUIBase:
         #     sibling or the ``__budget_override__`` pseudo-tool makes
         #     candidates < pending, AND
         #   - call_ids must be unique — some local models emit duplicate
-        #     non-empty tool-call ids (``_ensure_tool_call_ids`` only fills
+        #     non-empty tool-call ids (``model_turn.ensure_tool_call_ids`` only fills
         #     MISSING ones), which collapse in the ``needed`` set and would let
         #     one verdict clear two distinct calls (their args differ).
         # Either mismatch → hold the whole batch for a human.  Checked

--- a/turnstone/core/streaming_text.py
+++ b/turnstone/core/streaming_text.py
@@ -75,22 +75,20 @@ class ThinkTagSplitter:
     def close_run(self) -> str:
         """Close the current run at an out-of-band interleave signal.
 
-        For the boundary where a provider-parsed ``reasoning_delta``
-        arrives mid-stream: everything decided emits at the CURRENT
-        state, and a possible partial-tag tail
-        (:func:`partial_tag_tail`) is RETURNED to the caller — the drain
-        closes its per-run split at the same boundary with the same
-        rule, which is what keeps the displayed and committed
-        interpretations of one stream identical there.  The carry's
-        lifetime belongs to the run owner, NOT to :attr:`pending`: the
+        For a provider-parsed ``reasoning_delta`` arriving mid-stream:
+        everything decided emits at the CURRENT state, and a possible
+        partial-tag tail (:func:`partial_tag_tail`) is RETURNED to the
+        caller.  The drain splits its runs at the same boundary by the
+        same rule, so the displayed and committed readings of one stream
+        agree.
+
+        The carry belongs to the run owner, not to :attr:`pending`: the
         tail was cut in the closing run's state, while ``pending`` is
         read under whatever state later flushes hit (``in_think`` flips
         across the reasoning block), which would relabel a content-state
-        carry as reasoning — both halves of the live-caught #832
-        display/commit divergence.  The caller re-feeds the carry when
-        content resumes (reassembling a tag the server split across the
-        block) or flushes it at its original state at a terminal
-        boundary, mirroring the drain's separate carry variable.
+        carry as reasoning.  The caller re-feeds it when content resumes
+        — reassembling a tag the server split across the block — or
+        flushes it at its original state at a terminal boundary.
         """
         if not self.pending:
             return ""
@@ -148,9 +146,9 @@ def partial_tag_tail(text: str) -> str:
     limit = min(len(text), ThinkTagSplitter.MAX_TAG_LEN - 1)
     for size in range(limit, 0, -1):
         suffix = text[-size:]
-        # Proper prefix only: without the length check a COMPLETE tag
-        # shorter than the longest one self-matches via startswith and
-        # gets carried as a "partial", violating the contract above.
+        # Proper prefix only: without the length check a complete tag
+        # shorter than the longest one self-matches and gets carried as
+        # a "partial".
         if any(
             len(suffix) < len(tag) and tag.startswith(suffix) for tag in ThinkTagSplitter.ALL_TAGS
         ):

--- a/turnstone/core/streaming_text.py
+++ b/turnstone/core/streaming_text.py
@@ -72,27 +72,34 @@ class ThinkTagSplitter:
             self._emit(self.pending, self.in_think)
             self.pending = ""
 
-    def close_run(self) -> None:
+    def close_run(self) -> str:
         """Close the current run at an out-of-band interleave signal.
 
         For the boundary where a provider-parsed ``reasoning_delta``
         arrives mid-stream: everything decided emits at the CURRENT
-        state, and only a possible partial-tag tail
-        (:func:`partial_tag_tail`) is held for the next run — the drain
+        state, and a possible partial-tag tail
+        (:func:`partial_tag_tail`) is RETURNED to the caller — the drain
         closes its per-run split at the same boundary with the same
         rule, which is what keeps the displayed and committed
-        interpretations of one stream identical there.  A consumer that
-        instead flipped :attr:`in_think` with the tail still pending
-        would relabel buffered content as reasoning at the next flush
-        (the live-caught #832 display/commit divergence).
+        interpretations of one stream identical there.  The carry's
+        lifetime belongs to the run owner, NOT to :attr:`pending`: the
+        tail was cut in the closing run's state, while ``pending`` is
+        read under whatever state later flushes hit (``in_think`` flips
+        across the reasoning block), which would relabel a content-state
+        carry as reasoning — both halves of the live-caught #832
+        display/commit divergence.  The caller re-feeds the carry when
+        content resumes (reassembling a tag the server split across the
+        block) or flushes it at its original state at a terminal
+        boundary, mirroring the drain's separate carry variable.
         """
         if not self.pending:
-            return
+            return ""
         tail = partial_tag_tail(self.pending)
         closeable = self.pending[: len(self.pending) - len(tail)] if tail else self.pending
         if closeable:
             self._emit(closeable, self.in_think)
-        self.pending = tail
+        self.pending = ""
+        return tail
 
     def _drain(self) -> None:
         if not self._scan_tags:

--- a/turnstone/core/streaming_text.py
+++ b/turnstone/core/streaming_text.py
@@ -93,7 +93,7 @@ class ThinkTagSplitter:
         if not self.pending:
             return ""
         tail = partial_tag_tail(self.pending)
-        closeable = self.pending[: len(self.pending) - len(tail)] if tail else self.pending
+        closeable = self.pending.removesuffix(tail)
         if closeable:
             self._emit(closeable, self.in_think)
         self.pending = ""

--- a/turnstone/core/streaming_text.py
+++ b/turnstone/core/streaming_text.py
@@ -72,6 +72,28 @@ class ThinkTagSplitter:
             self._emit(self.pending, self.in_think)
             self.pending = ""
 
+    def close_run(self) -> None:
+        """Close the current run at an out-of-band interleave signal.
+
+        For the boundary where a provider-parsed ``reasoning_delta``
+        arrives mid-stream: everything decided emits at the CURRENT
+        state, and only a possible partial-tag tail
+        (:func:`partial_tag_tail`) is held for the next run — the drain
+        closes its per-run split at the same boundary with the same
+        rule, which is what keeps the displayed and committed
+        interpretations of one stream identical there.  A consumer that
+        instead flipped :attr:`in_think` with the tail still pending
+        would relabel buffered content as reasoning at the next flush
+        (the live-caught #832 display/commit divergence).
+        """
+        if not self.pending:
+            return
+        tail = partial_tag_tail(self.pending)
+        closeable = self.pending[: len(self.pending) - len(tail)] if tail else self.pending
+        if closeable:
+            self._emit(closeable, self.in_think)
+        self.pending = tail
+
     def _drain(self) -> None:
         if not self._scan_tags:
             # Nothing to resolve, so nothing to hold: a tag-free contract
@@ -119,7 +141,12 @@ def partial_tag_tail(text: str) -> str:
     limit = min(len(text), ThinkTagSplitter.MAX_TAG_LEN - 1)
     for size in range(limit, 0, -1):
         suffix = text[-size:]
-        if any(tag.startswith(suffix) for tag in ThinkTagSplitter.ALL_TAGS):
+        # Proper prefix only: without the length check a COMPLETE tag
+        # shorter than the longest one self-matches via startswith and
+        # gets carried as a "partial", violating the contract above.
+        if any(
+            len(suffix) < len(tag) and tag.startswith(suffix) for tag in ThinkTagSplitter.ALL_TAGS
+        ):
             return suffix
     return ""
 


### PR DESCRIPTION
Advances #832. The interactive send path no longer owns the plant call: it makes one `model_turn` call per attempt with a chunk callback, and chunk→Turn assembly moves under `drain_stream` with every other lane. `ChatSession` keeps ρ and the event surface — chunk→UI translation, cancellation generations, commit, calibration.

## What changed

`model_turn` gains a streaming surface: `on_chunk` tees each normalized chunk to the caller upstream of the drain, so the callback sees exactly the sequence the assembler consumes, and the assembled Turn comes back as usual. `prepare_wire` lets a caller compose its own deterministic lowering — called with the serving lane, so a fallback folds system turns on its own capabilities rather than the primary's. The result carries `wire_msgs` for calibration and an accurate `producer`.

Deleted from the session: the hand-rolled chunk assembler, the stream-creation ladder, and the fallback walk's stream plumbing. `_try_fallback` becomes a lane swap. Cancellation converges — every model-call site now builds a fresh generation-scoped `_CancelRef`, closing the force-cancel hole where the old shared gen-0 ref read `aborted=False` for an orphaned generation.

Ladder arithmetic is unchanged: per-lane creation retries inside the fallback walk, wrapped by the mid-stream re-issue ladder, with no third multiplicative layer. Health still records success at the request-accepted instant and failure once per lane's whole ladder.

## What it does not do

The session no longer **calls** the provider Protocol on the plant path, and imports no provider module — but it still **holds** provider and client handles across ~30 sites, and reads three attributes off them (compaction's producer stamp and retry predicate, the fatal formatter's backend label). That is the remaining half of #832's acceptance, enumerated with file:line and a closure criterion in turnstonelabs/turnstone#979; that issue closing closes #832.

## Behavior changes worth a release note

- **Trailing citation footers now enter the committed turn.** Web-search source lists were an ephemeral info line that never survived a reload; they now fold into content on the same conditional rule the drain uses. Consequence accepted deliberately: web-controlled text reaches conversation storage, full-text search, later model context, and exports.
- **A stream that ends with no finish reason is a mid-stream death.** It used to commit its partial silently; it now re-issues through the mid-stream ladder and surfaces an honest error if it never recovers. Servers that legitimately omit terminal signals keep the existing `finish_reason_optional` shim.
- **The displayed stream and the committed turn now agree at reasoning boundaries.** Previously both dropped the splitter's held tail; the fold made the commit correct and left the display behind, so this closes the gap in the other direction too.
- Smaller ones: stored reasoning is segregated rather than interleaved for mixed-mode models; `producer` names the lane that actually served the turn, so a fallback-served turn stops wearing the primary's name; a superseded generation now exits silently as cancelled instead of propagating its exception class into the thread runner; and with debug enabled the request dump reprints after compact-and-retry, where the wire genuinely changed.

## Verification

Full suite green at 10,704 passed / 10 skipped, with strict mypy and ruff clean. A replay-parity harness pins the streaming phase against baselines captured from the pre-fold path: the same chunk script must produce the same UI event sequence and the same committed message, and every transform applied to a baseline restates in full the behavior change that justifies it. A mirror test asserts the displayed content and the committed content are identical across adversarial interleaves of content, reasoning, tool-call and info chunks. Golden wire payloads were untouched by the fold.

Six review rounds ran against the branch, each fix pinned by a test that was mutation-probed — reverting the fix must fail its pin — including the cancellation guards that only fire in a race window and had never been executed by the suite before.

## Follow-ups filed

- turnstonelabs/turnstone#979 — the session still holds provider/client handles; carries the full residual inventory that closes #832
- turnstonelabs/turnstone#980 — delete the unused `is_first` chunk field
- turnstonelabs/turnstone#981 — commit→save window in `/history`
- turnstonelabs/turnstone#982 — no used/total context readout while a task agent runs
- turnstonelabs/turnstone#983 — the inline reasoning-tag vocabulary is in-band, so content *about* those tags cannot round-trip
