### PR TITLE
Support partial MCP resource discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,16 @@ Earlier stable lines (`stable/1.6`, `stable/1.5`) are frozen.
 
 ### Fixed
 
+- **MCP servers may expose resources without resource templates, or templates
+  without concrete resources (#993).** The MCP handshake has one aggregate
+  `resources` capability, but implementations are not required to support both
+  list methods. An exact JSON-RPC `Method not found` response from either
+  method is now treated as an empty half-catalog during static and per-user
+  discovery and refresh, while every other error still fails closed. A failed
+  static registration also tears down its transport and publishes none of its
+  staged tools/resources/prompts, eliminating the live callable “ghost” tools
+  that could remain after the UI reported registration failure.
+
 - **A cancelled judge, guard, or compaction call can now stop before its
   request goes out (#972).** Previously it could not: `model_turn` refused
   to *re-issue* an abandoned call after a mid-stream death, but nothing

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -871,6 +871,13 @@ capabilities for the `resources` capability. For servers that declare it:
 2. `list_resource_templates` fetches URI templates (parameterized patterns like
    `db://tables/{table}/rows/{id}`).
 
+The protocol advertises both lists through one aggregate `resources`
+capability, so a server may implement only one of them. If either request
+returns the JSON-RPC `Method not found` code (`-32601`), turnstone treats that
+half of the catalog as empty and keeps the other half; authentication,
+validation, transport, and all other discovery errors still fail the
+connection or refresh.
+
 Both are stored as `{uri, name, description, mimeType, server}` dicts and
 merged into a unified catalog.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,11 @@ markers = [
     "e2e_recovery: opt-in end-to-end SSE recovery harness (real server + real SSE consumers, scripted provider — NOT live, no LLM backend needed); tens of seconds each. CI lanes run ``-m 'not live and not e2e_recovery'``; select with ``-m e2e_recovery``.",
 ]
 filterwarnings = [
+    # The MCP v1 FastMCP integration fixture rebuilds its incomplete generic
+    # Settings model before construction. Keep the new pydantic-settings 2.15
+    # diagnostic fatal so removing that compatibility step cannot regress
+    # into a warning hidden in the full-suite summary.
+    "error:Field 'lifespan' has an incomplete definition",
     # mcp v1 deprecates streamablehttp_client for an entry point whose call
     # shape only settles in v2 — adoption rides the deliberate v2 migration
     # (pin capped <2); silence exactly this message until then.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,20 @@ from unittest.mock import MagicMock
 import pytest
 
 
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Resolve MCP v1's generic FastMCP settings model for test servers.
+
+    MCP 1.29.0 defines ``Settings`` before ``FastMCP``, so its ``lifespan``
+    annotation remains an unresolved forward reference after import. Rebuild
+    once, after the module is fully loaded, before any integration fixture
+    constructs a FastMCP server. Pydantic's public hook is a no-op once the SDK
+    ships a complete model.
+    """
+    from mcp.server.fastmcp.server import Settings as FastMCPSettings
+
+    FastMCPSettings.model_rebuild()
+
+
 def stop_loop_thread(loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
     """Fully tear down a ``loop.run_forever``-in-a-thread test loop.
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -4069,6 +4069,75 @@ class TestStaticNotificationRefresh:
             "the hung sibling must be cancelled and reaped inside the scope"
         )
 
+    def test_resources_refresh_accepts_missing_template_method(self) -> None:
+        """Push/manual refresh shares the per-method compatibility behavior."""
+        from mcp import McpError
+
+        mgr = MCPClientManager({})
+        session = MagicMock()
+        session.list_resources = AsyncMock(
+            return_value=mcp_types.ListResourcesResult(
+                resources=[
+                    mcp_types.Resource(
+                        uri="res://fresh",
+                        name="fresh",
+                        mimeType="text/plain",
+                    )
+                ]
+            )
+        )
+        session.list_resource_templates = AsyncMock(
+            side_effect=McpError(
+                mcp_types.ErrorData(
+                    code=mcp_types.METHOD_NOT_FOUND,
+                    message="templates disabled",
+                )
+            )
+        )
+        state = _seed_static_state(
+            mgr,
+            "srv",
+            session=session,
+            supports_resources=True,
+            resources=[{"uri": "res://old", "server": "srv"}],
+        )
+        mgr._rebuild_resources()
+
+        asyncio.run(mgr._refresh_server_resources("srv"))
+
+        assert [r["uri"] for r in state.resources] == ["res://fresh"]
+        assert [r["uri"] for r in mgr.get_resources()] == ["res://fresh"]
+
+    def test_resources_refresh_rejects_message_only_method_match(self) -> None:
+        """Only -32601 is normalized; a lookalike error leaves catalog intact."""
+        from mcp import McpError
+
+        mgr = MCPClientManager({})
+        session = MagicMock()
+        session.list_resources = AsyncMock(return_value=mcp_types.ListResourcesResult(resources=[]))
+        session.list_resource_templates = AsyncMock(
+            side_effect=McpError(
+                mcp_types.ErrorData(
+                    code=mcp_types.INVALID_PARAMS,
+                    message="Method not found",
+                )
+            )
+        )
+        old_resources = [{"uri": "res://old", "server": "srv"}]
+        state = _seed_static_state(
+            mgr,
+            "srv",
+            session=session,
+            supports_resources=True,
+            resources=old_resources,
+        )
+
+        with pytest.raises(McpError) as raised:
+            asyncio.run(mgr._refresh_server_resources("srv"))
+
+        assert raised.value.error.code == mcp_types.INVALID_PARAMS
+        assert state.resources is old_resources
+
     def test_reap_bounded_reraises_external_cancel(self) -> None:
         """An EXTERNAL cancel delivered during the reap window must be
         HONOURED (re-raised), not swallowed — else a shutdown/cancel of

--- a/tests/test_mcp_transport_owner.py
+++ b/tests/test_mcp_transport_owner.py
@@ -157,9 +157,7 @@ class TestTransportOwnerLifecycle:
         assert state.owner_task is None
         assert state.close_requested is None
 
-    def test_tools_only_connect_skips_unchanged_catalog_listeners(
-        self, running_loop_mgr
-    ) -> None:
+    def test_tools_only_connect_skips_unchanged_catalog_listeners(self, running_loop_mgr) -> None:
         """A tools-only registration must not rebuild every live chat twice."""
         mgr, loop, _ = running_loop_mgr
         patches: dict[str, Any] = {}
@@ -465,9 +463,7 @@ class TestTransportOwnerLifecycle:
         assert len(state.tools) == 1
         assert mgr.is_mcp_tool("mcp__new__late") is True
 
-    def test_blocked_loop_cannot_return_failure_before_add_outcome(
-        self, running_loop_mgr
-    ) -> None:
+    def test_blocked_loop_cannot_return_failure_before_add_outcome(self, running_loop_mgr) -> None:
         """A synchronous listener stall may delay success, never expose a ghost."""
         mgr, _loop, _ = running_loop_mgr
 

--- a/tests/test_mcp_transport_owner.py
+++ b/tests/test_mcp_transport_owner.py
@@ -26,7 +26,9 @@ from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import mcp.types as mcp_types
 import pytest
+from mcp import McpError
 
 from turnstone.core.mcp_client import MCPClientManager
 
@@ -155,6 +157,352 @@ class TestTransportOwnerLifecycle:
         assert state.owner_task is None
         assert state.close_requested is None
 
+    def test_tools_only_connect_skips_unchanged_catalog_listeners(
+        self, running_loop_mgr
+    ) -> None:
+        """A tools-only registration must not rebuild every live chat twice."""
+        mgr, loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        _fake_transport_and_session(patches)
+        notifications: list[str] = []
+        mgr.add_listener(lambda: notifications.append("tools"))
+        mgr.add_resource_listener(lambda: notifications.append("resources"))
+        mgr.add_prompt_listener(lambda: notifications.append("prompts"))
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            _run(loop, mgr._connect_one_locked("srv", mgr._server_configs["srv"]))
+            assert notifications == ["tools"]
+            _run(loop, mgr._teardown_static_session("srv"))
+
+    def test_connect_notifies_when_dropped_capability_clears_stale_catalog(
+        self, running_loop_mgr
+    ) -> None:
+        """Capability loss clears and broadcasts genuinely stale catalogs."""
+        mgr, loop, _ = running_loop_mgr
+        state = mgr._ensure_static_state("srv")
+        state.resources = [
+            {
+                "uri": "res://stale",
+                "name": "stale",
+                "description": "",
+                "mimeType": "text/plain",
+                "server": "srv",
+            }
+        ]
+        state.prompts = [
+            {
+                "name": "mcp__srv__stale",
+                "original_name": "stale",
+                "server": "srv",
+                "description": "",
+                "arguments": [],
+            }
+        ]
+        mgr._rebuild_resources()
+        mgr._rebuild_prompts()
+
+        patches: dict[str, Any] = {}
+        _fake_transport_and_session(patches)
+        notifications: list[str] = []
+        mgr.add_listener(lambda: notifications.append("tools"))
+        mgr.add_resource_listener(lambda: notifications.append("resources"))
+        mgr.add_prompt_listener(lambda: notifications.append("prompts"))
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            _run(loop, mgr._connect_one_locked("srv", mgr._server_configs["srv"]))
+            assert state.resources == []
+            assert state.prompts == []
+            assert mgr.get_resources() == []
+            assert mgr.get_prompts() == []
+            assert notifications == ["tools", "resources", "prompts"]
+            _run(loop, mgr._teardown_static_session("srv"))
+
+    def test_static_connect_accepts_resources_without_template_method(
+        self, running_loop_mgr
+    ) -> None:
+        """The aggregate resources capability does not require both list methods.
+
+        A server with concrete resources but no templates still publishes its
+        tools/resources and retains a usable live session when the unsupported
+        half returns the protocol's exact METHOD_NOT_FOUND code.
+        """
+        mgr, loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        fake = _fake_transport_and_session(patches)
+        session = fake["session"]
+        session.get_server_capabilities = MagicMock(
+            return_value=mcp_types.ServerCapabilities(
+                tools=mcp_types.ToolsCapability(listChanged=False),
+                resources=mcp_types.ResourcesCapability(listChanged=False),
+            )
+        )
+        session.list_tools = AsyncMock(
+            return_value=mcp_types.ListToolsResult(
+                tools=[
+                    mcp_types.Tool(
+                        name="echo",
+                        description="Echo input",
+                        inputSchema={"type": "object", "properties": {}},
+                    )
+                ]
+            )
+        )
+        session.list_resources = AsyncMock(
+            return_value=mcp_types.ListResourcesResult(
+                resources=[
+                    mcp_types.Resource(
+                        uri="res://one",
+                        name="one",
+                        mimeType="text/plain",
+                    )
+                ]
+            )
+        )
+        session.list_resource_templates = AsyncMock(
+            side_effect=McpError(
+                mcp_types.ErrorData(
+                    code=mcp_types.METHOD_NOT_FOUND,
+                    message="templates disabled",
+                )
+            )
+        )
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            _run(loop, mgr._connect_one_locked("srv", mgr._server_configs["srv"]))
+            state = mgr._static_servers["srv"]
+
+            assert state.session is session
+            assert state.owner_task is not None and not state.owner_task.done()
+            assert mgr.is_mcp_tool("mcp__srv__echo") is True
+            assert {r["uri"] for r in mgr.get_resources()} == {"res://one"}
+
+            _run(loop, mgr._teardown_static_session("srv"))
+
+    def test_failed_add_is_atomic_and_rejects_message_only_method_match(
+        self, running_loop_mgr
+    ) -> None:
+        """A later discovery failure cannot leave a callable ghost tool.
+
+        The error deliberately says ``Method not found`` but carries
+        INVALID_PARAMS: compatibility is classified by JSON-RPC code only.
+        """
+        mgr, _loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        fake = _fake_transport_and_session(patches)
+        session = fake["session"]
+        session.get_server_capabilities = MagicMock(
+            return_value=mcp_types.ServerCapabilities(
+                tools=mcp_types.ToolsCapability(listChanged=False),
+                resources=mcp_types.ResourcesCapability(listChanged=False),
+            )
+        )
+        session.list_tools = AsyncMock(
+            return_value=mcp_types.ListToolsResult(
+                tools=[
+                    mcp_types.Tool(
+                        name="ghost",
+                        description="Must never publish",
+                        inputSchema={"type": "object", "properties": {}},
+                    )
+                ]
+            )
+        )
+        session.list_resources = AsyncMock(
+            side_effect=McpError(
+                mcp_types.ErrorData(
+                    code=mcp_types.INVALID_PARAMS,
+                    message="Method not found",
+                )
+            )
+        )
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            result = mgr.add_server_sync(
+                "new",
+                {"type": "stdio", "command": "fake-cmd"},
+                timeout=5,
+            )
+
+        assert result["connected"] is False
+        assert "Method not found" in result["error"]
+        assert "new" not in mgr._server_configs
+        state = mgr._static_servers["new"]
+        assert state.session is None
+        assert state.owner_task is None
+        assert state.close_requested is None
+        assert mgr.is_mcp_tool("mcp__new__ghost") is False
+        assert mgr.get_tools() == []
+        assert mgr.get_resources() == []
+        assert fake["events"] == [
+            "transport_enter",
+            "session_enter",
+            "session_exit",
+            "transport_exit",
+        ]
+
+    def test_timed_out_add_waits_for_atomic_rollback(self, running_loop_mgr) -> None:
+        """Returning timeout must not strand an unconfigured live transport."""
+        mgr, _loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        fake = _fake_transport_and_session(patches)
+        session = fake["session"]
+        session.get_server_capabilities = MagicMock(
+            return_value=mcp_types.ServerCapabilities(
+                tools=mcp_types.ToolsCapability(listChanged=False),
+                resources=mcp_types.ResourcesCapability(listChanged=False),
+            )
+        )
+        session.list_tools = AsyncMock(
+            return_value=mcp_types.ListToolsResult(
+                tools=[
+                    mcp_types.Tool(
+                        name="ghost",
+                        description="Must never publish",
+                        inputSchema={"type": "object", "properties": {}},
+                    )
+                ]
+            )
+        )
+
+        async def _park_resources() -> Any:
+            await asyncio.sleep(3600)
+
+        session.list_resources = _park_resources
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            result = mgr.add_server_sync(
+                "new",
+                {"type": "stdio", "command": "fake-cmd"},
+                timeout=0.05,
+            )
+
+        assert result == {
+            "connected": False,
+            "tools": 0,
+            "resources": 0,
+            "prompts": 0,
+            "error": "MCP server 'new' registration timed out",
+        }
+        assert "new" not in mgr._server_configs
+        state = mgr._static_servers["new"]
+        assert state.session is None
+        assert state.owner_task is None
+        assert state.close_requested is None
+        assert state.tools == []
+        assert state.resources == []
+        assert state.prompts == []
+        assert mgr.is_mcp_tool("mcp__new__ghost") is False
+        assert fake["events"] == [
+            "transport_enter",
+            "session_enter",
+            "session_exit",
+            "transport_exit",
+        ]
+
+    def test_add_reports_late_success_when_connect_suppresses_timeout(
+        self, running_loop_mgr
+    ) -> None:
+        """The sync result reflects the definitive loop-side outcome.
+
+        A dependency can suppress cancellation. In that case ``asyncio.timeout``
+        cannot honestly report a timeout, so the registration is a late success
+        rather than a failed result with a live ghost catalog.
+        """
+        mgr, _loop, _ = running_loop_mgr
+
+        async def _late_success(name: str, _cfg: dict[str, Any]) -> None:
+            # Model the completion-vs-timeout race: the connect finishes and
+            # commits after the sync caller's deadline but before its
+            # cancellation can make the operation fail.
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(3600)
+            state = mgr._ensure_static_state(name)
+            state.session = MagicMock()
+            state.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"mcp__{name}__late",
+                        "description": "late",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            mgr._rebuild_tools()
+
+        with patch.object(mgr, "_connect_one_locked", side_effect=_late_success):
+            result = mgr.add_server_sync(
+                "new",
+                {"type": "stdio", "command": "fake-cmd"},
+                timeout=0.05,
+            )
+
+        assert result == {
+            "connected": True,
+            "tools": 1,
+            "resources": 0,
+            "prompts": 0,
+            "error": "",
+        }
+        assert mgr._server_configs["new"] == {"type": "stdio", "command": "fake-cmd"}
+        state = mgr._static_servers["new"]
+        assert state.session is not None
+        assert len(state.tools) == 1
+        assert mgr.is_mcp_tool("mcp__new__late") is True
+
+    def test_blocked_loop_cannot_return_failure_before_add_outcome(
+        self, running_loop_mgr
+    ) -> None:
+        """A synchronous listener stall may delay success, never expose a ghost."""
+        mgr, _loop, _ = running_loop_mgr
+
+        async def _publish_then_notify(name: str, _cfg: dict[str, Any]) -> None:
+            state = mgr._ensure_static_state(name)
+            state.session = MagicMock()
+            state.tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"mcp__{name}__live",
+                        "description": "live",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+            mgr._rebuild_tools()
+
+        mgr.add_listener(lambda: time.sleep(0.1))
+        started = time.monotonic()
+        with patch.object(mgr, "_connect_one_locked", side_effect=_publish_then_notify):
+            result = mgr.add_server_sync(
+                "new",
+                {"type": "stdio", "command": "fake-cmd"},
+                timeout=0.01,
+            )
+        elapsed = time.monotonic() - started
+
+        assert elapsed >= 0.08
+        assert result["connected"] is True
+        assert result["error"] == ""
+        assert "new" in mgr._server_configs
+        assert mgr._static_servers["new"].session is not None
+        assert mgr.is_mcp_tool("mcp__new__live") is True
+
     def test_owner_death_evicts_session(self, running_loop_mgr) -> None:
         """Trigger-A observer: the transport collapsing under a live session
         (owner task dies without a requested close) evicts the session so the
@@ -234,6 +582,54 @@ class TestTransportOwnerLifecycle:
         assert elapsed < 5.0  # prompt fail — not the attempt-timeout hang
         assert mgr._static_servers["srv"].session is None
         # The owner unwound its cms despite dying mid-discovery.
+        assert fake["events"][-2:] == ["session_exit", "transport_exit"]
+
+    def test_owner_death_same_turn_as_discovery_cannot_publish_catalog(
+        self, running_loop_mgr
+    ) -> None:
+        """When discovery and owner death tie, transport death wins."""
+        mgr, _loop, _ = running_loop_mgr
+        patches: dict[str, Any] = {}
+        fake = _fake_transport_and_session(patches)
+
+        async def _cancel_owner_and_return_tool() -> mcp_types.ListToolsResult:
+            owner = mgr._static_servers["new"].owner_task
+            assert owner is not None
+            owner.cancel()
+            # Let the owner consume cancellation before this discovery task
+            # returns, putting both futures in the completed set observed by
+            # ``_await_owner_discovery``.
+            await asyncio.sleep(0)
+            return mcp_types.ListToolsResult(
+                tools=[
+                    mcp_types.Tool(
+                        name="ghost",
+                        description="Must never publish",
+                        inputSchema={"type": "object", "properties": {}},
+                    )
+                ]
+            )
+
+        fake["session"].list_tools = AsyncMock(side_effect=_cancel_owner_and_return_tool)
+
+        with (
+            patch("turnstone.core.mcp_client.stdio_client", patches["stdio_client"]),
+            patch("turnstone.core.mcp_client.ClientSession", patches["ClientSession"]),
+        ):
+            result = mgr.add_server_sync(
+                "new",
+                {"type": "stdio", "command": "fake-cmd"},
+                timeout=5,
+            )
+
+        assert result["connected"] is False
+        assert "died during discovery" in result["error"]
+        assert "new" not in mgr._server_configs
+        state = mgr._static_servers["new"]
+        assert state.session is None
+        assert state.owner_task is None
+        assert state.tools == []
+        assert mgr.is_mcp_tool("mcp__new__ghost") is False
         assert fake["events"][-2:] == ["session_exit", "transport_exit"]
 
     def test_base_exception_escape_resolves_waiter_and_propagates(self, running_loop_mgr) -> None:

--- a/tests/test_mcp_user_catalog.py
+++ b/tests/test_mcp_user_catalog.py
@@ -1414,6 +1414,67 @@ def test_pool_resource_discovery_on_connect_via_real_streamable_http(
     assert {r["uri"] for r in mgr._user_resources["user-1"]} == {"res://test/1", "res://test/2"}
 
 
+@pytest.mark.parametrize(
+    ("unsupported_method", "expected_uri", "is_template"),
+    [
+        ("templates", "res://concrete", False),
+        ("resources", "res://items/{id}", True),
+    ],
+)
+def test_pool_resource_discovery_accepts_either_list_method_unsupported(
+    running_loop_mgr: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    unsupported_method: str,
+    expected_uri: str,
+    is_template: bool,
+) -> None:
+    """Real SDK boundary: either half of resource discovery may be absent.
+
+    The server advertises the aggregate resources capability and exposes a
+    tool plus exactly one resource-list method. A wire-level -32601 from the
+    other method is an empty half-catalog, not a failed pool registration.
+    """
+    mgr, loop, _ = running_loop_mgr
+    unsupported = {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "error": {"code": -32601, "message": "Method not found"},
+    }
+    concrete = _list_resources_payload([_resource_spec("res://concrete")])
+    templates = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "result": {
+            "resourceTemplates": [
+                {
+                    "uriTemplate": "res://items/{id}",
+                    "name": "item",
+                    "mimeType": "text/plain",
+                }
+            ]
+        },
+    }
+    handler = _make_jsonrpc_handler(
+        init_response=_init_response_with_caps(resources=True),
+        list_tools_response=_list_tools_payload([_tool_spec("echo")]),
+        list_resources_response=unsupported if unsupported_method == "resources" else concrete,
+        list_resource_templates_response=(
+            unsupported if unsupported_method == "templates" else templates
+        ),
+    )
+    _build_mock_transport_factory(mgr, monkeypatch, handler)
+    _patch_tcp_probe(mgr, monkeypatch)
+
+    entry = _connect_pool(mgr, loop, user_id="user-1", server_name="pool-srv")
+
+    assert entry.session is not None
+    assert mgr.is_mcp_tool("mcp__pool-srv__echo", user_id="user-1") is True
+    assert entry.resources is not None
+    assert [(r["uri"], bool(r.get("template"))) for r in entry.resources] == [
+        (expected_uri, is_template)
+    ]
+
+
 def test_pool_prompt_discovery_on_connect_via_real_streamable_http(
     running_loop_mgr: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -507,6 +507,45 @@ def _cap_server_prompts(server_name: str, prompts: list[Any]) -> list[Any]:
     return prompts[:_MAX_PROMPTS_PER_SERVER]
 
 
+async def _list_resources_compatible(session: Any, server_name: str) -> Any:
+    """List concrete resources, treating an unsupported method as empty.
+
+    MCP exposes one aggregate ``resources`` capability for both concrete
+    resources and resource templates. Servers may legitimately implement only
+    one of the two list methods, so the capability bit alone cannot tell us
+    which request is supported. Only the protocol's exact METHOD_NOT_FOUND code
+    is normalized; every other error remains a real discovery failure.
+    """
+    try:
+        return await session.list_resources()
+    except McpError as exc:
+        if exc.error.code != mcp_types.METHOD_NOT_FOUND:
+            raise
+        log.debug(
+            "MCP server '%s' does not implement resources/list; treating it as empty",
+            server_name,
+        )
+        return mcp_types.ListResourcesResult(resources=[])
+
+
+async def _list_resource_templates_compatible(session: Any, server_name: str) -> Any:
+    """List resource templates, treating an unsupported method as empty.
+
+    See :func:`_list_resources_compatible` for why the aggregate capability
+    requires per-method probing and exact JSON-RPC error classification.
+    """
+    try:
+        return await session.list_resource_templates()
+    except McpError as exc:
+        if exc.error.code != mcp_types.METHOD_NOT_FOUND:
+            raise
+        log.debug(
+            "MCP server '%s' does not implement resources/templates/list; treating it as empty",
+            server_name,
+        )
+        return mcp_types.ListResourceTemplatesResult(resourceTemplates=[])
+
+
 # ---------------------------------------------------------------------------
 # Per-server state containers
 # ---------------------------------------------------------------------------
@@ -2336,95 +2375,132 @@ class MCPClientManager:
         state.close_requested = close_requested
         state.session = session
 
-        # Check push notification support for each capability
-        caps = session.get_server_capabilities()
+        # Capability flags and all three catalogs are STAGED until discovery
+        # succeeds in full. A later resource/prompt failure must not publish a
+        # callable tool backed by a registration that add_server_sync reports
+        # as failed. The live owner/session must likewise be torn down before
+        # the error escapes.
+        try:
+            caps = session.get_server_capabilities()
 
-        tools_cap = getattr(caps, "tools", None) if caps else None
-        state.supports_list_changed = bool(getattr(tools_cap, "listChanged", False))
+            tools_cap = getattr(caps, "tools", None) if caps else None
+            supports_list_changed = bool(getattr(tools_cap, "listChanged", False))
 
-        resources_cap = getattr(caps, "resources", None) if caps else None
-        state.supports_resources = resources_cap is not None
-        state.supports_resource_list_changed = bool(getattr(resources_cap, "listChanged", False))
+            resources_cap = getattr(caps, "resources", None) if caps else None
+            supports_resources = resources_cap is not None
+            supports_resource_list_changed = bool(getattr(resources_cap, "listChanged", False))
 
-        prompts_cap = getattr(caps, "prompts", None) if caps else None
-        state.supports_prompts = prompts_cap is not None
-        state.supports_prompt_list_changed = bool(getattr(prompts_cap, "listChanged", False))
+            prompts_cap = getattr(caps, "prompts", None) if caps else None
+            supports_prompts = prompts_cap is not None
+            supports_prompt_list_changed = bool(getattr(prompts_cap, "listChanged", False))
 
-        # Discover tools. Discovery runs in THIS caller task while the
-        # transport is hosted by the owner, so a transport collapse
-        # mid-discovery cancels the OWNER, not us — ``_await_owner_discovery``
-        # races the owner so that death surfaces as a prompt ConnectionError
-        # instead of hanging to the caller-side attempt timeout.
-        result = await self._await_owner_discovery(owner, session.list_tools())
-        capped = _cap_server_tools(name, result.tools)
-        server_tools: list[dict[str, Any]] = [_mcp_to_openai(name, tool) for tool in capped]
+            # Discover tools. Discovery runs in THIS caller task while the
+            # transport is hosted by the owner, so a transport collapse
+            # mid-discovery cancels the OWNER, not us — ``_await_owner_discovery``
+            # races the owner so that death surfaces as a prompt ConnectionError
+            # instead of hanging to the caller-side attempt timeout.
+            result = await self._await_owner_discovery(owner, session.list_tools())
+            capped = _cap_server_tools(name, result.tools)
+            server_tools: list[dict[str, Any]] = [_mcp_to_openai(name, tool) for tool in capped]
 
-        state.tools = server_tools
-        self._rebuild_tools()
-
-        # Discover resources
-        resource_count = 0
-        if resources_cap is not None:
+            # Discover resources. The protocol advertises the pair with one
+            # aggregate capability, but either list method may independently be
+            # absent; the compatibility wrappers normalize only -32601.
             server_resources: list[dict[str, Any]] = []
-            res_result = await self._await_owner_discovery(owner, session.list_resources())
-            # Capped like the tools list above (and like the pool twins): a
-            # misbehaving server must not balloon the shared node's merged
-            # catalogs.
-            for r in _cap_server_resources(name, res_result.resources):
-                server_resources.append(
-                    {
-                        "uri": str(r.uri),
-                        "name": r.name or "",
-                        "description": r.description or "",
-                        "mimeType": r.mimeType or "",
-                        "server": name,
-                    }
+            if resources_cap is not None:
+                res_result = await self._await_owner_discovery(
+                    owner, _list_resources_compatible(session, name)
                 )
-            # Also include resource templates (catalog-only — not directly
-            # readable via read_resource since they contain URI placeholders)
-            tmpl_result = await self._await_owner_discovery(
-                owner, session.list_resource_templates()
-            )
-            for t in _cap_server_resource_templates(name, tmpl_result.resourceTemplates):
-                server_resources.append(
-                    {
-                        "uri": str(t.uriTemplate),
-                        "name": t.name or "",
-                        "description": t.description or "",
-                        "mimeType": t.mimeType or "",
-                        "server": name,
-                        "template": True,
-                    }
+                # Capped like the tools list above (and like the pool twins): a
+                # misbehaving server must not balloon the shared node's merged
+                # catalogs.
+                for r in _cap_server_resources(name, res_result.resources):
+                    server_resources.append(
+                        {
+                            "uri": str(r.uri),
+                            "name": r.name or "",
+                            "description": r.description or "",
+                            "mimeType": r.mimeType or "",
+                            "server": name,
+                        }
+                    )
+                # Templates are catalog-only — not directly readable via
+                # read_resource since they contain URI placeholders.
+                tmpl_result = await self._await_owner_discovery(
+                    owner, _list_resource_templates_compatible(session, name)
                 )
-            resource_count = len(server_resources)
-            state.resources = server_resources
-            self._rebuild_resources()
+                for t in _cap_server_resource_templates(name, tmpl_result.resourceTemplates):
+                    server_resources.append(
+                        {
+                            "uri": str(t.uriTemplate),
+                            "name": t.name or "",
+                            "description": t.description or "",
+                            "mimeType": t.mimeType or "",
+                            "server": name,
+                            "template": True,
+                        }
+                    )
 
-        # Discover prompts
-        prompt_count = 0
-        if prompts_cap is not None:
+            # Discover prompts.
             server_prompts: list[dict[str, Any]] = []
-            prompt_result = await self._await_owner_discovery(owner, session.list_prompts())
-            for p in _cap_server_prompts(name, prompt_result.prompts):
-                server_prompts.append(
-                    {
-                        "name": f"mcp__{name}__{p.name}",
-                        "original_name": p.name,
-                        "server": name,
-                        "description": p.description or "",
-                        "arguments": [
-                            {
-                                "name": a.name,
-                                "description": a.description or "",
-                                "required": a.required or False,
-                            }
-                            for a in (p.arguments or [])
-                        ],
-                    }
+            if prompts_cap is not None:
+                prompt_result = await self._await_owner_discovery(owner, session.list_prompts())
+                for p in _cap_server_prompts(name, prompt_result.prompts):
+                    server_prompts.append(
+                        {
+                            "name": f"mcp__{name}__{p.name}",
+                            "original_name": p.name,
+                            "server": name,
+                            "description": p.description or "",
+                            "arguments": [
+                                {
+                                    "name": a.name,
+                                    "description": a.description or "",
+                                    "required": a.required or False,
+                                }
+                                for a in (p.arguments or [])
+                            ],
+                        }
+                    )
+
+            # The owner done-callback can evict the session in the same loop
+            # turn that the final discovery call completes. Revalidate the
+            # exact wiring immediately before commit; there are no awaits from
+            # this check through publication, so a callable catalog can never
+            # be installed behind a dead/replaced transport.
+            if (
+                owner.done()
+                or state.owner_task is not owner
+                or state.session is not session
+            ):
+                raise ConnectionError(
+                    f"MCP server '{name}' transport died before catalog commit"
                 )
-            prompt_count = len(server_prompts)
-            state.prompts = server_prompts
+        except BaseException:
+            await self._teardown_static_session(name)
+            raise
+
+        # Publish the staged connection and catalogs only after every enabled
+        # discovery method succeeded. Successful reconnects also clear a stale
+        # resource/prompt catalog when the server drops that capability.
+        resources_changed = state.resources != server_resources
+        prompts_changed = state.prompts != server_prompts
+        state.supports_list_changed = supports_list_changed
+        state.supports_resources = supports_resources
+        state.supports_resource_list_changed = supports_resource_list_changed
+        state.supports_prompts = supports_prompts
+        state.supports_prompt_list_changed = supports_prompt_list_changed
+        state.tools = server_tools
+        state.resources = server_resources
+        state.prompts = server_prompts
+        self._rebuild_tools()
+        if resources_changed:
+            self._rebuild_resources()
+        if prompts_changed:
             self._rebuild_prompts()
+
+        resource_count = len(server_resources)
+        prompt_count = len(server_prompts)
 
         push_parts: list[str] = []
         if state.supports_list_changed:
@@ -2776,6 +2852,16 @@ class MCPClientManager:
             call.cancel()
             await asyncio.gather(call, return_exceptions=True)
             raise
+        # If both futures completed in the same scheduling turn, owner death
+        # wins. Returning a successful list result after its backing transport
+        # has already exited would let the caller publish a catalog with no
+        # live session. Gathering a completed call also retrieves any exception
+        # it carried, avoiding an unobserved-task warning.
+        if owner.done():
+            if not call.done():
+                call.cancel()
+            await asyncio.gather(call, return_exceptions=True)
+            raise ConnectionError("MCP transport owner died during discovery")
         if call.done():
             if call.cancelled():
                 # The discovery future was cancelled out from under us (an
@@ -2985,10 +3071,7 @@ class MCPClientManager:
                     # ordering is irrelevant.
                     res_result, tmpl_result = await self._await_owner_discovery(
                         owner,
-                        asyncio.gather(
-                            session.list_resources(),
-                            session.list_resource_templates(),
-                        ),
+                        self._list_resource_pair(session, server_name),
                     )
             except asyncio.CancelledError:
                 task = asyncio.current_task()
@@ -3067,6 +3150,19 @@ class MCPClientManager:
                         ],
                     }
                 )
+
+        # Mirror the static commit guard. A transport owner can finish in the
+        # same scheduling turn as the final discovery response; never publish
+        # that response into the per-user maps after its session was evicted.
+        if (
+            owner.done()
+            or entry.owner_task is not owner
+            or entry.session is not session
+        ):
+            await self._teardown_pool_entry(key)
+            raise ConnectionError(
+                f"MCP pool server '{server_name}' transport died before catalog commit"
+            )
 
         entry.tools = server_tools
         entry.resources = server_resources if resources_cap is not None else None
@@ -4320,7 +4416,7 @@ class MCPClientManager:
             )
         return added, removed
 
-    async def _list_resource_pair(self, session: Any) -> tuple[Any, Any]:
+    async def _list_resource_pair(self, session: Any, server_name: str) -> tuple[Any, Any]:
         """``list_resources`` + ``list_resource_templates`` in one bounded RTT.
 
         The ONE copy of the paired-list protocol for both refresh twins
@@ -4329,8 +4425,10 @@ class MCPClientManager:
         timeout budget and target disjoint catalogs (resources vs.
         templates), so ordering is irrelevant.
 
-        Fail-FAST on the first real error — a fast, meaningful failure
-        (an auth or method rejection) must surface as ITSELF, not be
+        Each method independently treats an exact JSON-RPC METHOD_NOT_FOUND as
+        an empty half-catalog. Fail-FAST on the first remaining real error — a
+        fast, meaningful failure (for example auth or invalid params) must
+        surface as ITSELF, not be
         masked behind a hung sibling's eventual ``TimeoutError`` — but
         with the surviving sibling CANCELLED and REAPED inside this
         scope before the error re-raises: bare fail-fast ``gather``
@@ -4350,8 +4448,10 @@ class MCPClientManager:
         task, GC-reaped) rather than held onto.
         """
         async with asyncio.timeout(self._CONNECT_TIMEOUT):
-            res_task = asyncio.create_task(session.list_resources())
-            tmpl_task = asyncio.create_task(session.list_resource_templates())
+            res_task = asyncio.create_task(_list_resources_compatible(session, server_name))
+            tmpl_task = asyncio.create_task(
+                _list_resource_templates_compatible(session, server_name)
+            )
             try:
                 res_result, tmpl_result = await asyncio.gather(res_task, tmpl_task)
             except BaseException:
@@ -4424,7 +4524,7 @@ class MCPClientManager:
         user_id, server_name = key
         old_uris = {r["uri"] for r in (entry.resources or []) if not r.get("template")}
 
-        res_result, tmpl_result = await self._list_resource_pair(session)
+        res_result, tmpl_result = await self._list_resource_pair(session, server_name)
         if self._user_pool_entries.get(key) is not entry:
             # Entry replaced mid-flight — stale result, discard.
             return [], []
@@ -5035,7 +5135,7 @@ class MCPClientManager:
         # turn the second list_resource_templates() call into AttributeError.
         session = state.session
 
-        res_result, tmpl_result = await self._list_resource_pair(session)
+        res_result, tmpl_result = await self._list_resource_pair(session, name)
 
         server_resources: list[dict[str, Any]] = []
         # Capped like the pool twin — a misbehaving server's push must not
@@ -5687,15 +5787,78 @@ class MCPClientManager:
                 "error": "MCP event loop not running",
             }
 
-        # Add to config so _refresh_all can reconnect on failure
+        # Add to config so _refresh_all can reconnect on failure.
         self._server_configs[name] = cfg
 
-        future = asyncio.run_coroutine_threadsafe(self._connect_one(name, cfg), self._loop)
+        def _clear_failed_add_state() -> None:
+            """Remove this registration's config and every public catalog."""
+            if self._server_configs.get(name) is cfg:
+                self._server_configs.pop(name, None)
+            failed_state = self._static_servers.get(name)
+            tools_changed = bool(failed_state and failed_state.tools)
+            resources_changed = bool(failed_state and failed_state.resources)
+            prompts_changed = bool(failed_state and failed_state.prompts)
+            if failed_state is not None:
+                failed_state.tools = []
+                failed_state.resources = []
+                failed_state.prompts = []
+                failed_state.supports_list_changed = False
+                failed_state.supports_resources = False
+                failed_state.supports_resource_list_changed = False
+                failed_state.supports_prompts = False
+                failed_state.supports_prompt_list_changed = False
+            if tools_changed:
+                self._rebuild_tools()
+            if resources_changed:
+                self._rebuild_resources()
+            if prompts_changed:
+                self._rebuild_prompts()
+
+        async def _add() -> None:
+            # Keep failure rollback under the SAME per-name lock as connect.
+            # The timeout is loop-owned: the sync bridge waits for a definitive
+            # outcome instead of racing a second wall-clock deadline against
+            # rollback. If the loop is temporarily blocked, this may report a
+            # late success, but it can never report failure while a published
+            # session/catalog remains live.
+            async with self._static_connect_lock_for(name):
+                try:
+                    async with asyncio.timeout(timeout):
+                        await self._connect_one_locked(name, cfg)
+                except BaseException as exc:
+                    try:
+                        await self._teardown_static_session(name)
+                    finally:
+                        # A newer concurrent add may already have replaced the
+                        # config while waiting on this lock. Remove only the
+                        # registration this coroutine owns; its successor will
+                        # run after this cleanup releases the lock.
+                        _clear_failed_add_state()
+                    if isinstance(exc, TimeoutError):
+                        raise TimeoutError(
+                            f"MCP server '{name}' registration timed out"
+                        ) from None
+                    raise
+
+        future = asyncio.run_coroutine_threadsafe(_add(), self._loop)
         try:
-            future.result(timeout=timeout)
+            # ``_add`` owns both its deadline and rollback. A caller-side
+            # timeout here could return a failed result while cleanup is merely
+            # queued on a stalled loop, exposing a live unconfigured tool.
+            future.result()
+        except concurrent.futures.TimeoutError:
+            return {
+                "connected": False,
+                "tools": 0,
+                "resources": 0,
+                "prompts": 0,
+                "error": f"MCP server '{name}' registration timed out",
+            }
         except Exception as exc:
-            # Remove from configs on failure
-            self._server_configs.pop(name, None)
+            # The loop-side rollback normally removed this exact registration;
+            # retain a defensive cleanup for failures before _add could start.
+            if self._server_configs.get(name) is cfg:
+                self._server_configs.pop(name, None)
             return {"connected": False, "tools": 0, "resources": 0, "prompts": 0, "error": str(exc)}
 
         state = self._static_servers.get(name)

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2468,14 +2468,8 @@ class MCPClientManager:
             # exact wiring immediately before commit; there are no awaits from
             # this check through publication, so a callable catalog can never
             # be installed behind a dead/replaced transport.
-            if (
-                owner.done()
-                or state.owner_task is not owner
-                or state.session is not session
-            ):
-                raise ConnectionError(
-                    f"MCP server '{name}' transport died before catalog commit"
-                )
+            if owner.done() or state.owner_task is not owner or state.session is not session:
+                raise ConnectionError(f"MCP server '{name}' transport died before catalog commit")
         except BaseException:
             await self._teardown_static_session(name)
             raise
@@ -3154,11 +3148,7 @@ class MCPClientManager:
         # Mirror the static commit guard. A transport owner can finish in the
         # same scheduling turn as the final discovery response; never publish
         # that response into the per-user maps after its session was evicted.
-        if (
-            owner.done()
-            or entry.owner_task is not owner
-            or entry.session is not session
-        ):
+        if owner.done() or entry.owner_task is not owner or entry.session is not session:
             await self._teardown_pool_entry(key)
             raise ConnectionError(
                 f"MCP pool server '{server_name}' transport died before catalog commit"
@@ -5835,9 +5825,7 @@ class MCPClientManager:
                         # run after this cleanup releases the lock.
                         _clear_failed_add_state()
                     if isinstance(exc, TimeoutError):
-                        raise TimeoutError(
-                            f"MCP server '{name}' registration timed out"
-                        ) from None
+                        raise TimeoutError(f"MCP server '{name}' registration timed out") from None
                     raise
 
         future = asyncio.run_coroutine_threadsafe(_add(), self._loop)

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -2856,23 +2856,17 @@ class MCPClientManager:
                 call.cancel()
             await asyncio.gather(call, return_exceptions=True)
             raise ConnectionError("MCP transport owner died during discovery")
-        if call.done():
-            if call.cancelled():
-                # The discovery future was cancelled out from under us (an
-                # SDK-internal cancellation shape, not this method's own reap)
-                # — the transport can no longer answer, which is the same
-                # failure class as the owner dying. Convert instead of leaking
-                # a bare CancelledError the caller would misread as its own
-                # cancellation.
-                raise ConnectionError("MCP discovery request cancelled by transport failure")
-            return call.result()  # normal result, or the real discovery error
-        # Owner finished first — the transport died under discovery. Reap the
-        # discovery future (gather absorbs its cancellation outcome; a caller
-        # cancellation arriving DURING the reap propagates instead — honoring
-        # the cancel beats reporting the dead transport).
-        call.cancel()
-        await asyncio.gather(call, return_exceptions=True)
-        raise ConnectionError("MCP transport owner died during discovery")
+        # FIRST_COMPLETED returned normally and the owner is not done, so the
+        # discovery future is necessarily the completed member of the pair.
+        if call.cancelled():
+            # The discovery future was cancelled out from under us (an
+            # SDK-internal cancellation shape, not this method's own reap)
+            # — the transport can no longer answer, which is the same
+            # failure class as the owner dying. Convert instead of leaking
+            # a bare CancelledError the caller would misread as its own
+            # cancellation.
+            raise ConnectionError("MCP discovery request cancelled by transport failure")
+        return call.result()  # normal result, or the real discovery error
 
     async def _connect_one_pool(
         self,


### PR DESCRIPTION
## Summary

- treat an exact JSON-RPC `METHOD_NOT_FOUND` from either MCP resource-list method as an empty half-catalog across static and per-user discovery and refresh
- stage static catalogs until discovery completes, roll failed registrations back atomically, and reject catalog commits whose transport owner has died
- avoid resource and prompt listener fan-out when those catalogs did not change
- rebuild the MCP v1 incomplete FastMCP settings model before lifecycle integration tests and make the associated lifespan warning test-fatal

## Verification

- `uv run pytest` — 11,838 passed, 13 skipped
- `uv run pytest -q tests/test_mcp*.py` — 1,141 passed
- `uv run ruff check turnstone/ tests/`
- `uv run mypy turnstone/`
- timeout, owner-death, listener fan-out, and warning-sentinel mutation controls
- independent pre-commit review completed with no findings

Closes #993