### PR TITLE
Document immutable memory index snapshots

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1758,7 +1758,7 @@ Status code: `403`
 
 ### `GET /v1/api/memories`
 
-List structured memories with optional filters. Requires `read` scope. Without
+List body-free memory metadata with optional filters. Requires `read` scope. Without
 `scope`, returns only `global` plus the authenticated caller's `user`
 namespace. The public endpoint accepts `global`, `workstream`, and `user`;
 explicit workstream access is owner-bound.
@@ -1784,9 +1784,10 @@ explicit workstream access is owner-bound.
       "type": "general",
       "scope": "global",
       "scope_id": "",
-      "content": "The project uses a hexagonal architecture...",
       "created": "2026-03-10T10:00:00",
-      "updated": "2026-03-12T14:30:00"
+      "updated": "2026-03-12T14:30:00",
+      "last_accessed": "",
+      "access_count": 0
     }
   ],
   "total": 1
@@ -1798,8 +1799,9 @@ explicit workstream access is owner-bound.
 ### `POST /v1/api/memories`
 
 Save or upsert a structured memory. Requires `write` scope. Returns `201` on
-create, `200` on update. Every write must include a non-empty, non-whitespace
-`description`; content-only updates are rejected.
+create, `200` on update. Every write must include an authored `description`
+that normalizes to 1-512 characters on one line; content-only updates are
+rejected.
 
 **Request body:**
 
@@ -1818,7 +1820,7 @@ create, `200` on update. Every write must include a non-empty, non-whitespace
 |--------------|--------|----------|-------------|--------------------------------------|
 | `name`       | string | yes      | --          | Memory name (max 256 chars)          |
 | `content`    | string | yes      | --          | Memory content (max 65536 chars)     |
-| `description`| string | yes      | --          | Non-empty relevance summary, required on create and update |
+| `description`| string | yes      | --          | Authored one-line index hook (1-512 characters), required on every write |
 | `type`       | string | no       | unset       | user, general, feedback, or reference |
 | `scope`      | string | no       | `"global"`  | One of: global, workstream, user     |
 | `scope_id`   | string | no       | `""`        | Scope qualifier (auto-resolved for user scope) |
@@ -1833,11 +1835,15 @@ create, `200` on update. Every write must include a non-empty, non-whitespace
   "type": "general",
   "scope": "global",
   "scope_id": "",
-  "content": "Deploy via GitHub Actions...",
   "created": "2026-03-14T10:00:00",
-  "updated": "2026-03-14T10:00:00"
+  "updated": "2026-03-14T10:00:00",
+  "last_accessed": "",
+  "access_count": 0
 }
 ```
+
+The response is body-free; use the exact-name GET endpoint when content is
+needed.
 
 **Error responses:**
 
@@ -1852,7 +1858,7 @@ create, `200` on update. Every write must include a non-empty, non-whitespace
 
 ### `POST /v1/api/memories/search`
 
-Search memories by query. Uses POST for the request body but is non-mutating
+Search body-free memory metadata by query. Uses POST for the request body but is non-mutating
 (requires only `read` scope). An omitted scope searches only `global` plus the
 authenticated caller's `user` namespace.
 
@@ -1887,9 +1893,10 @@ authenticated caller's `user` namespace.
       "type": "general",
       "scope": "global",
       "scope_id": "",
-      "content": "JWT tokens with HS256...",
       "created": "2026-03-10T10:00:00",
-      "updated": "2026-03-12T14:30:00"
+      "updated": "2026-03-12T14:30:00",
+      "last_accessed": "",
+      "access_count": 0
     }
   ],
   "total": 1
@@ -1897,6 +1904,27 @@ authenticated caller's `user` namespace.
 ```
 
 **Error:** `400` with `{"error": "query is required"}` if `query` is empty.
+
+---
+
+### `GET /v1/api/memories/{name}`
+
+Fetch one live full memory body by exact name and scope. Requires `read` scope
+and records the access. List and search do not update access metadata.
+
+| Parameter  | Location | Required | Default    | Description         |
+|------------|----------|----------|------------|---------------------|
+| `name`     | path     | yes      | --         | Memory name         |
+| `scope`    | query    | no       | `"global"` | Scope of the memory |
+| `scope_id` | query    | no       | `""`       | Scope qualifier     |
+
+**Response (success):** `200` -- the full memory schema, including `content`.
+
+**Response (not found):** `404`
+
+```json
+{"error": "Memory 'auth_patterns' not found"}
+```
 
 ---
 
@@ -1935,7 +1963,7 @@ actor in the audit log.
 
 ### `GET /v1/api/admin/memories` (Console)
 
-List structured memories across all scopes. Requires `admin.memories`
+List body-free memory metadata across all scopes. Requires `admin.memories`
 permission.
 
 **Query parameters:**
@@ -1947,7 +1975,9 @@ permission.
 | `scope_id` | string | no       | `""`    | Filter by scope ID           |
 | `limit`    | int    | no       | `100`   | Max results (capped at 200)  |
 
-**Response:** `200` -- same schema as `GET /v1/api/memories`.
+**Response:** `200` -- `AdminMemorySummary`, the public body-free metadata plus
+`scope_label`, a human-readable label for `scope_id` (empty when there is no
+scope ID, with the raw ID as fallback).
 
 ---
 
@@ -1965,7 +1995,8 @@ Search memories by query. Requires `admin.memories` permission.
 | `scope_id` | string | no       | `""`    | Filter by scope ID            |
 | `limit`    | int    | no       | `20`    | Max results (capped at 50)    |
 
-**Response:** `200` -- same schema as `GET /v1/api/memories`.
+**Response:** `200` -- the same `AdminMemorySummary` schema as
+`GET /v1/api/admin/memories`.
 
 **Error:** `400` with `{"error": "q is required"}` if `q` is empty.
 
@@ -1973,7 +2004,8 @@ Search memories by query. Requires `admin.memories` permission.
 
 ### `GET /v1/api/admin/memories/{memory_id}` (Console)
 
-Get a single memory by ID. Requires `admin.memories` permission.
+Get a single memory body by ID and record an access. Requires
+`admin.memories` permission.
 
 **Path parameters:**
 
@@ -1991,17 +2023,81 @@ Get a single memory by ID. Requires `admin.memories` permission.
   "type": "general",
   "scope": "global",
   "scope_id": "",
+  "scope_label": "",
   "content": "The project uses...",
   "created": "2026-03-10T10:00:00",
-  "updated": "2026-03-12T14:30:00"
+  "updated": "2026-03-12T14:30:00",
+  "last_accessed": "2026-03-12T14:31:00",
+  "access_count": 1
 }
 ```
+
+The response is `AdminMemoryInfo` (`AdminMemorySummary` plus `content`), and
+the counters include the completed GET touch.
 
 **Error (not found):** `404`
 
 ```json
 {"error": "Memory not found"}
 ```
+
+Storage-operation failures return `500`; unavailable storage returns `503`.
+
+---
+
+### `PATCH /v1/api/admin/memories/{memory_id}` (Console)
+
+Replace the authored one-line index hook (1-512 characters) without changing
+the memory body. Records `memory.description_update`. Existing immutable
+snapshots remain unchanged.
+
+```json
+{"description": "Updated retrieval hook"}
+```
+
+Returns the updated body-free `AdminMemorySummary`:
+
+```json
+{
+  "memory_id": "a1b2c3d4-e5f6-...",
+  "name": "project_architecture",
+  "description": "Updated retrieval hook",
+  "type": "general",
+  "scope": "global",
+  "scope_id": "",
+  "scope_label": "",
+  "created": "2026-03-10T10:00:00",
+  "updated": "2026-03-14T09:00:00",
+  "last_accessed": "",
+  "access_count": 0
+}
+```
+
+Invalid descriptions return `400`, missing memories return `404`, storage
+operation failures return `500`, and unavailable storage returns `503`.
+
+---
+
+### `GET /v1/api/admin/memories/index-health` (Console)
+
+Return derived, persistent health for every visibility envelope possible in
+the live workstream/project topology. The result is independent of whether a
+snapshot row already exists and reports the configured character budget, worst
+complete live index, overage, and legacy descriptions that need editing.
+
+```json
+{
+  "budget_chars": 65536,
+  "over_budget": false,
+  "max_char_count": 18420,
+  "max_entry_count": 210,
+  "over_by_chars": 0,
+  "invalid_description_count": 0,
+  "envelope_count": 3
+}
+```
+
+Calculation failures return `500`; unavailable storage returns `503`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -451,13 +451,15 @@ class Workstream:
     _state_tail_lock: threading.Lock  # durable state/observer ordering
 ```
 
-The durable incarnation token and lifecycle fields are internal and never appear in
-public workstream/config projections. They distinguish successive objects that
-reuse one logical ID. Manager-created rows receive the token at registration;
-legacy rows acquire one atomically when rehydration, delete, or fork preflight
-takes its authoritative snapshot. This prevents an old manager state
-transition, buffered lifecycle-state write, stale delete authorization, or
-fork operation from targeting a replacement incarnation.
+The durable reservation token and lifecycle fields are internal and never
+appear in public workstream/config projections. `workstreams.ws_id` is the
+authoritative live-ID reservation: a concurrent or caller-selected collision is
+rejected while the row exists, and successful hard deletion releases the ID
+after removing its owned state. The token identifies the exact retryable
+reservation and is installed atomically for legacy rows during rehydration,
+delete, or fork preflight. It prevents an old provisional create, buffered
+lifecycle-state write, stale delete authorization, or fork operation from
+targeting a replacement row that reused the same ID.
 
 ### SessionManager
 
@@ -523,8 +525,8 @@ after the committed snapshot is adopted in memory does the normal
 `creating -> idle -> ws_created` publication run.
 
 Rehydration binds the private token before constructing the session, then
-rechecks it after configuration and history are loaded; a delete/re-register
-crossing retires the hybrid candidate and retries from a fresh snapshot.
+rechecks it after configuration and history are loaded; a concurrent lifecycle
+change retires the hybrid candidate and retries from a fresh snapshot.
 Loaded hard-delete similarly compares the endpoint's authorized token with
 both the local and current durable incarnations before making any terminal
 mutation. It closes generation publication, drains every already-admitted
@@ -535,9 +537,9 @@ a false `ws_closed` event.
 
 That drain covers manager-owned session durability admitted through the ticket
 lane. Direct legacy storage helpers that mutate only by `ws_id` are not made
-token-conditional by this refactor and must not be used as a same-ID reuse
-fence; the incarnation token guarantees exact create/fork/delete target
-selection, not a new transaction contract for every maintenance API.
+token-conditional by this refactor. The reservation token guarantees exact
+create/fork/delete target selection during provisional lifecycle races; the
+primary key separately prevents reuse while the durable row exists.
 
 #### Crash-Abandoned Create Recovery
 
@@ -629,9 +631,10 @@ non-idle background workstreams above the input prompt.
   run outside it.
 - `Workstream._lock`: guards one workstream's worker pair and short state
   mutations.
-- The per-ID lifecycle lane orders create/open/close/hard-delete across object
-  incarnations; `Workstream._lifecycle_lock` orders one object's birth against
-  its terminal paths.
+- The per-ID lifecycle lane orders create/open/close/hard-delete, including a
+  rolled-back hidden reservation followed by its retry;
+  `Workstream._lifecycle_lock` orders one object's birth against its terminal
+  paths.
 - `Workstream._state_tail_lock` orders accepted state persistence and observer
   events. `_state_revision` rejects superseded tails, while
   `_state_incarnation` and `StateWriter` prevent close/reopen ABA writes.
@@ -999,13 +1002,16 @@ simultaneous generations for that alias in one process. Every registry-backed
 role carries the same gate on its `ModelLane`, so main turns, judges, task
 agents, perception, compaction, and background generation coordinate through
 one FIFO. Two aliases never share a gate implicitly, even when their URLs are
-identical. `model_turn()` materializes attachment fallbacks before admission,
-then holds one lease across eager stream creation and the complete drain,
-releasing before retry backoff. Admission wait is credited out of deadline
-accounting, preventing queued judges from spending their request budget before
-dispatch. The gate survives cap-only reloads in place; the field is excluded
-from semantic `ModelConfig` equality so a capacity edit does not reset judges
-or output-guard state.
+identical. For calls with context-first request admission, `model_turn()` admits
+the request before materializing attachment fallbacks; an oversized refusal
+therefore invokes neither attachment resolution nor nested perception/audio.
+Ordinary calls preserve their lowering cadence. Both paths finish attachment
+materialization before acquiring model capacity, then hold one lease across
+eager stream creation and the complete drain, releasing before retry backoff.
+Capacity wait is credited out of deadline accounting, preventing queued judges
+from spending their request budget before dispatch. The gate survives cap-only
+reloads in place; the field is excluded from semantic `ModelConfig` equality so
+a capacity edit does not reset judges or output-guard state.
 
 Primary loops, recursive compaction, judges, title generation, audio, and task
 agents all consume `ModelLane` rather than inspecting provider/client handles.
@@ -1375,9 +1381,9 @@ ChatSession / SessionManager / HTTP lifecycle
   │ (FTS5 search) │    │ (tsvector/ILIKE)  │
   └─────────────┘    └──────────────────┘
         ↓                     ↓
-    storage._schema  (SQLAlchemy Core tables — single source of truth)
+    storage._schema  (current metadata / create-all SQLAlchemy tables)
         ↓
-    storage._migrate  (programmatic Alembic)
+    storage._migrate  (parallel, manually maintained Alembic history)
 ```
 
 **SQLite** is the default (zero-config, single file at `.turnstone.db`).
@@ -1436,18 +1442,26 @@ workstream_config
   -- private durable incarnation token also lives here but is filtered from
   -- every ordinary config read/snapshot
 
+memory_index_snapshots
+  ws_id                     TEXT PRIMARY KEY -- one binding per durable workstream row
+  principal_id, project_id, project_name     -- first-admission witnesses
+  visibility_key, content, format_version
+  entry_count, char_count, invalid_description_count, captured_at
+
 conversations_fts                    -- SQLite FTS5 virtual table (optional)
   content     (content=conversations, content_rowid=id)
 ```
 
-Table definitions live in `storage/_schema.py` (SQLAlchemy Core `Table` objects)
-and are the single source of truth for both backends and Alembic migrations.
+Current metadata and create-all definitions live in `storage/_schema.py`
+(SQLAlchemy Core `Table` objects). Alembic revisions are a parallel, manually
+maintained history rather than generated from that module; schema-parity tests
+keep the two definitions aligned.
 
 ### StorageBackend Protocol
 
 | Method | Purpose |
 |--------|---------|
-| `register_workstream(..., fork_reservation_token=...)` | Atomically insert `creating` row plus private incarnation token; report collision |
+| `register_workstream(..., fork_reservation_token=...)` | Atomically reserve a live ID and insert its row plus private reservation token; report current-row collisions |
 | `ensure_workstream_incarnation_snapshot(ws_id)` | Lock and return one exact row plus its private token, installing a token atomically for legacy rows |
 | `finalize_deferred_create(...)` | Apply alias/config/node writes only if row and token still match |
 | `publish_deferred_create(ws_id, token)` | Compare-and-swap the exact reservation from `creating` to `idle` |
@@ -1457,6 +1471,8 @@ and are the single source of truth for both backends and Alembic migrations.
 | `load_message_turns(ws_id, checkpointed=True)` | Rehydrate canonical `Turn` objects, bounded by the latest valid compaction checkpoint |
 | `load_messages(ws_id, include_compaction=...)` | Materialized display/export projection; optionally surface compaction cards |
 | `clone_workstream(source, destination, ..., expected_session=...)` | Transactionally compare source and destination incarnations, authorize, and copy canonical history/config/project/attachment ownership |
+| `get_memory_index_snapshot(ws_id)` | Load the immutable memory-index binding without creating it |
+| `acquire_memory_index_snapshot(ws_id, principal_id, commit_context=...)` | Transactionally resolve first-admission visibility, capture or load one immutable index, and let the caller validate before commit |
 | `get_compaction_watermark/floor/checkpoint(...)` | Maintain resume checkpoints without deleting audit history |
 | `update_workstream_state(...)` | Persist a lifecycle state after manager/state-writer fencing |
 | `resolve_workstream(alias_or_id)` | Resolve alias, exact ID, or ID prefix |

--- a/docs/diagrams/09-workstream-states.puml
+++ b/docs/diagrams/09-workstream-states.puml
@@ -19,7 +19,7 @@ state "ATTENTION" as attention <<attention>> : Blocked on user action.\nTool app
 state "ERROR" as error <<error>> : Exception occurred.\nRecoverable on next send().
 state "CLOSED (persisted only)" as closed <<lifecycle>> : Unloaded, explicitly reopenable row.\nNot a live WorkstreamState member.
 
-[*] --> creating : register exact incarnation\nstate="creating"
+[*] --> creating : reserve live id\nstate="creating"
 creating --> idle : finalize + publish create\nemit ws_created
 creating --> [*] : immediate exact-token rollback\n(no lifecycle birth emitted)
 creating --> [*] : stale >2h recovery\natomic hard delete; no close event
@@ -51,6 +51,12 @@ running --> closed : close\n[journal reconciled]
 attention --> closed : close\n[journal reconciled]
 closed --> [*] : hard delete
 closed --> idle : open / rehydrate
+
+note right of creating
+  The workstreams primary key reserves the ID while this row exists.
+  Rollback, stale-create reap, and hard deletion release it for reuse
+  after owned state is removed in the same transaction.
+end note
 
 note right of closed
   Before every soft-close / eviction transition,

--- a/docs/diagrams/14-storage-architecture.puml
+++ b/docs/diagrams/14-storage-architecture.puml
@@ -15,6 +15,8 @@ interface "StorageBackend" as Storage <<protocol>> {
     + load_message_turns(ws_id, checkpointed=True) → list[Turn]
     + save_message(ws_id, role, content, metadata...)
     + clone_workstream(source, destination, principal, expected_session) → ForkCloneSnapshot
+    + get_memory_index_snapshot(ws_id) → row | None
+    + acquire_memory_index_snapshot(ws_id, principal, commit_context) → row | None
     --
     + register_workstream(..., state, reservation_token) → bool
     + ensure_workstream_incarnation_snapshot(ws_id) → row + token
@@ -91,6 +93,14 @@ class "workstream_config" as WorkstreamConfig <<schema>> {
     __fork_destination_reservation
 }
 
+class "memory_index_snapshots" as MemoryIndexSnapshots <<schema>> {
+    ws_id PK: one binding per durable row
+    principal + project witnesses
+    visibility key + rendered content
+    format / entry / character counts
+    captured_at
+}
+
 class "workstream_attachments" as Attachments <<schema>> {
     content-addressed blob
     attachment_id, bytes, kind
@@ -124,11 +134,13 @@ PG --> Utils
 Storage --> Workstreams
 Storage --> Conversations
 Storage --> WorkstreamConfig
+Storage --> MemoryIndexSnapshots
 Storage --> Attachments
 Storage --> Projects
 
 Manager --> Storage : lifecycle reservation + state
 Session --> Storage : turn durability + resume
+Session --> MemoryIndexSnapshots : first-admission prefix binding
 Session --> Expectation : construction witness
 Storage --> Snapshot : atomic clone result
 Expectation --> Utils : checked inside transaction
@@ -145,8 +157,10 @@ note right of Manager
   5. Only then emit ws_created.
 
   Any normal prepublication failure immediately calls exact token-checked
-  deletion. The token survives publication as the row's incarnation fence:
-  rollback or later hard delete can never ABA-delete a replacement row.
+  deletion. The workstreams primary key reserves the ID while its row exists;
+  rollback and hard deletion release it after removing owned state. The token
+  prevents stale provisional operations from deleting a same-ID replacement
+  reservation.
   A legacy row acquires the same private token atomically when rehydrate,
   delete, or fork preflight takes its authoritative snapshot. Loaded hard
   delete drains admitted session durability before its token-checked delete.
@@ -186,6 +200,12 @@ note bottom of Conversations
   Full transcript rows are never deleted by compaction. Normal resume
   loads the latest valid [summary] + rows after its watermark; audit and
   export can request the full marker-free history.
+end note
+
+note bottom of MemoryIndexSnapshots
+  Capture resolves project access and visible metadata in one transaction.
+  The caller validates the complete final system prefix before first commit.
+  Hard workstream deletion removes the snapshot in the same transaction.
 end note
 
 @enduml

--- a/docs/diagrams/23-memory-architecture.puml
+++ b/docs/diagrams/23-memory-architecture.puml
@@ -1,4 +1,6 @@
 @startuml
+' This long sequence must be rendered with PLANTUML_LIMIT_SIZE=8192;
+' PlantUML's 4096px default clips the admin and configuration phases.
 !theme plain
 title Turnstone — Structured Memory Architecture
 
@@ -32,77 +34,108 @@ Session -> Session : resolve live project access\nselect exact/inherited scope
 Session -> Session : _exec_memory(item)
 
 alt action = save
-    Session -> Session : require non-empty description
+    Session -> Session : require one-line description\n(1..512 chars)
     Session -> Facade : save_structured_memory_strict(\n..., require_active_project)
     Facade -> Facade : normalize_key(name)
     Facade -> Storage : guarded atomic upsert\nON CONFLICT ... RETURNING
     Storage --> Facade : (saved row, was_update)
     Facade --> Session : saved row
-    Session -> Session : invalidate prefix/cache\naudit acting principal
+    Session -> Session : audit acting principal
+    Session -> Facade : prospective_memory_index()
+    Facade -> Storage : one visibility-union query
+    Storage --> Facade : complete live metadata
+    Session -> Session : append informational health prose\nto successful model-tool result
+    note right
+      Legacy-description health is reported here.
+      Over-budget prose requires
+      model_index_over_budget_notice = true
+      (default false). REST/SDK saves are unchanged;
+      console admin health remains unconditional.
+    end note
 end
 
 alt action = get
-    Session -> Facade : get_structured_memory_by_name_strict()
-    Facade -> Storage : exact scoped-name lookup
-    Storage --> Session : full row / not found
+    Session -> Facade : get_and_touch_structured_memory_by_name_strict()
+    Facade -> Storage : UPDATE exact scoped name\naccess_count += 1 RETURNING full row
+    Storage --> Session : touched full row / not found
 end
 
-alt action = search
+alt action = search or list
     Session -> Storage : search exact scope or\nactor-visible scope union
-    Storage --> Session : matched rows
+    Storage --> Session : body-free metadata rows
 end
 
 alt action = delete
     Session -> Facade : delete_structured_memory_returning_strict()
     Facade -> Storage : DELETE ... RETURNING
     Storage --> Session : deleted row / not found
-    Session -> Session : invalidate + audit\nmark prefix dirty
+    Session -> Session : audit acting principal\nimmutable prefix unchanged
 end
 
-== Phase 2: BM25 Relevance Injection ==
+== Phase 2: Immutable Index + Live Metadata Pointers ==
 
-Session -> Session : _init_system_messages()\nevery conversation turn
+Session -> Session : first admitted model turn\nafter principal binding
 
 Session -> Session : resolve acting principal\nand live project ACL
-Session -> Session : _list_visible_memories(\nlimit=fetch_limit)
 note right
   **Scope resolution:**
   Interactive: global + workstream
-  + acting user + readable project
+  + acting user + active, readable project
   Coordinator: acting user's coordinator
-  + readable project
+  + active, readable project
+  Missing, archived, or access-revoked attachments
+  produce empty project witnesses and no project rows.
 end note
 
-Session -> Facade : list_visible_structured_memories()
-Facade -> Storage : one visibility-union query
-Storage --> Session : up to fetch_limit rows
-
-Session -> Relevance : extract_recent_context(\nmessages, max_messages=3)
-Relevance --> Session : user text context
-
-Session -> Relevance : score_memories(\nmemories, context,\nk=relevance_k)
+Session -> Facade : acquire_memory_index_snapshot(\nws, acting principal)
+Facade -> Storage : load durable snapshot
+alt snapshot absent
+    Facade -> Storage : list every visible metadata row
+    Storage --> Facade : scope + type + name + description\n(no body)
+    Facade -> Facade : render complete <memory-index>\nwith authorized project witness
+    Facade --> Session : candidate before transaction commit
+    Session -> Session : estimate complete final system prefix\nagainst lane usable input capacity
+    break candidate prefix exceeds capacity
+        Session --> Facade : reject candidate
+        Facade --> Storage : ROLLBACK\n(no new snapshot)
+        note right
+          Refusal occurs before provider dispatch and
+          attachment/perception work. Consolidate/delete
+          memories and retry, or choose a larger model.
+        end note
+    end
+    Facade -> Storage : INSERT ... ON CONFLICT DO NOTHING\nRETURNING concurrent winner
+    Storage --> Session : immutable snapshot bytes
+else snapshot already bound
+    Storage --> Session : immutable snapshot bytes
+    Session -> Session : validate bound final system prefix
+    break bound prefix exceeds capacity
+        Session -> Session : refuse before provider dispatch
+        note right
+          A bound oversized prefix requires a larger-context
+          model for this workstream; memory edits do not rewrite it.
+        end note
+    end
+end
+Session -> Session : publish in initial system prefix
 note right
-  **BM25 scoring:**
-  Index over name + description
-  + content[:200] for each memory.
-  Returns top-k by relevance.
-  Empty query returns most recent k.
+  Saving, editing, and deleting memories never rewrite
+  an existing snapshot. The first model admission binds
+  one snapshot to the current durable workstream row.
+  Hard deletion removes it before the ID can be reused.
 end note
-Relevance --> Session : top-k memories
 
-Session -> Relevance : build_memory_context(\nrelevant_memories)
+Session -> Session : after each genuine user turn
+Session -> Storage : list every live visible metadata row
+Storage --> Session : body-free metadata rows
+Session -> Relevance : score_memories(\nmetadata, user turn, k=relevance_k)
+Relevance --> Session : exact relevant scope + name pairs
+Session -> Session : persist memory_pointer system turn
 note right
-  Formats as XML block:
-  <memories>
-    <memory name="..." type="..."
-     scope="..." description="...">
-      content (max 500 chars)
-    </memory>
-  </memories>
+  Pointer and index entries are untrusted metadata.
+  The model calls memory(action='get') to verify live
+  access and retrieve a body. Only get records access.
 end note
-Relevance --> Session : XML string
-
-Session -> Session : inject into\nsystem message
 
 == Phase 3: Server API Path ==
 
@@ -119,13 +152,18 @@ API -> Facade : save_structured_memory_strict()
 Facade -> Storage : atomic upsert
 Storage --> API : memory row
 API -> API : record_audit(actor)
-API --> SDK : 201 (created) / 200 (updated)
+API --> SDK : body-free summary\n201 (created) / 200 (updated)
 
 SDK -> API : POST /v1/api/memories/search\n{query, type, ...}
 API -> API : bind scope to caller
 API -> Storage : search visible rows
-Storage --> API : matched rows
+Storage --> API : matched metadata rows (no bodies)
 API --> SDK : {"memories": [...], "total": N}
+
+SDK -> API : GET /v1/api/memories/{name}\n?scope=global
+API -> Facade : exact scoped-name lookup
+Facade -> Storage : fetch full row + touch access
+API --> SDK : memory body
 
 SDK -> API : DELETE /v1/api/memories/{name}\n?scope=global
 API -> Facade : delete_structured_memory_returning_strict()
@@ -142,9 +180,18 @@ Storage --> Admin : rows
 Admin --> SDK : {"memories": [...], "total": N}
 
 SDK -> Admin : GET /v1/api/admin/memories/{id}
-Admin -> Storage : get_structured_memory(id)
-Storage --> Admin : memory row
+Admin -> Storage : UPDATE exact id\naccess_count += 1 RETURNING full row
+Storage --> Admin : touched memory row
 Admin --> SDK : memory JSON
+
+SDK -> Admin : PATCH /v1/api/admin/memories/{id}\n{description}
+Admin -> Storage : update authored hook
+Admin -> Admin : record_audit(\n"memory.description_update")
+Admin --> SDK : body-free metadata summary
+
+SDK -> Admin : GET /v1/api/admin/memories/index-health
+Admin -> Facade : derive live topology envelope health\n(snapshot rows not consulted)
+Facade --> Admin : budget + legacy-hook report
 
 SDK -> Admin : DELETE /v1/api/admin/memories/{id}
 Admin -> Storage : delete_structured_memory_by_id_returning()
@@ -154,12 +201,14 @@ Admin --> SDK : {"status": "ok"}
 == Configuration ==
 
 note over Session, Relevance
-  **MemoryConfig** (from [memory] in config.toml):
-  relevance_k = 5       -- top-k memories per turn
-  fetch_limit = 50       -- max memories fetched for scoring
+  **Server/console live ConfigStore (standalone CLI uses defaults):**
+  relevance_k = 5       -- live metadata pointers per user turn
+  index_budget_chars = 65536 -- complete-index soft budget
+  model_index_over_budget_notice = false -- model-tool save only
   max_content = 32768    -- max content length per memory
   nudge_cooldown = 300   -- seconds between metacognitive nudges
-  nudges = true          -- enable/disable memory nudges
+  nudges = true          -- live pointers + memory-directed nudges;
+                         -- immutable index and tool unaffected
 end note
 
 @enduml

--- a/docs/diagrams/png/09-workstream-states.png
+++ b/docs/diagrams/png/09-workstream-states.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33dddd8cd8b53fa464cc8a4c899896fee32035d63e0669fe327969e3356349c7
-size 329815
+oid sha256:c079944092e59abe673a2ea53f49012ec3bc5201cfda19b22cee2a9da3d82324
+size 348325

--- a/docs/diagrams/png/14-storage-architecture.png
+++ b/docs/diagrams/png/14-storage-architecture.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a510eeaabf4ed8dab3b268c8f6bb5b7fef629a664361f7fb5614a6b498db36e
-size 294415
+oid sha256:663bdae32f9c021da61263ad303641fa59aab9124bf39231b4501f2327798edf
+size 352357

--- a/docs/diagrams/png/23-memory-architecture.png
+++ b/docs/diagrams/png/23-memory-architecture.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:137d6c91a34695c820d8b0a33fd753e79165604aa92bf2ac8480d3744b2ef844
-size 305199
+oid sha256:a75cd70b4927eba44d9f20cd754c252fbee77829dc703d751018d9ac44d37272
+size 438470

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -3,17 +3,18 @@
 > See also: [Memory Architecture diagram](diagrams/png/23-memory-architecture.png)
 
 The structured memory system gives the AI persistent, typed, scoped memories
-that survive across sessions and workstreams. Memories are automatically
-surfaced in the system message via BM25 relevance scoring, so the model has
-contextual recall without explicit search.
+that survive across sessions and workstreams. The model receives a complete,
+body-free metadata index at its first admitted turn, then uses explicit
+`memory(action='get')` calls to read live bodies.
 
 ## Overview
 
-Each memory has three dimensions:
+Each memory has four index dimensions:
 
 - **Type** -- categorizes the memory's purpose
 - **Scope** -- controls visibility boundaries
 - **Name** -- unique identifier within a scope (snake_case, normalized)
+- **Description** -- a required authored retrieval hook (1-512 characters)
 
 ### Memory types
 
@@ -37,16 +38,38 @@ Each memory has three dimensions:
 A memory's identity is the tuple `(name, scope, scope_id)`. Saving a memory
 with the same identity upserts -- updating content while preserving the ID.
 
+### Name normalization and legacy rows
+
+Public name inputs may use supported Latin letters that fold to ASCII, ASCII
+digits, Unicode space separators, Unicode hyphens, and single underscores.
+Save, exact-name get, and exact-name delete normalize that input to lowercase
+ASCII `snake_case`; the stored key must be at most 256 characters after
+normalization. Other characters and leading, trailing, or repeated underscores
+are rejected.
+
+Legacy rows whose stored names do not satisfy the current rule remain visible
+in list, search, and memory-index summaries; those response surfaces do not
+pretend every historical name is canonical. Public exact-name operations still
+enforce current normalization and do not perform compatibility lookup or
+automatic rename. Admin ID-based routes can inspect the body, update the
+description, or delete a legacy row, but they cannot rename or recreate it.
+Before deleting, preserve the body and confirm an authorized surface can create
+the replacement in the same scope: the public API supports `global`,
+`workstream`, and `user`; `project` requires an attached writable session; and
+`coordinator` requires the acting coordinator session. Deletion is irreversible.
+
 ### Inherited target and coordinator scope
 
 Name-based operations use one inherited target when `scope` is omitted:
 
-- An attached active project selects `project` for `save`, `get`, and
-  `delete`.
-- Read-only project access permits `get`, but `save` and `delete` fail. They do
-  not fall back to a broader namespace.
-- Without a project, interactive sessions select `global`; coordinator
-  sessions select `coordinator`.
+- Any stored project attachment pins `save`, `get`, and `delete` to `project`.
+  If the project is missing or archived, or the acting principal's access has
+  been revoked, the operation fails closed and never falls back to another
+  namespace.
+- Authorized read-only project access permits `get`, but `save` and `delete`
+  fail. Authorized project reactivation restores eligibility.
+- Only when no project attachment is stored do interactive sessions select
+  `global` and coordinator sessions select `coordinator`.
 
 A valid explicit scope selects exactly that scope. `search` and `list` are the
 only actions that span every visible scope when `scope` is omitted.
@@ -72,49 +95,88 @@ the scope id:
 Coordinator sessions require an authenticated user identity -- an anonymous
 coordinator cannot be constructed, so the scope id is always a real user.
 
-### BM25 relevance injection
+### Immutable index and live pointers
 
-On every conversation turn, the system:
+At the first model turn admitted for an acting principal, the session resolves
+that principal's live project access and captures every visible memory's
+`scope`, `type`, `name`, and `description`. The rendered `<memory-index>` is
+stored durably. It records the attached project ID and name only when that
+project is active and readable by the first acting principal. A missing,
+archived, or access-revoked attachment produces empty project witnesses and no
+project rows. The stored attachment remains pinned for name-based operations,
+which fail closed until access or project state permits them. Bodies never enter
+the index.
 
-1. Resolves the acting principal and their live project access
-2. Fetches up to `fetch_limit` memories across that visibility envelope
-3. Extracts context from the last 3 user messages
-4. Scores memories against that context using a BM25 index
-5. Injects the top `relevance_k` memories into the system message as
-   `<memories>` XML tags
-6. Appends a hint telling the model how many memories are in scope
+The snapshot is bound to the current durable workstream row and addressed by
+its workstream ID. The first model admission binds that workstream to the acting
+principal's exact visibility envelope; every later turn reuses the same bytes
+for prompt-cache stability and an honest shared conversation ledger. Saving,
+editing, or deleting a memory therefore does not rewrite an existing snapshot:
+new entries can be absent and deleted entries can remain listed. Project names
+remain in the enclosing session context; the immutable index records the stable
+project ID so a rename cannot rewrite historical prompt state.
 
-This means the model always has its most relevant memories available without
-explicit recall -- but can still use `memory(action='search')` for deeper
-lookup.
+After each genuine user turn, BM25 scores the complete live metadata set and
+persists up to `relevance_k` exact `(scope, name)` pointers as a first-class
+system turn. These pointers are also body-free. The model must use
+`memory(action='get', name=..., scope=...)` to verify current access and read
+content. This keeps later conversation history truthful without invalidating
+the initial cached prefix.
 
-The persona memory lever gates this pathway: a workstream whose persona
-turns memory off receives no relevance injection at all -- the steps
-above run only when memory is enabled for the session. See
-[Personas](personas.md).
+Only an explicit full-body `get` updates `last_accessed` and `access_count`.
+Index capture, pointers, `list`, `search`, saves, and deletes do not count as
+accesses. The persona memory lever gates the index, pointers, tool, and
+memory-directed nudges together. See [Personas](personas.md).
+
+The default complete-index soft budget is 65,536 characters. It does not
+truncate or hide entries. The registered
+`memory.model_index_over_budget_notice` setting defaults to `false`. When an
+operator opts in, over-budget prose is appended only to a successful model
+`memory.save` tool result; REST and SDK save responses remain unchanged. The
+console always shows persistent health derived from live memories and every
+visibility envelope possible in the current workstream/project topology,
+regardless of that setting. The calculation does not depend on an index
+snapshot already existing. Legacy rows with invalid descriptions remain
+represented by an explicit sentinel until an administrator authors a valid
+hook.
+
+Separately from that soft character budget, each memory-bearing model request
+checks the complete final system prefix against the selected lane's usable
+input capacity (context window minus the output reservation). This is a prefix
+fit guard; tool definitions, conversation history, and the current user input
+remain subject to the normal provider request checks. A refusal occurs before
+provider dispatch and before attachment or perception work. Before first
+capture, the candidate transaction does not commit a new snapshot, so the user
+can consolidate or delete memories and retry, or select a larger-context model.
+If another worker wins the first-capture race, its durable snapshot governs the
+retry. Once a snapshot is bound, edits cannot shrink it for that workstream;
+select a larger-context model, or start a new workstream after memory cleanup.
 
 ### Nudges
 
 The metacognition layer can nudge the model to save memories at appropriate
 moments (e.g., after a correction or when resuming a workstream). Nudges are
-rate-limited by `nudge_cooldown` and can be disabled entirely.
+rate-limited by `nudge_cooldown`. Setting `memory.nudges=false` suppresses both
+live memory pointers and memory-directed nudges; it does not remove the
+immutable initial index or the memory tool.
 
 ---
 
 ## Configuration
 
-### config.toml
+Server and console sessions read memory settings live from the database-backed
+ConfigStore. Configure them through the Admin Settings UI or settings API; a
+`config.toml [memory]` section is not consumed by server or console, and the
+standalone CLI currently uses `MemoryConfig` defaults.
 
-```toml
-[memory]
-relevance_k = 5          # top-k memories injected per turn
-fetch_limit = 50          # max memories fetched from storage for scoring
-max_content = 32768       # max content length per memory (characters)
-nudge_cooldown = 300      # minimum seconds between memory nudges
-nudges = true             # enable/disable metacognitive nudges
-```
-
-All fields are optional. Defaults are shown above.
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `memory.relevance_k` | `5` | Maximum body-free metadata pointers persisted after a user turn |
+| `memory.index_budget_chars` | `65536` | Complete-index soft character budget; never truncates |
+| `memory.model_index_over_budget_notice` | `false` | Add over-budget prose to successful model-tool saves |
+| `memory.max_content` | `32768` | Maximum memory body size in characters |
+| `memory.nudge_cooldown` | `300` | Minimum seconds between memory-directed nudges |
+| `memory.nudges` | `true` | Enable live pointers and memory-directed nudges; does not remove the index or tool |
 
 ---
 
@@ -126,9 +188,9 @@ The `memory` tool supports five actions:
 
 Store or update a memory.
 
-Every save is a complete write for the relevance summary: `description` must
-be supplied and contain non-whitespace text on both creation and update.
-Content-only updates are rejected.
+Every save is a complete write for the index hook: `description` must be
+supplied on both creation and update, normalize to one non-empty line, and be
+at most 512 characters. Content-only updates are rejected.
 
 ```json
 {
@@ -143,15 +205,16 @@ Content-only updates are rejected.
 
 | Parameter     | Required | Default     | Description                              |
 |---------------|----------|-------------|------------------------------------------|
-| `name`        | yes      | --          | Snake_case identifier (max 256 chars)    |
+| `name`        | yes      | --          | Canonical snake_case identifier (max 256 chars) |
 | `content`     | yes      | --          | Memory content (max `max_content` chars) |
-| `description` | yes      | --          | Non-empty relevance summary, required on create and update |
+| `description` | yes      | --          | Authored index hook (1-512 normalized characters), required on every write |
 | `type`        | no       | `"general"` | One of: user, general, feedback, reference |
 | `scope`       | no       | inherited   | Kind-valid scope; see inherited target above |
 
 ### get
 
-Retrieve the full content of one memory by name.
+Retrieve the live full content of one memory by name. This is the only tool
+action that records an access.
 
 ```json
 {
@@ -168,7 +231,8 @@ Retrieve the full content of one memory by name.
 
 ### search
 
-Find memories by query (BM25 full-text search).
+Find memories by name or authored description. Results contain metadata only;
+follow a result with an exact `get` to read its body.
 
 ```json
 {
@@ -205,7 +269,7 @@ Remove a memory by name.
 
 ### list
 
-List all memories with optional filters.
+List all memories with optional filters. Results contain metadata only.
 
 ```json
 {
@@ -225,7 +289,9 @@ List all memories with optional filters.
 
 ## Server API
 
-Four endpoints on the server for programmatic memory access.
+Five endpoints on the server for programmatic memory access. List and search
+return metadata summaries; only the exact-name GET endpoint returns a body and
+records an access.
 
 ### `GET /v1/api/memories`
 
@@ -261,9 +327,10 @@ different supplied ID is rejected. `scope=workstream` requires `scope_id`.
       "type": "general",
       "scope": "global",
       "scope_id": "",
-      "content": "The project uses a hexagonal architecture...",
       "created": "2026-03-10T10:00:00",
-      "updated": "2026-03-12T14:30:00"
+      "updated": "2026-03-12T14:30:00",
+      "last_accessed": "",
+      "access_count": 0
     }
   ],
   "total": 1
@@ -276,8 +343,9 @@ different supplied ID is rejected. `scope=workstream` requires `scope_id`.
 
 Save or upsert a structured memory.
 
-`description` is mandatory for both creates and updates and must contain
-non-whitespace text. The API rejects content-only updates.
+`description` is mandatory for both creates and updates, normalizes to one
+non-empty line, and is limited to 512 characters. The API rejects content-only
+updates.
 
 **Request body:**
 
@@ -294,9 +362,9 @@ non-whitespace text. The API rejects content-only updates.
 
 | Field        | Type   | Required | Default     | Description                          |
 |--------------|--------|----------|-------------|--------------------------------------|
-| `name`       | string | yes      | --          | Memory name (max 256 chars)          |
+| `name`       | string | yes      | --          | Latin alias; stored snake_case key is max 256 chars after normalization |
 | `content`    | string | yes      | --          | Memory content (max 65536 chars)     |
-| `description`| string | yes      | --          | Non-empty relevance summary, required on create and update |
+| `description`| string | yes      | --          | Authored one-line index hook (1-512 characters), required on every write |
 | `type`       | string | no       | unset       | user, general, feedback, or reference |
 | `scope`      | string | no       | `"global"`  | One of: global, workstream, user     |
 | `scope_id`   | string | no       | `""`        | Scope qualifier (auto-resolved for user scope) |
@@ -311,11 +379,15 @@ non-whitespace text. The API rejects content-only updates.
   "type": "general",
   "scope": "global",
   "scope_id": "",
-  "content": "Deploy via GitHub Actions...",
   "created": "2026-03-14T10:00:00",
-  "updated": "2026-03-14T10:00:00"
+  "updated": "2026-03-14T10:00:00",
+  "last_accessed": "",
+  "access_count": 0
 }
 ```
+
+The save response is a metadata summary; fetch the exact name with `GET` when
+the body is needed.
 
 **Response (updated):** `200` -- same schema, returned when a memory with the
 same `(name, scope, scope_id)` already existed.
@@ -371,13 +443,59 @@ the list endpoint. It never means every row in the table.
       "type": "general",
       "scope": "global",
       "scope_id": "",
-      "content": "JWT tokens with HS256...",
       "created": "2026-03-10T10:00:00",
-      "updated": "2026-03-12T14:30:00"
+      "updated": "2026-03-12T14:30:00",
+      "last_accessed": "",
+      "access_count": 0
     }
   ],
   "total": 1
 }
+```
+
+---
+
+### `GET /v1/api/memories/{name}`
+
+Fetch one live memory body by exact name and scope. This is the only public
+memory read that updates `last_accessed` and `access_count`; list and search do
+not.
+
+**Path parameters:**
+
+| Parameter | Type   | Description |
+|-----------|--------|-------------|
+| `name`    | string | Raw Latin alias normalized to the exact stored name |
+
+**Query parameters:**
+
+| Parameter  | Type   | Required | Default    | Description         |
+|------------|--------|----------|------------|---------------------|
+| `scope`    | string | no       | `"global"` | Scope of the memory |
+| `scope_id` | string | no       | `""`       | Scope qualifier     |
+
+**Response (success):** `200`
+
+```json
+{
+  "memory_id": "a1b2c3d4-e5f6-...",
+  "name": "auth_patterns",
+  "description": "Authentication architecture",
+  "type": "general",
+  "scope": "global",
+  "scope_id": "",
+  "content": "JWT tokens with HS256...",
+  "created": "2026-03-10T10:00:00",
+  "updated": "2026-03-12T14:30:00",
+  "last_accessed": "2026-03-12T14:31:00",
+  "access_count": 1
+}
+```
+
+**Response (not found):** `404`
+
+```json
+{"error": "Memory 'auth_patterns' not found"}
 ```
 
 ---
@@ -393,7 +511,7 @@ row actually removed. A storage failure returns `500`, not a false `404`.
 
 | Parameter | Type   | Description          |
 |-----------|--------|----------------------|
-| `name`    | string | Memory name          |
+| `name`    | string | Raw Latin alias normalized to the exact stored name |
 
 **Query parameters:**
 
@@ -418,8 +536,8 @@ row actually removed. A storage failure returns `500`, not a false `404`.
 
 ## Console Admin API
 
-Four admin endpoints for cross-workstream memory management. All require the
-`admin.memories` permission.
+Six admin endpoints provide cross-workstream memory management and index
+health. All require the `admin.memories` permission.
 
 ### `GET /v1/api/admin/memories`
 
@@ -434,7 +552,9 @@ List memories across all scopes (no automatic scope resolution).
 | `scope_id` | string | no       | `""`    | Filter by scope ID           |
 | `limit`    | int    | no       | `100`   | Max results (capped at 200)  |
 
-**Response:** `200`
+**Response:** `200`. Each item is an `AdminMemorySummary`: the public
+body-free metadata plus `scope_label`, a human-readable label for `scope_id`
+(empty when there is no scope ID, with the raw ID as fallback).
 
 ```json
 {
@@ -446,9 +566,11 @@ List memories across all scopes (no automatic scope resolution).
       "type": "general",
       "scope": "global",
       "scope_id": "",
-      "content": "The project uses...",
+      "scope_label": "",
       "created": "2026-03-10T10:00:00",
-      "updated": "2026-03-12T14:30:00"
+      "updated": "2026-03-12T14:30:00",
+      "last_accessed": "",
+      "access_count": 0
     }
   ],
   "total": 1
@@ -471,13 +593,14 @@ Search memories by query (uses query parameters, not POST body).
 | `scope_id` | string | no       | `""`    | Filter by scope ID            |
 | `limit`    | int    | no       | `20`    | Max results (capped at 50)    |
 
-**Response:** `200` -- same schema as `GET /v1/api/admin/memories`.
+**Response:** `200` -- the same `AdminMemorySummary` schema as
+`GET /v1/api/admin/memories`.
 
 ---
 
 ### `GET /v1/api/admin/memories/{memory_id}`
 
-Get a single memory by ID.
+Get a single memory body by ID and record an access.
 
 **Path parameters:**
 
@@ -495,17 +618,85 @@ Get a single memory by ID.
   "type": "general",
   "scope": "global",
   "scope_id": "",
+  "scope_label": "",
   "content": "The project uses...",
   "created": "2026-03-10T10:00:00",
-  "updated": "2026-03-12T14:30:00"
+  "updated": "2026-03-12T14:30:00",
+  "last_accessed": "2026-03-12T14:31:00",
+  "access_count": 1
 }
 ```
+
+The response is `AdminMemoryInfo` (`AdminMemorySummary` plus `content`), and
+the counters include the completed GET touch. Storage-operation failures return
+`500`; unavailable storage returns `503`.
 
 **Response (not found):** `404`
 
 ```json
 {"error": "Memory not found"}
 ```
+
+---
+
+### `PATCH /v1/api/admin/memories/{memory_id}`
+
+Replace a memory's authored index hook without changing its body. The
+description normalizes to one non-empty line and is limited to 512 characters.
+Existing immutable snapshots remain unchanged; future visibility envelopes
+capture the edited hook. The operation records a
+`memory.description_update` audit event.
+
+```json
+{"description": "Updated retrieval hook"}
+```
+
+The response is the updated `AdminMemorySummary` and never includes the body:
+
+```json
+{
+  "memory_id": "a1b2c3d4-e5f6-...",
+  "name": "project_architecture",
+  "description": "Updated retrieval hook",
+  "type": "general",
+  "scope": "global",
+  "scope_id": "",
+  "scope_label": "",
+  "created": "2026-03-10T10:00:00",
+  "updated": "2026-03-14T09:00:00",
+  "last_accessed": "",
+  "access_count": 0
+}
+```
+
+Invalid descriptions return `400`, missing memories return `404`, storage
+operation failures return `500`, and unavailable storage returns `503`.
+
+---
+
+### `GET /v1/api/admin/memories/index-health`
+
+Return persistent, derived health for every visibility envelope possible in the
+live workstream/project topology. The endpoint does not rely on existing
+snapshot rows: it compares the complete live index for each possible envelope
+against `memory.index_budget_chars` and reports legacy descriptions that need
+editing.
+
+```json
+{
+  "budget_chars": 65536,
+  "over_budget": false,
+  "max_char_count": 18420,
+  "max_entry_count": 210,
+  "over_by_chars": 0,
+  "invalid_description_count": 0,
+  "envelope_count": 3
+}
+```
+
+The console governance page displays the over-budget or invalid-description
+state as a persistent banner rather than a transient notification.
+Calculation failures return `500`; unavailable storage returns `503`.
 
 ---
 
@@ -538,7 +729,9 @@ Delete a memory by ID. Records an audit event (`memory.delete`).
 ### Python
 
 The server SDK uses `mem_type` (not `type`) to avoid shadowing the Python
-builtin.
+builtin. Omit it to preserve an existing memory's type on update and use the
+server default on insert; pass `mem_type="general"` explicitly when an update
+should reclassify the memory to `general`.
 
 ```python
 from turnstone.sdk import TurnstoneServer
@@ -562,6 +755,9 @@ with TurnstoneServer("http://localhost:8080", token="tok_xxx") as client:
     # List memories
     all_mems = client.list_memories(mem_type="feedback", limit=50)
 
+    # Fetch one live body (and record the access)
+    body = client.get_memory("api_conventions", scope="global")
+
     # Delete a memory
     client.delete_memory("api_conventions", scope="global")
 ```
@@ -580,6 +776,10 @@ with TurnstoneConsole("http://localhost:9090", token="tok_xxx") as admin:
 
     # Get by ID
     mem = admin.get_memory("a1b2c3d4-e5f6-...")
+
+    # Repair an index hook and inspect persistent index health
+    admin.update_memory_description("a1b2c3d4-e5f6-...", "API conventions and endpoint structure")
+    health = admin.memory_index_health()
 
     # Delete by ID
     admin.delete_memory("a1b2c3d4-e5f6-...")
@@ -614,6 +814,9 @@ const results = await client.searchMemories({
 // List memories
 const all = await client.listMemories({ type: "feedback", limit: 50 });
 
+// Fetch one live body (and record the access)
+const body = await client.getMemory("api_conventions", { scope: "global" });
+
 // Delete a memory
 await client.deleteMemory("api_conventions", { scope: "global" });
 ```
@@ -632,6 +835,11 @@ const admin = new TurnstoneConsole({
 const mems = await admin.listMemories({ scope: "global" });
 const found = await admin.searchMemories({ q: "auth", limit: 20 });
 const one = await admin.getMemory("a1b2c3d4-e5f6-...");
+await admin.updateMemoryDescription(
+  "a1b2c3d4-e5f6-...",
+  "API conventions and endpoint structure",
+);
+const health = await admin.memoryIndexHealth();
 await admin.deleteMemory("a1b2c3d4-e5f6-...");
 ```
 
@@ -639,13 +847,35 @@ await admin.deleteMemory("a1b2c3d4-e5f6-...");
 
 ## Storage
 
-Memories are stored in the `structured_memories` table (migration 013).
-The unique constraint on `(name, scope, scope_id)` ensures upsert semantics.
-The name is normalized on save: lowercased, hyphens and spaces replaced with
+Memories are stored in the `structured_memories` table (migration 013). The
+unique constraint on `(name, scope, scope_id)` ensures upsert semantics. The
+name is normalized on save: lowercased, hyphens and spaces replaced with
 underscores.
+
+Immutable rendered indexes are stored in `memory_index_snapshots` (migration
+072), keyed by workstream ID. The first admitted acting principal and exact
+visibility-envelope JSON are stored as witnesses, along with `project_id` and
+entry/character/invalid-description counts. Workstream hard deletion removes
+the snapshot and workstream-scoped memories in the same transaction before the
+ID becomes reusable. Registration also clears stale rows on a successful new
+insert so a later same-ID workstream cannot inherit memory state.
+
+Migration 072 is an irreversible access-history semantics boundary. It resets
+legacy `structured_memories.last_accessed` and `access_count` values because
+those fields change from recording automatic prompt injection to recording
+explicit full-body `get` operations only. Values from before and after the
+upgrade are not comparable, and downgrading cannot reconstruct the cleared
+history. Export the memory metadata before upgrading if that history must be
+retained externally.
+
+The same migration removes every global and node-specific
+`memory.fetch_limit` setting. It deliberately does not map that retired token
+fetch cap to another setting: `memory.relevance_k` limits body-free live
+pointers, while `memory.index_budget_chars` is a character-based soft budget
+for the complete metadata index.
 
 ## Architecture
 
 See [Memory Architecture diagram](diagrams/png/23-memory-architecture.png) for
 the full data flow covering the session tool path, API path, admin path, and
-BM25 relevance injection.
+immutable index plus live metadata-pointer flow.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -14,7 +14,7 @@ A persona is exactly four levers — no more:
 | **Base prompt** | Replaces the BASE module of the composed system message. *Only* BASE: ENV, CONTEXT, TOOLS, and POLICIES keep composing, so mandatory [prompt policies](governance.md) ride on top of every persona. Built-in personas source their prose from a repo file; operator personas store it inline — see [Where persona prompts live](#where-persona-prompts-live). |
 | **Tool visibility** | Which tools the session advertises. Tri-state: *unrestricted* (tracks tool growth and MCP catalogs), *no tools* (the TOOLS prompt block self-suppresses and zero definitions go on the wire), or an *exact set* of names. Including `tool_search` in a set makes it **soft** — tools the model discovers through search join the visible set; omitting it makes the set **hard** (the search pathway is disabled entirely). On commercial providers a soft set costs one prompt-cache re-prime per `tool_search` expansion, since each expansion rewrites the wire tool set and recomposes the prompt. |
 | **MCP** | Whether the workstream talks to MCP at all. **Session-wide**: off means no MCP tools for the persona's own hands *or* for in-process task agents, no resource/prompt catalogs, and no listener registrations. This lever expresses infrastructure intent, not behavior shaping. |
-| **Memory** | Whether the persona's **own hands** get memory: recalled-memory injection into the prompt, memory-directed metacognitive nudges, and the `memory` tool. Task agents keep their own envelope, and compaction spill/markers are session mechanics that are never persona-gated. An exact tool set that hides `memory` also mutes those nudges, and the compaction-resume pointer follows `recall`'s visibility. |
+| **Memory** | Whether the persona's **own hands** get memory: the immutable metadata index, live metadata pointers, memory-directed metacognitive nudges, and the `memory` tool. Production task agents are memory-disabled in 1.8 regardless of a child persona's memory flag; a persona may narrow the final task-agent capability envelope but cannot add memory to that lane ([follow-up #1017](https://github.com/turnstonelabs/turnstone/issues/1017)). Compaction spill/markers are session mechanics and are never memory-gated. An exact tool set that hides `memory` also suppresses the index, pointers, and memory nudges, while the compaction-resume pointer follows `recall`'s visibility. |
 
 Visibility is behavior shaping, **not** a security boundary: any tool call
 that does reach the wire still clears the same approval, judge, and policy
@@ -66,15 +66,16 @@ personas existed:
 
 Notes:
 
-- `scribe` turns memory off deliberately: recalled memories would
+- `scribe` turns memory off deliberately: an index or live pointer could
   contaminate faithful summarization with unrelated context.
 - `researcher`'s set is soft (includes `tool_search`): it starts with
   read and evidence tools but can pull in others on demand — e.g. load
   `bash` to run a snippet and verify a calculation. It is evidence-first,
   not sandboxed; any escalated tool still hits the normal approval path.
-- Coordinator sessions do not merge MCP today, so the MCP lever on
-  coordinator personas is forward-compatible bookkeeping; it bites on
-  interactive workstreams.
+- Coordinator sessions merge the live MCP catalog into their main, directly
+  advertised wire-tool surface when the persona MCP lever permits it.
+  Coordinators have no task-agent tool lane. Turning MCP off removes the
+  catalog from both interactive and coordinator sessions.
 
 ## Where persona prompts live
 
@@ -123,6 +124,8 @@ seeded):
   sub-agent's identity and capability envelope (resolved against
   interactive-kind personas, frozen into the task at prep). Omitted keeps
   the default autonomous task-agent identity — never the parent's persona.
+  The selected persona can only narrow the production task-agent lane; in
+  1.8 that lane remains memory-disabled even when the persona enables memory.
 
 ## How agents discover personas
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -261,7 +261,7 @@ initialization:
 | `judge` | enabled, model, smart_approvals, confidence_threshold, max_context_ratio, timeout, parallel_evaluations, read_only_tools, output_guard, output_guard_budget_seconds, output_guard_llm, output_guard_model, output_guard_llm_timeout, redact_secrets, cancel_on_approval |
 | `interface` | close_tab_action, theme |
 | `skills` | discovery_url |
-| `memory` | relevance_k, fetch_limit, max_content, nudge_cooldown, nudges |
+| `memory` | relevance_k, index_budget_chars, model_index_over_budget_notice, max_content, nudge_cooldown, nudges |
 
 Settings are addressed by dotted key (e.g. `memory.relevance_k`). Each has a
 declared type (`int`, `float`, `str`, `bool`), optional `min_value`/`max_value`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -360,7 +360,7 @@ Search the web using a text query.
 
 The `rerank_web_search` toggle defaults on once a reranker is selected. If the endpoint is unreachable or errors, web_search falls back silently to the backend's native result order — reranking never makes a search fail.
 
-When `rerank_bm25` is enabled, the candidate text for memory, tool, and skill retrieval (memory name/description/content and tool/skill names + descriptions) is also sent to the rerank endpoint — a self-hosted endpoint (vLLM/TEI/llama.cpp) keeps it on your infrastructure, a hosted provider (Cohere/Jina/Voyage) sends it off-box.
+When `rerank_bm25` is enabled, Turnstone also sends the current query and BM25 candidate metadata to the rerank endpoint. Live memory-pointer candidates contain only the memory name and authored description—never the body. Tool and skill candidates contain their names and descriptive metadata. A self-hosted endpoint (vLLM/TEI/llama.cpp) keeps this on your infrastructure; a hosted provider (Cohere/Jina/Voyage) sends it off-box.
 
 **Serving a Qwen3-Reranker with vLLM.** The model is instruction-aware, so vLLM **must** apply its chat template — pass `--chat-template` explicitly. Without it the bare query produces near-random scores and reranking actively *hurts* retrieval (verified: an irrelevant passage outscored the correct one):
 
@@ -376,7 +376,7 @@ Then add a reranker model in the **Models** tab with `base_url` `http://vllm:800
 
 For an endpoint that does *not* apply the model's template, set `rerank_instruction` instead — Turnstone then wraps each query as `<Instruct>: {instruction}` / `<Query>: {query}` (Qwen3's own default is `Given a web search query, retrieve relevant passages that answer the query`). Use the chat template **or** the instruction, not both (they double-wrap).
 
-**Picking `rerank_bm25_threshold`.** The relevance floor that gates proactive memory injection is a probability in `[0, 1]`, but the right value differs per model (a sharp 0.6B reranker may want ~0.95; a broader 4B ~0.33). Calibrate it against your endpoint:
+**Picking `rerank_bm25_threshold`.** The relevance floor that filters live memory pointers is a probability in `[0, 1]`, but the right value differs per model (a sharp 0.6B reranker may want ~0.95; a broader 4B ~0.33). Calibrate it against your endpoint:
 
 ```bash
 turnstone-admin rerank-calibrate           # probe the endpoint, recommend a floor
@@ -433,7 +433,12 @@ Delegate a general-purpose task to an autonomous sub-agent.
 |-----------|--------|----------|-------------|
 | `prompt`  | string | yes      | Complete task description for the sub-agent. |
 
-- **What it does**: Spawns a sub-agent that inherits the `TASK_AGENT_TOOLS` set (read, write, edit, search, bash, and web tools). The sub-agent runs autonomously to completion. Use for work that requires file modifications or command execution.
+- **What it does**: Spawns a sub-agent that inherits the production
+  `TASK_AGENT_TOOLS` set (read, write, edit, search, bash, and web tools). The
+  sub-agent runs autonomously to completion. A selected persona can narrow
+  that final lane but cannot add memory: task agents are memory-disabled in
+  1.8 regardless of the child persona's memory flag. Use for work that requires
+  file modifications or command execution.
 - **Auto-approve**: No -- requires user confirmation.
 - **Agent availability**: Top-level only.
 
@@ -450,7 +455,7 @@ Structured persistent memory across sessions with typed, scoped entries.
 | `action`      | string  | yes      | `save`, `get`, `search`, `delete`, or `list`. |
 | `name`        | string  | save/get/delete | Short snake_case identifier for the memory. |
 | `content`     | string  | save     | Memory content to store. |
-| `description` | string  | save     | Non-empty description for relevance matching; required on create and update. |
+| `description` | string  | save     | Authored one-line index hook (1-512 characters); required on every create or update. |
 | `type`        | string  | no       | Memory type: `user`, `general`, `feedback`, or `reference`. Default: `general`. |
 | `scope`       | string  | no       | Memory scope: `global`, `workstream`, `user`, `coordinator`, or `project`. See defaults below. |
 | `query`       | string  | search   | Search query for finding memories. |
@@ -459,12 +464,24 @@ Structured persistent memory across sessions with typed, scoped entries.
 - **What it does**: Manages structured persistent memories in the database.
   Memories persist across sessions, have a type classification, and live in a
   role-specific visible scope. Unscoped `save`/`get`/`delete` resolve to one
-  target: the attached active project, otherwise `global` for an interactive
-  session or `coordinator` for a coordinator. Read-only project access permits
-  `get` but makes `save`/`delete` fail without falling back. A valid explicit
-  scope selects exactly that scope. Unscoped `search`/`list` cover all visible
-  scopes; use the displayed scope when following a result with `get` or
-  `delete`.
+  target. Any stored project attachment pins that target to `project`; a
+  missing or archived project, or revoked access, fails closed without falling
+  back. Authorized read-only access permits `get` but makes `save`/`delete`
+  fail. Authorized reactivation restores eligibility. Only a workstream with
+  no stored project attachment defaults to `global` (interactive) or
+  `coordinator`. A valid explicit scope selects exactly that scope. Unscoped
+  `search`/`list` cover all visible scopes; use the displayed scope when
+  following a result with `get` or `delete`. The initial system prefix contains
+  an immutable, complete, body-free metadata index for the acting principal.
+  It records an explicit project ID only when the attached project is active
+  and readable at first admission. Later user turns may add live body-free
+  `(scope, name)` pointers. Setting `memory.nudges=false` suppresses those live
+  pointers and memory-directed nudges, but not the immutable index or the
+  memory tool. `get` is the sole full-body read and the sole action that updates
+  access counters.
+  The model-facing over-budget notice is opt-in, defaults off, and can appear
+  only on a successful memory-tool save; REST/SDK saves are unchanged and
+  console health remains unconditional.
 - **Auto-approve**: Yes.
 - **Agent availability**: Not available to task agents.
 


### PR DESCRIPTION
## Summary

- document immutable memory-index capture, capacity refusal, project visibility, and recovery semantics
- update settings, tools, API-reference, and architecture inventories
- regenerate the affected PlantUML diagrams

## Relationship to #1022

#1022 has merged. This documentation-only follow-up is rebased directly onto the resulting `main` commit; its 12-file diff is the same documentation content that was validated before the split.

The split kept the implementation PR within GitHub Copilot code review's size limit without dropping generated OpenAPI contracts or trimming useful tests/comments.
