### PR TITLE
fix: make tool approval timeout configurable

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -36,6 +36,21 @@ users to the admin Settings API.
 
 ---
 
+## Approval Wait Timeout
+
+`tools.approval_timeout_seconds` controls how long a workstream waits for a
+human approval decision. The default `0` disables passive timeout denial: the
+workstream waits until an authorized user approves or rejects the request, or
+until the workstream is cancelled or closed. Set `3600` to restore the previous
+one-hour behavior.
+
+The value is captured when each approval batch begins. A hot reload therefore
+affects the next approval without changing the deadline of a request already
+waiting. This setting does not make approvals durable across process restarts;
+pending approval cycles remain in memory.
+
+---
+
 ## Per-Model Sampling Overrides
 
 The global `model.temperature`, `model.max_tokens`, and `model.reasoning_effort`
@@ -253,7 +268,7 @@ initialization:
 |---------|----------|
 | `model` | default_alias, auth_audience_allowlist, auth_fail_closed, temperature, max_tokens, reasoning_effort, task_alias, task_effort |
 | `session` | instructions, retention_days, compact_max_tokens, auto_compact_pct |
-| `tools` | timeout, truncation, agent_max_turns, skip_permissions, search, search_threshold, search_max_results |
+| `tools` | timeout, approval_timeout_seconds, truncation, agent_max_turns, skip_permissions, search, search_threshold, search_max_results |
 | `server` | workstream_idle_timeout, max_workstreams |
 | `cluster` | node_fan_out_limit, mcp_max_servers |
 | `mcp` | config_path, registry_url |
@@ -463,8 +478,8 @@ reload.
 - New workstreams pick up updated values immediately (via `session_factory`)
 - Most workstream/session settings remain the snapshot captured at creation or
   resume. Component docs call out deliberate live-read exceptions; for
-  example, Smart Approval settings are snapshotted coherently at the start of
-  each approval batch.
+  example, Smart Approval settings and the human approval timeout are
+  snapshotted at the start of each approval batch.
 - Settings marked `restart_required=True` need a server restart to take effect
 
 ### Model-definition reloads

--- a/tests/test_session_manager_lifecycle_races.py
+++ b/tests/test_session_manager_lifecycle_races.py
@@ -131,6 +131,9 @@ class _DurabilitySession(FakeSession):
         self.shutdown_entered.set()
         ChatSession.shutdown_publication_and_drain_durability(self)  # type: ignore[arg-type]
 
+    def resolve_close_approvals(self) -> None:
+        pass
+
 
 class _ReplaceAfterSnapshotStorage(FakeStorage):
     """Replace A immediately after returning its first open snapshot."""

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -2829,6 +2829,61 @@ def _wait_for_cycles(ui: SessionUIBase, count: int, deadline: float = 5.0) -> No
     raise AssertionError(f"never saw {count} live cycles")
 
 
+def test_zero_approval_timeout_waits_until_explicit_resolution() -> None:
+    """The registry's zero sentinel reaches ``Event.wait`` as ``None``."""
+    ui = _make_ui()
+    item = _pending_item("no-timeout")
+    item["_approval_wait_seconds"] = None
+
+    with _gate_harness(ui) as spawn:
+        gate, outcome = spawn(item)
+        _wait_for_cycles(ui, 1)
+        assert gate.is_alive(), "zero was passed through as an immediate timeout"
+        assert ui.resolve_approval(True, "approved later", call_id="no-timeout") is not None
+        gate.join(timeout=2.0)
+
+    assert not gate.is_alive()
+    assert outcome == {"approved": True, "feedback": "approved later"}
+
+
+def test_hard_delete_terminal_barrier_wakes_unbounded_approval() -> None:
+    """The hard-delete barrier signals gates after advancing their witness."""
+    from tests._session_helpers import make_session
+    from turnstone.core.session import _ApprovalCancelWitness
+
+    session = make_session(ws_id="hard-delete-approval")
+    ui = session.ui
+    item = _pending_item("hard-delete-call")
+    item["_approval_cancel_witness"] = _ApprovalCancelWitness(session)
+    item["_approval_wait_seconds"] = None
+
+    with _gate_harness(ui) as spawn:
+        gate, outcome = spawn(item)
+        _wait_for_cycles(ui, 1)
+        session.shutdown_publication_and_drain_durability()
+        gate.join(timeout=2.0)
+
+    assert not gate.is_alive()
+    assert outcome == {"approved": False, "feedback": "Workstream closed"}
+    assert ui._approval_cycles == {}
+
+
+def test_finite_approval_timeout_uses_captured_batch_value() -> None:
+    """A positive setting retains passive denial and its exact audit text."""
+    ui = _make_ui()
+    item = _pending_item("finite-timeout")
+    item["_approval_wait_seconds"] = 0.01
+
+    with _patch_get_storage(MagicMock()), _patch_policies({}):
+        approved, feedback = ui.approve_tools([item])
+
+    assert approved is False
+    assert feedback == "Approval timed out after 0.01s"
+    assert item["denied"] is True
+    assert item["denial_msg"] == "Denied by user: Approval timed out after 0.01s"
+    assert ui._recent_decisions["finite-timeout"] == ("timeout", None)
+
+
 def test_concurrent_gates_resolve_independently() -> None:
     """THE cross-approval regression: two parallel gates, two separate
     decisions.  Approving A's cycle must not wake B, and B's later
@@ -4037,8 +4092,8 @@ def test_concurrent_smart_gate_and_human_gate() -> None:
         assert box_a["approved"] is True
 
 
-def test_chat_session_stamps_one_smart_config_snapshot_without_mutating_ui() -> None:
-    """The gate producer copies one JudgeConfig generation onto every item."""
+def test_chat_session_stamps_live_approval_config_without_mutating_ui() -> None:
+    """Each batch captures Smart settings plus the current human deadline."""
     from turnstone.core.judge import JudgeConfig
     from turnstone.core.session import ChatSession
 
@@ -4054,13 +4109,30 @@ def test_chat_session_stamps_one_smart_config_snapshot_without_mutating_ui() -> 
         confidence_threshold=0.87,
         timeout=4.5,
     )
+    session._config_store = MagicMock()
+    session._config_store.get.return_value = 0
+    session._approval_wait_seconds.side_effect = lambda: ChatSession._approval_wait_seconds(session)
     items = [_pending_item("snapshot-a"), _pending_item("snapshot-b")]
 
     ChatSession._push_smart_approval_config(session, items)
 
     snapshot = items[0]["_smart_approval_config"]
-    assert snapshot == _SmartApprovalConfig(enabled=True, threshold=0.87, wait_seconds=4.5)
+    assert snapshot == _SmartApprovalConfig(
+        enabled=True,
+        threshold=0.87,
+        wait_seconds=4.5,
+    )
     assert items[1]["_smart_approval_config"] is snapshot
+    assert items[0]["_approval_wait_seconds"] is None
+    assert items[1]["_approval_wait_seconds"] is None
+
+    # A hot reload affects the next gate but cannot mutate this batch's
+    # already-captured immutable deadline.
+    session._config_store.get.return_value = 90_000
+    next_items = [_pending_item("snapshot-next")]
+    ChatSession._push_smart_approval_config(session, next_items)
+    assert next_items[0]["_approval_wait_seconds"] == 90_000.0
+    assert items[0]["_approval_wait_seconds"] is None
     assert (
         ui.smart_approvals_enabled,
         ui.smart_approval_threshold,

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from turnstone.core.settings_registry import (
@@ -53,6 +55,29 @@ class TestValidateKey:
         assert defn.default is False  # opt-in: off by default
         assert defn.section == "judge"
         assert "judge.smart_approvals" in SETTINGS
+
+    def test_approval_timeout_defaults_to_waiting_indefinitely(self):
+        defn = validate_key("tools.approval_timeout_seconds")
+        assert defn.type == "int"
+        assert defn.default == 0
+        assert defn.min_value == 0
+        assert defn.max_value == int(threading.TIMEOUT_MAX)
+        assert defn.section == "tools"
+        assert "0 = wait indefinitely" in defn.description
+
+        assert validate_value("tools.approval_timeout_seconds", 0) == 0
+        assert validate_value("tools.approval_timeout_seconds", "90000") == 90_000
+        assert validate_value(
+            "tools.approval_timeout_seconds",
+            int(threading.TIMEOUT_MAX),
+        ) == int(threading.TIMEOUT_MAX)
+        with pytest.raises(ValueError, match="minimum"):
+            validate_value("tools.approval_timeout_seconds", -1)
+        with pytest.raises(ValueError, match="maximum"):
+            validate_value(
+                "tools.approval_timeout_seconds",
+                int(threading.TIMEOUT_MAX) + 1,
+            )
 
     def test_memory_index_over_budget_notice_is_opt_in(self):
         defn = validate_key("memory.model_index_over_budget_notice")

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -193,7 +193,10 @@ from turnstone.core.preview import (
 from turnstone.core.ratelimit import TokenBucket
 from turnstone.core.safety import is_command_blocked, sanitize_command
 from turnstone.core.session_worker import WorkerClaim, current_worker_claim
-from turnstone.core.settings_registry import DEFAULT_AUTO_COMPACT_PCT
+from turnstone.core.settings_registry import (
+    DEFAULT_APPROVAL_TIMEOUT_SECONDS,
+    DEFAULT_AUTO_COMPACT_PCT,
+)
 from turnstone.core.skill_field_validation import SKILL_RUNTIME_CONFIG_FIELDS
 from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
 from turnstone.core.storage import (
@@ -10492,6 +10495,11 @@ class ChatSession:
                 structural_condition.notify_all()
             durability_high_water = self._durability_next_ticket
 
+        # Hard delete is terminal even when its durable outcome is ambiguous.
+        # Wake registered cycles and pre-cycle Smart Approval waits here: the
+        # retained-tombstone path deliberately skips ordinary UI cleanup.
+        self.resolve_close_approvals()
+
         terminal_error: BaseException | None = None
         if structural_debt is not None:
             try:
@@ -11491,8 +11499,9 @@ class ChatSession:
                             "needs_approval": True,
                             # Synchronization-only state. SessionUIBase projects
                             # approval items through an explicit wire allowlist,
-                            # so this witness never crosses SSE / persistence.
+                            # so these fields never cross SSE / persistence.
                             "_approval_cancel_witness": budget_cancel_witness,
+                            "_approval_wait_seconds": self._approval_wait_seconds(),
                         }
                     ]
                 )
@@ -17535,17 +17544,28 @@ class ChatSession:
     # Phase 2 — approve: display all previews, single prompt (serial)
     # Phase 3 — execute: run approved tools (parallel if multiple)
 
+    def _approval_wait_seconds(self) -> float | None:
+        """Resolve the live human-approval deadline; zero means unbounded."""
+        timeout_seconds = DEFAULT_APPROVAL_TIMEOUT_SECONDS
+        if self._config_store is not None:
+            timeout_seconds = self._config_store.get(
+                "tools.approval_timeout_seconds",
+                DEFAULT_APPROVAL_TIMEOUT_SECONDS,
+            )
+        return float(timeout_seconds) if timeout_seconds > 0 else None
+
     def _push_smart_approval_config(self, items: list[dict[str, Any]]) -> None:
         """Stamp one coherent live Smart Approvals config on a gate batch.
 
         Called just before EVERY ``approve_tools`` — the main loop's and
         each sub-agent gate's — so a hot-reloaded ``judge.*`` change
-        takes effect on the next batch whichever path gates it.  The snapshot
+        takes effect on the next batch whichever path gates it. The snapshot
         rides the private prepared-item channel so parallel task-agent gates
-        cannot combine fields from different hot-reload generations.  Only
+        cannot combine fields from different hot-reload generations. Only
         SessionUIBase carries this gate; CLI/eval UIs keep their own approval
-        behavior.  The feature stays inert unless both the judge and Smart
-        Approvals are enabled in this exact snapshot.
+        behavior. The feature stays inert unless both the judge and Smart
+        Approvals are enabled in this exact snapshot. The same private batch
+        channel carries the independently resolved human wait deadline.
         """
         from turnstone.core.session_ui_base import SessionUIBase, _SmartApprovalConfig
 
@@ -17556,8 +17576,10 @@ class ChatSession:
                 threshold=jc.confidence_threshold if jc is not None else 0.95,
                 wait_seconds=jc.timeout if jc is not None else 0.0,
             )
+            approval_wait_seconds = self._approval_wait_seconds()
             for item in items:
                 item["_smart_approval_config"] = snapshot
+                item["_approval_wait_seconds"] = approval_wait_seconds
 
     def _execute_tools(
         self,

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -2179,7 +2179,7 @@ class SessionUIBase:
         7. Check the batch's private cancellation witness around every
            pre-cycle wait/publication, register an :class:`ApprovalCycle`,
            re-check once more, emit its ``approve_request`` card, and block on
-           the CYCLE's event up to ``_APPROVAL_WAIT_TIMEOUT``.
+           the CYCLE's event up to the batch's configured human wait deadline.
 
         ``__budget_override__`` is interactive-only today (coord
         workstreams don't have token budgets), but the carve-out check
@@ -2218,10 +2218,10 @@ class SessionUIBase:
                 self._end_approval_admission()
 
         # Production ChatSession gates carry the coherent judge-config
-        # snapshot captured for THIS batch.  Parallel task-agent gates may be
+        # snapshot captured for THIS batch. Parallel task-agent gates may be
         # queued while another batch observes a hot reload; reading mutable UI
         # attributes here would let one gate combine the other's enabled flag,
-        # threshold, and timeout.  Direct/legacy UI callers do not stamp the
+        # threshold, and timeout. Direct/legacy UI callers do not stamp the
         # private field, so retain their established instance-attribute path.
         stamped_configs = [it.get("_smart_approval_config") for it in items]
         if any(isinstance(cfg, _SmartApprovalConfig) for cfg in stamped_configs):
@@ -2240,6 +2240,17 @@ class SessionUIBase:
                 self.smart_approval_threshold,
                 self.smart_approval_wait_seconds,
             )
+
+        # The independently configured human wait uses the same immutable
+        # per-item channel. Every member must carry one identical value; a
+        # partial/mixed stamp falls back to the historical one-hour deadline.
+        approval_wait_seconds: float | None = float(self._APPROVAL_WAIT_TIMEOUT)
+        if items and all("_approval_wait_seconds" in item for item in items):
+            candidate = items[0]["_approval_wait_seconds"]
+            if all(item["_approval_wait_seconds"] == candidate for item in items) and (
+                candidate is None or isinstance(candidate, (int, float))
+            ):
+                approval_wait_seconds = float(candidate) if candidate is not None else None
 
         # The batch's judge generation, stamped by ``_evaluate_intent`` —
         # one event per spawn, shared by every item in the batch.  Read
@@ -2579,17 +2590,21 @@ class SessionUIBase:
         for persist in deferred_auto_audit:
             persist()
         try:
-            if not cycle.event.wait(timeout=self._APPROVAL_WAIT_TIMEOUT):
+            if not cycle.event.wait(timeout=approval_wait_seconds):
+                # ``Event.wait(None)`` only returns after the event is set.
+                # Reaching this branch therefore proves a finite deadline.
+                assert approval_wait_seconds is not None
                 # Approval timed out (e.g., user disconnected). Deny via
                 # resolve_approval so verdicts and state are updated
                 # consistently — targeted at THIS cycle so a sibling gate
                 # timing out can't deny someone else's round.  Feedback
-                # string derives from ``_APPROVAL_WAIT_TIMEOUT`` so the
-                # text follows the constant if the timeout knob moves.
+                # derives from this cycle's immutable config snapshot so a
+                # hot reload cannot make the audit text disagree with the
+                # deadline that actually fired.
                 log.warning("Approval timed out for ws_id=%s", self.ws_id)
                 self.resolve_approval(
                     False,
-                    f"Approval timed out after {self._APPROVAL_WAIT_TIMEOUT}s",
+                    f"Approval timed out after {approval_wait_seconds:g}s",
                     timeout=True,
                     cycle_id=cycle.cycle_id,
                 )
@@ -2881,11 +2896,9 @@ class SessionUIBase:
     # can't grow unbounded. FIFO eviction on insert.
     _LLM_VERDICT_CACHE_MAX = 50
 
-    # Hard cap on how long a worker thread blocks waiting for an
-    # approval decision. Subclasses' ``approve_tools`` references this
-    # rather than the literal so a future
-    # ``settings.approval_timeout_seconds`` knob can swap it in one
-    # place.
+    # Compatibility fallback for direct/legacy SessionUIBase callers whose
+    # items were not produced by ChatSession. Production batches carry the
+    # live ``tools.approval_timeout_seconds`` value per private approval item.
     _APPROVAL_WAIT_TIMEOUT = 3600
 
     def on_intent_verdict(

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -9,6 +9,7 @@ excluded — they are needed before storage is available.
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -36,6 +37,12 @@ class SettingDef:
 # with the ChatSession constructor (default + sub-0.1 coercion fallback) so the
 # "invalid → default" behavior cannot drift between the registry and the engine.
 DEFAULT_AUTO_COMPACT_PCT = 0.8
+
+# A human approval is an operator-owned wait, not an execution deadline. Zero
+# disables passive timeout denial; cancel/close still wakes every pending gate.
+# Shared with ChatSession so the registry default and the value stamped onto
+# approval batches cannot drift.
+DEFAULT_APPROVAL_TIMEOUT_SECONDS = 0
 
 
 def _build_registry() -> dict[str, SettingDef]:
@@ -193,6 +200,19 @@ def _build_registry() -> dict[str, SettingDef]:
             "tools",
             min_value=1,
             max_value=3600,
+        ),
+        SettingDef(
+            "tools.approval_timeout_seconds",
+            "int",
+            DEFAULT_APPROVAL_TIMEOUT_SECONDS,
+            "Human approval timeout in seconds (0 = wait indefinitely)",
+            "tools",
+            min_value=0,
+            max_value=int(threading.TIMEOUT_MAX),
+            help="How long a workstream waits for an operator to approve or deny a "
+            "pending action. The default 0 waits until someone decides or the "
+            "workstream is cancelled or closed. Set 3600 to restore the previous "
+            "one-hour timeout.",
         ),
         SettingDef(
             "tools.truncation",


### PR DESCRIPTION
## Summary

- add `tools.approval_timeout_seconds`, defaulting to `0` for an indefinite operator wait while retaining positive finite deadlines
- snapshot the live timeout per approval batch without coupling `SessionUIBase` to `ConfigStore`, and cap finite values at `threading.TIMEOUT_MAX`
- resolve approval cycles at the hard-delete terminal barrier so indefinite waits cannot strand retained tombstones

## Testing

- `.venv/bin/ruff check turnstone tests`
- `.venv/bin/ruff format --check turnstone tests`
- `.venv/bin/mypy turnstone`
- `.venv/bin/pytest -q` — 12,431 passed, 30 skipped

Closes #1038