### PR TITLE
Keep structured-memory indexes in schema parity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,6 +362,49 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+def _pg_base_url() -> str:
+    return os.environ.get(
+        "TURNSTONE_TEST_PG_URL",
+        "postgresql+psycopg://postgres:postgres@localhost:5432/turnstone_test",
+    )
+
+
+@pytest.fixture
+def fresh_pg_url(request: pytest.FixtureRequest) -> Iterator[Any]:
+    """Create a throwaway PostgreSQL database for migration-path tests.
+
+    Skips unless the suite is running against PostgreSQL. Tests that exercise
+    migrations from scratch cannot use the shared ``turnstone_test`` schema.
+    """
+    if request.config.getoption("--storage-backend") != "postgresql":
+        pytest.skip("PostgreSQL-only migration path")
+
+    import uuid
+
+    import sqlalchemy as sa
+
+    base = sa.make_url(_pg_base_url())
+    db_name = f"ts_migtest_{uuid.uuid4().hex[:12]}"
+    # CREATE/DROP DATABASE cannot run in a transaction.
+    admin = sa.create_engine(base.set(database="postgres"), isolation_level="AUTOCOMMIT")
+    try:
+        with admin.connect() as conn:
+            conn.execute(sa.text(f'CREATE DATABASE "{db_name}"'))
+        yield base.set(database=db_name)
+    finally:
+        with admin.connect() as conn:
+            # Terminate any lingering backends before dropping the database.
+            conn.execute(
+                sa.text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :d AND pid <> pg_backend_pid()"
+                ),
+                {"d": db_name},
+            )
+            conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin.dispose()
+
+
 @pytest.fixture
 def tmp_db(tmp_path):
     """Provide a temporary SQLite storage backend (singleton registry)."""

--- a/tests/test_migration_concurrency.py
+++ b/tests/test_migration_concurrency.py
@@ -17,53 +17,10 @@ lock path). Runs in CI's ``test-postgres`` job (``--storage-backend=postgresql``
 
 from __future__ import annotations
 
-import os
 import threading
-import uuid
 from typing import Any
 
-import pytest
 import sqlalchemy as sa
-
-
-def _pg_base_url() -> str:
-    return os.environ.get(
-        "TURNSTONE_TEST_PG_URL",
-        "postgresql+psycopg://postgres:postgres@localhost:5432/turnstone_test",
-    )
-
-
-@pytest.fixture
-def fresh_pg_url(request: pytest.FixtureRequest) -> Any:
-    """Create a throwaway PostgreSQL database, yield its URL, drop it after.
-
-    Skips unless the suite is running against PostgreSQL — migrations must run
-    from scratch (so 041's CONCURRENTLY actually executes), which the shared
-    ``turnstone_test`` schema can't provide.
-    """
-    if request.config.getoption("--storage-backend") != "postgresql":
-        pytest.skip("PostgreSQL-only (advisory-lock / CREATE INDEX CONCURRENTLY path)")
-
-    base = sa.make_url(_pg_base_url())
-    db_name = f"ts_migtest_{uuid.uuid4().hex[:12]}"
-    # CREATE/DROP DATABASE can't run in a transaction → AUTOCOMMIT admin engine.
-    admin = sa.create_engine(base.set(database="postgres"), isolation_level="AUTOCOMMIT")
-    try:
-        with admin.connect() as conn:
-            conn.execute(sa.text(f'CREATE DATABASE "{db_name}"'))
-        yield base.set(database=db_name)
-    finally:
-        with admin.connect() as conn:
-            # Terminate any lingering backends before dropping.
-            conn.execute(
-                sa.text(
-                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    "WHERE datname = :d AND pid <> pg_backend_pid()"
-                ),
-                {"d": db_name},
-            )
-            conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{db_name}"'))
-        admin.dispose()
 
 
 class _EngineStub:

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -9,7 +9,9 @@ Nothing else enforces that they agree, so a column added to a migration but not
 to `_schema.py` (or the reverse) would silently give `create_all`-based tests a
 different schema than production — and most tests use `create_all`, so a
 migration bug could pass CI unnoticed.  This test is that enforcement: it fails
-the moment the two paths drift on a table, column, or named constraint.
+the moment the two paths drift on a table, column, named constraint, or selected
+named index definition. Index coverage is opt-in because partial and
+dialect-specific indexes require table-specific normalization.
 
 (It does NOT check seed DATA: `create_all` builds structure only, so migration
 seeds — e.g. the built-in personas — exist only on migrated DBs.  Tests that
@@ -25,6 +27,23 @@ from alembic import command
 from alembic.config import Config
 
 _MIGRATIONS = str(Path(__file__).resolve().parent.parent / "turnstone/core/storage/migrations")
+_STRUCTURED_MEMORY_INDEXES = {
+    "idx_smem_scope": ("scope", "scope_id"),
+    "idx_smem_type": ("type",),
+}
+
+
+def _structured_memory_indexes(inspector: sa.Inspector) -> dict[str, tuple[str, ...]]:
+    indexes: dict[str, tuple[str, ...]] = {}
+    for index in inspector.get_indexes("structured_memories"):
+        name = index.get("name")
+        if name is None or not name.startswith("idx_smem_"):
+            continue
+        columns = index.get("column_names") or []
+        if any(column is None for column in columns):
+            raise AssertionError(f"expression-based structured-memory index: {index}")
+        indexes[name] = tuple(column for column in columns if column is not None)
+    return indexes
 
 
 def _inspect_migrated(db_path: Path) -> sa.Inspector:
@@ -75,6 +94,34 @@ def test_create_all_matches_migrations(tmp_path: Path) -> None:
 
     assert not col_drift, f"column drift: {col_drift}"
     assert not check_drift, f"check-constraint drift: {check_drift}"
+    assert _structured_memory_indexes(mig) == _STRUCTURED_MEMORY_INDEXES
+    assert _structured_memory_indexes(meta) == _STRUCTURED_MEMORY_INDEXES
+
+
+def test_postgresql_structured_memory_indexes_match_both_paths(
+    fresh_pg_url: sa.URL,
+) -> None:
+    from turnstone.core.storage._schema import metadata
+
+    cfg = Config()
+    cfg.set_main_option("script_location", _MIGRATIONS)
+    cfg.set_main_option("sqlalchemy.url", fresh_pg_url.render_as_string(hide_password=False))
+    command.upgrade(cfg, "head")
+
+    engine = sa.create_engine(fresh_pg_url)
+    try:
+        migrated_indexes = _structured_memory_indexes(sa.inspect(engine))
+
+        # The database is fixture-owned and disposable. Rebuild it through the
+        # second schema path so PostgreSQL reflection covers both definitions.
+        metadata.drop_all(engine)
+        metadata.create_all(engine)
+        create_all_indexes = _structured_memory_indexes(sa.inspect(engine))
+    finally:
+        engine.dispose()
+
+    assert migrated_indexes == _STRUCTURED_MEMORY_INDEXES
+    assert create_all_indexes == _STRUCTURED_MEMORY_INDEXES
 
 
 def test_personas_prompt_source_check_present_on_both_paths(tmp_path: Path) -> None:

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -27,6 +27,9 @@ structured_memories = sa.Table(
     sa.UniqueConstraint("name", "scope", "scope_id", name="uq_smem_name_scope"),
 )
 
+sa.Index("idx_smem_type", structured_memories.c.type)
+sa.Index("idx_smem_scope", structured_memories.c.scope, structured_memories.c.scope_id)
+
 # Every metadata-only memory surface shares this projection. Keeping it next
 # to the table definition makes omitting ``content`` a storage contract rather
 # than an endpoint convention that can drift when fields are added.


### PR DESCRIPTION
## Summary

- declare the migration-014 structured-memory indexes in canonical SQLAlchemy metadata
- extend schema parity coverage to pin index names and ordered columns on SQLite and PostgreSQL
- share the disposable PostgreSQL database fixture across migration-path tests

## Verification

- `uv run pytest tests/test_structured_memory_storage.py tests/test_memory_index.py tests/test_schema_parity.py -q` (118 passed, 16 skipped)
- the same affected suite with `--storage-backend=postgresql` (134 passed)
- PostgreSQL schema parity and migration concurrency together (4 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy turnstone`

Closes #1028