### PR TITLE
Surface specific backend errors before generic stream failures

### DIFF
--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -2171,6 +2171,39 @@ class TestCancelRef:
 
         _CancelRef(session).append(mock_stream)  # Should not raise
 
+    def test_cancel_only_handle_is_closeable_without_arming_attempt(self, tmp_db):
+        session = _make_session()
+        fired: list[int] = []
+        ref = _CancelRef(session, on_first_append=lambda: fired.append(1))
+        handle = MagicMock()
+
+        ref.register_cancel_handle(handle)
+
+        assert session._cancel_stream is handle
+        assert ref == []
+        assert not ref.armed
+        assert fired == []
+        session.cancel()
+        handle.close.assert_called_once_with()
+
+        ref.unregister_cancel_handle(handle)
+        assert session._cancel_stream is None
+
+    def test_superseded_cancel_only_handle_cannot_replace_successor(self, tmp_db):
+        session = _make_session()
+        session._generation = 5
+        successor = MagicMock()
+        session._cancel_stream = successor
+        zombie = MagicMock()
+
+        ref = _CancelRef(session, 4)
+        ref.register_cancel_handle(zombie)
+
+        assert session._cancel_stream is successor
+        assert not ref.armed
+        zombie.close.assert_called_once_with()
+        successor.close.assert_not_called()
+
     def test_no_shared_cancel_ref_attribute(self, tmp_db):
         """The long-lived shared ref is GONE (#832): every model-call site
         builds a fresh per-attempt, generation-scoped _CancelRef, so a

--- a/tests/test_deadline.py
+++ b/tests/test_deadline.py
@@ -203,6 +203,32 @@ class TestStreamAbortRef:
         ref.append(stream)
         stream.close.assert_called_once()
 
+    def test_cancel_only_handle_closes_without_arming_list(self) -> None:
+        from unittest.mock import MagicMock
+
+        from turnstone.core.deadline import StreamAbortRef
+
+        ref = StreamAbortRef()
+        handle = MagicMock()
+        ref.register_cancel_handle(handle)
+
+        assert ref == []
+        ref.abort()
+        handle.close.assert_called_once_with()
+
+    def test_unregistered_cancel_only_handle_is_not_closed_by_later_abort(self) -> None:
+        from unittest.mock import MagicMock
+
+        from turnstone.core.deadline import StreamAbortRef
+
+        ref = StreamAbortRef()
+        handle = MagicMock()
+        ref.register_cancel_handle(handle)
+        ref.unregister_cancel_handle(handle)
+
+        ref.abort()
+        handle.close.assert_not_called()
+
     def test_cancel_event_is_visible_before_explicit_abort(self) -> None:
         """A worker observes cancellation before the polling parent aborts it."""
         from unittest.mock import MagicMock

--- a/tests/test_sdk_stream_boundary.py
+++ b/tests/test_sdk_stream_boundary.py
@@ -1,6 +1,6 @@
-"""Offline pins of the SDK boundary behaviors the #937 retry design rests on.
+"""Offline pins of SDK boundary behaviors used by stream error handling.
 
-Four facts, each probed against the REAL SDKs over mock/loopback
+Five facts, each probed against the REAL SDKs over mock/loopback
 transports (no network, no live backend):
 
 1. OpenAI v3's ``max_retries`` covers request time only — a mid-BODY death
@@ -14,24 +14,35 @@ transports (no network, no live backend):
    wire release surfaces as an ``httpx2.TransportError`` on the blocked
    ``next()``. The production ``transport_guarded`` seam must normalize it
    before the retry gate.
+5. OpenAI v3 raises real HTTP errors before returning a stream, while an HTTP
+   200 ``application/json`` response becomes an empty iterator unless the
+   adapter rejects it before arming the stream.
 
-If an SDK/httpx upgrade changes any of these, the ``transport_guarded``
-conversion (and the retry gate consuming it) must be re-verified — these
-tests are the tripwire.  Wire framing bytes (CRLF, the SSE double-LF) are
-built via ``chr`` rather than escape literals so the payloads are
-byte-exact regardless of source-encoding handling.
+If an SDK/httpx upgrade changes any of these, the provider boundary and
+``transport_guarded`` conversion (including the retry gate consuming it) must
+be re-verified — these tests are the tripwire. Wire framing bytes (CRLF, the
+SSE double-LF) are built via ``chr`` rather than escape literals so the
+payloads are byte-exact regardless of source-encoding handling.
 """
 
 import contextlib
+import json
 import socket
 import threading
 import time
+from types import SimpleNamespace
 
 import anthropic
 import httpx
 import httpx2
 import openai
 import pytest
+
+from turnstone.core.providers._openai_common import (
+    UpstreamRateLimitError,
+    UpstreamResponseError,
+    UpstreamTransientError,
+)
 
 LF = chr(10)
 CRLF = chr(13) + chr(10)
@@ -91,6 +102,42 @@ class _Httpx2DyingStream(httpx2.SyncByteStream):
         raise httpx2.ReadError("[SSL] record layer failure (_ssl.c:2590)")
 
 
+class _BlockingJsonStream(httpx2.SyncByteStream):
+    """JSON body that blocks until cross-thread close releases it."""
+
+    def __init__(self) -> None:
+        self.read_started = threading.Event()
+        self.closed = threading.Event()
+
+    def __iter__(self):
+        self.read_started.set()
+        if not self.closed.wait(5):
+            raise AssertionError("JSON response body was not cancelled")
+        raise httpx2.ReadError("JSON response closed by cancellation")
+        yield b""  # pragma: no cover - make this a generator
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+class _OversizedJsonStream(httpx2.SyncByteStream):
+    """Unbounded-looking body that records how far the guard consumes."""
+
+    def __init__(self) -> None:
+        self.read_count = 0
+        self.closed = False
+
+    def __iter__(self):
+        yield b'{"error":{"message":"'
+        for _ in range(100):
+            self.read_count += 1
+            yield b"x" * 1024
+        raise AssertionError("bounded JSON reader consumed the response to EOF")
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def _dying_transport(payload: str, requests: list) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
@@ -115,6 +162,263 @@ def _httpx2_dying_transport(payload: str, requests: list) -> httpx2.MockTranspor
         )
 
     return httpx2.MockTransport(handler)
+
+
+@pytest.mark.parametrize("surface", ["chat", "responses"])
+@pytest.mark.parametrize(
+    ("status_code", "message", "error_type"),
+    [
+        (
+            200,
+            "request (9870 tokens) exceeds the available context size (4096 tokens)",
+            UpstreamResponseError,
+        ),
+        (400, "request exceeds the available context size", openai.BadRequestError),
+        (413, "payload too large", openai.APIStatusError),
+        (429, "rate limit reached", openai.RateLimitError),
+    ],
+)
+def test_openai_v3_json_error_precedes_stream_arming(
+    surface: str,
+    status_code: int,
+    message: str,
+    error_type: type[Exception],
+):
+    """JSON failures retain their status and body before stream iteration.
+
+    The SDK owns real HTTP failures. Turnstone handles the compatibility case
+    where the endpoint returns the same payload under HTTP 200. Neither may
+    reach the finish-reason gate and become ``IncompleteStreamError``.
+    """
+    from turnstone.core.providers import create_provider
+
+    requests: list = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(
+            status_code,
+            headers={"content-type": "application/json"},
+            json={"error": {"message": message, "type": "upstream_error"}},
+            request=request,
+        )
+
+    client = openai.OpenAI(
+        api_key="probe",
+        base_url="http://probe.invalid/v1",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+    cancel_ref: list = []
+    provider = create_provider("openai-compatible", api_surface=surface)
+    try:
+        with pytest.raises(error_type) as excinfo:
+            provider.create_streaming(
+                client=client,
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                cancel_ref=cancel_ref,
+            )
+    finally:
+        client.close()
+
+    assert getattr(excinfo.value, "status_code", None) == status_code
+    assert message in str(excinfo.value)
+    assert cancel_ref == []
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("surface", ["chat", "responses"])
+@pytest.mark.parametrize(
+    ("code", "error_type", "expected_error"),
+    [
+        ("rate_limit_exceeded", "rate_limit_error", UpstreamRateLimitError),
+        ("server_error", "server_error", UpstreamTransientError),
+    ],
+)
+def test_http_200_json_transient_error_keeps_retry_classification(
+    surface: str,
+    code: str,
+    error_type: str,
+    expected_error: type[UpstreamResponseError],
+):
+    from turnstone.core.providers import create_provider
+
+    message = "maximum number of tokens allowed per minute is temporarily unavailable"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"error": {"message": message, "type": error_type, "code": code}},
+            request=request,
+        )
+
+    client = openai.OpenAI(
+        api_key="probe",
+        base_url="http://probe.invalid/v1",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+    cancel_ref: list = []
+    provider = create_provider("openai-compatible", api_surface=surface)
+    try:
+        with pytest.raises(expected_error) as excinfo:
+            provider.create_streaming(
+                client=client,
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                cancel_ref=cancel_ref,
+            )
+    finally:
+        client.close()
+
+    assert excinfo.value.code == code
+    assert excinfo.value.error_type == error_type
+    assert type(excinfo.value).__name__ in provider.retryable_error_names
+    assert cancel_ref == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": {"role": "assistant", "content": "generated text must stay private"}},
+        {
+            "error": None,
+            "choices": [{"message": {"content": "generated text must stay private"}}],
+        },
+    ],
+)
+def test_non_stream_ambiguous_json_omits_generated_content_from_error(payload: dict):
+    from turnstone.core.providers._openai_common import reject_non_stream_response
+
+    private_output = "generated text must not enter diagnostics"
+    payload_text = json.dumps(payload).replace("generated text must stay private", private_output)
+    response = httpx2.Response(
+        200,
+        headers={"content-type": "application/json"},
+        content=payload_text.encode(),
+    )
+    stream = SimpleNamespace(response=response, close=response.close)
+
+    with pytest.raises(UpstreamResponseError) as excinfo:
+        reject_non_stream_response(stream)
+
+    assert excinfo.value.body == "<JSON response did not contain a valid error object>"
+    assert private_output not in str(excinfo.value)
+
+
+def test_non_stream_unparseable_json_fails_closed():
+    from turnstone.core.providers._openai_common import reject_non_stream_response
+
+    private_output = "generated text must not enter diagnostics"
+    response = httpx2.Response(
+        200,
+        headers={"content-type": "application/json"},
+        content=f"not-json {private_output}".encode(),
+    )
+    stream = SimpleNamespace(response=response, close=response.close)
+
+    with pytest.raises(UpstreamResponseError) as excinfo:
+        reject_non_stream_response(stream)
+
+    assert excinfo.value.body == "<JSON response did not contain a valid error object>"
+    assert private_output not in str(excinfo.value)
+
+
+def test_non_stream_error_excludes_sibling_completion_content():
+    from turnstone.core.providers._openai_common import reject_non_stream_response
+
+    private_output = "generated text must not enter diagnostics"
+    response = httpx2.Response(
+        200,
+        headers={"content-type": "application/json"},
+        json={
+            "error": {"message": "backend rejected the request", "type": "invalid_request"},
+            "choices": [{"message": {"content": private_output}}],
+        },
+    )
+    stream = SimpleNamespace(response=response, close=response.close)
+
+    with pytest.raises(UpstreamResponseError) as excinfo:
+        reject_non_stream_response(stream)
+
+    assert "backend rejected the request" in excinfo.value.body
+    assert private_output not in str(excinfo.value)
+
+
+def test_non_stream_json_body_read_is_bounded():
+    from turnstone.core.providers._openai_common import reject_non_stream_response
+
+    raw_stream = _OversizedJsonStream()
+    response = httpx2.Response(
+        200,
+        headers={"content-type": "application/json"},
+        stream=raw_stream,
+    )
+    stream = SimpleNamespace(response=response, close=response.close)
+
+    with pytest.raises(UpstreamResponseError) as excinfo:
+        reject_non_stream_response(stream)
+
+    assert excinfo.value.body == "<JSON response did not contain a valid error object>"
+    assert raw_stream.read_count < 100
+    assert raw_stream.closed
+
+
+@pytest.mark.parametrize("surface", ["chat", "responses"])
+def test_non_stream_json_body_read_is_cancellable_without_arming(surface: str):
+    from turnstone.core.deadline import StreamAbortRef
+    from turnstone.core.providers import create_provider
+    from turnstone.core.providers._protocol import IncompleteStreamError
+
+    raw_stream = _BlockingJsonStream()
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200,
+            headers={"content-type": "application/json"},
+            stream=raw_stream,
+            request=request,
+        )
+
+    client = openai.OpenAI(
+        api_key="probe",
+        base_url="http://probe.invalid/v1",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+    cancel_ref = StreamAbortRef()
+    errors: list[BaseException] = []
+    provider = create_provider("openai-compatible", api_surface=surface)
+
+    def run() -> None:
+        try:
+            provider.create_streaming(
+                client=client,
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                cancel_ref=cancel_ref,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    try:
+        assert raw_stream.read_started.wait(2)
+        assert cancel_ref == []
+        cancel_ref.abort()
+        worker.join(2)
+    finally:
+        cancel_ref.abort()
+        worker.join(2)
+        client.close()
+
+    assert not worker.is_alive()
+    assert raw_stream.closed.is_set()
+    assert len(errors) == 1
+    assert isinstance(errors[0], IncompleteStreamError)
 
 
 def test_openai_v3_chat_midbody_death_is_unwrapped_httpx2_error_and_no_rerequest():

--- a/tests/test_session_backend_error_format.py
+++ b/tests/test_session_backend_error_format.py
@@ -116,6 +116,23 @@ class RateLimitError(Exception):
     pass
 
 
+class APIError(Exception):
+    pass
+
+
+class BackendStatusError(Exception):
+    def __init__(self, message: str, *, status_code: int, reason_phrase: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = SimpleNamespace(reason_phrase=reason_phrase)
+
+
+class BadStatusAccessorError(Exception):
+    @property
+    def status_code(self) -> int:
+        raise RuntimeError("boom")
+
+
 class ReadError(Exception):  # noqa: N818
     pass
 
@@ -216,6 +233,99 @@ def test_rate_limit_with_overflow_phrasing_is_not_mislabeled_overflow():
     assert msg is not None
     assert "Backend rate-limited" in msg
     assert "Context window exceeded" not in msg
+
+
+@pytest.mark.parametrize(
+    ("error_name", "code", "error_type", "expected_message"),
+    [
+        (
+            "UpstreamRateLimitError",
+            "rate_limit_exceeded",
+            "rate_limit_error",
+            "Backend rate-limited",
+        ),
+        (
+            "UpstreamTransientError",
+            "server_error",
+            "server_error",
+            "Backend returned a transient application error",
+        ),
+    ],
+)
+def test_http_200_json_transient_errors_outrank_overflow_wording(
+    error_name: str, code: str, error_type: str, expected_message: str
+):
+    from turnstone.core.providers import _openai_common
+
+    error_class = getattr(_openai_common, error_name)
+    exc = error_class(
+        status_code=200,
+        content_type="application/json",
+        body="maximum number of tokens allowed per minute is temporarily unavailable",
+        code=code,
+        error_type=error_type,
+    )
+
+    msg = _format(_stub(), exc)
+
+    assert msg is not None
+    assert expected_message in msg
+    assert "Context window exceeded" not in msg
+
+
+def test_http_status_error_names_backend_status_model_and_raw_payload():
+    msg = _format(
+        _stub(model="gemma", model_alias="local-gemma"),
+        BackendStatusError(
+            '{"error":{"message":"payload too large"}}',
+            status_code=413,
+            reason_phrase="Payload Too Large",
+        ),
+    )
+    assert msg is not None
+    assert "Backend request failed (HTTP 413 Payload Too Large)" in msg
+    assert "openai-compatible" in msg
+    assert "http://192.168.0.5:8000/v1" in msg
+    assert "model=local-gemma (id=gemma)" in msg
+    assert 'raw=\'{"error":{"message":"payload too large"}}\'' in msg
+
+
+def test_in_band_api_error_is_enriched_but_overflow_keeps_specific_message():
+    generic = _format(_stub(), APIError("backend overloaded"))
+    assert generic is not None
+    assert "Backend returned an error instead of a usable stream (APIError)" in generic
+    assert "backend overloaded" in generic
+
+    overflow = _format(
+        _stub(),
+        APIError("request (9870 tokens) exceeds the available context size (4096 tokens)"),
+    )
+    assert overflow is not None
+    assert "Context window exceeded" in overflow
+    assert "Backend returned an error instead" not in overflow
+
+
+def test_http_200_json_error_is_rendered_as_context_overflow():
+    from turnstone.core.providers._openai_common import UpstreamResponseError
+
+    raw_body = (
+        '{"error":{"message":"request (9870 tokens) exceeds the available '
+        'context size (4096 tokens)"}}'
+    )
+    msg = _format(
+        _stub(model="Gemma-4-31B-it-GGUF", model_alias="gemma-4-amd-halo-one"),
+        UpstreamResponseError(
+            status_code=200,
+            content_type="application/json",
+            body=raw_body,
+        ),
+    )
+    assert msg is not None
+    assert "Context window exceeded" in msg
+    assert "model=gemma-4-amd-halo-one (id=Gemma-4-31B-it-GGUF)" in msg
+    assert "9870 tokens" in msg
+    assert "4096 tokens" in msg
+    assert "Backend stream died mid-response" not in msg
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +462,10 @@ def test_unknown_exception_returns_none():
 
 def test_unknown_exception_value_error_returns_none():
     assert _format(_stub(), ValueError("not a backend error")) is None
+
+
+def test_unknown_exception_with_bad_status_accessor_returns_none():
+    assert _format(_stub(), BadStatusAccessorError("original")) is None
 
 
 def test_trailing_slash_and_query_string_stripped():

--- a/tests/test_session_chat_reasoning_replay.py
+++ b/tests/test_session_chat_reasoning_replay.py
@@ -290,20 +290,8 @@ class TestReasoningFieldReachesWireBytes:
             captured.append({"url": str(request.url), "body": body})
             return httpx.Response(
                 200,
-                json={
-                    "id": "chatcmpl-vllm-spike",
-                    "object": "chat.completion",
-                    "created": 0,
-                    "model": "qwen3-test",
-                    "choices": [
-                        {
-                            "index": 0,
-                            "message": {"role": "assistant", "content": "ok"},
-                            "finish_reason": "stop",
-                        }
-                    ],
-                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
-                },
+                headers={"content-type": "text/event-stream"},
+                content=b"data: [DONE]\n\n",
             )
 
         client = OpenAI(

--- a/turnstone/core/deadline.py
+++ b/turnstone/core/deadline.py
@@ -60,6 +60,7 @@ class StreamAbortRef(list[Any]):
     __slots__ = (
         "_aborted",
         "_cancel_event",
+        "_cancel_handles",
         "_timing_lock",
         "_admission_wait_started",
         "_admission_wait_credit",
@@ -71,6 +72,7 @@ class StreamAbortRef(list[Any]):
         super().__init__()
         self._aborted = False
         self._cancel_event = cancel_event
+        self._cancel_handles: list[Any] = []
         self._timing_lock = threading.Lock()
         self._admission_wait_started: float | None = None
         self._admission_wait_credit = 0.0
@@ -83,10 +85,30 @@ class StreamAbortRef(list[Any]):
             with contextlib.suppress(Exception):
                 stream.close()
 
+    def register_cancel_handle(self, handle: Any) -> None:
+        """Expose *handle* to abort without marking a stream as accepted.
+
+        Providers use this while validating an HTTP response body that arrived
+        before a usable event stream.  Keeping it out of the list preserves the
+        caller's creation-vs-mid-stream classifier; the same late-arrival race
+        as :meth:`append` still closes an already-aborted handle immediately.
+        """
+        self._cancel_handles.append(handle)
+        if self.aborted:
+            with contextlib.suppress(Exception):
+                handle.close()
+
+    def unregister_cancel_handle(self, handle: Any) -> None:
+        """Remove one identity-matched cancellation-only handle."""
+        for index, registered in enumerate(self._cancel_handles):
+            if registered is handle:
+                self._cancel_handles.pop(index)
+                break
+
     def abort(self) -> None:
         """Close any captured stream; late arrivals close on append."""
         self._aborted = True
-        for stream in list(self):
+        for stream in [*list(self), *list(self._cancel_handles)]:
             with contextlib.suppress(Exception):
                 stream.close()
 

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -20,6 +20,7 @@ from turnstone.core.providers._openai_common import (
     apply_tool_search,
     extract_usage,
     format_citations,
+    reject_non_stream_response,
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
@@ -347,6 +348,7 @@ class OpenAIChatCompletionsProvider:
         )
         refuse_aborted_request(cancel_ref)
         stream = client.chat.completions.create(**kwargs)
+        reject_non_stream_response(stream, cancel_ref=cancel_ref)
         if cancel_ref is not None:
             cancel_ref.append(stream)
         return self._iter_stream(stream, finish_reason_optional=caps.finish_reason_optional)

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -7,6 +7,7 @@ formatting, and message sanitisation live here so both
 
 from __future__ import annotations
 
+import json
 import uuid
 from dataclasses import replace
 from typing import Any
@@ -16,6 +17,7 @@ import structlog
 from turnstone.core.attachments import safe_attachment_label
 from turnstone.core.lowering import CANCELLED_TOOL_RESULT
 from turnstone.core.providers._protocol import (
+    IncompleteStreamError,
     ModelCapabilities,
     UsageInfo,
     _lookup_capabilities,
@@ -24,6 +26,214 @@ from turnstone.core.providers._protocol import (
 )
 
 log = structlog.get_logger(__name__)
+
+_UPSTREAM_ERROR_BODY_MAX_BYTES = 4096
+_INVALID_UPSTREAM_ERROR_BODY = "<JSON response did not contain a valid error object>"
+_UPSTREAM_RATE_LIMIT_CODES = frozenset(
+    {"rate_limit_exceeded", "rate_limit_error", "too_many_requests"}
+)
+_UPSTREAM_TRANSIENT_CODES = frozenset(
+    {"server_error", "internal_server_error", "overloaded_error", "service_unavailable"}
+)
+
+
+class UpstreamResponseError(RuntimeError):
+    """An OpenAI-compatible endpoint returned JSON instead of an SSE stream."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        content_type: str,
+        body: str,
+        code: str = "",
+        error_type: str = "",
+        upstream_status_code: int | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.content_type = content_type
+        self.body = body
+        self.code = code
+        self.error_type = error_type
+        self.upstream_status_code = upstream_status_code
+        super().__init__(
+            f"backend returned HTTP {status_code} {content_type} instead of an event stream: {body}"
+        )
+
+
+class UpstreamRateLimitError(UpstreamResponseError):
+    """A JSON-under-200 response reported a retryable rate limit."""
+
+
+class UpstreamTransientError(UpstreamResponseError):
+    """A JSON-under-200 response reported a retryable server failure."""
+
+
+def _read_response_prefix(response: Any) -> tuple[bytes, bool]:
+    """Read at most one byte beyond the diagnostic cap."""
+    captured = bytearray()
+    for chunk in response.iter_bytes(chunk_size=_UPSTREAM_ERROR_BODY_MAX_BYTES + 1):
+        remaining = _UPSTREAM_ERROR_BODY_MAX_BYTES + 1 - len(captured)
+        if remaining <= 0:
+            break
+        captured.extend(chunk[:remaining])
+        if len(captured) > _UPSTREAM_ERROR_BODY_MAX_BYTES:
+            return bytes(captured[:_UPSTREAM_ERROR_BODY_MAX_BYTES]), True
+    return bytes(captured), False
+
+
+def _non_blank_string(value: Any) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def _embedded_status_code(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and 100 <= value <= 599:
+        return value
+    return None
+
+
+def _extract_upstream_error(
+    raw_body: bytes, *, truncated: bool
+) -> tuple[str, str, str, int | None]:
+    """Return a safe error-only body plus classification fields.
+
+    Successful, ambiguous, truncated, and unparsable JSON fails closed: only a
+    non-empty ``error`` string or an error object with a standard identifying
+    field may enter diagnostics.  Sibling completion output is never copied.
+    """
+    if truncated:
+        return _INVALID_UPSTREAM_ERROR_BODY, "", "", None
+    try:
+        payload = json.loads(raw_body.decode("utf-8"))
+    except (UnicodeDecodeError, TypeError, ValueError):
+        return _INVALID_UPSTREAM_ERROR_BODY, "", "", None
+    if not isinstance(payload, dict):
+        return _INVALID_UPSTREAM_ERROR_BODY, "", "", None
+
+    error = payload.get("error")
+    top_code = _non_blank_string(payload.get("code"))
+    top_type = _non_blank_string(payload.get("type"))
+    top_status = _embedded_status_code(payload.get("status_code"))
+    if isinstance(error, str):
+        message = error.strip()
+        if not message:
+            return _INVALID_UPSTREAM_ERROR_BODY, "", "", None
+        safe_payload: dict[str, Any] = {"error": message}
+        if top_code:
+            safe_payload["code"] = top_code
+        if top_type and top_type != "error":
+            safe_payload["type"] = top_type
+        if top_status is not None:
+            safe_payload["status_code"] = top_status
+        return (
+            json.dumps(safe_payload, ensure_ascii=False, separators=(",", ":")),
+            top_code,
+            top_type,
+            top_status,
+        )
+    if not isinstance(error, dict):
+        return _INVALID_UPSTREAM_ERROR_BODY, "", "", None
+
+    message = _non_blank_string(error.get("message"))
+    nested_code = _non_blank_string(error.get("code"))
+    nested_type = _non_blank_string(error.get("type"))
+    nested_status = _embedded_status_code(error.get("status_code"))
+    if not (message or nested_code or nested_type or nested_status is not None):
+        return _INVALID_UPSTREAM_ERROR_BODY, "", "", None
+    code = nested_code or top_code
+    error_type = nested_type or top_type
+    upstream_status = nested_status or top_status
+
+    safe_error: dict[str, Any] = {}
+    if message:
+        safe_error["message"] = message
+    if error_type:
+        safe_error["type"] = error_type
+    if code:
+        safe_error["code"] = code
+    param = error.get("param")
+    if isinstance(param, str):
+        safe_error["param"] = param
+    if upstream_status is not None:
+        safe_error["status_code"] = upstream_status
+    return (
+        json.dumps({"error": safe_error}, ensure_ascii=False, separators=(",", ":")),
+        code,
+        error_type,
+        upstream_status,
+    )
+
+
+def _upstream_error_class(
+    code: str, error_type: str, upstream_status: int | None
+) -> type[UpstreamResponseError]:
+    identifiers = {value.casefold() for value in (code, error_type) if value}
+    if upstream_status == 429 or identifiers & _UPSTREAM_RATE_LIMIT_CODES:
+        return UpstreamRateLimitError
+    if (
+        upstream_status is not None and 500 <= upstream_status <= 599
+    ) or identifiers & _UPSTREAM_TRANSIENT_CODES:
+        return UpstreamTransientError
+    return UpstreamResponseError
+
+
+def reject_non_stream_response(stream: Any, *, cancel_ref: Any = None) -> None:
+    """Surface a JSON response before Turnstone arms an SDK stream.
+
+    The SDK raises real HTTP 4xx/5xx responses before returning ``stream``.  A
+    compatibility endpoint can instead acknowledge the request with HTTP 200
+    while returning ``application/json``; without this guard the SDK exposes an
+    empty iterator and Turnstone later reports a misleading stream failure.
+    """
+    response = getattr(stream, "response", None)
+    headers = getattr(response, "headers", None)
+    if response is None or headers is None:
+        return
+    raw_content_type = headers.get("content-type", "")
+    if not isinstance(raw_content_type, str):
+        return
+    content_type = raw_content_type.partition(";")[0].strip().lower()
+    if content_type != "application/json" and not content_type.endswith("+json"):
+        return
+
+    register = getattr(cancel_ref, "register_cancel_handle", None)
+    unregister = getattr(cancel_ref, "unregister_cancel_handle", None)
+    cancellation_registered = False
+    try:
+        if callable(register) and callable(unregister):
+            register(stream)
+            cancellation_registered = True
+        raw_body, truncated = _read_response_prefix(response)
+    except Exception as exc:
+        raise IncompleteStreamError(
+            "backend returned JSON instead of an event stream, but reading the "
+            f"response body failed ({type(exc).__name__})"
+        ) from exc
+    finally:
+        try:
+            stream.close()
+        except Exception:
+            log.debug("openai.stream.invalid_response_close_failed", exc_info=True)
+        if cancellation_registered and callable(unregister):
+            try:
+                unregister(stream)
+            except Exception:
+                log.debug("openai.stream.cancel_handle_unregister_failed", exc_info=True)
+
+    body, code, error_type, upstream_status = _extract_upstream_error(raw_body, truncated=truncated)
+    status_code = getattr(response, "status_code", 0)
+    if not isinstance(status_code, int) or isinstance(status_code, bool):
+        status_code = 0
+    error_class = _upstream_error_class(code, error_type, upstream_status)
+    raise error_class(
+        status_code=status_code,
+        content_type=content_type,
+        body=body,
+        code=code,
+        error_type=error_type,
+        upstream_status_code=upstream_status,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Model capability table
@@ -701,6 +911,8 @@ RETRYABLE_ERROR_NAMES: frozenset[str] = frozenset(
         "APIError",
         "APIConnectionError",
         "RateLimitError",
+        "UpstreamRateLimitError",
+        "UpstreamTransientError",
         "Timeout",
         "APITimeoutError",
         # Transport-level: the drained stream ended with no finish signal

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -27,6 +27,7 @@ from turnstone.core.providers._openai_common import (
     format_citations,
     format_document_wrapper,
     lookup_openai_capabilities,
+    reject_non_stream_response,
     resolve_server_side_tools,
     sanitize_messages,
 )
@@ -590,6 +591,7 @@ class OpenAIResponsesProvider:
 
         refuse_aborted_request(cancel_ref)
         stream = client.responses.create(**kwargs)
+        reject_non_stream_response(stream, cancel_ref=cancel_ref)
         if cancel_ref is not None:
             cancel_ref.append(stream)
         return self._iter_stream(stream, finish_reason_optional=caps.finish_reason_optional)

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -927,6 +927,12 @@ class LLMProvider(Protocol):
         per adapter.  The caller can then close the stream from another
         thread to abort a blocked HTTP read immediately.
 
+        A provider that must read and reject a response body BEFORE that
+        accepted-stream instant may temporarily call the cancel ref's duck-typed
+        ``register_cancel_handle`` / ``unregister_cancel_handle`` pair.  This
+        exposes the closeable response to Stop/deadline without appending it and
+        falsely arming a creation failure.
+
         This is the ONLY transport — single-shot callers drain it through
         :func:`drain_stream` instead of a separate non-streaming entry
         (retired on #831), so per-adapter request shaping cannot drift

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -518,6 +518,11 @@ class _CancelRef(list[Any]):
     classifier, and the per-turn usage-slot resets all key on it.  A
     superseded arrival does not fire it — an orphan must not record
     health or reset the successor's usage slots.
+
+    ``register_cancel_handle`` is the deliberately unarmed sibling used while
+    an adapter validates a non-stream HTTP body.  It publishes the closeable
+    handle for Stop/close, but does not append, set ``armed``, or fire the hook;
+    a rejected response must remain a creation failure.
     """
 
     __slots__ = ("_session", "_my_generation", "_on_first_append", "_armed")
@@ -570,6 +575,28 @@ class _CancelRef(list[Any]):
         if refused:
             with contextlib.suppress(Exception):
                 stream.close()
+
+    def register_cancel_handle(self, handle: Any) -> None:
+        """Publish *handle* for cancellation without arming this attempt."""
+        session = self._session
+        with session._generation_lock:
+            refused = (
+                session._publication_shutdown
+                or self._superseded()
+                or session._cancel_event.is_set()
+            )
+            if not refused:
+                session._cancel_stream = handle
+        if refused:
+            with contextlib.suppress(Exception):
+                handle.close()
+
+    def unregister_cancel_handle(self, handle: Any) -> None:
+        """Clear a still-current cancellation-only handle by identity."""
+        session = self._session
+        with session._generation_lock:
+            if session._cancel_stream is handle:
+                session._cancel_stream = None
 
     @property
     def aborted(self) -> bool:
@@ -1992,7 +2019,19 @@ _BACKEND_NOT_FOUND_EXC_NAMES: frozenset[str] = frozenset({"NotFoundError"})
 _BACKEND_AUTH_EXC_NAMES: frozenset[str] = frozenset(
     {"AuthenticationError", "PermissionDeniedError"}
 )
-_BACKEND_RATE_LIMIT_EXC_NAMES: frozenset[str] = frozenset({"RateLimitError"})
+_BACKEND_RATE_LIMIT_EXC_NAMES: frozenset[str] = frozenset(
+    {"RateLimitError", "UpstreamRateLimitError"}
+)
+_BACKEND_TRANSIENT_EXC_NAMES: frozenset[str] = frozenset({"UpstreamTransientError"})
+# Backend-reported stream errors stay OUT of ``_BACKEND_KNOWN_EXC_NAMES``:
+# their messages can carry a real context-window rejection, which
+# ``_is_ctx_overflow`` must see before the formatter categorizes them.  The
+# OpenAI SDK raises ``APIError`` for an in-band SSE error object;
+# ``UpstreamResponseError`` is Turnstone's equivalent for a compatibility
+# proxy that returns the same error as an HTTP-200 JSON body.  Its classified
+# rate-limit and transient subclasses stay IN the known set above so their
+# token-quota wording cannot be mistaken for context overflow.
+_BACKEND_REPORTED_EXC_NAMES: frozenset[str] = frozenset({"APIError", "UpstreamResponseError"})
 # Mid-response stream deaths: the normalized shape every guarded iterator
 # raises (``IncompleteStreamError`` from ``drain_stream`` /
 # ``transport_guarded``) plus the raw HTTPX/HTTPX2 names for any future
@@ -2012,6 +2051,7 @@ _BACKEND_KNOWN_EXC_NAMES: frozenset[str] = (
     | _BACKEND_NOT_FOUND_EXC_NAMES
     | _BACKEND_AUTH_EXC_NAMES
     | _BACKEND_RATE_LIMIT_EXC_NAMES
+    | _BACKEND_TRANSIENT_EXC_NAMES
     | _BACKEND_STREAM_EXC_NAMES
 )
 
@@ -2056,6 +2096,7 @@ def _is_ctx_overflow(exc: BaseException) -> bool:
         for s in (
             "context length",
             "maximum context",
+            "available context size",
             "context window",
             "context limit",
             "prompt is too long",
@@ -8187,7 +8228,21 @@ class ChatSession:
                 f"{available}{raw_tail}"
             )
 
-        if name not in _BACKEND_KNOWN_EXC_NAMES:
+        try:
+            status_code = getattr(exc, "status_code", None)
+        except Exception:
+            log.debug("session.fatal.status_code_failed", exc_info=True)
+            status_code = None
+        is_http_status_error = (
+            isinstance(status_code, int)
+            and not isinstance(status_code, bool)
+            and 400 <= status_code <= 599
+        )
+        if (
+            name not in _BACKEND_KNOWN_EXC_NAMES
+            and name not in _BACKEND_REPORTED_EXC_NAMES
+            and not is_http_status_error
+        ):
             return None
 
         # Pull backend identity — every branch swallows so a bad
@@ -8239,6 +8294,31 @@ class ChatSession:
                 f"Backend rate-limited ({name}): {provider_label} "
                 f"at {base_url} (model={model_label})."
                 f"{raw_tail}"
+            )
+        if name in _BACKEND_TRANSIENT_EXC_NAMES:
+            return (
+                f"Backend returned a transient application error ({name}): "
+                f"{provider_label} at {base_url} (model={model_label}); retries "
+                f"did not recover it.{raw_tail}"
+            )
+        if name in _BACKEND_REPORTED_EXC_NAMES:
+            return (
+                f"Backend returned an error instead of a usable stream ({name}): "
+                f"{provider_label} at {base_url} (model={model_label})."
+                f"{raw_tail}"
+            )
+        if is_http_status_error:
+            status_label = f"HTTP {status_code}"
+            try:
+                reason = getattr(getattr(exc, "response", None), "reason_phrase", "")
+                if isinstance(reason, str) and reason.strip():
+                    status_label += f" {reason.strip()}"
+            except Exception:
+                log.debug("session.fatal.status_reason_failed", exc_info=True)
+            return (
+                f"Backend request failed ({status_label}): {provider_label} "
+                f"at {base_url} (model={model_label}). The upstream server returned "
+                f"an application error before generation started.{raw_tail}"
             )
         if name in _BACKEND_STREAM_EXC_NAMES:
             # First sentence kept short so Discord's message[:500] cut keeps


### PR DESCRIPTION
## Summary

- detect HTTP 200 JSON error responses before OpenAI SDK streams are armed
- bound diagnostic body reads and expose them to Stop/deadline cancellation without reclassifying creation failures as mid-stream failures
- preserve rate-limit and transient server classifications so retry and context-overflow handling remain correct
- fail closed when redacting ambiguous, truncated, or unparsable JSON payloads
- apply the shared guard to Chat Completions and Responses, including inherited Google/Gemini and xAI adapters

Normal SSE handling remains unchanged. Anthropic and Anthropic-compatible use their separate SDK boundary and need no adapter changes for this issue.

## Validation

- 207 focused provider/session/cancellation tests passed
- 12,345 non-live tests passed; 26 skipped; 15 deselected
- 7 live tests passed; 1 optional Anthropic-compatible live probe skipped because its URL was unset
- Ruff format and lint passed
- mypy passed for all 250 source files

Closes #995