### PR TITLE
fix(session): unblock approval-gated soft close

### DIFF
--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -5626,6 +5626,16 @@
               }
             }
           },
+          "409": {
+            "description": "Error 409",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "502": {
             "description": "Error 502",
             "content": {
@@ -6942,7 +6952,7 @@
         "tags": [
           "Coordinator"
         ],
-        "description": "Releases the worker thread + UI listeners and marks the row ``state=closed`` in storage.  The row remains queryable (audit / history) but cannot be reopened \u2014 a closed coordinator is terminal from the manager's perspective. Returns 409 while an accepted live conversation row still requires persistence reconciliation; the coordinator remains loaded and its history journal is retained.",
+        "description": "Releases the worker thread + UI listeners and marks the row ``state=closed`` in storage.  The row remains queryable (audit / history) but cannot be reopened \u2014 a closed coordinator is terminal from the manager's perspective. Returns 409 while an accepted live conversation row still requires persistence reconciliation; the coordinator remains loaded and its history journal is retained. Returns 503 when cancellation cleanup has not yet finished; retrying close is safe.",
         "parameters": [
           {
             "name": "ws_id",

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -167,7 +167,7 @@
         "tags": [
           "Workstreams"
         ],
-        "description": "Unloads the live workstream while preserving storage. Returns 409 when any accepted live conversation row still requires persistence reconciliation; the workstream remains loaded and its history journal is retained.",
+        "description": "Unloads the live workstream while preserving storage. Returns 409 when any accepted live conversation row still requires persistence reconciliation; the workstream remains loaded and its history journal is retained. Returns 503 when cancellation cleanup has not yet finished; retrying close is safe.",
         "parameters": [
           {
             "name": "ws_id",
@@ -221,6 +221,16 @@
           },
           "409": {
             "description": "Error 409",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
             "content": {
               "application/json": {
                 "schema": {

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -12,11 +12,14 @@ import pytest
 from tests._session_helpers import (
     arm_session,
     make_registered_session,
+    make_result,
     make_session,
     provider_shell,
     replace_session_lane,
     scripted_chat_client,
 )
+from turnstone.cli import WorkstreamTerminalUI
+from turnstone.console.coordinator_ui import ConsoleCoordinatorUI
 from turnstone.core.providers import (
     IncompleteStreamError,
     StreamChunk,
@@ -294,6 +297,17 @@ class TestCancelEvent:
         session.cancel()
         session.cancel()  # Double call is harmless
         assert session._cancel_event.is_set()
+
+    def test_close_approval_sweep_preserves_legacy_single_slot_wake(self, tmp_db):
+        ui = NullUI()
+        ui._approval_event = threading.Event()
+        ui._approval_result = (True, "stale")
+        session = _make_session(ui=ui)
+
+        session.resolve_close_approvals()
+
+        assert ui._approval_event.is_set()
+        assert ui._approval_result == (False, None)
 
     def test_cancel_event_cleared_on_send_start(self, tmp_db):
         """send() clears a stale cancel flag before starting."""
@@ -907,6 +921,167 @@ class TestTaskAgentStreamAbort:
         assert isinstance(outcomes[0], GenerationCancelled)
         executor.assert_not_called()
         assert ui._approval_cycles == {}
+
+    def test_soft_close_wakes_main_tool_approval_before_structural_wait(self, tmp_db):
+        """Soft close lets the owning send journal denied TOOL receipts.
+
+        The accepted assistant row owns structural debt before the manual
+        approval gate opens. Cancellation alone advances the gate witness but
+        does not wake its wait; preparation must sweep approvals before it
+        waits for the worker to synthesize the matching TOOL receipt.
+        """
+        ui = ConsoleCoordinatorUI(ws_id="ws-soft-close-gate", user_id="u1")
+        session = _make_registered_session(
+            ui=ui,
+            ws_id="ws-soft-close-gate",
+            user_id="u1",
+        )
+        session._title_generated = True
+        tool_call = {
+            "id": "call-soft-close",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+        executor = MagicMock(return_value=("call-soft-close", "must not run"))
+        send_errors: list[BaseException] = []
+
+        def _prepare(tc: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "call_id": tc["id"],
+                "func_name": "read_file",
+                "header": "Read file",
+                "preview": "",
+                "needs_approval": True,
+                "execute": executor,
+            }
+
+        def _send() -> None:
+            try:
+                session.send("use the tool", acting_user_id="u1")
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                send_errors.append(exc)
+
+        with (
+            patch.object(
+                session,
+                "_stream_response",
+                return_value=make_result(tool_calls=[tool_call]),
+            ),
+            patch.object(session, "_prepare_tool", side_effect=_prepare),
+            patch.object(session, "_evaluate_intent", return_value=None),
+            patch("turnstone.core.policy.evaluate_tool_policies_batch", return_value={}),
+        ):
+            worker = threading.Thread(target=_send, daemon=True)
+            worker.start()
+            try:
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline:
+                    with ui._ws_lock:
+                        if ui._approval_cycles:
+                            break
+                    time.sleep(0.005)
+                with ui._ws_lock:
+                    assert len(ui._approval_cycles) == 1
+                assert session.has_tool_structural_debt() is True
+
+                assert session.prepare_soft_close() is True
+                worker.join(2)
+            finally:
+                session.cancel()
+                ui.resolve_all_approvals(False, "test teardown")
+                worker.join(2)
+
+        assert not worker.is_alive()
+        assert send_errors == []
+        executor.assert_not_called()
+        assert ui._approval_cycles == {}
+        assert session.has_tool_structural_debt() is False
+        assert [turn.role for turn in session.messages][-2:] == [Role.ASSISTANT, Role.TOOL]
+
+    def test_soft_close_cancels_background_cli_approval_without_prompt(self, tmp_db):
+        """A background CLI gate observes close without changing foreground.
+
+        WorkstreamTerminalUI parks on ``_fg_event`` until its workstream is
+        selected. Soft close must still let the worker journal its denied TOOL
+        receipt, but setting the foreground event as the wake mechanism would
+        corrupt live UI state if durability later refused the close.
+        """
+        manager = MagicMock()
+        manager.active_id = "another-workstream"
+        manager.set_state_deferred.return_value = True
+        ui = WorkstreamTerminalUI("cli-background-close", manager)
+        ui.set_foreground(False)
+        session = _make_registered_session(
+            ui=ui,
+            ws_id="cli-background-close",
+        )
+        session._title_generated = True
+        tool_call = {
+            "id": "call-cli-close",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+        executor = MagicMock(return_value=("call-cli-close", "must not run"))
+        send_errors: list[BaseException] = []
+
+        def _prepare(tc: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "call_id": tc["id"],
+                "func_name": "read_file",
+                "header": "Read file",
+                "preview": "",
+                "needs_approval": True,
+                "execute": executor,
+            }
+
+        def _send() -> None:
+            try:
+                session.send("use the tool")
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                send_errors.append(exc)
+
+        with (
+            patch.object(
+                session,
+                "_stream_response",
+                return_value=make_result(tool_calls=[tool_call]),
+            ),
+            patch.object(session, "_prepare_tool", side_effect=_prepare),
+            patch.object(session, "_evaluate_intent", return_value=None),
+            patch("turnstone.core.policy.evaluate_tool_policies_batch", return_value={}),
+            patch("builtins.input", return_value="y") as prompt,
+        ):
+            worker = threading.Thread(target=_send, daemon=True)
+            worker.start()
+            try:
+                deadline = time.monotonic() + 2
+                waiting = False
+                while time.monotonic() < deadline:
+                    with ui._print_lock:
+                        waiting = any(
+                            event_type == "info" and "Waiting for approval" in text
+                            for event_type, text in ui._output_buffer
+                        )
+                    if waiting and session.has_tool_structural_debt():
+                        break
+                    time.sleep(0.005)
+                assert waiting is True
+                assert session.has_tool_structural_debt() is True
+                assert ui._fg_event.is_set() is False
+
+                assert session.prepare_soft_close() is True
+                worker.join(2)
+            finally:
+                session.cancel()
+                ui._fg_event.set()
+                worker.join(2)
+
+        assert not worker.is_alive()
+        assert send_errors == []
+        prompt.assert_not_called()
+        executor.assert_not_called()
+        assert session.has_tool_structural_debt() is False
+        assert [turn.role for turn in session.messages][-2:] == [Role.ASSISTANT, Role.TOOL]
 
     def test_stop_at_task_agent_approval_folds_confirmed_no_effect(self, tmp_db):
         """Stop at consent records a denied, never-executed child as NONE.

--- a/tests/test_close_reason_persistence.py
+++ b/tests/test_close_reason_persistence.py
@@ -16,6 +16,7 @@ from starlette.testclient import TestClient
 import turnstone.server as srv_mod
 from turnstone.core.auth import JWT_AUD_SERVER, create_jwt
 from turnstone.core.metrics import MetricsCollector
+from turnstone.core.session_manager import CloseOutcome
 from turnstone.core.storage._sqlite import SQLiteBackend
 from turnstone.core.workstream import WorkstreamState
 
@@ -67,7 +68,7 @@ def _make_app(storage: Any) -> TestClient:
     mock_ws.parent_ws_id = None
     mock_mgr = MagicMock()
     mock_mgr.get.return_value = mock_ws
-    mock_mgr.close.return_value = True
+    mock_mgr.close_with_outcome.return_value = CloseOutcome.CLOSED
     mock_mgr.list_all.return_value = [mock_ws]
     mock_mgr.max_active = 10
 

--- a/tests/test_coordinator_endpoints.py
+++ b/tests/test_coordinator_endpoints.py
@@ -1145,6 +1145,7 @@ def test_close_returns_409_when_unresolved_persistence_refuses_unload(storage):
     mgr = _build_mgr(storage)
     ws = mgr.create(user_id="user-1")
     ws.session.prepare_soft_close = MagicMock(return_value=False)
+    ws.session.has_unresolved_conversation_persistence = MagicMock(return_value=True)
     client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
 
     resp = client.post(f"/v1/api/workstreams/{ws.id}/close", headers=_COORD_HEADERS)
@@ -1152,6 +1153,24 @@ def test_close_returns_409_when_unresolved_persistence_refuses_unload(storage):
     assert resp.status_code == 409
     assert resp.json() == {"error": "workstream has unresolved persistence"}
     assert mgr.get(ws.id) is ws
+
+
+def test_close_returns_503_when_structural_cleanup_refuses_unload(storage, caplog):
+    mgr = _build_mgr(storage)
+    ws = mgr.create(user_id="user-1")
+    ws.session.prepare_soft_close = MagicMock(return_value=False)
+    ws.session.has_tool_structural_debt = MagicMock(return_value=True)
+    client = _make_client(storage, coord_mgr=mgr, registry=_fake_registry())
+
+    resp = client.post(f"/v1/api/workstreams/{ws.id}/close", headers=_COORD_HEADERS)
+
+    assert resp.status_code == 503
+    assert resp.json() == {"error": "workstream cleanup is still in progress; try again shortly"}
+    assert mgr.get(ws.id) is ws
+    assert any(
+        "session_mgr.close_refused" in record.message and "cleanup_pending" in record.message
+        for record in caplog.records
+    )
 
 
 def test_approve_resolves_ui_event(storage):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -88,6 +88,8 @@ class TestServerSpec:
         assert "history_resync" in events["description"]
         assert "numeric event replay is not a substitute" in events["description"]
         assert "accepted live conversation row" in close["description"]
+        assert "cancellation cleanup" in close["description"]
+        assert "503" in close["responses"]
         assert "handoff_token" in history_schema["properties"]
         assert (
             "Admission of a later row changes the token"
@@ -286,6 +288,8 @@ class TestConsoleSpec:
         assert "history_resync" in events["description"]
         assert "numeric replay is not a substitute" in events["description"]
         assert "accepted live conversation row" in close["description"]
+        assert "cancellation cleanup" in close["description"]
+        assert "503" in close["responses"]
 
     def test_routing_paths_and_extended_response_contracts(self):
         from turnstone.api.console_spec import build_console_spec
@@ -301,6 +305,7 @@ class TestConsoleSpec:
 
         coordinator_approve = paths["/v1/api/workstreams/{ws_id}/approve"]["post"]
         coordinator_cancel = paths["/v1/api/workstreams/{ws_id}/cancel"]["post"]
+        routed_close = paths["/v1/api/route/workstreams/{ws_id}/close"]["post"]
         assert coordinator_approve["responses"]["200"]["content"]["application/json"]["schema"] == {
             "$ref": "#/components/schemas/ApproveResponse"
         }
@@ -308,6 +313,7 @@ class TestConsoleSpec:
             "$ref": "#/components/schemas/CancelResponse"
         }
         assert coordinator_cancel["requestBody"]["required"] is False
+        assert "409" in routed_close["responses"]
 
     def test_route_create_and_live_contracts(self):
         from turnstone.api.console_spec import build_console_spec

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -29,7 +29,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from turnstone.core.model_registry import ModelClientConstructionError, UnknownModelAliasError
-from turnstone.core.session_manager import SessionKindAdapter, SessionManager
+from turnstone.core.session_manager import CloseOutcome, SessionKindAdapter, SessionManager
 from turnstone.core.workstream import (
     BULK_CLOSE_STATE_VALUES,
     Workstream,
@@ -1592,6 +1592,7 @@ def test_close_last_workstream_succeeds() -> None:
 
 def test_close_unknown_returns_false() -> None:
     mgr, _, _ = _make_manager()
+    assert mgr.close_with_outcome("not-there") is CloseOutcome.NOT_FOUND
     closed = mgr.close("not-there")
     assert closed is False
 

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -1305,7 +1305,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "Proxy workstream close to routed node",
         request_model=CloseWorkstreamRequest,
         response_model=StatusResponse,
-        error_codes=[400, 403, 404, 502, 503],
+        error_codes=[400, 403, 404, 409, 502, 503],
         tags=["Routing"],
     ),
     EndpointSpec(
@@ -1547,7 +1547,9 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
             "/ history) but cannot be reopened — a closed coordinator is "
             "terminal from the manager's perspective. Returns 409 while an "
             "accepted live conversation row still requires persistence reconciliation; "
-            "the coordinator remains loaded and its history journal is retained."
+            "the coordinator remains loaded and its history journal is retained. "
+            "Returns 503 when cancellation cleanup has not yet finished; retrying "
+            "close is safe."
         ),
         response_model=StatusResponse,
         error_codes=[403, 404, 409, 500, 503],

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -103,11 +103,12 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
             "Unloads the live workstream while preserving storage. Returns 409 "
             "when any accepted live conversation row still requires persistence "
             "reconciliation; the workstream remains loaded and its history journal "
-            "is retained."
+            "is retained. Returns 503 when cancellation cleanup has not yet "
+            "finished; retrying close is safe."
         ),
         request_model=CloseWorkstreamRequest,
         response_model=StatusResponse,
-        error_codes=[400, 404, 409],
+        error_codes=[400, 404, 409, 503],
         tags=["Workstreams"],
     ),
     # --- Chat ---

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -158,11 +158,20 @@ class TerminalUI(SessionUI):
         sys.stdout.write("\n")
         sys.stdout.flush()
 
+    @staticmethod
+    def _approval_was_cancelled(items: list[dict[str, Any]]) -> bool:
+        """Whether a close/Stop retired the operation owning this gate."""
+        return any(
+            bool(getattr(item.get("_approval_cancel_witness"), "aborted", False)) for item in items
+        )
+
     def approve_tools(self, items: list[dict[str, Any]]) -> tuple[bool, str | None]:
         """Display tool previews and prompt for batch approval.
 
         Returns (approved: bool, feedback: str | None).
         """
+        if self._approval_was_cancelled(items):
+            return False, "Cancelled by user"
         pending = [it for it in items if it.get("needs_approval") and not it.get("error")]
 
         # Evaluate admin tool policies (deny/allow/ask) before prompting.
@@ -194,6 +203,12 @@ class TerminalUI(SessionUI):
                         ]
             except Exception:
                 logging.getLogger(__name__).debug("Policy evaluation unavailable", exc_info=True)
+
+        # Policy lookup is the one potentially blocking step before the prompt.
+        # Recheck ownership so a close that landed during storage I/O cannot
+        # paint or solicit approval for a retired tool batch.
+        if self._approval_was_cancelled(items):
+            return False, "Cancelled by user"
 
         with self._print_lock:
             # Print all headers, previews, and heuristic verdicts
@@ -542,7 +557,14 @@ class WorkstreamTerminalUI(TerminalUI):
             )
             if tool_names:
                 self._buffer("info", f"{YELLOW}Waiting for approval: {tool_names}{RESET}")
-            self._fg_event.wait()
+            # Foreground state is persistent, so close must not set this event
+            # merely to wake us: a later durability refusal would leave a live
+            # background workstream acting foregrounded. Poll the gate's
+            # monotonic cancellation witness instead; the bounded interval is
+            # comfortably inside soft-close's structural grace period.
+            while not self._fg_event.wait(timeout=0.05):
+                if self._approval_was_cancelled(items):
+                    return False, "Cancelled by user"
         return super().approve_tools(items)
 
     def flush_buffer(self) -> None:

--- a/turnstone/core/adapters/_ui_cleanup.py
+++ b/turnstone/core/adapters/_ui_cleanup.py
@@ -15,6 +15,8 @@ import contextlib
 import queue
 from typing import TYPE_CHECKING, Any
 
+from turnstone.core.workstream import concrete_method
+
 if TYPE_CHECKING:
     from turnstone.core.session import SessionUI
     from turnstone.core.workstream import Workstream
@@ -49,10 +51,20 @@ def cleanup_session_ui(ws: Workstream) -> None:
         ws.session.cancel()
     ui = ws.ui
     if ui is not None:
-        if hasattr(ui, "resolve_all_approvals"):
+        resolve_close = (
+            concrete_method(ws.session, "resolve_close_approvals")
+            if ws.session is not None
+            else None
+        )
+        if resolve_close is not None:
+            # Production ChatSession owns the one close-sweep helper shared by
+            # soft-close preparation, direct close, and adapter cleanup.
+            with contextlib.suppress(Exception):
+                resolve_close()
+        elif hasattr(ui, "resolve_all_approvals"):
             # Deny + unblock EVERY live approval cycle — with parallel
-            # task agents several gate threads can be parked at once,
-            # and each must wake with its own (denied) result.
+            # task agents several gate threads can be parked at once. This is
+            # the compatibility path for non-ChatSession implementations.
             with contextlib.suppress(Exception):
                 ui.resolve_all_approvals(False, "Workstream closed")
         elif hasattr(ui, "_approval_event"):

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -4904,18 +4904,10 @@ class ChatSession:
         if main_stream is not None:
             with contextlib.suppress(Exception):
                 main_stream.close()
-        # Direct close paths do not all pass through the adapter cleanup that
-        # normally resolves UI gates first.  Wake every cycle that was already
-        # registered when the terminal latch landed; a gate still in its
-        # pre-registration window observes the epoch above immediately after
-        # inserting itself and self-denies.  Together those two arms make close
-        # exhaustive without coupling the UI lock to the generation lock.
-        resolve_all_approvals = getattr(self.ui, "resolve_all_approvals", None)
-        if resolve_all_approvals is not None:
-            try:
-                resolve_all_approvals(False, "Workstream closed")
-            except Exception:
-                log.debug("ui.resolve_all_approvals raised during close", exc_info=True)
+        # Direct close paths do not all pass through adapter cleanup.  Use the
+        # same workstream-wide sweep as soft-close preparation so registered
+        # cycles and pre-cycle Smart Approval waits cannot strand teardown.
+        self.resolve_close_approvals()
         # Refuse new child model calls and abort every registered child stream.
         # The shutdown latch shares the registration lock, so a racing run is
         # either included in this snapshot or born aborted.
@@ -9226,6 +9218,34 @@ class ChatSession:
                 with contextlib.suppress(OSError, ProcessLookupError):
                     proc.kill()
 
+    def resolve_close_approvals(self, feedback: str = "Workstream closed") -> None:
+        """Deny every approval wait that could otherwise strand close.
+
+        ``resolve_all_approvals`` covers both registered cycles and the
+        pre-cycle Smart Approval verdict wait. Older single-slot UIs retain
+        their event wake as a compatibility floor. The sweep is idempotent
+        because soft-close preparation, adapter cleanup, and direct ``close()``
+        can all converge on the same terminal session.
+        """
+        ui: Any = self.ui
+        resolve_all = getattr(ui, "resolve_all_approvals", None)
+        if callable(resolve_all):
+            try:
+                resolve_all(False, feedback)
+            except Exception:
+                log.debug("ui.resolve_all_approvals raised during close", exc_info=True)
+            return
+
+        approval_event = getattr(ui, "_approval_event", None)
+        if approval_event is None:
+            return
+        try:
+            if hasattr(ui, "_approval_result"):
+                ui._approval_result = (False, None)
+            approval_event.set()
+        except Exception:
+            log.debug("legacy approval wake raised during close", exc_info=True)
+
     def _check_cancelled(self, my_generation: int = 0) -> None:
         """Raise ``GenerationCancelled`` if cancellation has been requested
         or if this thread belongs to an orphaned generation (force cancel).
@@ -10157,6 +10177,13 @@ class ChatSession:
                 self._soft_close_preparing = False
                 self._tool_structural_condition.notify_all()
             raise
+
+        # Cancellation advances every gate's monotonic witness, while this
+        # sweep supplies the wake edge.  Run it before waiting for structural
+        # debt: the owning worker cannot journal denied TOOL receipts until its
+        # approval wait returns.  "requested" remains truthful if later
+        # durability reconciliation refuses the close and keeps the session.
+        self.resolve_close_approvals("Workstream close requested")
 
         deadline = time.monotonic() + _SOFT_CLOSE_STRUCTURAL_WAIT_SECONDS
         with self._tool_structural_condition:

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -10,6 +10,7 @@ persistence, per-ws lock refcount for concurrent lazy rehydrate.
 from __future__ import annotations
 
 import contextlib
+import enum
 import functools
 import threading
 import time
@@ -39,6 +40,15 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
+class CloseOutcome(enum.Enum):
+    """Detailed soft-close result for callers that expose refusal reasons."""
+
+    CLOSED = "closed"
+    NOT_FOUND = "not_found"
+    UNRESOLVED_PERSISTENCE = "unresolved_persistence"
+    CLEANUP_PENDING = "cleanup_pending"
+
+
 def _session_has_unresolved_persistence(session: Any) -> bool:
     """Read the concrete ChatSession hook without MagicMock auto-vivification.
 
@@ -47,6 +57,12 @@ def _session_has_unresolved_persistence(session: Any) -> bool:
     Retirement scans use :func:`_session_persistence_blocks_retirement`.
     """
     check = concrete_method(session, "has_unresolved_conversation_persistence")
+    return bool(check()) if check is not None else False
+
+
+def _session_has_tool_structural_debt(session: Any) -> bool:
+    """Read the concrete structural-cleanup hook after close preparation."""
+    check = concrete_method(session, "has_tool_structural_debt")
     return bool(check()) if check is not None else False
 
 
@@ -1918,30 +1934,34 @@ class SessionManager:
     # ------------------------------------------------------------------
 
     def close(self, ws_id: str) -> bool:
-        """Soft-close one incarnation on the stable per-id lifecycle lane."""
+        """Soft-close one incarnation, preserving the historical bool API."""
+        return self.close_with_outcome(ws_id) is CloseOutcome.CLOSED
+
+    def close_with_outcome(self, ws_id: str) -> CloseOutcome:
+        """Soft-close on the stable per-id lane and retain refusal detail."""
         with self._id_lifecycle(ws_id):
             return self._close_serialized(ws_id)
 
-    def _close_serialized(self, ws_id: str) -> bool:
+    def _close_serialized(self, ws_id: str) -> CloseOutcome:
         """Soft-close: unload from memory + mark state=closed in storage.
 
-        Returns ``True`` when a live workstream was removed,
-        ``False`` if the id wasn't tracked.
+        The detailed result lets HTTP callers distinguish an unresolved
+        durability conflict from bounded cleanup that has not finished yet.
         """
         with self._lock:
             ws = self._workstreams.get(ws_id)
             if ws is None:
-                return False
+                return CloseOutcome.NOT_FOUND
             if (
                 ws._create_publication_active
                 and ws._create_publication_thread == threading.get_ident()
             ):
-                return False
+                return CloseOutcome.NOT_FOUND
 
         with ws._lifecycle_lock:
             with self._lock:
                 if self._workstreams.get(ws_id) is not ws:
-                    return False
+                    return CloseOutcome.NOT_FOUND
             # Close admission must become terminal to dispatch before the
             # session fence begins. ``prepare_soft_close`` may wait for an
             # admitted durability batch; leaving ``_closed`` false across that
@@ -1951,18 +1971,30 @@ class SessionManager:
             # this the linearization point for close versus dispatch.
             with ws._lock:
                 if ws._closed:
-                    return False
+                    return CloseOutcome.NOT_FOUND
                 ws._closed = True
                 ws._state_revision += 1
 
             prepared = False
             try:
                 if not _session_prepare_soft_close(ws.session):
-                    # An accepted conversation row is still unresolved.
-                    # Removing the sole live handoff journal would make that
-                    # row disappear on reopen; retain the exact workstream so
-                    # storage recovery can reconcile it idempotently.
-                    return False
+                    # The first failed fence wins the response classification.
+                    # Structural debt means a cancelled turn still needs to
+                    # journal its terminal TOOL receipts. Otherwise preserve
+                    # the historical durability-conflict classification when
+                    # the accepted conversation row is still unresolved.
+                    if _session_has_tool_structural_debt(ws.session):
+                        outcome = CloseOutcome.CLEANUP_PENDING
+                    elif _session_has_unresolved_persistence(ws.session):
+                        outcome = CloseOutcome.UNRESOLVED_PERSISTENCE
+                    else:
+                        outcome = CloseOutcome.CLEANUP_PENDING
+                    log.warning(
+                        "session_mgr.close_refused ws=%s reason=%s",
+                        ws_id[:8],
+                        outcome.value,
+                    )
+                    return outcome
                 prepared = True
             finally:
                 if not prepared:
@@ -1976,7 +2008,7 @@ class SessionManager:
                         ws._state_revision += 1
             with self._lock:
                 if self._workstreams.get(ws_id) is not ws:
-                    return False
+                    return CloseOutcome.NOT_FOUND
                 self._workstreams.pop(ws_id, None)
                 was_unadvertised = self._pending_creates.get(ws_id) is ws
                 if was_unadvertised:
@@ -1999,7 +2031,7 @@ class SessionManager:
                     self._persist_closed_state(ws)
             if self._event_emitter is not None and not was_unadvertised:
                 self._event_emitter.emit_closed(ws_id, name=ws.name)
-            return True
+            return CloseOutcome.CLOSED
 
     def set_state(
         self,

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -42,7 +42,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from turnstone.core.log import get_logger
-from turnstone.core.session_manager import WorkstreamAlreadyExistsError
+from turnstone.core.session_manager import CloseOutcome, WorkstreamAlreadyExistsError
 from turnstone.core.session_replay import session_replay_preamble
 from turnstone.core.session_ui_base import CrossPrincipalApprovalError
 from turnstone.core.workstream import (
@@ -1042,16 +1042,18 @@ def make_close_handler(
         ws_before = mgr.get(ws_id)
         if ws_before is None:
             return JSONResponse({"error": cfg.not_found_label}, status_code=404)
-        if not await asyncio.to_thread(mgr.close, ws_id):
-            # A durability-poisoned session deliberately refuses soft close so
-            # its live journal cannot be discarded. Distinguish that conflict
-            # from the ordinary get-vs-close race where another caller already
-            # removed the workstream.
-            if mgr.get(ws_id) is not None:
-                return JSONResponse(
-                    {"error": "workstream has unresolved persistence"},
-                    status_code=409,
-                )
+        close_outcome = await asyncio.to_thread(mgr.close_with_outcome, ws_id)
+        if close_outcome is CloseOutcome.UNRESOLVED_PERSISTENCE:
+            return JSONResponse(
+                {"error": "workstream has unresolved persistence"},
+                status_code=409,
+            )
+        if close_outcome is CloseOutcome.CLEANUP_PENDING:
+            return JSONResponse(
+                {"error": "workstream cleanup is still in progress; try again shortly"},
+                status_code=503,
+            )
+        if close_outcome is not CloseOutcome.CLOSED:
             return JSONResponse({"error": cfg.not_found_label}, status_code=404)
 
         storage = getattr(request.app.state, "auth_storage", None)


### PR DESCRIPTION
## Summary

- deny and wake every approval gate before soft close waits on tool structural debt
- make background CLI approval waits cancellation-aware without mutating persistent foreground state
- preserve close refusal detail: 409 for unresolved persistence and 503 for cleanup still in progress, with regenerated OpenAPI contracts

## Validation

- uv run ruff format --check .
- uv run ruff check .
- uv run mypy turnstone
- uv run pytest -q (12,417 passed, 30 skipped)
- uv run python scripts/recovery_e2e.py --scenario all (all scenarios emitted their RECOVERY-READY marker; exit 0)

Closes #1013