### PR TITLE
fix(task-agent): compact long-running task context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ that minor, so the current stable line never has two independently writable
 branches. Earlier stable lines (`stable/1.7`, `stable/1.6`, `stable/1.5`) are
 frozen.
 
+## [Unreleased]
+
+### Added
+
+- **Task-agent compaction.** Long-running agents now receive the same soft
+  warning, hard compaction, recursive overflow recovery, and visible progress
+  as the foreground while retaining bounded execution evidence for cancellation
+  disposition and task recall. The generalized `compaction` lifecycle targets
+  either the workstream or a parent task card; task compaction is transient and
+  never persists the agent's private summary. Python and TypeScript SDKs expose
+  the target fields.
+
 ## [1.8.0]
 
 Turnstone 1.8 focuses on dependable long-running workstreams: one model-call

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -624,44 +624,64 @@ Each item in `items` (shared by `tool_info` and `approve_request`):
 {"type": "info", "message": "Session cleared."}
 ```
 
-**`compaction`** -- context-compaction lifecycle (manual `/compact` and
-auto-compaction). `phase: "start"` opens the operation (`trigger` is
-`"manual"` or `"auto"`; auto adds `where` — e.g. `"mid-turn"` — and, when
-the percentage threshold actually fired, `pct`; the context-overflow retry
-path compacts without a `pct` since no threshold was evaluated).
+**`compaction`** -- context-compaction lifecycle. `target` is
+`"workstream"` for manual `/compact` and foreground auto-compaction, or
+`"task_agent"` for a delegated agent's transient model context. Task-agent
+events also carry `parent_call_id`, which keys the existing task card. A
+missing `target` means `"workstream"`. `phase: "start"` opens the operation
+(`trigger` is `"manual"` or `"auto"`; auto adds `where` — e.g. `"mid-turn"`
+— and, when the percentage threshold actually fired, `pct`; the
+context-overflow retry path compacts without a `pct` since no threshold was
+evaluated).
 `phase: "progress"` reports chunked summarization (`part`/`total`/`depth`,
 where depth 0 summarizes transcript batches and deeper levels merge partial
 summaries), a transient-error retry wait (`retry_in` seconds + `error`), or
 `warning: "summary_truncated"`. `phase: "end"` settles it: `ok: true`
-carries `before_tokens`/`after_tokens` and the produced `summary`;
+carries `before_tokens`/`after_tokens`; workstream ends also carry the produced
+`summary`, while task-agent ends deliberately omit it because that summary is
+private transient model context;
 `ok: false` carries a `reason`
 (`"not_enough_messages"` / `"irreducible"` / `"empty_summary"` /
-`"cancelled"` / `"error"`) and a human-readable `message` — for
-`reason: "error"` the same message is also emitted as a paired typed
-`error` event (that is the renderable error surface; the end event is
-card-teardown). Failed ends also carry `notice`: the emitter-computed
-display verdict — show `message` only when it is `true` (the server
-suppresses error-reason, superseded, and cancelled-auto notices once,
-centrally, so clients don't re-derive that policy). Every end (ok or
-failed) carries `trigger`, and every event carries `compaction_id` — an
-opaque integer correlating the start/progress/end of one compaction run (a
-client that force-stopped one compaction can use it to ignore stragglers
-from the abandoned run). End events also carry `superseded`: `true` marks
+`"cancelled"` / `"error"`) and a human-readable `message`. A workstream
+`reason: "error"` end is paired with a typed `error` event, so its `notice`
+is false and the end only tears down the compaction card. A task-agent error
+has no workstream-level `error` twin: its targeted end carries `notice: true`
+so the message renders inside the parent task card. Failed ends always carry
+the emitter-computed `notice` verdict; clients display `message` only when it
+is true rather than reconstructing policy from `reason`, `trigger`, and
+`superseded`. Superseded failures and automatic cancellation stay silent.
+Every end (ok or failed) carries `trigger`, and every event carries
+`compaction_id` — an
+opaque session-local integer correlating the start/progress/end of one
+compaction attempt. It is independent of the send generation, so concurrent
+task agents and repeated compactions in one turn receive distinct IDs (a client
+that force-stopped one compaction can use it to ignore stragglers from the
+abandoned run). End events also carry `superseded`: `true` marks
 a force-abandoned compaction retiring after a successor generation took
 over (an OK end's result card still stands: the history swap happened).
 Superseded start/progress events are never emitted.
-Exactly one `start` and one `end` are emitted per attempt,
+Exactly one `start` and one `end` are emitted per admitted attempt,
 so clients can key an in-progress affordance (progress bar) on the pair. A
-successful end is also persisted: the summary replays from `/history` as a
+successful **workstream** end is also persisted: the summary replays from
+`/history` as a
 `role: "system"`, `source: "compaction"` entry whose `meta` carries
 `{watermark, before_tokens, after_tokens, trigger}` and whose `event_id`
-matches the end event's id (dedup across repaint + replay).
+matches the end event's id (dedup across repaint + replay). Task-agent
+compaction is nested progress only: fresh/truncated SSE recovery includes its
+latest active lifecycle edge, and the matching parent `tool_result` retires it.
+Its summary is used only as the task's next private model context: it is absent
+from the workstream transcript, persistence, task recall, and every event.
 
 ```json
-{"type": "compaction", "phase": "start", "compaction_id": 7, "trigger": "auto", "where": "mid-turn", "pct": 80}
-{"type": "compaction", "phase": "progress", "compaction_id": 7, "part": 2, "total": 5, "depth": 0}
-{"type": "compaction", "phase": "end", "ok": true, "compaction_id": 7, "trigger": "auto",
+{"type": "compaction", "target": "workstream", "phase": "start", "compaction_id": 7, "trigger": "auto", "where": "mid-turn", "pct": 80}
+{"type": "compaction", "target": "workstream", "phase": "progress", "compaction_id": 7, "part": 2, "total": 5, "depth": 0}
+{"type": "compaction", "target": "workstream", "phase": "end", "ok": true, "compaction_id": 7, "trigger": "auto",
  "before_tokens": 128400, "after_tokens": 9200, "summary": "## Decisions\n..."}
+{"type": "compaction", "target": "task_agent", "parent_call_id": "call_task_abc123",
+ "phase": "start", "compaction_id": 8, "trigger": "auto", "where": "mid-turn", "pct": 80}
+{"type": "compaction", "target": "task_agent", "parent_call_id": "call_task_abc123",
+ "phase": "end", "ok": true, "compaction_id": 8, "trigger": "auto",
+ "before_tokens": 115000, "after_tokens": 18000}
 ```
 
 **`error`** -- an error message.
@@ -789,9 +809,10 @@ either the event-ring delta after its cursor or a synthetic recovery replay.
 The synthetic replay includes `connected`, cached `status`, every pending
 approval cycle, the current `state_change`, an optional
 `in_progress_snapshot` with partial content/reasoning, and the latest
-`agent_context` reading for each running task agent. A matching `tool_result`
-ends that reading. Conversation history stays on the REST `/history` endpoint;
-completed task-agent readings are not retained.
+`agent_context` reading and active targeted `compaction` edge for each running
+task agent. A matching `tool_result` ends both transient states. Conversation
+history stays on the REST `/history` endpoint; completed task-agent readings
+and compactions are not retained.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -367,11 +367,12 @@ eviction from discarding that recovery state. Soft close returns 409 and leaves
 the workstream loaded; hard delete remains the explicit discard boundary.
 
 `on_stream_discarded` removes a failed attempt's partial projection before a
-mid-stream retry. `on_system_turn` and `on_compaction` return the assigned SSE
-event ID when the frontend has one; persistence stamps the corresponding row
-with that cursor so reconnect replay and `/history` agree. The `judge_event`
-argument is the intent-judge generation identity used to reject stale verdicts
-from a prior approval round.
+mid-stream retry. `on_system_turn` and workstream-targeted `on_compaction`
+return the assigned SSE event ID when the frontend has one; persistence stamps
+the corresponding row with that cursor so reconnect replay and `/history`
+agree. Task-targeted compaction also receives an SSE ID for stream ordering but
+has no durable row. The `judge_event` argument is the intent-judge generation
+identity used to reject stale verdicts from a prior approval round.
 
 `on_rename` is called by the `/name` command (on success) and after a successful `/resume` (if the resumed session has an alias or title). `WebUI.on_rename` broadcasts a `ws_rename` event on the global SSE channel and updates the in-memory `Workstream.name`; `TerminalUI.on_rename` is a no-op.
 
@@ -755,6 +756,18 @@ then returns the final content as the tool result.
   stops calling tools or hits `finish_reason: "length"`.
 - **Retry**: each API call in the agent loop uses the same retry+backoff logic
   as the main loop's per-lane ladder (`_model_turn_with_retry`).
+- **Context compaction**: the task lane resolves its own context window and
+  applies the same soft warning, hard ceiling, recursive summarizer, and
+  compact-and-retry overflow backstop as the foreground. The immutable
+  system/skill/delegation prefix is reattached verbatim; only the autonomous
+  suffix is summarized. The replaceable model context is separate from a
+  purpose-built execution journal: it keeps the exact unresolved call batch,
+  aggregate effect dispositions across a bounded tool-name set, and the latest
+  100 clipped recall steps with bounded, digest-disambiguated identifiers.
+  Resolved raw provider blocks and large tool payloads can therefore be released
+  after compaction without erasing cancellation evidence. Successful replacement
+  clears that task's file-read set and adds a resume nudge requiring exact files
+  to be read again.
 - **Finish reason handling**: `finish_reason: "length"` stops the agent early
   and returns whatever content was generated. `finish_reason: "content_filter"`
   returns a placeholder.
@@ -1603,8 +1616,10 @@ Every model call streams (#831); retry lives at two stacked layers:
   `model_turn`) use the same pattern: 4 total attempts (1 initial + 3 retries,
   `_MAX_RETRIES = 3`), exponential backoff base 1 second
   (`delay = 1s * 2^attempt`), `ui.on_info()` on retry, exception
-  propagates on final failure. `_compact_messages()` wraps its drained
-  call in the same loop.
+  propagates on final failure. `CompactionEngine.summarize_once()` owns the
+  equivalent cancellable retry ladder for summary calls; its owner-supplied
+  `SummaryRuntime` provides retry classification and backoff while routing
+  progress to the foreground or task-agent lifecycle owner.
 - **`model_turn`'s drain ladder** — inside every single-shot call,
   mid-stream deaths (errors raised while draining, e.g.
   `IncompleteStreamError`) are re-issued up to 2 more times with a
@@ -1635,8 +1650,10 @@ Agent sub-sessions (`_run_agent()`) check `finish_reason` on each
 drained turn and stop the agent early on `"length"` or
 `"content_filter"`.
 
-`_compact_messages()` checks `finish_reason` on the compaction response and
-warns if the summary was truncated.
+`CompactionEngine.summarize_once()` also checks the summary call's
+`finish_reason`; on `"length"` it emits a `summary_truncated` warning through
+the owner's compaction-progress callback for both foreground and task-agent
+compaction.
 
 ### State Emission on Errors
 
@@ -1985,8 +2002,15 @@ summarizing the selected trajectory into a structured summary. Manual
 the send generation that triggered it. Both use the same cancellation,
 publication, and FIFO durability fences as a model turn.
 
-Compaction pins one `ModelLane` for the complete operation. Blocks are packed
-to an estimated window budget; a real provider overflow recursively
+Foreground and task-agent compaction share the lifecycle-agnostic policy,
+provider-calibrated estimator, input packing, retry, and recursive summarizer
+in `turnstone/core/compaction.py`; their lifecycle owners remain separate.
+Foreground owns a durable conversation swap and checkpoint. A task agent owns
+only its private replaceable model context beside the bounded execution journal
+described above.
+
+Each compaction pins one `ModelLane` for the complete operation. Blocks are
+packed to an estimated window budget; a real provider overflow recursively
 subdivides the batch and merges partial summaries rather than silently dropping
 the newest messages. The summary preserves:
 
@@ -2021,11 +2045,15 @@ message loss.
 
 Cancellation or generation supersession before the final commit leaves both
 the live trajectory and checkpoint untouched. Typed `compaction` lifecycle
-events (`start`, `progress`, exactly one `end`) let SSE clients correlate and
-retire one run even when a force-abandoned predecessor finishes after a
-successor generation begins. After a successful swap, `_read_files` is cleared
-so edits require fresh file reads against content no longer present in the
-bounded model context.
+events (`start`, `progress`, exactly one `end`) carry a session-local
+`compaction_id` and a `target`. Workstream events own the durable transcript
+card; task-agent events carry `parent_call_id`, render transiently under that
+task card, and never expose or persist their private summary. The independent
+attempt ID lets clients retire one run even when task agents compact in
+parallel, a generation compacts repeatedly, or a force-abandoned predecessor
+finishes after its successor. After a successful swap, the relevant file-read
+set is cleared so edits require fresh file reads against content no longer
+present in the bounded model context.
 
 ---
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -142,6 +142,7 @@ SSE events are deserialized into typed dataclasses. Use `event.type` to discrimi
 | `state_change` | `StateChangeEvent` | `state` ∈ `running`/`thinking`/`attention`/`idle`/`error` |
 | `in_progress_snapshot` | `InProgressSnapshotEvent` | `content`, `reasoning` (one-shot mid-stream refresh resume) |
 | `agent_context` | `AgentContextEvent` | `parent_call_id`, `prompt_tokens`, `context_window` (replace the latest reading for a running task agent; discard it on the matching `tool_result`) |
+| `compaction` | `CompactionEvent` | `target`, `parent_call_id`, `compaction_id`, `phase`, `ok`, `notice`; events without `target` are workstream events, while `task_agent` is transient nested progress and omits its private `summary` |
 | `approval_resolved` | `ApprovalResolvedEvent` | `cycle_id`, `call_ids`, `approved`, `feedback`, `always` |
 | `cancelled` | `CancelledEvent` | — |
 | `history_resync` | `HistoryResyncEvent` | `reason`, optional `ws_id` |

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -214,13 +214,19 @@ export interface CancelledEvent {
  * auto adds `where` + `pct`); `progress` carries chunked-summarization
  * `part`/`total`/`depth` (or `retry_in`/`error` for a retry wait); `end`
  * carries `ok` plus either `before_tokens`/`after_tokens`/`summary` or the
- * failure `reason`/`message`. The successful end's summary also replays from
- * `/history` as a `role: "system"`, `source: "compaction"` entry.
+ * failure `reason`/`message`. `target: "workstream"` owns the transcript and
+ * durable marker. `target: "task_agent"` carries `parent_call_id`, is
+ * transient nested progress, and omits its private `summary` on success.
+ * Events without a target are workstream events because that was the only
+ * compaction scope before targeted events existed.
  */
 export interface CompactionEvent {
   type: "compaction";
   phase: "start" | "progress" | "end";
-  /** Correlates every event of one compaction run (0 from legacy emitters). */
+  target?: "workstream" | "task_agent";
+  /** Present when target is `task_agent`; keys the nested task card. */
+  parent_call_id?: string;
+  /** Correlates every event of one compaction attempt. */
   compaction_id?: number;
   /**
    * End events only: true marks a force-abandoned compaction retiring
@@ -230,8 +236,8 @@ export interface CompactionEvent {
   superseded?: boolean;
   /**
    * Failed ends only: the emitter-computed display verdict — show
-   * `message` only when true, instead of re-deriving suppression from
-   * reason/trigger/superseded client-side.
+   * `message` only when true. Workstream errors use their paired typed error;
+   * task-agent errors use this targeted notice instead.
    */
   notice?: boolean;
   /** Present on start and on every end (ok or failed). */

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -32,6 +32,7 @@ from turnstone.core.session import (
     _CancelledToolResult,
     _CancelRef,
     _StreamTurnConsumer,
+    _TaskExecutionJournal,
     _tool_turn_meta,
 )
 from turnstone.core.session_manager import SessionManager
@@ -1556,12 +1557,13 @@ class TestTaskAgentStreamAbort:
             generation = kwargs["origin_generation"]
             if generation == old_generation:
                 session._current_read_files.add("old-generation.txt")
-                agent_turns.append(
-                    Turn.assistant(
-                        "",
-                        tool_calls=(ToolCall(id="old-action", name="bash", arguments="{}"),),
-                    )
+                issued = Turn.assistant(
+                    "",
+                    tool_calls=(ToolCall(id="old-action", name="bash", arguments="{}"),),
                 )
+                agent_turns.append(issued)
+                kwargs["execution_journal"].record_assistant(issued)
+                kwargs["execution_journal"].mark_started("old-action")
                 old_running.set()
                 if not release_old.wait(2):
                     raise RuntimeError("old task wrapper was not released")
@@ -1661,12 +1663,14 @@ class TestTaskAgentStreamAbort:
 
             with owners_lock:
                 owners[key] = _active_shell_owner.get()
-            agent_turns.append(
-                Turn.assistant(
-                    "",
-                    tool_calls=(ToolCall(id=child_id, name="bash", arguments="{}"),),
-                )
+            issued = Turn.assistant(
+                "",
+                tool_calls=(ToolCall(id=child_id, name="bash", arguments="{}"),),
             )
+            agent_turns.append(issued)
+            kwargs["execution_journal"].record_assistant(issued)
+            kwargs["execution_journal"].mark_started(child_id)
+            kwargs["execution_journal"].register_child(child_id)
             session._note_agent_child(child_id, parent_call_id)
             ready.set()
             if not release.wait(2):
@@ -1674,6 +1678,12 @@ class TestTaskAgentStreamAbort:
             if key == "old":
                 raise GenerationCancelled()
             agent_turns.append(Turn.tool(child_id, "done"))
+            kwargs["execution_journal"].record_result(
+                child_id,
+                "done",
+                is_error=False,
+                effect_status=None,
+            )
             return "fresh result"
 
         def record_reap(*, owner):
@@ -2103,7 +2113,7 @@ class TestTaskAgentStreamAbort:
         generation_event = session._cancel_event
         parent_call_id = "task-with-unknown-child"
         issued_child_ids: list[str] = []
-        stashed_turns: list[Turn] = []
+        stashed_steps: list[dict[str, object]] = []
         outcomes: list[object] = []
         second_request = _BlockingAgentStream()
 
@@ -2159,8 +2169,8 @@ class TestTaskAgentStreamAbort:
             patch.object(session, "_prepare_tool", side_effect=prepare_child),
             patch.object(
                 session,
-                "_stash_agent_trajectory",
-                side_effect=lambda _call_id, turns: stashed_turns.extend(turns),
+                "_stash_agent_steps",
+                side_effect=lambda _call_id, steps: stashed_steps.extend(steps),
             ),
         ):
             thread = self._start_task(session, item, outcomes)
@@ -2182,10 +2192,10 @@ class TestTaskAgentStreamAbort:
         assert "Results received with UNKNOWN effects before cancel: read_file." in disposition
         assert "Completed before cancel: read_file." not in disposition
 
-        child_turns = [turn for turn in stashed_turns if turn.role is Role.TOOL]
-        assert len(child_turns) == 1
-        assert child_turns[0].tool_call_id == issued_child_ids[0]
-        assert child_turns[0].effect_status is EffectStatus.UNKNOWN
+        assert len(stashed_steps) == 1
+        assert stashed_steps[0]["id"] == issued_child_ids[0]
+        assert stashed_steps[0]["is_error"] is True
+        assert "Outcome UNKNOWN" in str(stashed_steps[0]["output"])
         assert issued_child_ids[0] not in session._tool_status
         assert session._cancelled_tool_results[parent_call_id] == _CancelledToolResult(
             detail=disposition,
@@ -4787,32 +4797,35 @@ class TestCancelledAgentDisposition:
     def _result(call_id, text="ok"):
         return Turn.tool(call_id, text)
 
+    @staticmethod
+    def _journal(turns, *started_ids):
+        journal = _TaskExecutionJournal(turns)
+        for call_id in started_ids:
+            journal.mark_started(call_id)
+        journal.materialize_unstarted(turns)
+        return journal
+
     def test_status_none_when_no_actions(self):
         """Typed twin of the disposition: a task cancelled before any action is
         NONE, not UNKNOWN — the complement of the in-flight case."""
-        session = _make_session()
-        assert session._cancelled_agent_status([]) is EffectStatus.NONE
+        assert self._journal([]).cancelled_status() is EffectStatus.NONE
 
     def test_status_unknown_when_in_flight(self):
-        session = _make_session()
         msgs = [self._assistant("t1", "bash")]  # issued, no result → in flight
-        assert session._cancelled_agent_status(msgs) is EffectStatus.UNKNOWN
+        assert self._journal(msgs, "t1").cancelled_status() is EffectStatus.UNKNOWN
 
     def test_status_partial_when_all_answered(self):
         """Every issued call returned but the agent was stopped before finishing
         — effects are known (not UNKNOWN) yet the task is incomplete: PARTIAL."""
-        session = _make_session()
         msgs = [self._assistant("t1", "bash"), self._result("t1")]
-        assert session._cancelled_agent_status(msgs) is EffectStatus.PARTIAL
+        assert self._journal(msgs).cancelled_status() is EffectStatus.PARTIAL
 
     def test_no_actions_reports_no_side_effects(self, tmp_db):
-        session = _make_session()
-        out = session._cancelled_agent_disposition([], "task")
+        out = self._journal([]).cancelled_disposition("task")
         assert "no side effects" in out
         assert "UNKNOWN" not in out
 
     def test_marks_in_flight_action_unknown(self, tmp_db):
-        session = _make_session()
         # bash completed; web_fetch was in flight (issued, no result yet) —
         # the first unanswered call is the in-flight boundary.
         msgs = [
@@ -4820,7 +4833,7 @@ class TestCancelledAgentDisposition:
             self._result("t1"),
             self._assistant("t2", "web_fetch"),
         ]
-        out = session._cancelled_agent_disposition(msgs, "task")
+        out = self._journal(msgs, "t2").cancelled_disposition("task")
         assert out != "(task interrupted by user)"
         assert "Completed before cancel: bash." in out
         assert "In flight at cancel: web_fetch" in out
@@ -4829,9 +4842,8 @@ class TestCancelledAgentDisposition:
     def test_unanswered_tool_is_in_flight_unknown(self, tmp_db):
         # An output-flowing bash SIGKILL'd mid-stream raises (no result row) —
         # it is the in-flight boundary and must read UNKNOWN, never completed.
-        session = _make_session()
         msgs = [self._assistant("t1", "bash")]  # issued, no result
-        out = session._cancelled_agent_disposition(msgs, "task")
+        out = self._journal(msgs, "t1").cancelled_disposition("task")
         assert "In flight at cancel: bash" in out
         assert "UNKNOWN" in out
         assert "Completed before cancel" not in out
@@ -4840,9 +4852,8 @@ class TestCancelledAgentDisposition:
         # Every issued call returned a result — cancel landed between turns,
         # nothing in flight. Each result carries its own disposition; the
         # summary just lists what completed, with no UNKNOWN boundary.
-        session = _make_session()
         msgs = [self._assistant("t1", "bash"), self._result("t1", "(killed)")]
-        out = session._cancelled_agent_disposition(msgs, "task")
+        out = self._journal(msgs).cancelled_disposition("task")
         assert "Completed before cancel: bash." in out
         assert "In flight at cancel" not in out
 
@@ -4850,11 +4861,11 @@ class TestCancelledAgentDisposition:
         # Regression (bug-1): a turn issues [bash, web_fetch] executed
         # sequentially; cancel hits during bash (unanswered, side effects
         # possible) and web_fetch never runs. The in-flight UNKNOWN must be
-        # bash (the FIRST gap), and web_fetch must read "not started" — NOT
+        # bash, and the journal's executor witness must record web_fetch as
+        # confirmed no-effect — NOT
         # the inverse. The old code took the LAST issued call, labelling the
         # never-run web_fetch UNKNOWN and the actually-in-flight bash "not
         # started" — inviting a re-run of the destructive bash.
-        session = _make_session()
         msgs = [
             Turn.assistant(
                 "",
@@ -4864,16 +4875,15 @@ class TestCancelledAgentDisposition:
                 ),
             )
         ]  # neither answered: bash raised mid-flight, web_fetch never ran
-        out = session._cancelled_agent_disposition(msgs, "task")
+        out = self._journal(msgs, "t1").cancelled_disposition("task")
         assert "In flight at cancel: bash" in out
         assert "In flight at cancel: web_fetch" not in out
-        assert "Not started (cancelled first): web_fetch." in out
+        assert "Confirmed no effect before cancel: web_fetch." in out
 
-    def test_counts_and_not_started(self, tmp_db):
+    def test_counts_and_confirmed_unstarted(self, tmp_db):
         # Turn 1 completes [bash, bash, read_file]; turn 2 issues
         # [web_fetch (in flight), search (never ran)]. Exercises the ×N
         # count summary, the first-gap boundary, and not-started.
-        session = _make_session()
         msgs = [
             Turn.assistant(
                 "",
@@ -4894,20 +4904,32 @@ class TestCancelledAgentDisposition:
                 ),
             ),
         ]
-        out = session._cancelled_agent_disposition(msgs, "task")
+        out = self._journal(msgs, "t4").cancelled_disposition("task")
         assert "Completed before cancel: bash×2, read_file." in out
         assert "In flight at cancel: web_fetch" in out
-        assert "Not started (cancelled first): search." in out
+        assert "Confirmed no effect before cancel: search." in out
 
     def test_exec_task_routes_cancel_to_disposition(self, tmp_db):
         """_exec_task converts a GenerationCancelled from _run_agent into the
-        honest disposition, reading the in-place-mutated agent_turns."""
+        honest disposition from the production execution journal."""
         session = _make_session()
 
         def fake_run_agent(agent_turns, **kwargs):
-            agent_turns.append(self._assistant("t1", "bash"))
-            agent_turns.append(self._result("t1"))
-            agent_turns.append(self._assistant("t2", "web_fetch"))
+            journal = kwargs["execution_journal"]
+            first = self._assistant("t1", "bash")
+            first_result = self._result("t1")
+            second = self._assistant("t2", "web_fetch")
+            agent_turns.extend((first, first_result, second))
+            journal.record_assistant(first)
+            journal.mark_started("t1")
+            journal.record_result(
+                "t1",
+                first_result.text,
+                is_error=first_result.is_error,
+                effect_status=first_result.effect_status,
+            )
+            journal.record_assistant(second)
+            journal.mark_started("t2")
             raise GenerationCancelled()
 
         with patch.object(session, "_run_agent", side_effect=fake_run_agent):
@@ -4945,10 +4967,14 @@ class TestCancelledAgentDisposition:
         session = _make_session(ui=ui)
         generation = session._claim_generation()
         issued_child = self._assistant("child-1", "bash")
-        expected_disposition = session._cancelled_agent_disposition([issued_child], "task")
+        expected_journal = self._journal([issued_child], "child-1")
+        expected_disposition = expected_journal.cancelled_disposition("task")
 
         def fake_run_agent(agent_turns, **kwargs):
             agent_turns.append(issued_child)
+            journal = kwargs["execution_journal"]
+            journal.record_assistant(issued_child)
+            journal.mark_started("child-1")
             raise GenerationCancelled()
 
         prepared = {

--- a/tests/test_compaction_checkpoint.py
+++ b/tests/test_compaction_checkpoint.py
@@ -26,7 +26,7 @@ import json
 import pytest
 
 from tests._session_helpers import make_session
-from turnstone.core.session import _SummaryResult
+from turnstone.core.compaction import SummaryResult
 from turnstone.core.storage._utils import _fork_turn_insert_row
 from turnstone.core.trajectory import PROVENANCE_META_KEY, TurnProvenance, turns_from_dicts
 
@@ -250,9 +250,9 @@ def test_compaction_persists_checkpoint_and_resume_is_bounded(tmp_db, mock_opena
     sess.messages = turns_from_dicts(history)
     sess._msg_tokens = [1] * len(history)
     with patch.object(
-        sess,
-        "_summarize_blocks",
-        return_value=_SummaryResult(text="DENSE SUMMARY", producer="summary-producer"),
+        sess._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="DENSE SUMMARY", producer="summary-producer"),
     ):
         assert sess._compact_messages(auto=False) is True
 
@@ -308,9 +308,9 @@ def test_marker_watermark_read_blip_recovers_on_retry(tmp_db, mock_openai_client
 
     with (
         patch.object(
-            sess,
-            "_summarize_blocks",
-            return_value=_SummaryResult(text="DENSE SUMMARY", producer="summary-producer"),
+            sess._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(text="DENSE SUMMARY", producer="summary-producer"),
         ),
         patch.object(st, "get_compaction_watermark", side_effect=_flaky_watermark),
     ):
@@ -360,9 +360,9 @@ def test_compaction_summary_producer_survives_storage_round_trip(
     )
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(
-            sess,
-            "_summarize_blocks",
-            lambda *_args, **_kwargs: _SummaryResult(
+            sess._compaction_engine,
+            "summarize_blocks",
+            lambda *_args, **_kwargs: SummaryResult(
                 text="DENSE SUMMARY",
                 producer="final-summary-producer",
                 provenance=provenance,
@@ -677,9 +677,9 @@ def test_watermark_reads_inside_the_marker_persist_not_before_the_commit(
         patch.object(sess, "_journal_conversation_row_locked", side_effect=_journal_spy),
         patch.object(st, "get_compaction_watermark", side_effect=_watermark_spy),
         patch.object(
-            sess,
-            "_summarize_blocks",
-            return_value=_SummaryResult(text="DENSE SUMMARY", producer="summary-producer"),
+            sess._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(text="DENSE SUMMARY", producer="summary-producer"),
         ),
     ):
         assert sess._compact_messages(auto=False) is True

--- a/tests/test_compaction_crossing.py
+++ b/tests/test_compaction_crossing.py
@@ -73,6 +73,21 @@ def _stub_summary(text: str = "DENSE"):
     )
 
 
+def _summary_runtime(session):
+    return session._build_summary_runtime(session._primary_lane())
+
+
+def _carry_budget_chars(session, carries: int = 1) -> int:
+    return session._compaction_engine.carry_budget_chars(
+        _summary_runtime(session),
+        carries,
+    )
+
+
+def _summary_output_tokens(session) -> int:
+    return session._compaction_engine.summary_output_tokens(_summary_runtime(session))
+
+
 # ---------------------------------------------------------------------------
 # Provenance tags on the synthetic summary turns
 # ---------------------------------------------------------------------------
@@ -186,12 +201,12 @@ class TestCarryBudget:
         # overhead=0, reserve=100 (compact_max_tokens), margin=500,
         # spare=9_400; min(10_000 // 4, 9_400) = 2_500 tokens * 4.0 chars/token.
         _isolate_overhead(session)
-        assert session._carry_budget_chars() == 10_000
+        assert _carry_budget_chars(session) == 10_000
 
     def test_floors_on_tiny_window(self, tmp_db, mock_openai_client):
         tiny = make_session(client=mock_openai_client, context_window=1_000, tool_timeout=10)
         _isolate_overhead(tiny)
-        assert tiny._carry_budget_chars() == tiny._MIN_CARRY_BUDGET_CHARS
+        assert _carry_budget_chars(tiny) == tiny._compaction_engine.MIN_CARRY_BUDGET_CHARS
 
     @pytest.mark.parametrize("carries", [1, 2])
     def test_overhead_reserve_and_carries_fit_window_at_shipped_defaults(
@@ -206,9 +221,9 @@ class TestCarryBudget:
         away."""
         s = make_session(client=mock_openai_client, tool_timeout=10)
         _isolate_overhead(s, system_tokens=4_000)  # a chunky composed prompt
-        reserve = s._summary_output_tokens()
-        per_carry_tokens = s._carry_budget_chars(carries) / s._chars_per_token
-        margin = int(s.context_window * s._SUMMARY_SAFETY_MARGIN)
+        reserve = _summary_output_tokens(s)
+        per_carry_tokens = _carry_budget_chars(s, carries) / s._chars_per_token
+        margin = int(s.context_window * s._compaction_engine.SUMMARY_SAFETY_MARGIN)
         assert 4_000 + reserve + carries * per_carry_tokens + margin <= s.context_window
 
     def test_budget_shrinks_with_prompt_overhead(self, tmp_db, mock_openai_client):
@@ -216,9 +231,9 @@ class TestCarryBudget:
         a bigger system prompt leaves less to carry."""
         s = make_session(client=mock_openai_client, tool_timeout=10)
         _isolate_overhead(s, system_tokens=0)
-        roomy = s._carry_budget_chars(2)
+        roomy = _carry_budget_chars(s, 2)
         _isolate_overhead(s, system_tokens=8_000)
-        assert s._carry_budget_chars(2) < roomy
+        assert _carry_budget_chars(s, 2) < roomy
 
     def test_double_carry_splits_the_spare(self, tmp_db, mock_openai_client):
         """At shipped defaults the spare (window − overhead − reserve −
@@ -226,11 +241,11 @@ class TestCarryBudget:
         the solo quarter-window allowance."""
         s = make_session(client=mock_openai_client, tool_timeout=10)
         _isolate_overhead(s, system_tokens=2_000)
-        reserve = s._summary_output_tokens()
-        margin = int(s.context_window * s._SUMMARY_SAFETY_MARGIN)
+        reserve = _summary_output_tokens(s)
+        margin = int(s.context_window * s._compaction_engine.SUMMARY_SAFETY_MARGIN)
         spare = s.context_window - reserve - margin - 2_000
-        assert s._carry_budget_chars(2) == int((spare // 2) * s._chars_per_token)
-        assert s._carry_budget_chars(2) < s._carry_budget_chars(1)
+        assert _carry_budget_chars(s, 2) == int((spare // 2) * s._chars_per_token)
+        assert _carry_budget_chars(s, 2) < _carry_budget_chars(s, 1)
 
 
 class TestContinuationHintCarry:
@@ -372,7 +387,7 @@ class TestWindDownSpill:
         budget instead of stacking two solo quarter-window allowances on top
         of the half-window summary reserve."""
         s = _register_session_workstream(make_session(client=mock_openai_client, tool_timeout=10))
-        per_carry = s._carry_budget_chars(2)
+        per_carry = _carry_budget_chars(s, 2)
         ask = "ASK-HEAD " + "a" * (per_carry * 2) + " ASK-TAIL"
         spill = "PLAN-HEAD " + "b" * (per_carry * 2) + " PLAN-TAIL"
         s.messages = turns_from_dicts(
@@ -639,14 +654,22 @@ class TestCoordinatorHandles:
         miscount comes from forgetting the term or from rendering before it.
         """
         s = _coord_session(mock_openai_client)
-        with patch.object(s, "_carry_budget_chars", wraps=s._carry_budget_chars) as budget:
+        with patch.object(
+            s._compaction_engine,
+            "carry_budget_chars",
+            wraps=s._compaction_engine.carry_budget_chars,
+        ) as budget:
             _compact(s, carry_spill=True)
-        assert budget.call_args[0][0] == 3  # handles + spill + ask
+        assert budget.call_args.args[1] == 3  # handles + spill + ask
 
         bare = _coord_session(mock_openai_client, coord_client=_coord_client([], []))
-        with patch.object(bare, "_carry_budget_chars", wraps=bare._carry_budget_chars) as budget:
+        with patch.object(
+            bare._compaction_engine,
+            "carry_budget_chars",
+            wraps=bare._compaction_engine.carry_budget_chars,
+        ) as budget:
             _compact(bare, carry_spill=True)
-        assert budget.call_args[0][0] == 2  # no handles, no third share
+        assert budget.call_args.args[1] == 2  # no handles, no third share
 
     def test_block_fits_the_budget_and_cuts_only_at_row_boundaries(
         self, tmp_db, mock_openai_client
@@ -656,7 +679,7 @@ class TestCoordinatorHandles:
         cannot resolve, dressed as one that can."""
         many = [{"id": f"tsk_{i:04d}", "title": "x" * 180, "status": "pending"} for i in range(60)]
         s = _coord_session(mock_openai_client, coord_client=_coord_client(many, CHILDREN))
-        budget = s._carry_budget_chars(1)
+        budget = _carry_budget_chars(s, 1)
         block = s._render_handles_block(*s._coordinator_handle_rows(), budget)
 
         assert len(block) <= budget

--- a/tests/test_conversation_js.py
+++ b/tests/test_conversation_js.py
@@ -118,6 +118,113 @@ if (agentContextIsWarning(1, 0)) throw new Error("zero window warned");
     assert proc.returncode == 0, proc.stderr
 
 
+@node_skip
+def test_task_agent_compaction_reducer_is_nested_transient_and_id_safe() -> None:
+    """Task compaction reuses the shared lifecycle without leaking a result."""
+    script = f"""
+class Element {{
+  constructor(tag) {{
+    this.tagName = tag;
+    this.children = [];
+    this.parentNode = null;
+    this.className = "";
+    this.style = {{}};
+    this.textContent = "";
+    this.attributes = {{}};
+    this.classList = {{
+      remove: (...names) => {{
+        const drop = new Set(names);
+        this.className = this.className
+          .split(/\\s+/)
+          .filter((name) => name && !drop.has(name))
+          .join(" ");
+      }},
+      contains: (name) => this.className.split(/\\s+/).includes(name),
+    }};
+  }}
+  setAttribute(name, value) {{ this.attributes[name] = String(value); }}
+  appendChild(child) {{
+    if (child.parentNode) child.remove();
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }}
+  querySelector(selector) {{
+    const cls = selector.startsWith(".") ? selector.slice(1) : "";
+    for (const child of this.children) {{
+      if (cls && child.className.split(/\\s+/).includes(cls)) return child;
+      const nested = child.querySelector(selector);
+      if (nested) return nested;
+    }}
+    return null;
+  }}
+  remove() {{
+    if (!this.parentNode) return;
+    const i = this.parentNode.children.indexOf(this);
+    if (i >= 0) this.parentNode.children.splice(i, 1);
+    this.parentNode = null;
+  }}
+}}
+globalThis.document = {{ createElement: (tag) => new Element(tag) }};
+const {{ applyCompactionEvent }} = await import({json.dumps(_CONVERSATION_JS.as_uri())});
+
+const container = new Element("div");
+const nested = new Element("div");
+const holder = {{ card: null, cid: null }};
+let notices = 0;
+let scrolls = 0;
+const hooks = {{
+  container,
+  renderedIds: new Set(),
+  renderResult: false,
+  append: (node) => nested.appendChild(node),
+  onNotice: () => {{ notices += 1; }},
+  scroll: () => {{ scrolls += 1; }},
+}};
+applyCompactionEvent(holder, {{
+  phase: "start", target: "task_agent", trigger: "auto", compaction_id: 12,
+}}, hooks);
+if (!holder.card || holder.cid !== "12") throw new Error("start was not retained");
+if (nested.children.length !== 1 || container.children.length !== 0)
+  throw new Error("task progress escaped its nested placement");
+const header = holder.card.querySelector(".msg-compaction-header");
+if (!header || header.textContent !== "compacting task context… · auto")
+  throw new Error("task-specific progress copy was not rendered");
+
+applyCompactionEvent(holder, {{
+  phase: "progress", target: "task_agent", compaction_id: 12,
+  part: 2, total: 4, depth: 0,
+}}, hooks);
+const fill = holder.card.querySelector(".msg-compaction-bar-fill");
+if (fill.style.width !== "25%") throw new Error("progress did not advance");
+
+applyCompactionEvent(holder, {{
+  phase: "end", target: "task_agent", compaction_id: 11, ok: true,
+  summary: "must stay private",
+}}, hooks);
+if (!holder.card || nested.children.length !== 1)
+  throw new Error("stale end retired the live task compaction");
+if (container.children.length !== 0) throw new Error("task summary leaked to transcript");
+
+applyCompactionEvent(holder, {{
+  phase: "end", target: "task_agent", compaction_id: 12, ok: true,
+  summary: "must stay private",
+}}, hooks);
+if (holder.card || holder.cid != null || nested.children.length !== 0)
+  throw new Error("owning end did not retire progress");
+if (container.children.length !== 0 || notices !== 0)
+  throw new Error("task end rendered a durable result or notice");
+if (scrolls !== 2) throw new Error("unexpected lifecycle scroll count: " + scrolls);
+"""
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
 def test_normalize_risk_level_unknown_to_medium() -> None:
     """Unified canonical fallback (step 5e.1b): an unknown / unrecognized risk
     normalizes to "medium" (the user's decision; the coordinator's old rank used

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -21,13 +21,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._session_helpers import make_result, make_session
+from turnstone.core.compaction import (
+    CompactionIrreducibleError,
+    CompactionPolicy,
+    SummaryResult,
+    SummaryRuntime,
+)
 from turnstone.core.session import (
     COMPACTION_SOURCE,
     COMPACTION_SUMMARY_LABEL,
     GenerationCancelled,
-    _CompactionIrreducibleError,
     _is_ctx_overflow,
-    _SummaryResult,
 )
 from turnstone.core.storage import get_storage
 from turnstone.core.trajectory import dicts_from_turns, turns_from_dicts
@@ -55,6 +59,45 @@ def session(tmp_db, mock_openai_client):
         parent_ws_id=s._parent_ws_id,
     )
     return s
+
+
+def _summary_runtime(
+    session,
+    *,
+    my_generation: int = 0,
+) -> SummaryRuntime:
+    """Build the foreground adapter while engine tests target its real owner."""
+
+    return session._build_summary_runtime(
+        session._primary_lane(),
+        my_generation=my_generation,
+    )
+
+
+def _summarize_blocks(session, blocks, *, my_generation: int = 0):
+    return session._compaction_engine.summarize_blocks(
+        blocks,
+        _summary_runtime(session, my_generation=my_generation),
+    )
+
+
+def _summarize_once(session, system_prompt, body, *, my_generation: int = 0):
+    return session._compaction_engine.summarize_once(
+        system_prompt,
+        body,
+        _summary_runtime(session, my_generation=my_generation),
+    )
+
+
+def _mock_policy(*, owed=False, over_soft=False, over_hard=False):
+    """Return a policy-shaped mock for lifecycle wiring tests."""
+
+    policy = MagicMock(spec=CompactionPolicy)
+    policy.owed.side_effect = owed if callable(owed) else None
+    policy.owed.return_value = owed if not callable(owed) else False
+    policy.over_soft.return_value = over_soft
+    policy.over_hard.return_value = over_hard
+    return policy
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +232,7 @@ class TestMidturnCompactionPolicy:
             patch.object(session.ui, "on_compaction") as on_compaction,
         ):
             session._do_auto_compact("mid-turn")
-        impl.assert_called_once_with(True, 0, 0, False)
+        impl.assert_called_once_with(True, 0, 0, False, compaction_id=1)
         start = on_compaction.call_args_list[0].args[0]
         assert start["phase"] == "start"
         assert start["trigger"] == "auto"
@@ -515,20 +558,14 @@ class TestCompactBeforeTruncate:
         assert "call_1" in ids
 
     def test_compaction_owed_predicate(self, session):
+        policy = session._compaction_policy()
         # over hard ceiling (>9000) → owed regardless of the latch
-        with patch.object(session, "_estimated_prompt_tokens", return_value=9_500):
-            session._compaction_advised = False
-            assert session._compaction_owed() is True
+        assert policy.owed(9_500, advised=False) is True
         # over soft (>8000) → owed only when advised
-        with patch.object(session, "_estimated_prompt_tokens", return_value=8_500):
-            session._compaction_advised = True
-            assert session._compaction_owed() is True
-            session._compaction_advised = False
-            assert session._compaction_owed() is False
+        assert policy.owed(8_500, advised=True) is True
+        assert policy.owed(8_500, advised=False) is False
         # under soft → never owed
-        with patch.object(session, "_estimated_prompt_tokens", return_value=7_000):
-            session._compaction_advised = True
-            assert session._compaction_owed() is False
+        assert policy.owed(7_000, advised=True) is False
 
     def test_owed_compaction_runs_before_truncation_in_tool_path(self, session):
         """Wiring: in the tool path, an owed compaction fires with preserve_tail=1
@@ -554,7 +591,11 @@ class TestCompactBeforeTruncate:
             patch.object(session, "_emit_state"),
             # Owed on the tool turn (pre-truncation); _estimated_prompt_tokens stays
             # small so the end-of-turn path doesn't also compact.
-            patch.object(session, "_compaction_owed", side_effect=lambda: n["i"] == 1),
+            patch.object(
+                session,
+                "_compaction_policy",
+                return_value=_mock_policy(owed=lambda *_a, **_k: n["i"] == 1),
+            ),
             patch.object(session, "_maybe_compact_midturn"),  # isolate the pre-truncation call
             patch.object(session, "_do_auto_compact") as compact,
             patch("turnstone.core.session.save_message"),
@@ -591,8 +632,11 @@ class TestCompactBeforeTruncate:
             patch.object(session, "_print_status_line"),
             patch.object(session, "_emit_state"),
             # Owed on the tool turn → the pre-truncation compaction fires.
-            # _compaction_owed takes an optional ``used`` arg, so accept *a/**k.
-            patch.object(session, "_compaction_owed", side_effect=lambda *a, **k: n["i"] == 1),
+            patch.object(
+                session,
+                "_compaction_policy",
+                return_value=_mock_policy(owed=lambda *_a, **_k: n["i"] == 1),
+            ),
             patch.object(session, "_do_auto_compact") as compact,
             patch.object(session, "_maybe_compact_midturn") as midturn,
             patch("turnstone.core.session.save_message"),
@@ -631,7 +675,11 @@ class TestCompactBeforeTruncate:
             patch.object(session, "_print_status_line"),
             patch.object(session, "_emit_state"),
             # Never owed → no pre-truncation compaction this iteration.
-            patch.object(session, "_compaction_owed", side_effect=lambda *a, **k: False),
+            patch.object(
+                session,
+                "_compaction_policy",
+                return_value=_mock_policy(owed=False),
+            ),
             patch.object(session, "_do_auto_compact") as compact,
             patch.object(session, "_maybe_compact_midturn") as midturn,
             patch("turnstone.core.session.save_message"),
@@ -688,7 +736,11 @@ class TestCompactBeforeTruncate:
             patch.object(session, "_update_token_table"),
             patch.object(session, "_emit_state"),
             patch.object(session, "_estimated_prompt_tokens", return_value=0),
-            patch.object(session, "_compaction_owed", return_value=False),
+            patch.object(
+                session,
+                "_compaction_policy",
+                return_value=_mock_policy(owed=False),
+            ),
             patch.object(session, "_remaining_token_budget", return_value=0),
             patch.object(
                 session, "_compact_messages", side_effect=compact_then_terminal
@@ -731,7 +783,7 @@ class TestPackBlocks:
 
     def test_preserves_all_blocks_and_order(self, session):
         blocks = [f"block-{i}-{'x' * 50}" for i in range(10)]
-        batches = session._pack_blocks(blocks, budget_chars=200)
+        batches = session._compaction_engine.pack_blocks(blocks, budget_chars=200)
         flat = [b for batch in batches for b in batch]
         assert flat == blocks  # every block present, order preserved
         assert all(batch for batch in batches)  # never an empty batch
@@ -739,7 +791,7 @@ class TestPackBlocks:
     def test_each_batch_within_budget(self, session):
         budget = 200
         blocks = ["a" * 80 for _ in range(12)]
-        batches = session._pack_blocks(blocks, budget_chars=budget)
+        batches = session._compaction_engine.pack_blocks(blocks, budget_chars=budget)
         for batch in batches:
             assert len("\n\n".join(batch)) <= budget
 
@@ -747,7 +799,7 @@ class TestPackBlocks:
         budget = 100
         exact = "y" * budget  # len == budget: fits a batch, not oversized
         blocks = ["short", exact, "tail"]
-        batches = session._pack_blocks(blocks, budget_chars=budget)
+        batches = session._compaction_engine.pack_blocks(blocks, budget_chars=budget)
         flat = [b for batch in batches for b in batch]
         assert flat == blocks  # order + presence
         assert exact in flat  # untouched, not truncated
@@ -758,7 +810,7 @@ class TestPackBlocks:
         budget = 100
         huge = "z" * 500  # > budget → its own truncated batch
         blocks = ["before", huge, "after"]
-        batches = session._pack_blocks(blocks, budget_chars=budget)
+        batches = session._compaction_engine.pack_blocks(blocks, budget_chars=budget)
         flat = [b for batch in batches for b in batch]
         assert flat[0] == "before" and flat[-1] == "after"  # neighbours survive
         truncated = [b for b in flat if "[truncated" in b]
@@ -776,17 +828,21 @@ class TestSummaryInputBudget:
     def test_scales_with_context_window(self, session):
         session.compact_max_tokens = 100
         session.context_window = 20_000
-        smaller = session._summary_input_budget_chars()
+        smaller = session._compaction_engine.summary_input_budget_chars(_summary_runtime(session))
         session.context_window = 40_000
-        larger = session._summary_input_budget_chars()
+        larger = session._compaction_engine.summary_input_budget_chars(_summary_runtime(session))
         assert larger > smaller
 
     def test_subtracts_output_reserve(self, session):
         session.context_window = 50_000
         session.compact_max_tokens = 100
-        small_reserve = session._summary_input_budget_chars()
+        small_reserve = session._compaction_engine.summary_input_budget_chars(
+            _summary_runtime(session)
+        )
         session.compact_max_tokens = 20_000  # larger output reserve
-        large_reserve = session._summary_input_budget_chars()
+        large_reserve = session._compaction_engine.summary_input_budget_chars(
+            _summary_runtime(session)
+        )
         assert large_reserve < small_reserve  # less room left for input
 
     def test_budget_never_exceeds_true_input_capacity(self, session):
@@ -798,14 +854,19 @@ class TestSummaryInputBudget:
         session.context_window = 1200
         session.compact_max_tokens = 1200
         session._system_tokens = 0
-        budget_chars = session._summary_input_budget_chars()
+        budget_chars = session._compaction_engine.summary_input_budget_chars(
+            _summary_runtime(session)
+        )
         prompt_tokens = int(
-            (len(session._COMPACTOR_SYSTEM_PROMPT) + len(session._COMPACT_USER_PREFIX))
+            (
+                len(session._compaction_engine.COMPACTOR_SYSTEM_PROMPT)
+                + len(session._compaction_engine.COMPACT_USER_PREFIX)
+            )
             / session._chars_per_token
         )
         # The full summary call (output reserve + budgeted input + prompt) fits.
         total = (
-            session._summary_output_tokens()
+            session._compaction_engine.summary_output_tokens(_summary_runtime(session))
             + budget_chars / session._chars_per_token
             + prompt_tokens
         )
@@ -849,7 +910,7 @@ class TestChunkedCompaction:
         session.context_window = 5_000
         session.compact_max_tokens = 4_000  # squeezes the input budget to the floor
         session._system_tokens = 0
-        budget = session._summary_input_budget_chars()
+        budget = session._compaction_engine.summary_input_budget_chars(_summary_runtime(session))
 
         session.messages = turns_from_dicts(
             [
@@ -866,7 +927,7 @@ class TestChunkedCompaction:
 
         def fake_uc(messages, **_kwargs):
             body = messages[1].text
-            prefix = session._COMPACT_USER_PREFIX
+            prefix = session._compaction_engine.COMPACT_USER_PREFIX
             if body.startswith(prefix):
                 body = body[len(prefix) :]
             recorded.append(len(body))
@@ -895,27 +956,29 @@ class TestChunkedCompaction:
         )
         session._msg_tokens = [1] * len(session.messages)
         pinned_lane = session._primary_lane()
-        seen_lanes: list[object] = []
+        seen_runtimes: list[SummaryRuntime] = []
         prompts: list[str] = []
 
-        def fake_once(system_prompt, _body, _my_generation=0, *, lane=None):
+        def fake_once(system_prompt, _body, runtime):
             # Ancillary post-fold accounting may resolve capabilities again, but
             # recursive summarization itself must not re-resolve its lane.
             assert primary_lane.call_count == 1
-            seen_lanes.append(lane)
+            seen_runtimes.append(runtime)
             prompts.append(system_prompt)
-            return _SummaryResult(text="fold", producer="summary-producer")
+            return SummaryResult(text="fold", producer="summary-producer")
 
         with (
             patch.object(session, "_primary_lane", return_value=pinned_lane) as primary_lane,
-            patch.object(session, "_summary_input_budget_chars", return_value=450),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=450
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
         ):
             assert session._compact_messages(auto=False) is True
 
-        assert prompts.count(session._COMPACTOR_SYSTEM_PROMPT) >= 2
-        assert prompts[-1] == session._COMPACTOR_MERGE_SYSTEM_PROMPT
-        assert seen_lanes and all(lane is pinned_lane for lane in seen_lanes)
+        assert prompts.count(session._compaction_engine.COMPACTOR_SYSTEM_PROMPT) >= 2
+        assert prompts[-1] == session._compaction_engine.COMPACTOR_MERGE_SYSTEM_PROMPT
+        assert seen_runtimes and all(runtime is seen_runtimes[0] for runtime in seen_runtimes)
 
     def test_recursion_depth_ceiling_bails_to_false(self, session):
         """q-3: the ``depth >= _MAX_SUMMARY_DEPTH`` recursion backstop bails to
@@ -929,8 +992,10 @@ class TestChunkedCompaction:
         session.context_window = 5_000
         session.compact_max_tokens = 4_000  # squeezes the input budget
         session._system_tokens = 0
-        session._MAX_SUMMARY_DEPTH = 1  # positive, so depth 0 runs before the bail
-        budget = session._summary_input_budget_chars()
+        session._compaction_engine.MAX_SUMMARY_DEPTH = (
+            1  # positive, so depth 0 runs before the bail
+        )
+        budget = session._compaction_engine.summary_input_budget_chars(_summary_runtime(session))
 
         # ~30 messages, each block bigger than 1/6 of the budget → depth 0 packs
         # into several batches and recurses (depth 0 < MAX).
@@ -1010,9 +1075,15 @@ class TestChunkedCompaction:
         with patch.object(session, "_get_capabilities", return_value=caps):
             assert session._get_capabilities().max_output_tokens == 64000
             # Output reserve never claims more than half the window...
-            assert session._summary_output_tokens() <= session.context_window // 2
+            assert (
+                session._compaction_engine.summary_output_tokens(_summary_runtime(session))
+                <= session.context_window // 2
+            )
             # ...so the input budget is healthy, not floored to 2000.
-            assert session._summary_input_budget_chars() > 10_000
+            assert (
+                session._compaction_engine.summary_input_budget_chars(_summary_runtime(session))
+                > 10_000
+            )
 
             session._system_tokens = 0
             session.messages = turns_from_dicts(
@@ -1044,7 +1115,10 @@ class TestChunkedCompaction:
         assert recorded  # at least one summary call happened
         out_tokens = recorded[0]
         assert out_tokens <= session.context_window // 2
-        rep_input_tokens = session._summary_input_budget_chars() / session._chars_per_token
+        rep_input_tokens = (
+            session._compaction_engine.summary_input_budget_chars(_summary_runtime(session))
+            / session._chars_per_token
+        )
         assert out_tokens + rep_input_tokens < session.context_window
 
     def test_empty_summary_keeps_history(self, session):
@@ -1450,18 +1524,20 @@ class TestChunkerOverflowSplit:
         blocks = ["A" * 4000, "B" * 4000, "C" * 4000]
         bodies: list[int] = []
 
-        def fake_once(_system_prompt, body, _my_generation=0, *, lane=None):
-            assert lane is not None
+        def fake_once(_system_prompt, body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
             bodies.append(len(body))
             if len(body) > 6_000:  # a multi-block body overflows the token window
                 raise RuntimeError("maximum context length is 524288 tokens")
-            return _SummaryResult(text="S", producer="summary-producer")
+            return SummaryResult(text="S", producer="summary-producer")
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=100_000),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=100_000
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
         ):
-            result = session._summarize_blocks(blocks)
+            result = _summarize_blocks(session, blocks)
 
         assert result.text == "S"  # produced a summary, never raised _CompactionIrreducible
         assert any(n > 6_000 for n in bodies)  # the combined batch overflowed…
@@ -1478,18 +1554,20 @@ class TestChunkerOverflowSplit:
         blocks = [f"b{i:02d} " + "z" * 500 for i in range(8)]
         calls: list[str] = []
 
-        def fake_once(_system_prompt, body, _my_generation=0, *, lane=None):
-            assert lane is not None
+        def fake_once(_system_prompt, body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
             calls.append(body)
             if body.count("\n\n") >= 4:  # a body of 5+ blocks overflows the window
                 raise RuntimeError("maximum context length is 524288 tokens")
-            return _SummaryResult(text="S", producer="summary-producer")
+            return SummaryResult(text="S", producer="summary-producer")
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=1_000_000),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=1_000_000
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
         ):
-            result = session._summarize_blocks(blocks)
+            result = _summarize_blocks(session, blocks)
 
         assert result.text == "S"
         # Binary subdivision: [8] → two [4] halves that both fit — a handful of calls,
@@ -1502,21 +1580,23 @@ class TestChunkerOverflowSplit:
     def test_lone_oversized_block_floored_then_succeeds(self, session):
         # A single block that overflows even by itself is head/tail-truncated to
         # the floor and retried once — not bailed.
-        floor = session._MIN_SUMMARY_BUDGET_CHARS
+        floor = session._compaction_engine.MIN_SUMMARY_BUDGET_CHARS
         calls: list[int] = []
 
-        def fake_once(_system_prompt, body, _my_generation=0, *, lane=None):
-            assert lane is not None
+        def fake_once(_system_prompt, body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
             calls.append(len(body))
             if len(body) > floor:
                 raise RuntimeError("maximum context length is 524288 tokens")
-            return _SummaryResult(text="S", producer="summary-producer")
+            return SummaryResult(text="S", producer="summary-producer")
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=50_000),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=50_000
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
         ):
-            result = session._summarize_blocks(["Z" * 20_000])
+            result = _summarize_blocks(session, ["Z" * 20_000])
 
         assert result.text == "S"  # floored block summarized, not bailed
         assert any(n > floor for n in calls)  # the over-floor call overflowed…
@@ -1527,21 +1607,23 @@ class TestChunkerOverflowSplit:
         NOT slammed straight to the 2 000-char floor — so when a mid-size truncation
         already fits the window, far more of the message survives than a floor jump
         would keep (the single-block analogue of the multi-block binary subdivision)."""
-        floor = session._MIN_SUMMARY_BUDGET_CHARS
+        floor = session._compaction_engine.MIN_SUMMARY_BUDGET_CHARS
         calls: list[int] = []
 
-        def fake_once(_system_prompt, body, _my_generation=0, *, lane=None):
-            assert lane is not None
+        def fake_once(_system_prompt, body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
             calls.append(len(body))
             if len(body) > 9_000:  # only bodies well above the floor overflow
                 raise RuntimeError("maximum context length is 524288 tokens")
-            return _SummaryResult(text="S", producer="summary-producer")
+            return SummaryResult(text="S", producer="summary-producer")
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=50_000),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=50_000
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
         ):
-            result = session._summarize_blocks(["Z" * 16_000])
+            result = _summarize_blocks(session, ["Z" * 16_000])
 
         assert result.text == "S"
         # First shrink budget is len//2 == 8 000 (< the 9 000 overflow line), so it
@@ -1553,22 +1635,24 @@ class TestChunkerOverflowSplit:
     def test_non_shrinking_merge_bails_at_depth_not_recursionerror(self, session):
         """If per-block summaries never compress (the merge keeps overflowing),
         recursion is bounded by the depth ceiling and bails to
-        _CompactionIrreducibleError — NOT an unbounded recurse into RecursionError.
+        CompactionIrreducibleError — NOT an unbounded recurse into RecursionError.
         Regression for the depth-check-only-on-the-multi-batch-path bug."""
 
-        def no_shrink(_system_prompt, body, _my_generation=0, *, lane=None):
-            assert lane is not None
+        def no_shrink(_system_prompt, body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
             if "\n\n" in body:  # any multi-block body overflows the window
                 raise RuntimeError("maximum context length is 524288 tokens")
             # A single-block 'summary' is the block itself — no shrink.
-            return _SummaryResult(text=body, producer="summary-producer")
+            return SummaryResult(text=body, producer="summary-producer")
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=100_000),
-            patch.object(session, "_summarize_once", side_effect=no_shrink),
-            pytest.raises(_CompactionIrreducibleError),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=100_000
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=no_shrink),
+            pytest.raises(CompactionIrreducibleError),
         ):
-            session._summarize_blocks(["A" * 4000, "B" * 4000, "C" * 4000])
+            _summarize_blocks(session, ["A" * 4000, "B" * 4000, "C" * 4000])
 
     def test_later_batch_overflow_keeps_completed_siblings(self, session):
         """A later batch overflowing and splitting does NOT re-summarize earlier
@@ -1578,18 +1662,20 @@ class TestChunkerOverflowSplit:
         blocks = ["A" * 2000, "B" * 2000, "C" * 2000, "D" * 2000]
         bodies: list[str] = []
 
-        def fake_once(_system_prompt, body, _my_generation=0, *, lane=None):
-            assert lane is not None
+        def fake_once(_system_prompt, body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
             bodies.append(body)
             if "CC" in body and "\n\n" in body:  # the multi-block batch holding C
                 raise RuntimeError("maximum context length is 524288 tokens")
-            return _SummaryResult(text="S", producer="summary-producer")
+            return SummaryResult(text="S", producer="summary-producer")
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=4_500),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=4_500
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
         ):
-            result = session._summarize_blocks(blocks)
+            result = _summarize_blocks(session, blocks)
 
         assert result.text == "S"
         # The first batch (A+B) was summarized exactly once, never recomputed after
@@ -1619,7 +1705,9 @@ class TestChunkerOverflowSplit:
 
         try:
             with (
-                patch.object(session, "_summary_input_budget_chars", return_value=3_500),
+                patch.object(
+                    session._compaction_engine, "summary_input_budget_chars", return_value=3_500
+                ),
                 patch.object(session, "_utility_completion", side_effect=cancel_then_summarize),
                 pytest.raises(GenerationCancelled),
             ):
@@ -1652,7 +1740,9 @@ class TestChunkerOverflowSplit:
         try:
             with (
                 # Huge budget → all blocks pack into ONE batch → exactly one call.
-                patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+                patch.object(
+                    session._compaction_engine, "summary_input_budget_chars", return_value=100_000
+                ),
                 patch.object(session, "_utility_completion", side_effect=cancel_during_call),
                 pytest.raises(GenerationCancelled),
             ):
@@ -1679,7 +1769,9 @@ class TestChunkerOverflowSplit:
         before = list(session.messages)
         try:
             with (
-                patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+                patch.object(
+                    session._compaction_engine, "summary_input_budget_chars", return_value=100_000
+                ),
                 patch.object(session, "_utility_completion") as uc,
                 pytest.raises(GenerationCancelled),
             ):
@@ -1737,7 +1829,9 @@ class TestChunkerOverflowSplit:
             content="SUMMARY", finish_reason="stop", producer="summary-producer"
         )
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=100_000),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=100_000
+            ),
             patch.object(session, "_utility_completion", return_value=summary),
             pytest.raises(GenerationCancelled),
         ):
@@ -1775,9 +1869,9 @@ class TestChunkerOverflowSplit:
 
         with (
             patch.object(
-                session,
-                "_summarize_blocks",
-                return_value=_SummaryResult(text="stale summary", producer="stale-producer"),
+                session._compaction_engine,
+                "summarize_blocks",
+                return_value=SummaryResult(text="stale summary", producer="stale-producer"),
             ),
             patch(
                 "turnstone.core.session.require_lane_capabilities", side_effect=block_before_commit
@@ -1939,6 +2033,26 @@ class _ObservedRLock:
 
 
 class TestCompactionPublicationFence:
+    def test_repeated_workstream_compactions_use_distinct_attempt_ids(self, session):
+        _seed_two_messages(session)
+        summary = SimpleNamespace(
+            content="dense summary",
+            finish_reason="stop",
+            producer="summary-producer",
+        )
+        with (
+            patch.object(session, "_utility_completion", return_value=summary),
+            patch.object(session.ui, "on_compaction") as on_compaction,
+            patch("turnstone.core.session.save_message"),
+        ):
+            assert session._compact_messages() is True
+            assert session._compact_messages() is True
+
+        events = _compaction_events(on_compaction)
+        assert [event["phase"] for event in events] == ["start", "end", "start", "end"]
+        assert [event["compaction_id"] for event in events] == [1, 1, 2, 2]
+        assert {event["target"] for event in events} == {"workstream"}
+
     @pytest.mark.parametrize("phase", ["start", "progress"])
     @pytest.mark.parametrize("terminal", ["superseded", "cancelled", "closed"])
     def test_non_end_event_is_not_emitted_after_terminal_boundary(
@@ -2063,7 +2177,9 @@ class TestCompactionLifecycleEvents:
     def test_summary_error_emits_failed_end_and_returns_false(self, session):
         _seed_two_messages(session)
         with (
-            patch.object(session, "_summarize_blocks", side_effect=RuntimeError("boom")),
+            patch.object(
+                session._compaction_engine, "summarize_blocks", side_effect=RuntimeError("boom")
+            ),
             patch.object(session.ui, "on_compaction") as oc,
         ):
             assert session._compact_messages() is False
@@ -2076,7 +2192,11 @@ class TestCompactionLifecycleEvents:
         """A presentation teardown failure cannot re-enter the END backstop."""
         _seed_two_messages(session)
         with (
-            patch.object(session, "_summarize_blocks", side_effect=RuntimeError("summary boom")),
+            patch.object(
+                session._compaction_engine,
+                "summarize_blocks",
+                side_effect=RuntimeError("summary boom"),
+            ),
             patch.object(session.ui, "on_thinking_stop", side_effect=RuntimeError("ui boom")),
             patch.object(session.ui, "on_compaction") as on_compaction,
         ):
@@ -2099,7 +2219,7 @@ class TestCompactionLifecycleEvents:
             summary_started.set()
             if not release_summary.wait(2):
                 raise RuntimeError("test release timed out")
-            return _SummaryResult(text="late summary", producer="summary-producer")
+            return SummaryResult(text="late summary", producer="summary-producer")
 
         def run_compaction() -> None:
             try:
@@ -2108,7 +2228,7 @@ class TestCompactionLifecycleEvents:
                 outcomes.append(exc)
 
         with (
-            patch.object(session, "_summarize_blocks", side_effect=summarize),
+            patch.object(session._compaction_engine, "summarize_blocks", side_effect=summarize),
             patch.object(session.ui, "on_thinking_stop") as thinking_stop,
         ):
             worker = threading.Thread(target=run_compaction)
@@ -2128,7 +2248,11 @@ class TestCompactionLifecycleEvents:
     def test_irreducible_emits_failed_end(self, session):
         _seed_two_messages(session)
         with (
-            patch.object(session, "_summarize_blocks", side_effect=_CompactionIrreducibleError()),
+            patch.object(
+                session._compaction_engine,
+                "summarize_blocks",
+                side_effect=CompactionIrreducibleError(),
+            ),
             patch.object(session.ui, "on_compaction") as oc,
         ):
             assert session._compact_messages() is False
@@ -2151,7 +2275,9 @@ class TestCompactionLifecycleEvents:
         retire the in-progress card via a cancelled end event."""
         _seed_two_messages(session)
         with (
-            patch.object(session, "_summarize_blocks", side_effect=GenerationCancelled()),
+            patch.object(
+                session._compaction_engine, "summarize_blocks", side_effect=GenerationCancelled()
+            ),
             patch.object(session.ui, "on_compaction") as oc,
             pytest.raises(GenerationCancelled),
         ):
@@ -2169,7 +2295,9 @@ class TestCompactionLifecycleEvents:
         (str(KeyboardInterrupt()) is '')."""
         _seed_two_messages(session)
         with (
-            patch.object(session, "_summarize_blocks", side_effect=KeyboardInterrupt()),
+            patch.object(
+                session._compaction_engine, "summarize_blocks", side_effect=KeyboardInterrupt()
+            ),
             patch.object(session.ui, "on_error") as on_error,
             patch.object(session.ui, "on_compaction") as oc,
             pytest.raises(KeyboardInterrupt),
@@ -2264,20 +2392,22 @@ class TestCompactionLifecycleEvents:
         saved: dict = {}
         producers: list[str] = []
 
-        def fake_once(system_prompt, _body, _my_generation=0, *, lane=None):
-            assert lane is not None
-            is_merge = system_prompt == session._COMPACTOR_MERGE_SYSTEM_PROMPT
+        def fake_once(system_prompt, _body, runtime):
+            assert isinstance(runtime, SummaryRuntime)
+            is_merge = system_prompt == session._compaction_engine.COMPACTOR_MERGE_SYSTEM_PROMPT
             producer = "final-merge-producer" if is_merge else "leaf-producer"
             producers.append(producer)
-            return _SummaryResult(text="FINAL" if is_merge else "partial", producer=producer)
+            return SummaryResult(text="FINAL" if is_merge else "partial", producer=producer)
 
         def fake_save(ws_id, role, content, **kwargs):
             saved.update({"ws_id": ws_id, "role": role, "content": content, **kwargs})
             return 1
 
         with (
-            patch.object(session, "_summary_input_budget_chars", return_value=450),
-            patch.object(session, "_summarize_once", side_effect=fake_once),
+            patch.object(
+                session._compaction_engine, "summary_input_budget_chars", return_value=450
+            ),
+            patch.object(session._compaction_engine, "summarize_once", side_effect=fake_once),
             patch.object(get_storage(), "get_compaction_watermark", return_value=17),
             patch("turnstone.core.session.save_message", side_effect=fake_save),
         ):
@@ -2337,7 +2467,9 @@ class TestCompactNow:
             raise GenerationCancelled()
 
         with (
-            patch.object(session, "_summarize_blocks", side_effect=cancel_mid_summary),
+            patch.object(
+                session._compaction_engine, "summarize_blocks", side_effect=cancel_mid_summary
+            ),
             pytest.raises(GenerationCancelled),
         ):
             session.compact_now()
@@ -2363,10 +2495,10 @@ class TestCompactNow:
             # while this compaction is inside its summarize call.
             session._generation += 1
             session._cancel_event = threading.Event()
-            return _SummaryResult(text="stale summary", producer="stale-producer")
+            return SummaryResult(text="stale summary", producer="stale-producer")
 
         with (
-            patch.object(session, "_summarize_blocks", side_effect=supersede),
+            patch.object(session._compaction_engine, "summarize_blocks", side_effect=supersede),
             pytest.raises(GenerationCancelled),
         ):
             session.compact_now()
@@ -2875,7 +3007,7 @@ class TestOrphanedCompactionRetirement:
             patch.object(session, "_utility_completion") as uc,
             pytest.raises(GenerationCancelled),
         ):
-            session._summarize_blocks(["block-a"], my_generation=4)
+            _summarize_blocks(session, ["block-a"], my_generation=4)
         uc.assert_not_called()  # retired BEFORE spending another model call
 
     def test_cancel_during_retry_backoff_aborts_immediately(self, session):
@@ -2888,7 +3020,7 @@ class TestOrphanedCompactionRetirement:
             patch.object(session, "_stop_retrying", return_value=False),
             pytest.raises(GenerationCancelled),
         ):
-            session._summarize_once("sys", "body")
+            _summarize_once(session, "sys", "body")
 
     def test_summary_call_registers_abortable_stream(self, session):
         """Each summary attempt passes a fresh _CancelRef so cancel() can
@@ -2913,8 +3045,8 @@ class TestOrphanedCompactionRetirement:
             )
 
         with patch.object(session, "_utility_completion", side_effect=fake_uc):
-            assert session._summarize_once("sys", "body").text == "dense"
-            assert session._summarize_once("sys", "body").text == "dense"
+            assert _summarize_once(session, "sys", "body").text == "dense"
+            assert _summarize_once(session, "sys", "body").text == "dense"
         assert len(seen) == 2
         assert all(isinstance(ref, _CancelRef) for ref in seen)
         assert seen[0] is not seen[1]  # scoped to its call, never reused
@@ -2980,7 +3112,7 @@ class TestOrphanedCompactionRetirement:
             )
 
         with patch.object(session, "_utility_completion", side_effect=fake_uc):
-            session._summarize_once("sys", "body", my_generation=3)
+            _summarize_once(session, "sys", "body", my_generation=3)
         assert isinstance(seen[0], _CancelRef)
         assert seen[0]._my_generation == 3
 
@@ -2996,7 +3128,7 @@ class TestOrphanedCompactionRetirement:
             )
 
         with patch.object(session, "_utility_completion", side_effect=fake_uc):
-            session._summarize_once("sys", "body", my_generation=3)
+            _summarize_once(session, "sys", "body", my_generation=3)
 
         assert seen == ["user-a"]
 
@@ -3013,7 +3145,7 @@ class TestOrphanedCompactionRetirement:
             patch.object(session, "_utility_completion", side_effect=fake_uc),
             pytest.raises(GenerationCancelled),
         ):
-            session._summarize_once("sys", "body")
+            _summarize_once(session, "sys", "body")
 
 
 # ---------------------------------------------------------------------------
@@ -3028,7 +3160,9 @@ class TestCompactionErrorChannel:
         failures fed before the lifecycle events replaced on_error here."""
         _seed_two_messages(session)
         with (
-            patch.object(session, "_summarize_blocks", side_effect=RuntimeError("boom")),
+            patch.object(
+                session._compaction_engine, "summarize_blocks", side_effect=RuntimeError("boom")
+            ),
             patch.object(session.ui, "on_error") as on_error,
             patch.object(session.ui, "on_compaction") as oc,
         ):

--- a/tests/test_history_handoff_js.py
+++ b/tests/test_history_handoff_js.py
@@ -117,6 +117,7 @@ const pane = {
   _forceTimeout: null,
   _compaction: {},
   _agentContexts: new Map(),
+  _agentCompactions: new Map(),
   _streamHealth: { renderThrows: 0 },
   _actingUserId: null,
   pendingApproval: false,

--- a/tests/test_history_total_prefix.py
+++ b/tests/test_history_total_prefix.py
@@ -29,6 +29,7 @@ from turnstone.core import session as session_module
 from turnstone.core import session_worker
 from turnstone.core.attachment_buffer import get_attachment_buffer
 from turnstone.core.attachments import Attachment, resolve_staged_attachments
+from turnstone.core.compaction import SummaryResult
 from turnstone.core.storage._registry import get_storage
 from turnstone.core.trajectory import turns_from_dicts
 
@@ -378,9 +379,9 @@ def test_compaction_end_crossing_is_visible_to_fresh_history_handoff(tmp_db: Any
     registration: Any = None
     with (
         patch.object(
-            session,
-            "_summarize_blocks",
-            return_value=session_module._SummaryResult(
+            session._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(
                 text=summary,
                 producer="openai-compatible",
             ),
@@ -735,9 +736,9 @@ def test_compaction_marker_lost_ack_has_one_success_end_and_one_row(tmp_db: Any)
 
     with (
         patch.object(
-            session,
-            "_summarize_blocks",
-            return_value=session_module._SummaryResult(text=summary, producer="kernel"),
+            session._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(text=summary, producer="kernel"),
         ),
         patch.object(session.ui, "on_compaction", side_effect=[41, 42]) as compaction_events,
         patch.object(get_storage(), "get_compaction_watermark", return_value=2),

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -1454,8 +1454,17 @@ def test_task_agent_context_badge_is_keyed_idempotent_and_terminal_safe() -> Non
         )
     ]
     assert "this._agentContexts.set(parentId, { promptTokens, contextWindow });" in update
-    assert "terminal.row === parentRow" in update
+    assert "this._agentTransientRoute(parentId)" in update
     assert "this._ensureAgentCard(parentId, true)" in update
+
+    route = body[
+        body.index("_agentTransientRoute(parentId) {") : body.index(
+            "_handleAgentCompaction(evt) {", body.index("_agentTransientRoute(parentId) {")
+        )
+    ]
+    assert "terminal.row !== parentRow" in route
+    assert 'state: "blocked"' in route
+    assert 'state: "drop"' in route
 
     relink = body[
         body.index("_relinkAgentCards(items) {") : body.index(
@@ -1485,9 +1494,10 @@ def test_task_agent_context_badge_is_keyed_idempotent_and_terminal_safe() -> Non
     assert '"Warning: " + context.title' in accessible
     assert 'label.textContent || "0 steps"' in accessible
 
-    assert "blockedByTerminalRow: parentRow" in update
+    assert "blockedByTerminalRow: route.row" in update
     state_case = body[body.index('case "state_change":') : body.index('case "tool_pending":')]
     assert "reading.blockedByTerminalRow" in state_case
+    assert "holder.blockedByTerminalRow" in state_case
 
     result = body[
         body.index("appendToolOutput(callId") : body.index(
@@ -1506,6 +1516,238 @@ def test_task_agent_context_badge_is_keyed_idempotent_and_terminal_safe() -> Non
     ]
     assert "delete card.wrap.dataset.contextOnly;" in route
     assert "card.wrap.hidden = false;" in route
+
+
+def test_task_agent_compaction_is_buffered_nested_and_terminal_safe() -> None:
+    """Targeted compaction follows the parent task-card lifecycle."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    handler = body[
+        body.index("_handleAgentCompaction(evt) {") : body.index(
+            "_routeAgentItems(items", body.index("_handleAgentCompaction(evt) {")
+        )
+    ]
+    assert "this._agentCompactions.set(parentId, holder);" in handler
+    assert 'if (evt.phase === "end") return;' in handler
+    assert "incomingCid !== activeCid" in handler
+    assert "holder.pending = evt;" in handler
+    assert "this._agentTransientRoute(parentId)" in handler
+    assert "holder.blockedByTerminalRow = route.row" in handler
+    assert "renderResult: false" in handler
+    assert "card.wrap.insertBefore(node, card.body)" in handler
+    assert 'notice.className = "conv-agent-compaction-notice"' in handler
+    assert "this._agentCompactions.delete(parentId);" in handler
+
+    relink = body[
+        body.index("_relinkAgentCards(items) {") : body.index(
+            "_updateAgentLabel(", body.index("_relinkAgentCards(items) {")
+        )
+    ]
+    assert "this._agentCompactions.has(it.call_id)" in relink
+
+    result = body[
+        body.index("appendToolOutput(callId") : body.index(
+            "sendMessage() {", body.index("appendToolOutput(callId")
+        )
+    ]
+    assert "this._agentCompactions.delete(callId);" in result
+    assert "resetCompactionHolder(this._agentCompactions.get(callId))" in result
+
+    clear = body[
+        body.index("_clearAgentTracking() {") : body.index(
+            "_recordTruncatedGap()", body.index("_clearAgentTracking() {")
+        )
+    ]
+    assert "for (const holder of this._agentCompactions.values())" in clear
+    assert "this._agentCompactions.clear();" in clear
+
+
+def test_task_agent_compaction_handler_preserves_newer_attempt(tmp_path: Path) -> None:
+    """Execute the pane wrapper, not only the shared lifecycle reducer.
+
+    A stale end must neither clear a newer holder nor create an empty task card
+    when no local attempt exists.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which("node") is None:
+        pytest.skip("node binary not available on PATH")
+
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    handler = _extract_braced(body, "  _handleAgentCompaction(evt) {").strip()
+    script = tmp_path / "agent_compaction_handler_harness.mjs"
+    script.write_text(
+        "const handleAgentCompaction = function "
+        + handler
+        + r""";
+
+let ensureCalls = 0;
+let resets = 0;
+function resetCompactionHolder(holder) {
+  resets += 1;
+  holder.card = null;
+  holder.cid = null;
+}
+const pane = {
+  _agentCompactions: new Map(),
+  _agentTransientRoute() { return { state: "current", row: null }; },
+  _ensureAgentCard() {
+    ensureCalls += 1;
+    return {};
+  },
+  _syncAgentCompaction(parentId) {
+    const holder = this._agentCompactions.get(parentId);
+    const evt = holder && holder.pending;
+    if (!evt) return;
+    holder.pending = null;
+    if (evt.phase === "start") {
+      holder.card = {};
+      holder.cid = String(evt.compaction_id);
+    } else if (
+      evt.phase === "end" &&
+      (holder.cid == null || String(evt.compaction_id) === holder.cid)
+    ) {
+      resetCompactionHolder(holder);
+    }
+  },
+  _handleAgentCompaction: handleAgentCompaction,
+};
+
+pane._handleAgentCompaction({
+  phase: "end", parent_call_id: "task-A", compaction_id: 9, ok: true,
+});
+if (pane._agentCompactions.size !== 0 || ensureCalls !== 0)
+  throw new Error("orphan end manufactured task state");
+
+pane._handleAgentCompaction({
+  phase: "start", parent_call_id: "task-A", compaction_id: 12,
+});
+const live = pane._agentCompactions.get("task-A");
+if (!live || live.cid !== "12" || !live.card)
+  throw new Error("start did not establish attempt 12");
+
+pane._handleAgentCompaction({
+  phase: "end", parent_call_id: "task-A", compaction_id: 11, ok: true,
+});
+if (pane._agentCompactions.get("task-A") !== live || live.cid !== "12" || !live.card)
+  throw new Error("stale end retired attempt 12");
+
+pane._handleAgentCompaction({
+  phase: "end", parent_call_id: "task-A", compaction_id: 12, ok: true,
+});
+if (pane._agentCompactions.size !== 0 || live.card !== null || live.cid !== null)
+  throw new Error("owning end did not retire attempt 12");
+if (resets !== 2) throw new Error("unexpected reset count: " + resets);
+""",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["node", str(script)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, f"agent compaction harness failed:\n{proc.stderr}\n{proc.stdout}"
+
+
+def test_recycled_parent_compaction_waits_for_successor_occurrence(tmp_path: Path) -> None:
+    """Compaction and context share one terminal-occurrence gate."""
+
+    import shutil
+    import subprocess
+
+    if shutil.which("node") is None:
+        pytest.skip("node binary not available on PATH")
+
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    route = _extract_braced(body, "  _agentTransientRoute(parentId) {").strip()
+    handler = _extract_braced(body, "  _handleAgentCompaction(evt) {").strip()
+    relink = _extract_braced(body, "  _relinkAgentCards(items) {").strip()
+    script = tmp_path / "agent_compaction_occurrence_harness.mjs"
+    script.write_text(
+        "const agentTransientRoute = function "
+        + route
+        + ";\nconst handleAgentCompaction = function "
+        + handler
+        + ";\nconst relinkAgentCards = function "
+        + relink
+        + r""";
+
+function resetCompactionHolder(holder) {
+  holder.card = null;
+  holder.cid = null;
+}
+const oldRow = { name: "old" };
+const successorRow = { name: "successor" };
+const uniqueRow = { name: "unique" };
+let parentRow = oldRow;
+const attached = [];
+const pane = {
+  busy: true,
+  _agentCards: new Map(),
+  _agentContexts: new Map(),
+  _agentCompactions: new Map(),
+  _toolResultNodes: new Map([["task-A", { row: oldRow }]]),
+  _toolRow() { return parentRow; },
+  _agentTransientRoute: agentTransientRoute,
+  _handleAgentCompaction: handleAgentCompaction,
+  _relinkAgentCards: relinkAgentCards,
+  _ensureAgentCard(parentId) {
+    if (!parentRow) return null;
+    attached.push(parentRow);
+    const card = { wrap: { dataset: { state: "running" } } };
+    this._syncAgentCompaction(parentId, card);
+    return card;
+  },
+  _syncAgentCompaction(parentId) {
+    const holder = this._agentCompactions.get(parentId);
+    if (!holder || !holder.pending || holder.blockedByTerminalRow) return;
+    const evt = holder.pending;
+    holder.pending = null;
+    if (evt.phase === "start") {
+      holder.card = {};
+      holder.cid = String(evt.compaction_id);
+    }
+  },
+  _flushAgentOrphans() {},
+};
+
+pane._handleAgentCompaction({
+  phase: "start", parent_call_id: "task-A", compaction_id: 1,
+});
+const blocked = pane._agentCompactions.get("task-A");
+if (!blocked || blocked.blockedByTerminalRow !== oldRow || attached.length !== 0)
+  throw new Error("recycled id attached compaction to the terminal occurrence");
+
+parentRow = successorRow;
+pane._relinkAgentCards([{ call_id: "task-A" }]);
+if (attached.length !== 1 || attached[0] !== successorRow)
+  throw new Error("successor occurrence did not receive buffered compaction");
+if (blocked.blockedByTerminalRow || blocked.cid !== "1" || !blocked.card)
+  throw new Error("buffered compaction did not activate on successor row");
+
+pane._agentCompactions.clear();
+pane._toolResultNodes.clear();
+parentRow = null;
+pane._handleAgentCompaction({
+  phase: "start", parent_call_id: "task-B", compaction_id: 2,
+});
+if (attached.length !== 1)
+  throw new Error("unique pre-parent event attached without a row");
+parentRow = uniqueRow;
+pane._relinkAgentCards([{ call_id: "task-B" }]);
+if (attached.length !== 2 || attached[1] !== uniqueRow)
+  throw new Error("unique id control did not attach when its row painted");
+""",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["node", str(script)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, f"occurrence harness failed:\n{proc.stderr}\n{proc.stdout}"
 
 
 def test_idless_agent_context_snapshot_relinks_after_parent_runtime(tmp_path: Path) -> None:
@@ -1537,8 +1779,10 @@ let attached = 0;
 const pane = {
   busy: true,
   _agentContexts: new Map(),
+  _agentCompactions: new Map(),
   _toolResultNodes: new Map(),
   _toolRow() { return parentRow; },
+  _agentTransientRoute() { return { state: "current", row: parentRow }; },
   _ensureAgentCard(parentId, contextOnly) {
     if (!parentRow) return null;
     const reading = this._agentContexts.get(parentId);

--- a/tests/test_per_user_message_context.py
+++ b/tests/test_per_user_message_context.py
@@ -21,8 +21,9 @@ from unittest.mock import MagicMock, patch
 
 from tests._session_helpers import make_session
 from turnstone.core import fence
+from turnstone.core.compaction import SummaryResult
 from turnstone.core.providers._anthropic import AnthropicProvider
-from turnstone.core.session import _prefix_sender_label, _SummaryResult
+from turnstone.core.session import _prefix_sender_label
 from turnstone.core.storage._utils import reconstruct_turns
 from turnstone.core.trajectory import Role, turn_from_dict, turn_to_dict
 
@@ -598,9 +599,9 @@ def test_resume_recovers_compacted_out_sender_end_to_end(tmp_db, mock_openai_cli
     sess.messages = turns_from_dicts(history)
     sess._msg_tokens = [1] * len(history)
     with _patch.object(
-        sess,
-        "_summarize_blocks",
-        return_value=_SummaryResult(text="owner and alice spoke", producer="summary-producer"),
+        sess._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="owner and alice spoke", producer="summary-producer"),
     ):
         assert sess._compact_messages(auto=False) is True  # summarizes BOTH away
 

--- a/tests/test_sdk_events.py
+++ b/tests/test_sdk_events.py
@@ -11,6 +11,7 @@ from turnstone.sdk.events import (
     ClusterWsClosedEvent,
     ClusterWsCreatedEvent,
     ClusterWsRenameEvent,
+    CompactionEvent,
     ConnectedEvent,
     ContentEvent,
     ErrorEvent,
@@ -482,6 +483,32 @@ def test_agent_context_event_round_trip():
     assert e.parent_call_id == "task-A"
     assert e.prompt_tokens == 41_000
     assert e.context_window == 128_000
+
+
+def test_task_agent_compaction_event_round_trip():
+    e = ServerEvent.from_dict(
+        {
+            "type": "compaction",
+            "phase": "progress",
+            "target": "task_agent",
+            "parent_call_id": "task-A",
+            "compaction_id": 17,
+            "part": 2,
+            "total": 4,
+        }
+    )
+    assert isinstance(e, CompactionEvent)
+    assert e.target == "task_agent"
+    assert e.parent_call_id == "task-A"
+    assert e.compaction_id == 17
+    assert e.part == 2
+
+
+def test_compaction_event_without_target_means_workstream():
+    e = ServerEvent.from_dict({"type": "compaction", "phase": "start", "compaction_id": 3})
+    assert isinstance(e, CompactionEvent)
+    assert e.target == "workstream"
+    assert e.parent_call_id == ""
 
 
 def test_state_change_event_round_trip():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -35,9 +35,11 @@ from turnstone.core.session import (
     _IMAGE_SIZE_CAP,
     _MEMORY_MIXED_BATCH_ERROR,
     ChatSession,
+    _TaskExecutionJournal,
 )
 from turnstone.core.storage import get_storage
 from turnstone.core.trajectory import (
+    EffectStatus,
     Role,
     Turn,
     dicts_from_turns,
@@ -3899,7 +3901,7 @@ class TestAgentContextReporting:
 
         assert ui.context_calls == []
 
-    def test_unparented_agent_does_not_compute_or_emit_badge_usage(self) -> None:
+    def test_unparented_agent_resolves_compaction_window_but_emits_no_badge(self) -> None:
         from turnstone.core.providers import UsageInfo
 
         ui = self._ContextUI()
@@ -3910,12 +3912,12 @@ class TestAgentContextReporting:
         )
 
         with (
-            patch.object(session, "_context_window_for_lane") as window,
+            patch.object(session, "_context_window_for_lane", return_value=128_000) as window,
             patch("turnstone.core.session.model_turn", return_value=result),
         ):
             session._run_agent([Turn.user("test")], tools=[], auto_tools=set())
 
-        window.assert_not_called()
+        window.assert_called_once()
         assert ui.context_calls == []
 
     def test_superseded_generation_cannot_publish_context(self) -> None:
@@ -4062,13 +4064,13 @@ class TestAgentChildRegistration:
             ("task-1::r1s2::call_0", "task-1"),
         ]
         # Recall projection: two steps, each paired to its OWN result.
-        steps = ChatSession._project_agent_steps(agent_turns)
+        journal = _TaskExecutionJournal(agent_turns)
+        steps = journal.project_steps()
         assert [s["id"] for s in steps] == ["task-1::r1s1::call_0", "task-1::r1s2::call_0"]
         assert [s["output"] for s in steps] == ["contents-1", "contents-2"]
-        # Cancel ledger agrees: both calls answered, no in-flight gap.
-        issued, first_gap = ChatSession._cancel_ledger(agent_turns)
-        assert issued == [("read_file", True), ("read_file", True)]
-        assert first_gap is None
+        # Cancellation truth agrees: both calls answered, so the incomplete
+        # overall task is PARTIAL rather than an in-flight UNKNOWN.
+        assert journal.cancelled_status() is EffectStatus.PARTIAL
 
     @staticmethod
     def _reusing_provider(session, tool_turns: int = 1):
@@ -4581,10 +4583,8 @@ class TestRunAgentDenialMessage:
         assert text == "Blocked by tool policy ('notify')"
 
 
-class TestProjectAgentSteps:
-    """``_project_agent_steps`` projects a finished sub-agent's trajectory into
-    recall step items for the task card — one per tool call, matched to its
-    result by call_id, landmine-safe on a multimodal result."""
+class TestTaskExecutionJournalProjection:
+    """The live journal projects bounded task-card recall step items."""
 
     def test_calls_matched_to_results_in_order(self):
         from turnstone.core.trajectory import ToolCall, Turn
@@ -4601,7 +4601,7 @@ class TestProjectAgentSteps:
             ),
             Turn.tool("c2", "boom", is_error=True),
         ]
-        steps = ChatSession._project_agent_steps(turns)
+        steps = _TaskExecutionJournal(turns).project_steps()
         assert [s["id"] for s in steps] == ["c1", "c2"]
         assert steps[0] == {
             "id": "c1",
@@ -4625,7 +4625,7 @@ class TestProjectAgentSteps:
             ),
             Turn.tool("c1", [{"type": "image_url"}]),
         ]
-        steps = ChatSession._project_agent_steps(turns)
+        steps = _TaskExecutionJournal(turns).project_steps()
         assert steps[0]["output"] == "[non-text result]"
 
     def test_output_capped(self):
@@ -4637,7 +4637,7 @@ class TestProjectAgentSteps:
             Turn.assistant(tool_calls=(ToolCall(id="c1", name="bash", arguments="{}"),)),
             Turn.tool("c1", big),
         ]
-        steps = ChatSession._project_agent_steps(turns)
+        steps = _TaskExecutionJournal(turns).project_steps()
         assert len(steps[0]["output"]) < len(big)
         assert "truncated from 2500 chars" in steps[0]["output"]
 
@@ -4647,10 +4647,33 @@ class TestProjectAgentSteps:
         from turnstone.core.trajectory import ToolCall, Turn
 
         turns = [Turn.assistant(tool_calls=(ToolCall(id="c1", name="bash", arguments="{}"),))]
-        steps = ChatSession._project_agent_steps(turns)
+        steps = _TaskExecutionJournal(turns).project_steps()
         assert steps == [
             {"id": "c1", "name": "bash", "arguments": "{}", "output": "", "is_error": False}
         ]
+
+    def test_cancelled_siblings_remain_in_issue_order(self):
+        """Materializing a later never-started call must not precede the
+        earlier call that was in flight when cancellation won."""
+        from turnstone.core.trajectory import ToolCall, Turn
+
+        turns = [
+            Turn.assistant(
+                tool_calls=(
+                    ToolCall(id="c1", name="bash", arguments='{"command":"deploy"}'),
+                    ToolCall(id="c2", name="search", arguments='{"query":"status"}'),
+                )
+            )
+        ]
+        journal = _TaskExecutionJournal(turns)
+        journal.mark_started("c1")
+        journal.materialize_unstarted(turns)
+
+        steps = journal.project_steps()
+        assert [step["id"] for step in steps] == ["c1", "c2"]
+        assert steps[0]["output"] == ""
+        assert steps[1]["output"] == "(cancelled before execution; no side effects)"
+        assert journal.cancelled_status() is EffectStatus.UNKNOWN
 
     def test_colliding_ids_paired_fifo_not_last_wins(self):
         # A local provider reuses id "call_0" across turns; FIFO pairing gives
@@ -4670,7 +4693,7 @@ class TestProjectAgentSteps:
             ),
             Turn.tool("call_0", "out-B"),
         ]
-        steps = ChatSession._project_agent_steps(turns)
+        steps = _TaskExecutionJournal(turns).project_steps()
         assert [s["output"] for s in steps] == ["out-A", "out-B"]
 
     def test_step_count_capped_with_honest_marker(self):
@@ -4683,7 +4706,7 @@ class TestProjectAgentSteps:
                 Turn.assistant(tool_calls=(ToolCall(id=f"c{i}", name="bash", arguments="{}"),))
             )
             turns.append(Turn.tool(f"c{i}", f"out{i}"))
-        steps = ChatSession._project_agent_steps(turns)
+        steps = _TaskExecutionJournal(turns).project_steps()
         # Capped + one honest LEADING marker, keeping the most RECENT steps (the
         # tail) — not the earliest — and naming how many earlier ones fell out.
         assert len(steps) == _AGENT_STEP_COUNT_CAP + 1
@@ -4695,7 +4718,7 @@ class TestProjectAgentSteps:
 
 
 class TestAgentTrajectoryStashWiring:
-    """``_stash_agent_trajectory`` projects + forwards to the UI, getattr-guarded."""
+    """The bounded recall projection is forwarded through one guarded seam."""
 
     def test_projects_and_forwards(self):
         from turnstone.core.trajectory import ToolCall, Turn
@@ -4706,7 +4729,7 @@ class TestAgentTrajectoryStashWiring:
             Turn.assistant(tool_calls=(ToolCall(id="c1", name="bash", arguments="{}"),)),
             Turn.tool("c1", "ok"),
         ]
-        session._stash_agent_trajectory("task1", turns)
+        session._stash_agent_steps("task1", _TaskExecutionJournal(turns).project_steps())
         session.ui.stash_agent_trajectory.assert_called_once()
         cid, steps = session.ui.stash_agent_trajectory.call_args[0]
         assert cid == "task1"
@@ -4717,12 +4740,12 @@ class TestAgentTrajectoryStashWiring:
     def test_noop_without_call_id(self):
         session = _make_session()
         session.ui = MagicMock()
-        session._stash_agent_trajectory(None, [])
+        session._stash_agent_steps(None, [])
         session.ui.stash_agent_trajectory.assert_not_called()
 
     def test_noop_on_ui_without_support(self):
         # NullUI has no stash_agent_trajectory → getattr None → no-op, no raise.
-        _make_session()._stash_agent_trajectory("task1", [])
+        _make_session()._stash_agent_steps("task1", [])
 
 
 class TestReadFilesIsolation:
@@ -4839,7 +4862,7 @@ class TestSubAgentErrorRecall:
         assert tool_turns, "expected a tool result turn"
         assert tool_turns[-1].is_error is True
         # And it carries through the projection to the recalled step.
-        assert ChatSession._project_agent_steps(turns)[-1]["is_error"] is True
+        assert _TaskExecutionJournal(turns).project_steps()[-1]["is_error"] is True
 
 
 class TestExecTaskReporting:
@@ -4855,7 +4878,7 @@ class TestExecTaskReporting:
 
     def test_success_reports_result(self):
         session = self._bare_session()
-        session.ui.clear_agent_context = MagicMock()
+        session.ui.clear_agent_transients = MagicMock()
         with (
             patch.object(session, "_run_agent", return_value="the synthesis"),
             patch.object(session, "_report_tool_result") as rpt,
@@ -4863,7 +4886,7 @@ class TestExecTaskReporting:
             cid, out = session._exec_task({"call_id": "t1", "prompt": "go"})
         assert (cid, out) == ("t1", "the synthesis")
         rpt.assert_called_once_with("t1", "task_agent", "the synthesis")
-        assert session.ui.clear_agent_context.call_args_list == [
+        assert session.ui.clear_agent_transients.call_args_list == [
             call("t1", generation=0),
             call("t1", generation=0),
         ]
@@ -4916,7 +4939,7 @@ class TestExecTaskReporting:
 
         session = self._bare_session()
         generation = session._claim_generation()
-        session.ui.clear_agent_context = MagicMock()
+        session.ui.clear_agent_transients = MagicMock()
 
         def supersede(*_args, **_kwargs):
             session._claim_generation()
@@ -4931,7 +4954,7 @@ class TestExecTaskReporting:
                 }
             )
 
-        session.ui.clear_agent_context.assert_called_once_with("t1", generation=generation)
+        session.ui.clear_agent_transients.assert_called_once_with("t1", generation=generation)
 
 
 def _install_output_guard_judge(session: ChatSession, judge: MagicMock) -> None:
@@ -10575,7 +10598,9 @@ class TestReminderSidechannelIsolation:
             )
         )
         session.messages.append(turn_from_dict({"role": "assistant", "content": "ok"}))
-        summary = session._format_messages_for_summary(dicts_from_turns(session.messages))
+        summary = session._compaction_engine.format_messages_for_summary(
+            dicts_from_turns(session.messages)
+        )
         assert "SECRET_NUDGE_TEXT" not in summary
         assert "[start system-reminder]" not in summary
         assert "user said this" in summary
@@ -10600,7 +10625,9 @@ class TestReminderSidechannelIsolation:
                 }
             )
         )
-        summary = session._format_messages_for_summary(dicts_from_turns(session.messages))
+        summary = session._compaction_engine.format_messages_for_summary(
+            dicts_from_turns(session.messages)
+        )
         assert "[image]" in summary
         assert "screenshot:" in summary
 

--- a/tests/test_session_ui_base.py
+++ b/tests/test_session_ui_base.py
@@ -1641,7 +1641,13 @@ def test_register_listener_with_in_progress_snapshot_empty() -> None:
     lq, snap = ui.register_listener_with_in_progress_snapshot()
     assert isinstance(lq, queue.Queue)
     assert lq in ui._listeners
-    assert snap == {"content": "", "reasoning": "", "seq": 0, "agent_contexts": []}
+    assert snap == {
+        "content": "",
+        "reasoning": "",
+        "seq": 0,
+        "agent_contexts": [],
+        "agent_compactions": [],
+    }
 
 
 def test_register_listener_with_in_progress_snapshot_populated() -> None:
@@ -2602,10 +2608,10 @@ class TestAgentContextSnapshots:
 
         # The retiring predecessor can neither overwrite nor clear generation 5.
         ui.on_agent_context("reused", 99, 100, generation=4)
-        ui.clear_agent_context("reused", generation=4)
+        ui.clear_agent_transients("reused", generation=4)
         assert ui._snapshot_agent_contexts()[0]["prompt_tokens"] == 20
 
-        ui.clear_agent_context("reused", generation=5)
+        ui.clear_agent_transients("reused", generation=5)
         assert ui._snapshot_agent_contexts() == []
 
     def test_force_cutoff_clears_only_retired_generations(self) -> None:
@@ -2614,7 +2620,7 @@ class TestAgentContextSnapshots:
         ui.on_agent_context("old-B", 20, 100, generation=4)
         ui.on_agent_context("successor", 30, 100, generation=5)
 
-        ui.clear_agent_contexts_before_generation(5)
+        ui.clear_agent_transients_before_generation(5)
 
         readings = ui._snapshot_agent_contexts()
         assert [event["parent_call_id"] for event in readings] == ["successor"]
@@ -2662,6 +2668,127 @@ class TestAgentContextSnapshots:
 
         assert not writer.is_alive()
         assert listener.get_nowait()["type"] == "agent_context"
+
+
+class TestAgentCompactionSnapshots:
+    """Task compaction is nested transient state, never foreground activity."""
+
+    def test_live_progress_snapshots_and_end_clears_without_activity_latch(self) -> None:
+        ui = _make_ui()
+        listener = ui._register_listener()
+        ui._ws_current_activity = "Running tool: task_agent"
+        ui._ws_activity_state = "tool"
+
+        ui.on_compaction(
+            {
+                "phase": "start",
+                "trigger": "auto",
+                "target": "task_agent",
+                "parent_call_id": "task-A",
+                "compaction_id": 11,
+                "_generation": 7,
+            }
+        )
+        start = listener.get_nowait()
+        assert start["target"] == "task_agent"
+        assert start["parent_call_id"] == "task-A"
+        assert "_generation" not in start
+        assert ui._ws_current_activity == "Running tool: task_agent"
+        assert ui._ws_activity_state == "tool"
+        assert ui._compaction_activity_live is False
+
+        ui.on_compaction(
+            {
+                "phase": "progress",
+                "part": 2,
+                "total": 3,
+                "depth": 0,
+                "target": "task_agent",
+                "parent_call_id": "task-A",
+                "compaction_id": 11,
+                "_generation": 7,
+            }
+        )
+        listener.get_nowait()
+        _, snapshot = ui.register_listener_with_in_progress_snapshot()
+        assert snapshot["agent_compactions"] == [
+            {
+                "type": "compaction",
+                "phase": "progress",
+                "part": 2,
+                "total": 3,
+                "depth": 0,
+                "target": "task_agent",
+                "parent_call_id": "task-A",
+                "compaction_id": 11,
+                "ws_id": "ws-1",
+            }
+        ]
+
+        ui.on_compaction(
+            {
+                "phase": "end",
+                "ok": True,
+                "trigger": "auto",
+                "target": "task_agent",
+                "parent_call_id": "task-A",
+                "compaction_id": 11,
+                "_generation": 7,
+            }
+        )
+        end = listener.get_nowait()
+        assert end["superseded"] is False
+        assert ui._snapshot_agent_compactions() == []
+
+    def test_agent_scope_allows_targeted_event_but_still_drops_workstream_event(self) -> None:
+        ui = _make_ui()
+        listener = ui._register_listener()
+        ui.begin_agent_scope()
+        try:
+            ui.on_compaction(
+                {
+                    "phase": "start",
+                    "trigger": "auto",
+                    "target": "task_agent",
+                    "parent_call_id": "task-A",
+                    "compaction_id": 1,
+                    "_generation": 2,
+                }
+            )
+            ui.on_compaction(
+                {
+                    "phase": "start",
+                    "trigger": "auto",
+                    "target": "workstream",
+                    "compaction_id": 2,
+                }
+            )
+        finally:
+            ui.end_agent_scope()
+
+        assert listener.get_nowait()["target"] == "task_agent"
+        assert listener.empty()
+
+    def test_generation_cleanup_cannot_remove_successor_snapshot(self) -> None:
+        ui = _make_ui()
+        for generation, compaction_id in ((4, 1), (5, 2)):
+            ui.on_compaction(
+                {
+                    "phase": "start",
+                    "trigger": "auto",
+                    "target": "task_agent",
+                    "parent_call_id": "reused",
+                    "compaction_id": compaction_id,
+                    "_generation": generation,
+                }
+            )
+
+        ui.clear_agent_transients("reused", generation=4)
+        assert ui._snapshot_agent_compactions()[0]["compaction_id"] == 2
+        ui.clear_agent_transients_before_generation(5)
+        assert ui._snapshot_agent_compactions()[0]["compaction_id"] == 2
+        ui.clear_agent_transients("reused", generation=5)
+        assert ui._snapshot_agent_compactions() == []
 
 
 class TestAgentScopeInfoSuppression:

--- a/tests/test_sse_reconnect_replay.py
+++ b/tests/test_sse_reconnect_replay.py
@@ -857,6 +857,70 @@ def test_handler_replay_ok_uses_buffered_agent_context_only() -> None:
     assert "id: 1" in blob
 
 
+def _start_task_compaction(ui: Any) -> None:
+    ui.on_compaction(
+        {
+            "phase": "start",
+            "trigger": "auto",
+            "target": "task_agent",
+            "parent_call_id": "task-A",
+            "compaction_id": 17,
+            "_generation": 2,
+        }
+    )
+
+
+def test_handler_fresh_connect_replays_active_task_compaction() -> None:
+    """Task compaction progress is recoverable without becoming history."""
+    ui = _make_ui()
+    _start_task_compaction(ui)
+
+    _, blob = _drain_handler_yields(ui, max_yields=4)
+
+    assert blob.count('"type": "compaction"') == 1
+    assert '"target": "task_agent"' in blob
+    assert '"parent_call_id": "task-A"' in blob
+    assert '"compaction_id": 17' in blob
+    assert "_generation" not in blob
+
+
+def test_handler_truncated_replays_active_task_compaction(monkeypatch: Any) -> None:
+    """An evicted task-compaction start is restored from transient state."""
+    import collections
+
+    monkeypatch.setattr("turnstone.core.session_ui_base._TOKEN_BATCH_WINDOW_SECS", 0.0)
+    ui = _make_ui()
+    ui._event_buffer = collections.deque(maxlen=3)
+    _start_task_compaction(ui)
+    for i in range(8):
+        ui.on_content_token(str(i))
+
+    _, blob = _drain_handler_yields(
+        ui,
+        headers={"Last-Event-ID": "1"},
+        max_yields=6,
+    )
+
+    assert "replay_truncated" in blob
+    assert blob.count('"type": "compaction"') == 1
+    assert '"compaction_id": 17' in blob
+
+
+def test_handler_replay_ok_uses_buffered_task_compaction_only() -> None:
+    """Covered reconnects must not add a synthetic compaction duplicate."""
+    ui = _make_ui()
+    _start_task_compaction(ui)
+
+    _, blob = _drain_handler_yields(
+        ui,
+        headers={"Last-Event-ID": "0"},
+        max_yields=3,
+    )
+
+    assert blob.count('"type": "compaction"') == 1
+    assert "id: 1" in blob
+
+
 def test_handler_tokenless_fresh_path_forces_old_client_history_repair() -> None:
     """A pre-handoff browser repairs in place without a reconnect loop."""
     ui = _make_ui()

--- a/tests/test_task_agent_compaction.py
+++ b/tests/test_task_agent_compaction.py
@@ -1,0 +1,831 @@
+"""Task-agent context compaction keeps execution truth outside the summary.
+
+The task loop owns a bounded execution journal for cancellation and recall
+beside a bounded model context that may be replaced. These tests pin the
+cooperative soft warning, hard and reactive compaction paths, prefix
+preservation, and the task-local cancellation/read seams.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from tests._session_helpers import make_result, make_session
+from turnstone.core.compaction import CompactionEngine, SummaryResult
+from turnstone.core.metacognition import (
+    NUDGE_TASK_COMPACTION_RESUME,
+    format_nudge,
+)
+from turnstone.core.providers import UsageInfo
+from turnstone.core.session import (
+    GenerationCancelled,
+    _active_read_files,
+    _TaskExecutionJournal,
+)
+from turnstone.core.trajectory import EffectStatus, Role, ToolCall, Turn
+
+TOOL_NAME = "search"
+TOOL_CALL = {
+    "id": "call-search",
+    "type": "function",
+    "function": {"name": TOOL_NAME, "arguments": '{"query":"needle"}'},
+}
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": TOOL_NAME,
+            "description": "Search files",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+]
+
+
+def _usage(prompt_tokens: int, completion_tokens: int = 1) -> UsageInfo:
+    return UsageInfo(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+
+
+def _tool_result(*, prompt_tokens: int, content: str = "working"):
+    return make_result(
+        content,
+        tool_calls=[TOOL_CALL],
+        finish_reason="tool_calls",
+        usage=_usage(prompt_tokens),
+    )
+
+
+def _prepared_tool(tool_call: dict[str, Any], _principal: str):
+    call_id = tool_call["id"]
+    return {
+        "call_id": call_id,
+        "func_name": TOOL_NAME,
+        "needs_approval": False,
+        "execute": lambda _item: (call_id, "x"),
+    }
+
+
+def _run_script(
+    session,
+    ledger: list[Turn],
+    responses: list[Any],
+    *,
+    window: int = 100,
+    tools: list[dict[str, Any]] = TOOLS,
+    execution_journal: _TaskExecutionJournal | None = None,
+    on_call: Callable[[int, list[Turn]], None] | None = None,
+):
+    queue = list(responses)
+    contexts: list[list[Turn]] = []
+
+    def plant(_lane, turns, **_kwargs):
+        contexts.append(list(turns))
+        if on_call is not None:
+            on_call(len(contexts), list(turns))
+        response = queue.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        if callable(response):
+            response = response()
+        return response
+
+    with (
+        patch.object(session, "_context_window_for_lane", return_value=window),
+        patch.object(session, "_prepare_tool_for_principal", side_effect=_prepared_tool),
+        patch("turnstone.core.session.model_turn", side_effect=plant),
+    ):
+        output = session._run_agent(
+            ledger,
+            label="task",
+            tools=tools,
+            auto_tools={TOOL_NAME},
+            parent_call_id="task-parent",
+            principal_id="user-a",
+            execution_journal=execution_journal,
+        )
+    assert queue == []
+    return output, contexts
+
+
+def _texts(turns: list[Turn]) -> list[str]:
+    return [turn.text for turn in turns]
+
+
+def test_soft_crossing_warns_then_compacts_after_wind_down():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.system("immutable task identity"), Turn.user("delegated contract")]
+    journal = _TaskExecutionJournal(ledger)
+    summary = SummaryResult(text="dense task summary", producer="summary-kernel")
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=summary,
+    ) as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=82),
+                make_result(
+                    "Goal recorded; resume by checking the parser.",
+                    usage=_usage(86),
+                ),
+                make_result("implemented and verified", usage=_usage(30)),
+            ],
+            execution_journal=journal,
+        )
+
+    assert output == "implemented and verified"
+    assert len(contexts) == 3
+    assert format_nudge("compaction_pending") in _texts(contexts[1])
+    assert _texts(contexts[2])[:2] == ["immutable task identity", "delegated contract"]
+    assert _texts(contexts[2])[-3] == "[Conversation summary]"
+    assert _texts(contexts[2])[-2].startswith("dense task summary")
+    assert "## Wind-down (verbatim)" in _texts(contexts[2])[-2]
+    assert "Goal recorded; resume by checking the parser." in _texts(contexts[2])[-2]
+    assert _texts(contexts[2])[-1] == NUDGE_TASK_COMPACTION_RESUME
+
+    # The immutable delegation prefix is reattached, not summarized again.
+    summarized_blocks = summarize.call_args.args[0]
+    assert not any("immutable task identity" in block for block in summarized_blocks)
+    assert not any("delegated contract" in block for block in summarized_blocks)
+
+    # Raw pre-compaction payloads are released. Cancellation/recall truth lives
+    # in the bounded journal and never contains synthetic summary/warning turns.
+    assert [turn.role for turn in ledger] == [Role.SYSTEM, Role.USER, Role.ASSISTANT]
+    assert not any(turn.source == "compaction" for turn in ledger)
+    assert journal.project_steps() == [
+        {
+            "id": "call-search",
+            "name": TOOL_NAME,
+            "arguments": '{"query":"needle"}',
+            "output": "x",
+            "is_error": False,
+        }
+    ]
+
+
+def test_wind_down_compaction_releases_replaced_native_payload_before_resume():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.system("immutable task identity"), Turn.user("delegated contract")]
+    payload_refs: list[weakref.ReferenceType[Any]] = []
+
+    class Payload:
+        pass
+
+    def wind_down_result():
+        payload = Payload()
+        payload_refs.append(weakref.ref(payload))
+        return make_result(
+            "wind-down recorded",
+            usage=_usage(86),
+            native_blocks=[{"type": "opaque", "payload": payload}],
+        )
+
+    def inspect_resume_call(call_number: int, _turns: list[Turn]) -> None:
+        if call_number == 3:
+            gc.collect()
+            assert len(payload_refs) == 1
+            assert payload_refs[0]() is None
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="dense task summary", producer="summary-kernel"),
+    ):
+        output, _contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=82),
+                wind_down_result,
+                make_result("implemented and verified", usage=_usage(30)),
+            ],
+            on_call=inspect_resume_call,
+        )
+
+    assert output == "implemented and verified"
+
+
+def test_soft_compaction_rearms_only_after_tool_progress():
+    """An irreducible soft-only floor cannot create a summary/model-call loop.
+
+    The 32K immutable prefix leaves every successful replacement above soft but
+    below hard.  The post-summary no-tool response must therefore terminate the
+    task; another advisory would repeat the same compaction forever without
+    advancing the configured tool-turn bound.
+    """
+
+    session = make_session(auto_compact_pct=0.8, agent_max_turns=2)
+    ledger = [Turn.system("p" * 32_000), Turn.user("delegated contract")]
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="short summary", producer="summary-kernel"),
+    ) as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=8_200),
+                make_result("wind-down recorded", usage=_usage(8_300)),
+                make_result("finished after resume", usage=_usage(8_300)),
+            ],
+            window=10_000,
+        )
+
+    assert output == "finished after resume"
+    assert len(contexts) == 3
+    summarize.assert_called_once()
+    assert format_nudge("compaction_pending") in _texts(contexts[1])
+    assert format_nudge("compaction_pending") not in _texts(contexts[2])
+
+
+def test_execution_journal_bounds_completed_raw_payloads():
+    journal = _TaskExecutionJournal([])
+
+    for index in range(5_000):
+        call_id = f"call-{index}"
+        journal.record_assistant(
+            Turn.assistant(
+                tool_calls=(
+                    ToolCall(
+                        id=call_id,
+                        name="read_file",
+                        arguments="a" * 16_000,
+                    ),
+                )
+            )
+        )
+        journal.mark_started(call_id)
+        journal.record_result(
+            call_id,
+            "x" * 16_000,
+            is_error=False,
+            effect_status=EffectStatus.COMMITTED,
+        )
+
+    steps = journal.project_steps()
+    assert journal.retained_step_count == 100
+    assert journal.retained_step_chars < 410_000
+    assert len(steps) == 101
+    assert steps[0]["output"] == "(+4900 earlier steps not retained)"
+    assert steps[-1]["id"] == "call-4999"
+    assert journal.cancelled_status() is EffectStatus.PARTIAL
+
+
+def test_execution_journal_bounds_adversarial_ids_and_tool_name_cardinality():
+    journal = _TaskExecutionJournal([])
+
+    for index in range(5_000):
+        call_id = f"call-{index}-" + "i" * 2_000
+        name = f"invented-tool-{index}-" + "n" * 2_000
+        journal.record_assistant(
+            Turn.assistant(tool_calls=(ToolCall(id=call_id, name=name, arguments="{}"),))
+        )
+        journal.mark_started(call_id)
+        journal.record_result(
+            call_id,
+            "done",
+            is_error=True,
+            effect_status=EffectStatus.NONE,
+        )
+
+    steps = journal.project_steps()
+    disposition = journal.cancelled_disposition("task")
+    assert journal.retained_step_count == 100
+    assert journal.retained_effect_name_count <= 65  # 64 named keys + overflow bucket
+    assert all(len(str(step["id"])) <= 256 for step in steps)
+    assert all(len(str(step["name"])) <= 128 for step in steps)
+    assert len(disposition) < 12_000
+    assert "<other tool names>" in disposition
+
+
+def test_successful_compaction_publishes_post_swap_context_before_next_call():
+    session = make_session(auto_compact_pct=0.8, agent_max_turns=2)
+    ledger = [Turn.system("p" * 32_000), Turn.user("delegated contract")]
+    observed: dict[str, int] = {}
+
+    def inspect_third_call(call_number: int, _turns: list[Turn]) -> None:
+        if call_number != 3:
+            return
+        ends = [
+            call.args[0]
+            for call in lifecycle.call_args_list
+            if call.args[0].get("phase") == "end" and call.args[0].get("ok")
+        ]
+        snapshot = session.ui._snapshot_agent_contexts()
+        assert len(ends) == 1
+        assert len(snapshot) == 1
+        observed["event"] = ends[0]["after_tokens"]
+        observed["snapshot"] = snapshot[0]["prompt_tokens"]
+
+    with (
+        patch.object(
+            session._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(text="short summary", producer="summary-kernel"),
+        ),
+        patch.object(session.ui, "on_compaction", wraps=session.ui.on_compaction) as lifecycle,
+    ):
+        output, _contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=8_200),
+                make_result("wind-down recorded", usage=_usage(8_300)),
+                make_result("finished after resume", usage=_usage(8_300)),
+            ],
+            window=10_000,
+            on_call=inspect_third_call,
+        )
+
+    assert output == "finished after resume"
+    assert observed["snapshot"] == observed["event"]
+
+
+def test_raising_context_hook_cannot_reclassify_committed_compaction():
+    session = make_session(auto_compact_pct=0.8)
+    session.ui.on_agent_context = MagicMock(side_effect=RuntimeError("broken custom UI"))
+    ledger = [Turn.user("delegated contract")]
+
+    with (
+        patch.object(
+            session._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(text="private summary", producer="summary-kernel"),
+        ),
+        patch.object(session.ui, "on_compaction", wraps=session.ui.on_compaction) as lifecycle,
+    ):
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=92),
+                make_result("done after compaction", usage=_usage(30)),
+            ],
+        )
+
+    assert output == "done after compaction"
+    assert "private summary" in _texts(contexts[1])
+    events = [call.args[0] for call in lifecycle.call_args_list]
+    assert [event["phase"] for event in events] == ["start", "end"]
+    assert events[-1]["ok"] is True
+
+
+def test_hard_crossing_compacts_before_another_agent_call():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="hard-limit summary", producer="summary-kernel"),
+    ) as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=92),
+                make_result("done after hard compaction", usage=_usage(30)),
+            ],
+        )
+
+    assert output == "done after hard compaction"
+    summarize.assert_called_once()
+    assert len(contexts) == 2
+    assert format_nudge("compaction_pending") not in _texts(contexts[1])
+    assert _texts(contexts[1])[-3:] == [
+        "[Conversation summary]",
+        "hard-limit summary",
+        NUDGE_TASK_COMPACTION_RESUME,
+    ]
+
+
+def test_repeated_task_compactions_have_distinct_targeted_attempt_ids():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+
+    with (
+        patch.object(
+            session._compaction_engine,
+            "summarize_blocks",
+            side_effect=[
+                SummaryResult(text="first summary", producer="summary-kernel"),
+                SummaryResult(text="second summary", producer="summary-kernel"),
+            ],
+        ),
+        patch.object(
+            session.ui,
+            "on_compaction",
+            wraps=session.ui.on_compaction,
+        ) as on_compaction,
+    ):
+        output, _contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=92),
+                _tool_result(prompt_tokens=92),
+                make_result("done", usage=_usage(30)),
+            ],
+        )
+
+    assert output == "done"
+    events = [call.args[0] for call in on_compaction.call_args_list]
+    assert [event["phase"] for event in events] == ["start", "end", "start", "end"]
+    assert [event["compaction_id"] for event in events] == [1, 1, 2, 2]
+    assert {event["target"] for event in events} == {"task_agent"}
+    assert {event["parent_call_id"] for event in events} == {"task-parent"}
+    assert all("summary" not in event for event in events if event["phase"] == "end")
+
+
+def test_task_summary_stays_private_and_uses_the_shared_compactor_contract():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+    journal = _TaskExecutionJournal(ledger)
+    secret = "TASK_PRIVATE_SUMMARY_SENTINEL_7f0c4e"
+    summary_requests: list[list[Turn]] = []
+
+    def summarize(turns: list[Turn], **_kwargs: Any):
+        summary_requests.append(list(turns))
+        return make_result(secret)
+
+    with (
+        patch.object(session, "_utility_completion", side_effect=summarize),
+        patch.object(session.ui, "on_compaction", wraps=session.ui.on_compaction) as lifecycle,
+        patch("turnstone.core.session.save_message") as save,
+    ):
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=40),
+                RuntimeError("maximum context length exceeded"),
+                make_result("done after private summary", usage=_usage(30)),
+            ],
+            window=10_000,
+            execution_journal=journal,
+        )
+
+    assert output == "done after private summary"
+    assert len(summary_requests) == 1
+    assert summary_requests[0][0].role is Role.SYSTEM
+    assert summary_requests[0][0].text == CompactionEngine.COMPACTOR_SYSTEM_PROMPT
+    assert secret in _texts(contexts[2])
+
+    # The summary is a provider-facing context replacement, not workstream or
+    # task-recall data. Its only observable trace is token/lifecycle metadata.
+    assert secret not in repr([call.args[0] for call in lifecycle.call_args_list])
+    assert secret not in repr(journal.project_steps())
+    assert secret not in _texts(ledger)
+    assert secret not in _texts(session.messages)
+    save.assert_not_called()
+
+
+def test_provider_overflow_compacts_once_and_retries_same_step():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+    overflow = RuntimeError("maximum context length exceeded")
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="overflow summary", producer="summary-kernel"),
+    ) as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=40),
+                overflow,
+                make_result("done after retry", usage=_usage(30)),
+            ],
+        )
+
+    assert output == "done after retry"
+    summarize.assert_called_once()
+    assert len(contexts) == 3
+    assert _texts(contexts[2])[-3:] == [
+        "[Conversation summary]",
+        "overflow summary",
+        NUDGE_TASK_COMPACTION_RESUME,
+    ]
+
+
+def test_second_overflow_returns_partial_execution_without_retry_storm():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+    overflow = RuntimeError("maximum context length exceeded")
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="overflow summary", producer="summary-kernel"),
+    ) as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=40, content="useful partial analysis"),
+                overflow,
+                overflow,
+            ],
+        )
+
+    assert output == "useful partial analysis"
+    summarize.assert_called_once()
+    assert len(contexts) == 3
+
+
+def test_turn_limit_compacts_before_forced_synthesis():
+    session = make_session(auto_compact_pct=0.8, agent_max_turns=1)
+    # Keep enough message content in the immutable task prefix that the exact
+    # tool-free synthesis request is still over soft. This pins the general
+    # turn-limit compaction policy without relying on a schema the next request
+    # explicitly discards.
+    ledger = [Turn.user("delegated contract " * 50)]
+
+    with patch.object(
+        session._compaction_engine,
+        "summarize_blocks",
+        return_value=SummaryResult(text="turn-limit summary", producer="summary-kernel"),
+    ) as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=82),
+                make_result("forced synthesis", usage=_usage(30)),
+            ],
+        )
+
+    assert output == "forced synthesis"
+    summarize.assert_called_once()
+    assert len(contexts) == 2
+    assert "turn-limit summary" in _texts(contexts[1])
+    assert "You have reached the tool call limit" in contexts[1][-1].text
+
+
+def test_turn_limit_sizes_the_actual_tool_free_synthesis_request():
+    """A discarded tool schema alone must not trigger lossy final compaction."""
+
+    session = make_session(auto_compact_pct=0.8, agent_max_turns=1)
+    ledger = [Turn.user("delegated contract")]
+    large_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": TOOL_NAME,
+                "description": "d" * 3_558,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    with patch.object(session._compaction_engine, "summarize_blocks") as summarize:
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=900),
+                make_result("forced synthesis", usage=_usage(58)),
+            ],
+            window=1_000,
+            tools=large_tools,
+        )
+
+    assert output == "forced synthesis"
+    summarize.assert_not_called()
+    assert len(contexts) == 2
+    assert contexts[1][-2].role is Role.TOOL
+    assert contexts[1][-2].text == "x"
+    assert "You have reached the tool call limit" in contexts[1][-1].text
+    assert not any(turn.source == "compaction" for turn in contexts[1])
+
+
+def test_summary_uses_task_cancel_ref_and_clears_only_task_reads():
+    session = make_session(auto_compact_pct=0.8, reasoning_effort="low")
+    parent_reads = session._read_files
+    parent_reads.add("/parent/read.py")
+    task_reads = {"/parent/read.py", "/task/exact.py"}
+    token = _active_read_files.set(task_reads)
+    seen_cancel_refs: list[object] = []
+    seen_efforts: list[str | None] = []
+
+    def summary_completion(_turns, **kwargs):
+        seen_cancel_refs.append(kwargs["cancel_ref"])
+        seen_efforts.append(kwargs["reasoning_effort"])
+        return make_result("task-local summary")
+
+    def summarize(_blocks, runtime):
+        result = runtime.complete("summary system", "summary body", 100)
+        return SummaryResult(text=result.content, producer=result.producer)
+
+    ledger = [Turn.user("delegated contract")]
+    try:
+        with (
+            patch.object(session._compaction_engine, "summarize_blocks", side_effect=summarize),
+            patch.object(session, "_utility_completion", side_effect=summary_completion),
+        ):
+            output, _contexts = _run_script(
+                session,
+                ledger,
+                [
+                    _tool_result(prompt_tokens=92),
+                    make_result("done", usage=_usage(30)),
+                ],
+            )
+    finally:
+        _active_read_files.reset(token)
+
+    assert output == "done"
+    assert len(seen_cancel_refs) == 1
+    cancel_ref = seen_cancel_refs[0]
+    assert cancel_ref.__class__.__name__ == "StreamAbortRef"
+    assert seen_efforts == ["low"]
+    assert task_reads == set()
+    assert parent_reads == {"/parent/read.py"}
+
+
+def test_cancelled_summary_retires_event_without_mutating_effect_ledger():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+
+    with (
+        patch.object(
+            session._compaction_engine,
+            "summarize_blocks",
+            side_effect=GenerationCancelled(),
+        ),
+        patch.object(
+            session.ui,
+            "on_compaction",
+            wraps=session.ui.on_compaction,
+        ) as on_compaction,
+        pytest.raises(GenerationCancelled),
+    ):
+        _run_script(
+            session,
+            ledger,
+            [_tool_result(prompt_tokens=92)],
+        )
+
+    events = [call.args[0] for call in on_compaction.call_args_list]
+    assert [event["phase"] for event in events] == ["start", "end"]
+    assert events[1]["reason"] == "cancelled"
+    assert events[1]["notice"] is False
+    assert {event["target"] for event in events} == {"task_agent"}
+    assert [turn.role for turn in ledger] == [Role.USER, Role.ASSISTANT, Role.TOOL]
+    assert not any(turn.source == "compaction" for turn in ledger)
+
+
+def test_closed_summary_stream_uses_task_scope_cancellation_without_retrying():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+
+    def cancelled_summary(_turns, **kwargs):
+        kwargs["cancel_ref"].abort()
+        raise RuntimeError("summary stream closed by Stop")
+
+    with (
+        patch.object(session, "_utility_completion", side_effect=cancelled_summary) as complete,
+        patch.object(session, "_stop_retrying", return_value=True),
+        patch.object(
+            session.ui,
+            "on_compaction",
+            wraps=session.ui.on_compaction,
+        ) as on_compaction,
+        pytest.raises(GenerationCancelled),
+    ):
+        _run_script(
+            session,
+            ledger,
+            [_tool_result(prompt_tokens=92)],
+        )
+
+    complete.assert_called_once()
+    events = [call.args[0] for call in on_compaction.call_args_list]
+    assert events[0]["phase"] == "start"
+    assert events[-1]["phase"] == "end"
+    assert not any("retry_in" in event for event in events)
+    assert events[-1]["reason"] == "cancelled"
+    assert events[-1]["notice"] is False
+    assert [turn.role for turn in ledger] == [Role.USER, Role.ASSISTANT, Role.TOOL]
+
+
+def test_policy_boundaries_are_strict_and_shared():
+    policy = make_session(auto_compact_pct=0.8)._compaction_policy(100)
+
+    assert policy.over_soft(80) is False
+    assert policy.over_soft(81) is True
+    assert policy.over_hard(90) is False
+    assert policy.over_hard(91) is True
+    assert policy.owed(81, advised=False) is False
+    assert policy.owed(81, advised=True) is True
+    assert policy.owed(91, advised=False) is True
+
+
+def test_failed_compaction_is_not_retried_without_new_context():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+    overflow = RuntimeError("maximum context length exceeded")
+    failure = RuntimeError("summary backend unavailable")
+
+    with (
+        patch.object(
+            session._compaction_engine,
+            "summarize_blocks",
+            side_effect=failure,
+        ) as summarize,
+        patch.object(session, "_stop_retrying", return_value=True),
+        patch.object(session.ui, "on_compaction", wraps=session.ui.on_compaction) as lifecycle,
+        patch.object(session.ui, "on_error", wraps=session.ui.on_error) as on_error,
+    ):
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=92, content="partial before failure"),
+                overflow,
+            ],
+        )
+
+    assert output == "partial before failure"
+    summarize.assert_called_once()
+    assert len(contexts) == 2
+    events = [call.args[0] for call in lifecycle.call_args_list]
+    assert [event["phase"] for event in events] == ["start", "end"]
+    assert events[-1]["reason"] == "error"
+    assert events[-1]["notice"] is True
+    on_error.assert_not_called()
+
+
+def test_post_summary_exception_emits_one_terminal_end_without_swapping_context():
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+
+    with (
+        patch.object(
+            session._compaction_engine,
+            "summarize_blocks",
+            return_value=SummaryResult(text="valid summary", producer="summary-kernel"),
+        ),
+        patch(
+            "turnstone.core.session.PromptTokenEstimator.invalidate",
+            side_effect=RuntimeError("injected estimator failure"),
+        ),
+        patch.object(session.ui, "on_compaction", wraps=session.ui.on_compaction) as lifecycle,
+    ):
+        output, contexts = _run_script(
+            session,
+            ledger,
+            [
+                _tool_result(prompt_tokens=92),
+                make_result("continued on original context", usage=_usage(40)),
+            ],
+        )
+
+    assert output == "continued on original context"
+    events = [call.args[0] for call in lifecycle.call_args_list]
+    assert [event["phase"] for event in events] == ["start", "end"]
+    assert events[-1]["reason"] == "error"
+    assert events[-1]["ok"] is False
+    assert _texts(contexts[1])[-2:] == ["working", "x"]
+    assert not any(turn.source == "compaction" for turn in contexts[1])
+
+
+@pytest.mark.parametrize("prompt_tokens", [0, 1])
+def test_tiny_provider_usage_does_not_break_estimation(prompt_tokens: int):
+    session = make_session(auto_compact_pct=0.8)
+    ledger = [Turn.user("delegated contract")]
+
+    output, contexts = _run_script(
+        session,
+        ledger,
+        [make_result("done", usage=_usage(prompt_tokens))],
+    )
+
+    assert output == "done"
+    assert len(contexts) == 1

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -225,7 +226,11 @@ class TestContextOverflowRecovery:
             patch.object(session, "_stream_response", side_effect=mock_stream_response),
             patch.object(session, "_compact_messages", compact_mock),
             patch.object(session, "_full_messages", return_value=[]),
-            patch.object(session, "_over_soft", return_value=False),
+            patch.object(
+                session,
+                "_compaction_policy",
+                return_value=_policy(over_soft=False),
+            ),
             patch.object(session, "_update_token_table"),
             patch.object(session, "_print_status_line"),
             patch.object(session, "_emit_state"),
@@ -332,6 +337,14 @@ def _send_with_tool_batch(session, tool_calls, results, **extra_patches):
 
 def _tool_turn_texts(session):
     return [m.text for m in session.messages if m.role is Role.TOOL]
+
+
+def _policy(*, owed: bool = False, over_soft: bool = False, over_hard: bool = False):
+    return SimpleNamespace(
+        owed=lambda *_args, **_kwargs: owed,
+        over_soft=lambda *_args, **_kwargs: over_soft,
+        over_hard=lambda *_args, **_kwargs: over_hard,
+    )
 
 
 _SPAWN_CALL = [
@@ -461,7 +474,7 @@ class TestZeroBudgetDrain:
             [("tc_f", "page " * 2000)],
             _remaining_token_budget=budget,
             _compact_messages=compact,
-            _compaction_owed=MagicMock(return_value=False),
+            _compaction_policy=MagicMock(return_value=_policy(owed=False)),
         ):
             session.send("go")
 
@@ -489,7 +502,7 @@ class TestZeroBudgetDrain:
             [("tc_spawn", _SPAWN_RESULT)],
             _remaining_token_budget=MagicMock(return_value=0),
             _compact_messages=compact,
-            _compaction_owed=MagicMock(return_value=True),
+            _compaction_policy=MagicMock(return_value=_policy(owed=True)),
             _do_auto_compact=owed_compact,
         ):
             session.send("go")
@@ -514,7 +527,7 @@ class TestZeroBudgetDrain:
             [("tc_spawn", _SPAWN_RESULT), ("tc_f", "page " * 2000)],
             _remaining_token_budget=MagicMock(return_value=0),
             _compact_messages=compact,
-            _compaction_owed=MagicMock(return_value=False),
+            _compaction_policy=MagicMock(return_value=_policy(owed=False)),
         ):
             session.send("go")
 
@@ -545,7 +558,7 @@ class TestZeroBudgetDrain:
             batches,
             _remaining_token_budget=MagicMock(return_value=0),
             _compact_messages=compact,
-            _compaction_owed=MagicMock(return_value=False),
+            _compaction_policy=MagicMock(return_value=_policy(owed=False)),
         ):
             session.send("go")
 
@@ -578,7 +591,7 @@ class TestZeroBudgetDrain:
             batches,
             _remaining_token_budget=budget,
             _compact_messages=compact,
-            _compaction_owed=MagicMock(return_value=False),
+            _compaction_policy=MagicMock(return_value=_policy(owed=False)),
         ):
             session.send("go")
 
@@ -677,7 +690,7 @@ class TestZeroBudgetDrain:
             batches,
             _remaining_token_budget=budget,
             _compact_messages=compact,
-            _compaction_owed=MagicMock(return_value=False),
+            _compaction_policy=MagicMock(return_value=_policy(owed=False)),
         ):
             session.send("go")
 

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -3954,6 +3954,10 @@ function createCoordinatorPane(root, wsId, opts) {
         break;
       }
       case "compaction":
+        // The standalone coordinator viewer does not project task-agent
+        // sub-trajectories into nested cards. Never mis-render their transient
+        // model-context work as a durable coordinator transcript compaction.
+        if ((ev.target || "workstream") === "task_agent") break;
         // Context-compaction lifecycle — the shared reducer
         // (conversation.applyCompactionEvent) is the one state machine for
         // this viewer and the interactive pane, so the two can't drift.

--- a/turnstone/core/compaction.py
+++ b/turnstone/core/compaction.py
@@ -1,0 +1,578 @@
+"""Lifecycle-agnostic policy, sizing, and recursive summarization.
+
+The two compaction lifecycle owners live in :mod:`turnstone.core.session`:
+foreground conversation compaction owns durability/UI/generation commits, while
+task-agent compaction owns an ephemeral model context beside a bounded execution
+journal. This module contains only the mechanics both lifecycles share.
+It deliberately knows nothing about ``ChatSession``, storage, UI protocols, or
+which trajectory will receive the resulting summary.  Both owners deliberately
+use the same conversation-summary contract; lifecycle independence does not
+imply owner-specific prompt semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from turnstone.core.model_turn import ModelTurnResult
+from turnstone.core.trajectory import Turn, TurnProvenance
+
+
+class CompactionIrreducibleError(Exception):
+    """The recursive summarizer could not shrink an over-window input."""
+
+
+@dataclass(frozen=True, slots=True)
+class SummaryResult:
+    """Compacted text plus the identity of its final model turn."""
+
+    text: str
+    producer: str | None
+    provenance: TurnProvenance = field(default_factory=TurnProvenance)
+
+
+@dataclass(frozen=True, slots=True)
+class CompactionPolicy:
+    """Pure soft/hard compaction threshold policy.
+
+    ``owed`` is the cooperative mid-turn decision: compact immediately above
+    the hard ceiling, or above the soft threshold after the model has already
+    received its one wind-down advisory.  End-of-turn callers intentionally use
+    ``over_soft`` directly because there is no further cooperative turn to wait
+    for.
+    """
+
+    context_window: int
+    auto_compact_pct: float
+
+    def over_soft(self, used: int) -> bool:
+        return used > self.context_window * self.auto_compact_pct
+
+    def over_hard(self, used: int) -> bool:
+        return used > self.context_window * min(0.95, self.auto_compact_pct + 0.10)
+
+    def owed(self, used: int, *, advised: bool) -> bool:
+        return self.over_hard(used) or (self.over_soft(used) and advised)
+
+
+MessageMeasure = Callable[[dict[str, Any] | Turn], tuple[int, int, int]]
+
+
+def calibrated_chars_per_token(
+    *,
+    prompt_tokens: int,
+    messages: Sequence[dict[str, Any] | Turn],
+    tool_def_chars: int,
+    measure: MessageMeasure,
+    fallback: float,
+    image_tokens: int = 1000,
+) -> float:
+    """Return a provider-anchored text chars/token ratio.
+
+    Images receive a fixed token charge and documents contribute to budgeting
+    without polluting the text ratio, matching the foreground estimator's
+    established accounting.  If the provider count cannot yield a positive text
+    denominator, retain ``fallback``.
+    """
+
+    text_chars = tool_def_chars
+    image_count = 0
+    for message in messages:
+        message_text, images, _document_chars = measure(message)
+        text_chars += message_text
+        image_count += images
+    text_prompt_tokens = prompt_tokens - image_count * image_tokens
+    if text_prompt_tokens <= 0 or text_chars <= 0:
+        return fallback
+    return text_chars / text_prompt_tokens
+
+
+@dataclass(slots=True)
+class PromptTokenEstimator:
+    """One immutable-lane trajectory's provider-anchored prompt estimate.
+
+    A successful provider call anchors the exact object-identity prefix it saw.
+    Locally appended turns are estimated with the calibrated ratio.  Structural
+    replacement (compaction) invalidates only the anchor; the learned ratio and
+    most recently served tool-definition size remain useful.
+    """
+
+    measure: MessageMeasure
+    tool_def_chars: int
+    chars_per_token: float = 4.0
+    image_tokens: int = 1000
+    _prompt_tokens: int | None = None
+    _prefix_ids: tuple[int, ...] = ()
+
+    def _message_tokens(self, message: dict[str, Any] | Turn) -> int:
+        text_chars, images, document_chars = self.measure(message)
+        text_tokens = int((text_chars + document_chars) / self.chars_per_token)
+        return max(1, text_tokens + images * self.image_tokens)
+
+    def estimate(self, messages: Sequence[dict[str, Any] | Turn]) -> int:
+        prefix_len = len(self._prefix_ids)
+        if (
+            self._prompt_tokens is not None
+            and prefix_len <= len(messages)
+            and self._prefix_ids == tuple(id(message) for message in messages[:prefix_len])
+        ):
+            return self._prompt_tokens + sum(
+                self._message_tokens(message) for message in messages[prefix_len:]
+            )
+        tool_tokens = int(self.tool_def_chars / self.chars_per_token)
+        return sum(self._message_tokens(message) for message in messages) + tool_tokens
+
+    def estimate_with_tool_defs(
+        self,
+        messages: Sequence[dict[str, Any] | Turn],
+        *,
+        tool_def_chars: int,
+    ) -> int:
+        """Estimate an exact request shape with a different tool envelope.
+
+        The live provider anchor includes the tool definitions served on that
+        request.  A caller preparing a differently shaped next request (task
+        turn-limit synthesis uses no tools) must therefore rebase the anchor,
+        not merely estimate the same messages and ignore the discarded schema.
+        The calibrated ratio is the only provider-specific conversion available
+        before that next request is served, so apply the tool-character delta to
+        either the anchored or standalone estimate.
+        """
+
+        estimate = self.estimate(messages)
+        tool_delta = int((tool_def_chars - self.tool_def_chars) / self.chars_per_token)
+        return max(0, estimate + tool_delta)
+
+    def observe(
+        self,
+        *,
+        prompt_tokens: int,
+        messages: Sequence[dict[str, Any] | Turn],
+        wire_messages: Sequence[dict[str, Any]] | None = None,
+        tool_def_chars: int | None = None,
+    ) -> None:
+        """Anchor to one successful call before its assistant turn is appended."""
+
+        if tool_def_chars is not None:
+            self.tool_def_chars = tool_def_chars
+        measured_messages: Sequence[dict[str, Any] | Turn] = (
+            wire_messages if wire_messages is not None else messages
+        )
+        self.chars_per_token = calibrated_chars_per_token(
+            prompt_tokens=prompt_tokens,
+            messages=measured_messages,
+            tool_def_chars=self.tool_def_chars,
+            measure=self.measure,
+            fallback=self.chars_per_token,
+            image_tokens=self.image_tokens,
+        )
+        self._prompt_tokens = prompt_tokens
+        self._prefix_ids = tuple(id(message) for message in messages)
+
+    def append_exact(self, message: dict[str, Any] | Turn, tokens: int) -> None:
+        """Extend a live provider anchor with one accepted completion turn."""
+
+        if self._prompt_tokens is None:
+            return
+        self._prompt_tokens += max(1, tokens)
+        self._prefix_ids += (id(message),)
+
+    def invalidate(self) -> None:
+        self._prompt_tokens = None
+        self._prefix_ids = ()
+
+    def tokens_for(self, messages: Sequence[dict[str, Any] | Turn]) -> int:
+        """Estimate a standalone sequence without tool definitions or anchoring."""
+
+        return sum(self._message_tokens(message) for message in messages)
+
+
+SummaryCompletion = Callable[[str, str, int], ModelTurnResult]
+
+
+def _ignore_progress(_payload: dict[str, Any]) -> None:
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class SummaryRuntime:
+    """All mutable-world dependencies required by one summary transaction."""
+
+    context_window: int
+    chars_per_token: float
+    compact_max_tokens: int
+    lane_max_output_tokens: int | None
+    continuation_overhead_tokens: int
+    complete: SummaryCompletion
+    stop_retrying: Callable[[BaseException, int], bool]
+    is_context_overflow: Callable[[BaseException], bool]
+    check_cancelled: Callable[[], None]
+    backoff_or_cancelled: Callable[[float], None]
+    on_progress: Callable[[dict[str, Any]], None] = _ignore_progress
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+
+
+class CompactionEngine:
+    """Stateless recursive conversation summarizer."""
+
+    SUMMARY_SAFETY_MARGIN = 0.05
+    SUMMARY_BUDGET_FRACTION = 0.75
+    MAX_SUMMARY_DEPTH = 5
+    MIN_SUMMARY_BUDGET_CHARS = 2000
+    MIN_SUMMARY_OUTPUT_TOKENS = 512
+    MIN_CARRY_BUDGET_CHARS = 2000
+
+    COMPACT_OUTPUT_FORMAT = (
+        "1. **Output format** — use these exact sections, omit any that are empty:\n"
+        "   - **## Decisions**: Choices made (architecture, libraries, approaches).\n"
+        "   - **## Files**: Files read, created, or modified, with brief notes.\n"
+        "   - **## Key code**: Exact function names, class names, variable names, "
+        "and short code snippets the assistant will need. "
+        "Preserve identifiers verbatim — do NOT paraphrase.\n"
+        "   - **## Tool results**: Important tool outputs (errors, search matches, "
+        "file contents) that inform ongoing work.\n"
+        "   - **## Open tasks**: What the user asked for that is not yet done, "
+        "with enough context to continue.\n"
+        "   - **## User preferences**: Workflow preferences, constraints, or "
+        "instructions the user stated.\n"
+        "   - **## Memories to save**: Corrections, preferences, or learnings "
+        "the user expressed that should be persisted across sessions. "
+        "Format each as: `name: description — content`. "
+        "Only include items the user explicitly stated, not inferences.\n\n"
+    )
+    COMPACTOR_SYSTEM_PROMPT = (
+        "# Conversation Compactor\n\n"
+        "Your output REPLACES the conversation history — the assistant "
+        "will continue from your summary with no access to the original messages.\n\n"
+        + COMPACT_OUTPUT_FORMAT
+        + "2. **Density rules:**\n"
+        "   - Every token should carry information.\n"
+        "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
+        "   - Omit pleasantries, acknowledgments, and reasoning that led to dead ends.\n"
+        "   - If a tool call's result was an error that was later resolved, "
+        "keep only the resolution.\n\n"
+        "3. **Common mistakes to avoid:**\n"
+        "   - Paraphrasing file paths, function names, or variable names\n"
+        "   - Including dead-end explorations or superseded decisions\n"
+        "   - Omitting the open tasks section when work remains\n"
+        "   - Being verbose — this is a summary, not a transcript"
+    )
+    COMPACTOR_MERGE_SYSTEM_PROMPT = (
+        "# Summary Merger\n\n"
+        "You are given several partial summaries of ONE conversation, produced by "
+        "compacting consecutive slices in order. Merge these partial summaries into a "
+        "single summary that REPLACES the conversation history — the assistant will "
+        "continue from your merged summary with no access to the originals.\n\n"
+        + COMPACT_OUTPUT_FORMAT
+        + "2. **Merge rules:**\n"
+        "   - Preserve every distinct decision, file, identifier, and open task across "
+        "all partials; later partials reflect more recent state, so on conflict prefer "
+        "the later one.\n"
+        "   - Deduplicate: fold repeated items into one, keeping the most specific.\n"
+        "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
+        "   - Be dense; this is a summary, not a transcript."
+    )
+    COMPACT_USER_PREFIX = "Compact the following conversation:\n\n"
+
+    @staticmethod
+    def summary_tool_names(messages: Sequence[dict[str, Any]]) -> dict[str, str]:
+        """Map tool-call IDs over the full selection, not one packed batch."""
+
+        names: dict[str, str] = {}
+        for message in messages:
+            for tool_call in message.get("tool_calls", []):
+                call_id = tool_call.get("id", "")
+                name = tool_call.get("function", {}).get("name", "unknown")
+                if call_id:
+                    names[call_id] = name
+        return names
+
+    @staticmethod
+    def format_message_for_summary(
+        message: dict[str, Any], tool_names: dict[str, str]
+    ) -> str | None:
+        role = message["role"].upper()
+        content = message.get("content") or ""
+        if isinstance(content, list):
+            text_parts: list[str] = []
+            for part in content:
+                if part.get("type") == "text":
+                    text_parts.append(part["text"])
+                elif part.get("type") in ("image_url", "image"):
+                    text_parts.append("[image]")
+            content = " ".join(text_parts)
+        if message.get("tool_calls"):
+            calls = []
+            for tool_call in message["tool_calls"]:
+                name = tool_call.get("function", {}).get("name", "?")
+                arguments = tool_call.get("function", {}).get("arguments", "")
+                calls.append(f"{name}({arguments})")
+            content += "\n[Called: " + ", ".join(calls) + "]"
+        if role == "TOOL":
+            call_id = message.get("tool_call_id", "")
+            role = f"TOOL[{tool_names.get(call_id, 'tool')}]"
+        if not content:
+            return None
+        if len(content) > 2000:
+            content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
+        return f"{role}: {content}"
+
+    def summary_blocks(self, messages: Sequence[dict[str, Any]]) -> list[str]:
+        tool_names = self.summary_tool_names(messages)
+        return [
+            line
+            for message in messages
+            if (line := self.format_message_for_summary(message, tool_names)) is not None
+        ]
+
+    def format_messages_for_summary(self, messages: Sequence[dict[str, Any]]) -> str:
+        return "\n\n".join(self.summary_blocks(messages))
+
+    def summary_output_tokens(self, runtime: SummaryRuntime) -> int:
+        """Reserve summary output while leaving at least half the window for input.
+
+        ``compact_max_tokens`` may itself equal a small model's entire window.
+        Applying only that setting and the lane output cap would leave no room
+        for the history being summarized.
+        """
+
+        hard_cap = (
+            min(runtime.compact_max_tokens, runtime.lane_max_output_tokens)
+            if runtime.lane_max_output_tokens
+            else runtime.compact_max_tokens
+        )
+        window_cap = max(self.MIN_SUMMARY_OUTPUT_TOKENS, runtime.context_window // 2)
+        return min(hard_cap, window_cap)
+
+    def carry_budget_chars(self, runtime: SummaryRuntime, carries: int = 1) -> int:
+        """Return one verbatim carry's budget after accounting for its siblings.
+
+        Foreground compaction can carry a wind-down, the last user request, and
+        coordinator handles at once; task compaction may carry its wind-down.
+        Dividing the common spare prevents independently sized carries from
+        stacking past the post-compaction window. The floor deliberately wins
+        on pathological tiny windows so some exact state survives and the
+        provider-overflow backstop can make the final ruling.
+        """
+
+        reserve = self.summary_output_tokens(runtime)
+        margin = int(runtime.context_window * self.SUMMARY_SAFETY_MARGIN)
+        spare = max(
+            0,
+            runtime.context_window - reserve - margin - runtime.continuation_overhead_tokens,
+        )
+        budget_tokens = min(runtime.context_window // 4, spare // max(1, carries))
+        return max(self.MIN_CARRY_BUDGET_CHARS, int(budget_tokens * runtime.chars_per_token))
+
+    def summary_input_budget_chars(self, runtime: SummaryRuntime) -> int:
+        """Bound one summary call's formatted input in calibrated characters.
+
+        Reserve output, the fixed compactor prompt, and a safety margin, then
+        derate the remainder because a reactive path may still have the default
+        optimistic chars/token ratio. The ordinary minimum is capped at the
+        true remaining capacity; flooring beyond it would manufacture the very
+        summary-call overflow this budget prevents.
+        """
+
+        output_reserve = self.summary_output_tokens(runtime)
+        prompt_chars = len(self.COMPACTOR_SYSTEM_PROMPT) + len(self.COMPACT_USER_PREFIX)
+        prompt_tokens = int(prompt_chars / runtime.chars_per_token)
+        safety = int(runtime.context_window * self.SUMMARY_SAFETY_MARGIN)
+        input_tokens = runtime.context_window - output_reserve - prompt_tokens - safety
+        budget_tokens = max(0, int(input_tokens * self.SUMMARY_BUDGET_FRACTION))
+        budget_chars = max(
+            self.MIN_SUMMARY_BUDGET_CHARS,
+            int(budget_tokens * runtime.chars_per_token),
+        )
+        return min(budget_chars, max(0, int(input_tokens * runtime.chars_per_token)))
+
+    @staticmethod
+    def truncate_block(block: str, budget: int) -> str:
+        """Fit one oversized block head+tail around an honest size marker."""
+
+        if len(block) <= budget:
+            return block
+        marker = f"\n…[truncated — {len(block):,} chars total]…\n"
+        if budget <= len(marker):
+            return block[:budget]
+        keep = budget - len(marker)
+        head = (keep * 2) // 3
+        tail = keep - head
+        return block[:head] + marker + block[-tail:] if tail else block[:head] + marker
+
+    def pack_blocks(self, blocks: Sequence[str], budget_chars: int) -> list[list[str]]:
+        """Greedily pack ordered blocks without drops or oversized batches.
+
+        ``current_len`` exactly tracks the joined size including separators.
+        A block that cannot fit alone is the sole lossy case and is truncated
+        explicitly before being placed in its own batch.
+        """
+
+        budget = max(1, budget_chars)
+        separator_len = len("\n\n")
+        batches: list[list[str]] = []
+        current: list[str] = []
+        current_len = 0
+        for block in blocks:
+            if len(block) > budget:
+                if current:
+                    batches.append(current)
+                    current = []
+                    current_len = 0
+                batches.append([self.truncate_block(block, budget)])
+                continue
+            added = len(block) + (separator_len if current else 0)
+            if current and current_len + added > budget:
+                batches.append(current)
+                current = [block]
+                current_len = len(block)
+            else:
+                current.append(block)
+                current_len += added
+        if current:
+            batches.append(current)
+        return batches
+
+    def summarize_messages(
+        self,
+        messages: Sequence[dict[str, Any]],
+        runtime: SummaryRuntime,
+    ) -> SummaryResult:
+        blocks = self.summary_blocks(messages)
+        if not blocks:
+            raise CompactionIrreducibleError
+        return self.summarize_blocks(blocks, runtime)
+
+    def summarize_once(
+        self,
+        system_prompt: str,
+        body: str,
+        runtime: SummaryRuntime,
+    ) -> SummaryResult:
+        """Run one complete-or-error summary call with cancellable retries.
+
+        Deterministic context overflow escapes immediately for subdivision by
+        :meth:`summarize_batch`; other retryable failures report their backoff.
+        The lifecycle owner's cancellation check runs before classification so
+        a transport closed by Stop is never mislabeled as a summary failure.
+        """
+
+        result: ModelTurnResult | None = None
+        for attempt in range(runtime.max_retries + 1):
+            try:
+                result = runtime.complete(
+                    system_prompt,
+                    self.COMPACT_USER_PREFIX + body,
+                    self.summary_output_tokens(runtime),
+                )
+                break
+            except Exception as error:
+                runtime.check_cancelled()
+                if runtime.stop_retrying(error, attempt):
+                    raise
+                delay = runtime.retry_base_delay * (2**attempt)
+                runtime.on_progress(
+                    {
+                        "phase": "progress",
+                        "retry_in": delay,
+                        "error": type(error).__name__,
+                    }
+                )
+                runtime.backoff_or_cancelled(delay)
+        if result is None:
+            raise RuntimeError("summary retry ladder exhausted without a result")
+        summary = (result.content or "").strip()
+        if result.finish_reason == "length":
+            runtime.on_progress({"phase": "progress", "warning": "summary_truncated"})
+        return SummaryResult(
+            text=summary,
+            producer=result.producer,
+            provenance=getattr(result, "provenance", TurnProvenance()),
+        )
+
+    def summarize_blocks(
+        self,
+        blocks: Sequence[str],
+        runtime: SummaryRuntime,
+        *,
+        depth: int = 0,
+    ) -> SummaryResult:
+        """Summarize ordered blocks through packed leaves and recursive merges.
+
+        The recursion ceiling is checked before the single-batch base case so
+        it also bounds overflow-driven split/merge recursion. A block-count
+        progress guard would be incorrect: binary subdivision can legitimately
+        leave one summary per input block before the next merge shrinks them.
+        """
+
+        system_prompt = (
+            self.COMPACTOR_SYSTEM_PROMPT if depth == 0 else self.COMPACTOR_MERGE_SYSTEM_PROMPT
+        )
+        if depth >= self.MAX_SUMMARY_DEPTH:
+            raise CompactionIrreducibleError
+        batches = self.pack_blocks(blocks, self.summary_input_budget_chars(runtime))
+        if len(batches) == 1:
+            return self.summarize_batch(system_prompt, batches[0], depth, runtime)
+        total = len(batches)
+        summaries: list[str] = []
+        for part, batch in enumerate(batches, start=1):
+            runtime.on_progress(
+                {
+                    "phase": "progress",
+                    "part": part,
+                    "total": total,
+                    "depth": depth,
+                }
+            )
+            partial = self.summarize_batch(system_prompt, batch, depth, runtime)
+            summaries.append(partial.text)
+        return self.summarize_blocks(summaries, runtime, depth=depth + 1)
+
+    def summarize_batch(
+        self,
+        system_prompt: str,
+        batch: Sequence[str],
+        depth: int,
+        runtime: SummaryRuntime,
+    ) -> SummaryResult:
+        """Summarize one batch, recursively recovering from real overflows.
+
+        A multi-block overflow splits in half, summarizes both halves, and
+        merges them. A lone block progressively halves its head+tail input down
+        to the configured floor; if even that does not fit, the operation is
+        irreducible rather than silently dropping the block or fabricating a
+        summary.
+        """
+
+        runtime.check_cancelled()
+        try:
+            return self.summarize_once(system_prompt, "\n\n".join(batch), runtime)
+        except Exception as error:
+            if not runtime.is_context_overflow(error):
+                raise
+            if len(batch) > 1:
+                midpoint = len(batch) // 2
+                left = self.summarize_batch(system_prompt, batch[:midpoint], depth, runtime)
+                right = self.summarize_batch(system_prompt, batch[midpoint:], depth, runtime)
+                return self.summarize_blocks(
+                    [left.text, right.text],
+                    runtime,
+                    depth=depth + 1,
+                )
+            budget = max(self.MIN_SUMMARY_BUDGET_CHARS, len(batch[0]) // 2)
+            while True:
+                try:
+                    return self.summarize_once(
+                        system_prompt,
+                        self.truncate_block(batch[0], budget),
+                        runtime,
+                    )
+                except Exception as retry_error:
+                    if not runtime.is_context_overflow(retry_error):
+                        raise
+                    if budget <= self.MIN_SUMMARY_BUDGET_CHARS:
+                        raise CompactionIrreducibleError from retry_error
+                    budget = max(self.MIN_SUMMARY_BUDGET_CHARS, budget // 2)

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -138,6 +138,17 @@ NUDGE_COMPACTION_RESUME_NO_RECALL = (
     "final answer."
 )
 
+# Task-agent trajectories are ephemeral: unlike foreground compaction there is
+# no durable transcript or recall surface to promise.  The agent keeps its
+# immutable delegation prefix plus the compacted summary and must re-read any
+# file whose exact contents it needs before editing.
+NUDGE_TASK_COMPACTION_RESUME = (
+    "Your task-agent context was just compacted to free space. Continue from "
+    "the summary above without waiting for further instructions. Re-read files "
+    "before editing when you need exact current contents. If the delegated task "
+    "is complete, provide your final response now."
+)
+
 _NUDGE_MAP: dict[str, str] = {
     "correction": NUDGE_CORRECTION,
     "denial": NUDGE_DENIAL,

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -60,6 +60,14 @@ from turnstone.core.background_shells import (
     drain_pipe_lines,
     spawn_group_leader,
 )
+from turnstone.core.compaction import (
+    CompactionEngine,
+    CompactionIrreducibleError,
+    CompactionPolicy,
+    PromptTokenEstimator,
+    SummaryRuntime,
+    calibrated_chars_per_token,
+)
 from turnstone.core.config import get_searxng_engines, get_searxng_url, get_workspace_dir
 from turnstone.core.deadline import StreamAbortRef
 from turnstone.core.edit import find_occurrences, pick_nearest
@@ -118,6 +126,7 @@ from turnstone.core.metacognition import (
     NUDGE_COMPACTION_RESUME,
     NUDGE_COMPACTION_RESUME_NO_RECALL,
     NUDGE_REQUIRED_TOOL,
+    NUDGE_TASK_COMPACTION_RESUME,
     TASK_NOTE_MAX,
     TASK_TITLE_MAX,
     RepeatDetector,
@@ -237,7 +246,6 @@ from turnstone.core.trajectory import (
     ProviderNative,
     Role,
     TextBlock,
-    ToolCall,
     Turn,
     TurnProvenance,
     dicts_from_turns,
@@ -355,27 +363,6 @@ class _MalformedToolBatchError(RuntimeError):
 _CONVERSATION_PERSISTENCE_RETRY_BASE_SECONDS = 1.0
 _CONVERSATION_PERSISTENCE_RETRY_CAP_SECONDS = 60.0
 _SOFT_CLOSE_STRUCTURAL_WAIT_SECONDS = 1.0
-
-
-class _CompactionIrreducibleError(Exception):
-    """Raised by ``ChatSession._summarize_blocks`` when chunked summarisation
-    cannot shrink the input — a recursion level fails to reduce the block count,
-    or the depth ceiling is hit.
-
-    ``ChatSession._compact_messages`` turns it into the existing ``return False``
-    bail rather than fabricate a summary.  (Chunked compaction never drops or
-    fabricates whole turns; its one lossy path is ``_truncate_block`` head/tail-
-    truncating a single oversized block as summary *input*.)
-    """
-
-
-@dataclasses.dataclass(frozen=True)
-class _SummaryResult:
-    """Compacted text plus the identity of its final model turn."""
-
-    text: str
-    producer: str | None
-    provenance: TurnProvenance = dataclasses.field(default_factory=TurnProvenance)
 
 
 _ModelCalibrationKey = tuple[str, str, int]
@@ -619,8 +606,8 @@ class _CancelRef(list[Any]):
         provided both are asked about the same generation — which every
         model-call lane guarantees by construction, building a fresh ref
         per attempt that carries the ``my_generation`` its surrounding
-        checks use.  The pairing is load-bearing twice: compaction's
-        ``_summarize_once`` handler and the main-loop wrapper's except
+        checks use.  The pairing is load-bearing twice: the shared compaction
+        engine's summary-call handler and the main-loop wrapper's except
         arms both call ``_check_cancelled`` before reading the error,
         which is what turns ``model_turn``'s pre-dispatch raise into a
         cancellation rather than a red failure row.  Widening this
@@ -1178,6 +1165,289 @@ _AGENT_STEP_OUTPUT_CAP: int = 2000
 # not per-entry bytes), so a 100+-tool agent can't blow the memory budget; the
 # overflow is replaced by one honest "(+N not retained)" marker step.
 _AGENT_STEP_COUNT_CAP: int = 100
+# Provider-generated ids/names are bounded only by one response. Keep current
+# pending calls exact for execution/cancellation pairing, but bound the durable
+# recall/aggregate projection so a model cannot turn distinct bogus tool names
+# or huge call ids into run-lifetime memory growth.
+_AGENT_STEP_ID_CAP: int = 256
+_AGENT_STEP_NAME_CAP: int = 128
+_AGENT_EFFECT_NAME_COUNT_CAP: int = 64
+_AGENT_OTHER_TOOL_NAMES = "<other tool names>"
+
+
+def _clip_agent_text(text: str, cap: int) -> str:
+    """Head-clip task-agent text with one honest truncation marker."""
+
+    if len(text) <= cap:
+        return text
+    return text[:cap] + f"\n\n... (truncated from {len(text)} chars)"
+
+
+def _bound_agent_identity(text: str, cap: int) -> str:
+    """Bound an opaque task id/name while keeping truncations distinguishable."""
+
+    if len(text) <= cap:
+        return text
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
+    marker = f"…[{digest}]"
+    return text[: max(0, cap - len(marker))] + marker
+
+
+@dataclasses.dataclass(slots=True)
+class _PendingAgentCall:
+    """One issued task-agent tool call whose result is not yet journaled."""
+
+    call_id: str
+    name: str
+    recall_step: dict[str, Any]
+    started: bool = False
+
+
+class _TaskExecutionJournal:
+    """Bounded execution truth for one autonomous task-agent run.
+
+    Model turns remain in ``context_turns`` only as long as they are useful to
+    the provider. Cancellation needs exact state only for the currently issued
+    batch plus aggregate effect dispositions for completed calls; recall needs
+    only the most recent clipped steps. These purpose-built projections avoid
+    retaining every raw assistant/native block and multi-megabyte tool payload
+    after compaction.
+    """
+
+    def __init__(self, turns: list[Turn]) -> None:
+        self._effect_counts: dict[EffectStatus | None, collections.Counter[str]] = {}
+        self._effect_names: set[str] = set()
+        self._recent_steps: collections.deque[dict[str, Any]] = collections.deque(
+            maxlen=_AGENT_STEP_COUNT_CAP
+        )
+        self._dropped_steps = 0
+        self._pending: list[_PendingAgentCall] = []
+        self._pending_by_id: dict[str, collections.deque[_PendingAgentCall]] = {}
+        self._latest_assistant_text = ""
+        self._active_child_ids: set[str] = set()
+        for turn in turns:
+            if turn.role is Role.ASSISTANT:
+                self.record_assistant(turn)
+            elif turn.role is Role.TOOL and turn.tool_call_id:
+                raw = ""
+                if turn.content:
+                    raw = (
+                        turn.content[0].text
+                        if isinstance(turn.content[0], TextBlock)
+                        else "[non-text result]"
+                    )
+                self.record_result(
+                    turn.tool_call_id,
+                    raw,
+                    is_error=turn.is_error,
+                    effect_status=turn.effect_status,
+                )
+
+    @property
+    def latest_assistant_text(self) -> str:
+        return self._latest_assistant_text
+
+    @property
+    def active_child_ids(self) -> set[str]:
+        return set(self._active_child_ids)
+
+    @property
+    def retained_step_count(self) -> int:
+        """Test/diagnostic view of bounded recall-step retention."""
+
+        return len(self._recent_steps)
+
+    @property
+    def retained_step_chars(self) -> int:
+        """Test/diagnostic payload size after recall clipping."""
+
+        return sum(len(str(value)) for step in self._recent_steps for value in step.values())
+
+    @property
+    def retained_effect_name_count(self) -> int:
+        """Test/diagnostic cardinality of completed-call aggregate keys."""
+
+        return len(self._effect_names)
+
+    def record_assistant(self, turn: Turn) -> None:
+        text = last_assistant_text([turn])
+        if text:
+            self._latest_assistant_text = text
+        for tool_call in turn.tool_calls:
+            name = (tool_call.name or "tool").strip()
+            recall_step = {
+                "id": _bound_agent_identity(tool_call.id, _AGENT_STEP_ID_CAP),
+                "name": _bound_agent_identity(name, _AGENT_STEP_NAME_CAP),
+                "arguments": _clip_agent_text(tool_call.arguments, _AGENT_STEP_OUTPUT_CAP),
+                "output": "",
+                "is_error": False,
+            }
+            pending = _PendingAgentCall(
+                call_id=tool_call.id,
+                name=name,
+                recall_step=recall_step,
+            )
+            self._pending.append(pending)
+            self._pending_by_id.setdefault(tool_call.id, collections.deque()).append(pending)
+            if len(self._recent_steps) == _AGENT_STEP_COUNT_CAP:
+                self._dropped_steps += 1
+            self._recent_steps.append(recall_step)
+
+    def mark_started(self, call_id: str) -> None:
+        queue_for_id = self._pending_by_id.get(call_id)
+        if queue_for_id:
+            queue_for_id[0].started = True
+
+    def register_child(self, call_id: str) -> None:
+        if call_id:
+            self._active_child_ids.add(call_id)
+
+    def release_child(self, call_id: str) -> None:
+        self._active_child_ids.discard(call_id)
+
+    def record_result(
+        self,
+        call_id: str,
+        output: Any,
+        *,
+        is_error: bool,
+        effect_status: EffectStatus | None,
+    ) -> dict[str, Any] | None:
+        queue_for_id = self._pending_by_id.get(call_id)
+        if not queue_for_id:
+            return None
+        pending = queue_for_id.popleft()
+        if not queue_for_id:
+            del self._pending_by_id[call_id]
+        self._pending.remove(pending)
+
+        aggregate_name = _bound_agent_identity(pending.name, _AGENT_STEP_NAME_CAP)
+        if aggregate_name not in self._effect_names:
+            if len(self._effect_names) >= _AGENT_EFFECT_NAME_COUNT_CAP:
+                aggregate_name = _AGENT_OTHER_TOOL_NAMES
+            self._effect_names.add(aggregate_name)
+        counts = self._effect_counts.setdefault(effect_status, collections.Counter())
+        counts[aggregate_name] += 1
+        self.update_step(pending.recall_step, output, is_error=is_error)
+        return pending.recall_step
+
+    @staticmethod
+    def update_step(step: dict[str, Any] | None, output: Any, *, is_error: bool) -> None:
+        if step is None:
+            return
+        raw_output = output if isinstance(output, str) else "[non-text result]"
+        step["output"] = _clip_agent_text(raw_output, _AGENT_STEP_OUTPUT_CAP)
+        step["is_error"] = is_error
+
+    def materialize_unstarted(self, agent_turns: list[Turn]) -> None:
+        """Close issued calls that never crossed the executor boundary as NONE."""
+
+        for pending in list(self._pending):
+            if pending.started:
+                continue
+            message = "(cancelled before execution; no side effects)"
+            agent_turns.append(
+                Turn.tool(
+                    pending.call_id,
+                    message,
+                    is_error=True,
+                    effect_status=EffectStatus.NONE,
+                )
+            )
+            self.record_result(
+                pending.call_id,
+                message,
+                is_error=True,
+                effect_status=EffectStatus.NONE,
+            )
+
+    def project_steps(self) -> list[dict[str, Any]]:
+        retained = [dict(step) for step in self._recent_steps]
+        if self._dropped_steps:
+            retained.insert(
+                0,
+                {
+                    "id": "",
+                    "name": "…",
+                    "arguments": "{}",
+                    "output": f"(+{self._dropped_steps} earlier steps not retained)",
+                    "is_error": False,
+                },
+            )
+        return retained
+
+    def _count(self, status: EffectStatus | None) -> collections.Counter[str]:
+        return self._effect_counts.get(status, collections.Counter())
+
+    @staticmethod
+    def _summarize_counts(counts: collections.Counter[str]) -> str:
+        return ", ".join(f"{name}×{count}" if count > 1 else name for name, count in counts.items())
+
+    def cancelled_status(self) -> EffectStatus:
+        issued = sum(sum(counts.values()) for counts in self._effect_counts.values()) + len(
+            self._pending
+        )
+        if not issued:
+            return EffectStatus.NONE
+        if any(pending.started for pending in self._pending) or self._count(EffectStatus.UNKNOWN):
+            return EffectStatus.UNKNOWN
+        effectful = (
+            self._count(None)
+            + self._count(EffectStatus.COMMITTED)
+            + self._count(EffectStatus.PARTIAL)
+        )
+        return EffectStatus.PARTIAL if effectful else EffectStatus.NONE
+
+    def cancelled_disposition(self, label: str) -> str:
+        issued = sum(sum(counts.values()) for counts in self._effect_counts.values()) + len(
+            self._pending
+        )
+        if not issued:
+            return f"({label} cancelled by user before any action — no side effects)"
+
+        parts = [f"({label} cancelled by user before completion)"]
+        groups = (
+            (
+                self._count(None) + self._count(EffectStatus.COMMITTED),
+                "Completed before cancel: ",
+            ),
+            (self._count(EffectStatus.PARTIAL), "Partially completed before cancel: "),
+            (self._count(EffectStatus.NONE), "Confirmed no effect before cancel: "),
+            (
+                self._count(EffectStatus.ROLLED_BACK),
+                "Completed and rolled back before cancel: ",
+            ),
+        )
+        for counts, prefix in groups:
+            if counts:
+                parts.append(prefix + self._summarize_counts(counts) + ".")
+        unresolved = self._count(EffectStatus.UNKNOWN)
+        if unresolved:
+            parts.append(
+                "Results received with UNKNOWN effects before cancel: "
+                + self._summarize_counts(unresolved)
+                + ". Those actions may have completed, partially executed, or caused "
+                "side effects; reconcile before re-running."
+            )
+
+        in_flight = next((pending for pending in self._pending if pending.started), None)
+        if in_flight is None:
+            return "\n".join(parts)
+        parts.append(
+            f"In flight at cancel: {in_flight.name} — outcome UNKNOWN. It may have "
+            "completed, partially executed, or caused side effects before the "
+            "agent was stopped; its result was never observed. Do not assume "
+            "it did or did not happen — reconcile before re-running."
+        )
+        not_run = [pending.name for pending in self._pending if pending is not in_flight]
+        if not_run:
+            parts.append(
+                "Not started (cancelled first): "
+                + self._summarize_counts(collections.Counter(not_run))
+                + "."
+            )
+        return "\n".join(parts)
+
 
 # Per-task-agent file-read tracking.  ``_read_files`` (the blind-overwrite guard's
 # memory of "files this agent has read") is a single set on the session, but the
@@ -1246,7 +1516,7 @@ _REPEAT_EXEMPT_TOOLS: frozenset[str] = frozenset({"bash_output"})
 # coordinator can never ``wait_for_workstream`` a child whose ws_id it never
 # saw), while admitting a floored result costs at most
 # ``_TRUNCATION_FLOOR_CHARS`` against a safety margin the pre-send
-# ``_over_hard`` guard enforces anyway.  Only builtin names belong here: MCP
+# hard-compaction guard enforces anyway.  Only builtin names belong here: MCP
 # tools are namespaced ``mcp__{server}__{tool}`` and can never collide.
 # Background-bash spawn acks carry a shell_id handle too, but share the
 # "bash" name with foreground bash (whose huge outputs MUST stay
@@ -2177,19 +2447,26 @@ class SessionUI(Protocol):
         compaction marker row can be stamped with the matching resume
         cursor; ``None`` for UIs without an event stream.
 
-        The default body IS the pre-1.8 compat rendering — the classic
-        ``on_info`` lines via the shared renderer.  It must not be a bare
-        ``...`` stub: a Protocol member's body is inherited as a REAL
-        method by explicit subclasses, so a pre-1.8 ``class MyUI(SessionUI)``
-        that never implemented this hook would satisfy the getattr probe
-        in ``_compaction_event`` with a silent no-op and defeat the very
-        fallback built for it — every lifecycle event swallowed, history
-        swapping with zero announcement.  Event-stream UIs override and
-        return the assigned id; a subclass implementing neither hook
-        no-ops through ``on_info``'s own stub (the never-crash floor).
+        ``target`` is ``"workstream"`` or ``"task_agent"``; an omitted value
+        means workstream because all events emitted before targets existed had
+        that scope. Task events carry ``parent_call_id`` and never expose their
+        private summary. Failed ends carry the server-computed ``notice``
+        display verdict.
+
+        The default body retains the original workstream ``on_info`` rendering.
+        It must not be a bare ``...`` stub: Protocol methods are inherited as
+        concrete methods by explicit subclasses, so an existing
+        ``class MyUI(SessionUI)`` without this hook would otherwise satisfy the
+        getattr probe with a silent no-op and hide every foreground compaction.
+        Targeted task events cannot be placed without a parent-aware hook and
+        are therefore ignored here. Event-stream UIs override this method and
+        return the assigned id; a subclass implementing neither hook no-ops
+        through ``on_info``'s own stub (the never-crash floor).
         """
         from turnstone.core.compaction_render import render_compaction_event_as_info
 
+        if str(payload.get("target") or "workstream") != "workstream":
+            return None
         render_compaction_event_as_info(payload, self.on_info)
         return None
 
@@ -2675,6 +2952,7 @@ class ChatSession:
         self.auto_compact_pct = (
             auto_compact_pct if auto_compact_pct >= 0.1 else DEFAULT_AUTO_COMPACT_PCT
         )
+        self._compaction_engine = CompactionEngine()
         # Cooperative-compaction latch: set once the model has been advised to
         # reach a stopping point under context pressure; if it keeps working
         # past the advisory the send loop forces a compaction.
@@ -3046,6 +3324,10 @@ class ChatSession:
         self._approval_cancel_epoch = 0
         self._generation: int = 0  # monotonic counter; orphaned threads skip cleanup
         self._generation_principals: dict[int, str] = {}
+        # Compaction attempts are concurrent with one another (parallel task
+        # agents) and may repeat inside one send generation. Give each attempt
+        # its own correlation id; generation remains only the publication owner.
+        self._compaction_seq = 0
         # Task agents and model-backed foreground tools run concurrently on the
         # tool pool and must never publish their provider handles into
         # ``_cancel_stream``.  Each live child operation owns an independent
@@ -5311,9 +5593,10 @@ class ChatSession:
         """
         self._check_cancelled(my_generation)
         est = self._estimated_prompt_tokens()
-        if self._compaction_owed(est):
+        policy = self._compaction_policy()
+        if policy.owed(est, advised=self._compaction_advised):
             self._do_auto_compact("mid-turn", my_generation=my_generation)
-        elif self._over_soft(est):
+        elif policy.over_soft(est):
 
             def _publish_advisory(durable: list[Callable[[], None]]) -> None:
                 self._append_system_turn(
@@ -5330,39 +5613,13 @@ class ChatSession:
             ):
                 raise GenerationCancelled()
 
-    def _compaction_owed(self, used: int | None = None) -> bool:
-        """True when fullness mandates compaction now: over the hard ceiling, or
-        over the soft threshold after the model worked past a wrap-up advisory.
+    def _compaction_policy(self, context_window: int | None = None) -> CompactionPolicy:
+        """Bind the shared threshold policy to one trajectory's window."""
 
-        Shared by the compact-before-truncate check in the send loop and
-        :meth:`_maybe_compact_midturn`.  Pass a precomputed ``used`` to avoid a
-        redundant :meth:`_estimated_prompt_tokens` sum.  The hard ceiling sits a
-        band above the soft threshold (capped at 95%); if ``auto_compact_pct`` is
-        set above that, the band collapses and any over-soft state is "owed".
-        """
-        if used is None:
-            used = self._estimated_prompt_tokens()
-        return self._over_hard(used) or (self._over_soft(used) and self._compaction_advised)
-
-    def _over_soft(self, used: int) -> bool:
-        """True when ``used`` tokens exceed the soft auto-compaction threshold.
-
-        Single source for the ``context_window * auto_compact_pct`` predicate
-        shared by the mid-turn policy, :meth:`_compaction_owed`, and the
-        end-of-turn check, so they can't drift.
-        """
-        return used > self.context_window * self.auto_compact_pct
-
-    def _over_hard(self, used: int) -> bool:
-        """True when ``used`` tokens exceed the hard ceiling — a band above the
-        soft threshold (capped at 95%).
-
-        The "compact now, no turn to spare" line.  Single source shared by
-        :meth:`_compaction_owed` and the proactive pre-send guard; the latter uses
-        it ALONE (not ``_compaction_owed``, whose advised-soft arm belongs to the
-        cooperative mid/end-of-turn wind-down, not to a pre-send emergency).
-        """
-        return used > self.context_window * min(0.95, self.auto_compact_pct + 0.10)
+        return CompactionPolicy(
+            context_window=context_window or self.context_window,
+            auto_compact_pct=self.auto_compact_pct,
+        )
 
     def _do_auto_compact(
         self,
@@ -5423,7 +5680,7 @@ class ChatSession:
         it deliberately wins over BOTH the budget and an operator-set cap,
         because a lost ws_id or masked failure wedges the session outright
         (#883) while an admitted floor costs ~512 tokens against a margin
-        the pre-send ``_over_hard`` guard enforces regardless.
+        the pre-send hard-compaction guard enforces regardless.
 
         This ensures a single tool result cannot overflow the context window
         even when the conversation is already partially full.
@@ -8391,6 +8648,7 @@ class ChatSession:
         cancel_ref: list[Any] | None = None,
         lane: ModelLane | None = None,
         principal_id: str | None = None,
+        use_session_temperature: bool = True,
     ) -> ModelTurnResult:
         """Run a lightweight internal completion (title gen, compaction,
         extraction) through ``model_turn`` on the session's primary lane.
@@ -8425,7 +8683,10 @@ class ChatSession:
         ``temperature`` defaults to the session temperature (``self.temperature``)
         — the same operator/registry-resolved value the main turn uses — rather
         than a hard-coded constant: utility calls should not silently override an
-        explicit ``[models.*]`` temperature.  ``reasoning_effort`` ``None``
+        explicit ``[models.*]`` temperature. ``use_session_temperature=False``
+        leaves it unset for a distinct task-agent lane, allowing that lane's own
+        model configuration or backend default to apply instead of borrowing the
+        parent workstream's setting. ``reasoning_effort`` ``None``
         inherits the lane's full assignment scheme (operator rungs → model
         definition → omit) with NO code-supplied default: a code-chosen
         effort is an unvetted token on local vocabularies and can flip
@@ -8461,7 +8722,9 @@ class ChatSession:
             lane,
             turns,
             max_tokens=clamped,
-            temperature=self.temperature if temperature is None else temperature,
+            temperature=(
+                self.temperature if temperature is None and use_session_temperature else temperature
+            ),
             reasoning_effort=None if suppress_reasoning else reasoning_effort,
             # The abort seam (default None): compaction passes a fresh
             # per-attempt _CancelRef so a user Stop closes the in-flight
@@ -8667,14 +8930,6 @@ class ChatSession:
     # _MAX_RETRIES above.
     _MID_STREAM_RETRIES = 2
     _RETRY_BASE_DELAY = 1.0  # seconds
-
-    # Chunked-compaction tuning (see _summarize_blocks / _summary_input_budget_chars).
-    _SUMMARY_SAFETY_MARGIN = 0.05  # fraction of context_window held back
-    _SUMMARY_BUDGET_FRACTION = 0.75  # derate for the uncalibrated _chars_per_token
-    _MAX_SUMMARY_DEPTH = 5  # recursion ceiling before bailing
-    _MIN_SUMMARY_BUDGET_CHARS = 2000  # floor so a tiny window still makes progress
-    _MIN_SUMMARY_OUTPUT_TOKENS = 512  # floor on summary output even on a tiny window
-    _MIN_CARRY_BUDGET_CHARS = 2000  # floor on verbatim carry (ask quote / wind-down spill)
 
     def _get_health_tracker(self) -> BackendHealthTracker | None:
         """Get the health tracker for this session's current backend.
@@ -10265,7 +10520,7 @@ class ChatSession:
             debt = self._tool_structural_debt
             self._cancel_event.set()
             self._generation += 1
-            self._clear_agent_contexts_before_generation(self._generation)
+            self._clear_agent_transients_before_generation(self._generation)
             self._cancel_event = threading.Event()
             if debt is not None:
                 try:
@@ -11550,8 +11805,8 @@ class ChatSession:
             # switch to a smaller one — can arrive already over the window before
             # the FIRST send.  The mid-turn and end-of-turn triggers only fire AFTER
             # a successful call, so without this the first post-resume send goes out
-            # blind.  Gate on the HARD ceiling alone (NOT _compaction_owed, whose
-            # advised-soft arm is the cooperative wind-down the model must still get
+            # blind.  Gate on the HARD ceiling alone (not the advised-soft arm, whose
+            # cooperative wind-down the model must still get
             # to act on), run it ONCE here, and preserve from the last USER turn to
             # the end — the just-sent message plus any nudge _emit_pending_user_nudges
             # appended after it — so it isn't summarized out from under its own reply.
@@ -11562,7 +11817,7 @@ class ChatSession:
             # guarantee: the char-based estimate under-counts dense/CJK history on an
             # uncalibrated resume, so the send-loop compact-and-retry below stays the
             # backstop.
-            if self._over_hard(self._estimated_prompt_tokens()):
+            if self._compaction_policy().over_hard(self._estimated_prompt_tokens()):
                 boundaries = self._find_turn_boundaries()
                 preserve = len(self.messages) - boundaries[-1] if boundaries else 1
                 self._do_auto_compact(
@@ -11928,12 +12183,12 @@ class ChatSession:
                     if self._generation != my_generation:
                         return
                     # Auto-compact when the context exceeds the threshold, so the
-                    # next turn starts with headroom.  Bare-soft check (NOT
-                    # _compaction_owed()): the turn already ended, so there's no
+                    # next turn starts with headroom.  Bare-soft check (not the
+                    # cooperative owed policy): the turn already ended, so there's no
                     # model cooperation to wait for and the latch was just
                     # consumed above — compact whenever over soft.  None-safe via
                     # _estimated_prompt_tokens(), so no _last_usage guard.
-                    if self._over_soft(self._estimated_prompt_tokens()):
+                    if self._compaction_policy().over_soft(self._estimated_prompt_tokens()):
                         # carry_spill: when the model stopped to let us compact,
                         # its final turn is the plan spill the advisory asked
                         # for — copy it across verbatim, don't just paraphrase.
@@ -12135,7 +12390,9 @@ class ChatSession:
                 # guard is ever converted, keep the "am I still the active
                 # generation" reading rather than "was I superseded".
                 pre_attempted_compact = False
-                if self._generation == my_generation and self._compaction_owed():
+                if self._generation == my_generation and self._compaction_policy().owed(
+                    self._estimated_prompt_tokens(), advised=self._compaction_advised
+                ):
                     self._do_auto_compact("mid-turn", preserve_tail=1, my_generation=my_generation)
                     pre_attempted_compact = True
                 truncation_budget = self._remaining_token_budget()
@@ -12220,7 +12477,7 @@ class ChatSession:
                         # inviting the blind re-runs #865/#866 exist to
                         # prevent.  Worst case is bounded by the model's
                         # own batch width and lands on the pre-send
-                        # ``_over_hard`` guard / ctx-overflow retry: one
+                        # hard-compaction guard / ctx-overflow retry: one
                         # extra compaction round-trip, traded for never
                         # losing a handle or a disposition.
                         _floor = (
@@ -14080,23 +14337,14 @@ class ChatSession:
         served_tool_def_chars = (
             tool_def_chars if tool_def_chars is not None else self._tool_def_chars()
         )
-        text_chars = 0
-        image_count = 0
-        for m in all_msgs:
-            tc, ic, _doc = self._msg_text_chars(m)
-            text_chars += tc
-            image_count += ic
-        text_chars += served_tool_def_chars
-        image_tokens = image_count * self._IMAGE_TOKENS
-        text_prompt_tok = prompt_tok - image_tokens
-        if text_prompt_tok <= 0:
-            log.debug(
-                "Image token estimate (%d) >= prompt_tokens (%d), skipping calibration",
-                image_tokens,
-                prompt_tok,
-            )
-        elif text_chars > 0:
-            self._chars_per_token = text_chars / text_prompt_tok
+        self._chars_per_token = calibrated_chars_per_token(
+            prompt_tokens=prompt_tok,
+            messages=all_msgs,
+            tool_def_chars=served_tool_def_chars,
+            measure=self._msg_text_chars,
+            fallback=self._chars_per_token,
+            image_tokens=self._IMAGE_TOKENS,
+        )
 
         calibration_key = (
             self._provenance_calibration_key(provenance)
@@ -14161,509 +14409,82 @@ class ChatSession:
 
     # -- Conversation compaction ------------------------------------------------
 
-    # Shared "## Output format" section for both compactor prompts — the section
-    # list plus its trailing blank line.  Single-sourced so the two prompts can't
-    # drift (the merge prompt's "explicitly stated" line had already lost "the
-    # user").
-    _COMPACT_OUTPUT_FORMAT = (
-        "1. **Output format** — use these exact sections, omit any that are empty:\n"
-        "   - **## Decisions**: Choices made (architecture, libraries, approaches).\n"
-        "   - **## Files**: Files read, created, or modified, with brief notes.\n"
-        "   - **## Key code**: Exact function names, class names, variable names, "
-        "and short code snippets the assistant will need. "
-        "Preserve identifiers verbatim — do NOT paraphrase.\n"
-        "   - **## Tool results**: Important tool outputs (errors, search matches, "
-        "file contents) that inform ongoing work.\n"
-        "   - **## Open tasks**: What the user asked for that is not yet done, "
-        "with enough context to continue.\n"
-        "   - **## User preferences**: Workflow preferences, constraints, or "
-        "instructions the user stated.\n"
-        "   - **## Memories to save**: Corrections, preferences, or learnings "
-        "the user expressed that should be persisted across sessions. "
-        "Format each as: `name: description — content`. "
-        "Only include items the user explicitly stated, not inferences.\n\n"
-    )
-
-    # System prompt for the depth-0 summary call (the conversation compactor).
-    _COMPACTOR_SYSTEM_PROMPT = (
-        "# Conversation Compactor\n\n"
-        "Your output REPLACES the conversation history — the assistant "
-        "will continue from your summary with no access to the original messages.\n\n"
-        + _COMPACT_OUTPUT_FORMAT
-        + "2. **Density rules:**\n"
-        "   - Every token should carry information.\n"
-        "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
-        "   - Omit pleasantries, acknowledgments, and reasoning that led to dead ends.\n"
-        "   - If a tool call's result was an error that was later resolved, "
-        "keep only the resolution.\n\n"
-        "3. **Common mistakes to avoid:**\n"
-        "   - Paraphrasing file paths, function names, or variable names\n"
-        "   - Including dead-end explorations or superseded decisions\n"
-        "   - Omitting the open tasks section when work remains\n"
-        "   - Being verbose — this is a summary, not a transcript"
-    )
-
-    # System prompt for recursion levels (depth > 0): merge partial summaries of
-    # consecutive slices of ONE conversation back into a single summary.
-    _COMPACTOR_MERGE_SYSTEM_PROMPT = (
-        "# Summary Merger\n\n"
-        "You are given several partial summaries of ONE conversation, produced by "
-        "compacting consecutive slices in order. Merge these partial summaries into a "
-        "single summary that REPLACES the conversation history — the assistant will "
-        "continue from your merged summary with no access to the originals.\n\n"
-        + _COMPACT_OUTPUT_FORMAT
-        + "2. **Merge rules:**\n"
-        "   - Preserve every distinct decision, file, identifier, and open task across "
-        "all partials; later partials reflect more recent state, so on conflict prefer "
-        "the later one.\n"
-        "   - Deduplicate: fold repeated items into one, keeping the most specific.\n"
-        "   - Preserve exact paths, identifiers, and numbers — never paraphrase these.\n"
-        "   - Be dense; this is a summary, not a transcript."
-    )
-
-    # User-message wrapper prepended to every summary-call body (all depths).
-    _COMPACT_USER_PREFIX = "Compact the following conversation:\n\n"
-
-    @staticmethod
-    def _summary_tc_names(messages: list[dict[str, Any]]) -> dict[str, str]:
-        """Build a tool_call_id → tool_name lookup for labeling tool results.
-
-        Built over the full message set (not one batch) so a ``tool_use`` and its
-        later ``tool_result`` keep a consistent name even when chunking packs them
-        into different batches.
-        """
-        tc_names: dict[str, str] = {}
-        for m in messages:
-            for tc in m.get("tool_calls", []):
-                tc_id = tc.get("id", "")
-                tc_name = tc.get("function", {}).get("name", "unknown")
-                if tc_id:
-                    tc_names[tc_id] = tc_name
-        return tc_names
-
-    def _format_message_for_summary(
-        self, m: dict[str, Any], tc_names: dict[str, str]
-    ) -> str | None:
-        """Format one message into a summary line, or ``None`` when it carries no
-        renderable content.
-
-        ``tc_names`` (tool_call_id → tool_name, built by the caller over the full
-        selected set) labels tool results.  Long content is capped head+tail so a
-        single message can't dominate the summary input.
-        """
-        role = m["role"].upper()
-        content = m.get("content") or ""
-
-        # Flatten list content (image tool results) to text for summary
-        if isinstance(content, list):
-            text_parts = []
-            for p in content:
-                if p.get("type") == "text":
-                    text_parts.append(p["text"])
-                elif p.get("type") in ("image_url", "image"):
-                    # by-reference vision placeholder OR resolved inline image
-                    text_parts.append("[image]")
-            content = " ".join(text_parts)
-
-        if m.get("tool_calls"):
-            calls = []
-            for tc in m["tool_calls"]:
-                name = tc.get("function", {}).get("name", "?")
-                args = tc.get("function", {}).get("arguments", "")
-                calls.append(f"{name}({args})")
-            content += "\n[Called: " + ", ".join(calls) + "]"
-
-        # Label tool results with the tool name
-        if role == "TOOL":
-            tc_id = m.get("tool_call_id", "")
-            name = tc_names.get(tc_id, "tool")
-            role = f"TOOL[{name}]"
-
-        if content:
-            if len(content) > 2000:
-                content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
-            return f"{role}: {content}"
-        return None
-
-    def _summary_blocks(self, messages: list[dict[str, Any]]) -> list[str]:
-        """Format messages into summary blocks — one string per renderable
-        message, in order (drops messages with no renderable content)."""
-        tc_names = self._summary_tc_names(messages)
-        return [
-            line
-            for m in messages
-            if (line := self._format_message_for_summary(m, tc_names)) is not None
-        ]
-
-    def _format_messages_for_summary(self, messages: list[dict[str, Any]]) -> str:
-        """Format messages into a readable string for the summarization prompt."""
-        return "\n\n".join(self._summary_blocks(messages))
-
-    def _summary_output_tokens(self, lane: ModelLane | None = None) -> int:
-        """Output-token reserve for a summary call, bounded so the input (the
-        history being summarized) always keeps the larger share of the window.
-
-        ``compact_max_tokens`` defaults to the full window (32768); clamped only
-        by ``max_output_tokens`` it would reserve the entire context for output
-        and leave no room to send anything to summarize — flooring the input
-        budget and making the summary call overflow (or bail as "irreducible")
-        on a small/default window.  Cap the reserve at half the window so
-        compaction can actually run; large windows are unaffected because
-        ``compact_max_tokens`` stays the binding limit there.
-        """
-        caps = require_lane_capabilities(lane or self._primary_lane())
-        hard_cap = (
-            min(self.compact_max_tokens, caps.max_output_tokens)
-            if caps.max_output_tokens
-            else self.compact_max_tokens
-        )
-        window_cap = max(self._MIN_SUMMARY_OUTPUT_TOKENS, self.context_window // 2)
-        return min(hard_cap, window_cap)
-
-    def _carry_budget_chars(self, carries: int = 1, lane: ModelLane | None = None) -> int:
-        """Per-carry char budget for content carried VERBATIM across a
-        compaction — the continuation hint's quote of the user's last
-        message, the wind-down spill, and (coordinators only) the
-        ``## Handles`` block.
-
-        A quarter of the window per carry, clamped so ALL concurrent carries
-        fit what the window spares after the summary output reserve AND the
-        fixed prompt overhead (system message + tool definitions — the same
-        terms the ``_estimated_prompt_tokens`` fallback counts, because they
-        ride every request): the carried text lands in the same
-        post-compaction prompt as all of those, so
-        ``overhead + reserve + carries·budget + margin ≤ window`` must hold
-        by construction — sizing carries independently (or ignoring the
-        overhead) stacks past the window at default config exactly when
-        spill and hint fire together, and the overflow backstop would then
-        re-compact WITHOUT the carries.  Floored at
-        ``_MIN_CARRY_BUDGET_CHARS`` so small windows still carry something
-        meaningful; when the floor exceeds the spare (a tiny window, or a
-        system prompt that fills it) the floor wins deliberately — carrying
-        something beats carrying nothing, and the overflow backstop absorbs
-        the worst case.  Chars via the calibrated ``_chars_per_token``.
-        """
-        reserve = self._summary_output_tokens(lane)
-        margin = int(self.context_window * self._SUMMARY_SAFETY_MARGIN)
-        lane_caps = require_lane_capabilities(lane) if lane is not None else None
-        overhead = self._system_tokens + self._tool_def_tokens(lane_caps)
-        spare = max(0, self.context_window - reserve - margin - overhead)
-        budget_tokens = min(self.context_window // 4, spare // max(1, carries))
-        return max(self._MIN_CARRY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token))
-
-    def _summary_input_budget_chars(self, lane: ModelLane | None = None) -> int:
-        """Per-call input budget for a summary completion, in characters.
-
-        The summary runs on ``self.model`` via :meth:`_utility_completion`, so its
-        input + output must fit ``self.context_window``.  Sizing the *selection* by
-        the per-message token estimate (which disagrees with the head+tail-capped
-        formatted text) is what let a long conversation overflow the summary call
-        itself; this measures the call's real budget instead.
-
-        Reserve the output (the bounded :meth:`_summary_output_tokens` reserve),
-        the compactor prompt, and a safety margin; scale the remainder by
-        ``_SUMMARY_BUDGET_FRACTION`` to cover the uncalibrated ``_chars_per_token``
-        on the reactive path (no ``_last_usage`` yet); convert to chars; floor at
-        ``_MIN_SUMMARY_BUDGET_CHARS`` so a usable window still makes progress, but
-        never above the true input capacity — flooring past what actually fits
-        would reintroduce a summary-call overflow on a pathologically small
-        window (the call bails as "irreducible" instead).
-        """
-        output_reserve = self._summary_output_tokens(lane)
-        prompt_chars = len(self._COMPACTOR_SYSTEM_PROMPT) + len(self._COMPACT_USER_PREFIX)
-        prompt_tokens = int(prompt_chars / self._chars_per_token)
-        safety = int(self.context_window * self._SUMMARY_SAFETY_MARGIN)
-        input_tokens = self.context_window - output_reserve - prompt_tokens - safety
-        budget_tokens = max(0, int(input_tokens * self._SUMMARY_BUDGET_FRACTION))
-        budget_chars = max(
-            self._MIN_SUMMARY_BUDGET_CHARS, int(budget_tokens * self._chars_per_token)
-        )
-        # Cap the floor at the true input capacity: on a pathologically small
-        # window the floor would otherwise push the summary call (input + output
-        # reserve + prompt) past context_window instead of letting it bail.
-        return min(budget_chars, max(0, int(input_tokens * self._chars_per_token)))
-
-    @staticmethod
-    def _truncate_block(block: str, budget: int) -> str:
-        """Hard-truncate a single oversized block to ``budget`` chars, keeping
-        the head and tail around a marker that reports the ORIGINAL size — the
-        reader (the summarizer, or on the verbatim-carry paths the
-        post-compaction model) sees how much is missing, not just that a cut
-        happened.
-
-        Used for a lone block that can't fit any summary batch, and for the
-        verbatim carries (ask quote / wind-down spill).  The result is always
-        ``<= budget``.
-        """
-        if len(block) <= budget:
-            # Already fits — return as-is.  Without this, a budget wider than the
-            # block makes the head slice ``block[:head]`` and tail slice
-            # ``block[-tail:]`` overlap and DUPLICATE content around the marker.
-            return block
-        marker = f"\n…[truncated — {len(block):,} chars total]…\n"
-        if budget <= len(marker):
-            return block[:budget]
-        keep = budget - len(marker)
-        head = (keep * 2) // 3
-        tail = keep - head
-        return block[:head] + marker + block[-tail:] if tail else block[:head] + marker
-
-    def _pack_blocks(self, blocks: list[str], budget_chars: int) -> list[list[str]]:
-        """Greedily pack formatted blocks into batches that each fit ``budget_chars``.
-
-        In order, no reordering and no drops: blocks accumulate into the current
-        batch until the next one (plus the ``"\\n\\n"`` join) would overflow, then a
-        new batch starts.  A lone block larger than the budget gets its own batch,
-        hard-truncated via :meth:`_truncate_block`.  Never emits an empty batch.
-
-        ``current_len`` tracks ``len("\\n\\n".join(current))`` exactly, so every
-        returned batch's joined length is ``<= budget_chars``.
-        """
-        budget = max(1, budget_chars)
-        sep = len("\n\n")
-        batches: list[list[str]] = []
-        current: list[str] = []
-        current_len = 0
-        for block in blocks:
-            if len(block) > budget:
-                # Oversized lone block: flush the in-progress batch, then emit it
-                # alone, hard-truncated (head + tail preserved).
-                if current:
-                    batches.append(current)
-                    current = []
-                    current_len = 0
-                batches.append([self._truncate_block(block, budget)])
-                continue
-            added = len(block) + (sep if current else 0)
-            if current and current_len + added > budget:
-                batches.append(current)
-                current = [block]
-                current_len = len(block)
-            else:
-                current.append(block)
-                current_len += added
-        if current:
-            batches.append(current)
-        return batches
-
-    def _summarize_once(
+    def _build_summary_runtime(
         self,
-        system_prompt: str,
-        body: str,
-        my_generation: int = 0,
+        lane: ModelLane,
         *,
-        lane: ModelLane | None = None,
-    ) -> _SummaryResult:
-        """Run one summary completion and return its text plus producer.
+        my_generation: int = 0,
+        context_window: int | None = None,
+        chars_per_token: float | None = None,
+        continuation_overhead_tokens: int | None = None,
+        principal_id: str | None = None,
+        reasoning_effort: str | None = None,
+        cancel_ref_factory: Callable[[], list[Any]] | None = None,
+        check_cancelled: Callable[[], None] | None = None,
+        backoff_or_cancelled: Callable[[float], None] | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
+        use_session_temperature: bool = True,
+    ) -> SummaryRuntime:
+        """Adapt one lifecycle owner's immutable state to the shared engine."""
 
-        Owns the retry loop (transient errors only, exponential backoff).
-        Raises on a non-retryable error or retry exhaustion so the caller
-        can abort the whole compaction before any message swap.
-        """
-        summary_msgs = [
-            Turn.system(system_prompt),
-            Turn.user(self._COMPACT_USER_PREFIX + body),
-        ]
-        lane = lane or self._primary_lane()
-        principal_id = self._generation_principals.get(my_generation) if my_generation else None
-        result: ModelTurnResult | None = None
-        for attempt in range(self._MAX_RETRIES + 1):
-            try:
-                result = self._utility_completion(
-                    summary_msgs,
-                    max_tokens=self._summary_output_tokens(lane),
-                    # Fresh per-attempt abort seam: _CancelRef.append
-                    # registers the summary HTTP stream in _cancel_stream
-                    # eagerly (and closes on arrival if a Stop already
-                    # landed), so cancel() aborts the blocked read instead
-                    # of waiting out a whole model call — the force-stop
-                    # orphan window collapses from one summary call to the
-                    # next checkpoint.  A fresh generation-scoped ref per
-                    # attempt; the boundary checks in
-                    # _summarize_batch/_backoff guarantee a superseded
-                    # compaction makes no further calls, so it can never
-                    # clobber a successor's registration.
-                    cancel_ref=_CancelRef(self, my_generation),
-                    lane=lane,
-                    principal_id=principal_id,
-                )
-                break
-            except Exception as e:
-                # A closed-by-cancel stream surfaces as a provider error —
-                # map it to the cancel BEFORE the retry policy reads it, so
-                # a Stop on the final attempt ends the compaction as
-                # cancelled, never as a red "Compaction failed" (the main
-                # drain path makes the same closed-stream→GenerationCancelled
-                # translation).
-                self._check_cancelled(my_generation)
-                ename = type(e).__name__
-                if self._stop_retrying(e, attempt, lane):
-                    # Overflow is deterministic — let _summarize_batch subdivide
-                    # instead of retrying an identical oversized call.
-                    raise
-                delay = self._RETRY_BASE_DELAY * (2**attempt)
-                self._compaction_event(
-                    my_generation, {"phase": "progress", "retry_in": delay, "error": ename}
-                )
-                self._backoff_or_cancelled(delay, my_generation)
-        if result is None:
-            raise RuntimeError("summary retry ladder exhausted without a result")
-        # Inline think tags are already segregated at the drain seam; the
-        # trim is summary formatting (tag-free output is deliberately
-        # byte-identical at the seam, so edge whitespace is trimmed here
-        # before the summary is persisted and re-joined into merge input).
-        summary = (result.content or "").strip()
-        if result.finish_reason == "length":
-            self._compaction_event(
-                my_generation, {"phase": "progress", "warning": "summary_truncated"}
+        caps = require_lane_capabilities(lane)
+        resolved_principal = (
+            self._generation_principals.get(my_generation)
+            if principal_id is None and my_generation
+            else principal_id
+        )
+        make_cancel_ref = cancel_ref_factory or (lambda: _CancelRef(self, my_generation))
+
+        def _complete(
+            system_prompt: str,
+            user_prompt: str,
+            max_tokens: int,
+        ) -> ModelTurnResult:
+            return self._utility_completion(
+                [Turn.system(system_prompt), Turn.user(user_prompt)],
+                max_tokens=max_tokens,
+                cancel_ref=make_cancel_ref(),
+                lane=lane,
+                principal_id=resolved_principal,
+                reasoning_effort=reasoning_effort,
+                use_session_temperature=use_session_temperature,
             )
-        return _SummaryResult(
-            text=summary,
-            producer=result.producer,
-            # Lightweight seam fakes predating provenance remain valid; every
-            # production ModelTurnResult carries the field.
-            provenance=getattr(result, "provenance", TurnProvenance()),
+
+        progress: Callable[[dict[str, Any]], None]
+        if on_progress is None:
+
+            def progress(payload: dict[str, Any]) -> None:
+                self._compaction_event(my_generation, payload)
+
+        else:
+            progress = on_progress
+        return SummaryRuntime(
+            context_window=context_window or self.context_window,
+            chars_per_token=(self._chars_per_token if chars_per_token is None else chars_per_token),
+            compact_max_tokens=self.compact_max_tokens,
+            lane_max_output_tokens=caps.max_output_tokens,
+            continuation_overhead_tokens=(
+                self._system_tokens + self._tool_def_tokens(caps)
+                if continuation_overhead_tokens is None
+                else continuation_overhead_tokens
+            ),
+            complete=_complete,
+            stop_retrying=lambda error, attempt: self._stop_retrying(error, attempt, lane),
+            is_context_overflow=_is_ctx_overflow,
+            check_cancelled=(
+                check_cancelled
+                if check_cancelled is not None
+                else lambda: self._check_cancelled(my_generation)
+            ),
+            backoff_or_cancelled=(
+                backoff_or_cancelled
+                if backoff_or_cancelled is not None
+                else lambda delay: self._backoff_or_cancelled(delay, my_generation)
+            ),
+            on_progress=progress,
+            max_retries=self._MAX_RETRIES,
+            retry_base_delay=self._RETRY_BASE_DELAY,
         )
-
-    def _summarize_blocks(
-        self,
-        blocks: list[str],
-        *,
-        depth: int = 0,
-        my_generation: int = 0,
-        lane: ModelLane | None = None,
-    ) -> _SummaryResult:
-        """Summarize ``blocks`` into one dense summary, chunking + recursing so no
-        single model call exceeds the model window.
-
-        Blocks are packed to the char budget (:meth:`_summary_input_budget_chars`)
-        and each batch is summarized; the partials are recursively merged one level
-        deeper until they collapse to a single summary.  That char budget is only an
-        *estimate* — it divides by the uncalibrated ``_chars_per_token`` (which sits
-        at an optimistic 4.0 on resume) — so a batch that fits by chars can still
-        overflow the *token* window.  :meth:`_summarize_batch` absorbs that: an
-        over-window multi-block batch is split in half and each half summarized
-        (recursing as needed), then the partials merged (chunking, not truncation),
-        and only a lone block that overflows by itself is head/tail-truncated.
-
-        Bails with :class:`_CompactionIrreducibleError` only at the recursion
-        ceiling ``_MAX_SUMMARY_DEPTH`` (or when a floored lone block still overflows)
-        — the caller turns that into a ``return False`` rather than fabricate a
-        summary.
-        """
-        lane = lane or self._primary_lane()
-        system_prompt = (
-            self._COMPACTOR_SYSTEM_PROMPT if depth == 0 else self._COMPACTOR_MERGE_SYSTEM_PROMPT
-        )
-        # Recursion ceiling FIRST — before packing and the single-batch base case —
-        # so it also bounds the per-block-split merge, which can re-pack into one
-        # batch and would otherwise recurse without ever consulting the ceiling.
-        if depth >= self._MAX_SUMMARY_DEPTH:
-            raise _CompactionIrreducibleError
-        batches = self._pack_blocks(blocks, self._summary_input_budget_chars(lane))
-        if len(batches) == 1:
-            return self._summarize_batch(system_prompt, batches[0], depth, my_generation, lane=lane)
-
-        # More than one batch: recurse-merge the per-batch summaries.  A block-count
-        # guard would be wrong here — _summarize_batch's binary subdivision can
-        # legitimately leave one batch per block — so termination rides the depth
-        # ceiling above plus the progressive-shrink-to-floor bail in _summarize_batch.
-        total = len(batches)
-        summaries: list[str] = []
-        for k, batch in enumerate(batches, start=1):
-            # depth 0 = summarizing transcript batches; depth > 0 = merging
-            # partial summaries.  The web card renders depth 0 as a
-            # determinate part-k-of-N bar and deeper levels as a merge note.
-            self._compaction_event(
-                my_generation, {"phase": "progress", "part": k, "total": total, "depth": depth}
-            )
-            partial = self._summarize_batch(system_prompt, batch, depth, my_generation, lane=lane)
-            summaries.append(partial.text)
-        return self._summarize_blocks(
-            summaries,
-            depth=depth + 1,
-            my_generation=my_generation,
-            lane=lane,
-        )
-
-    def _summarize_batch(
-        self,
-        system_prompt: str,
-        batch: list[str],
-        depth: int,
-        my_generation: int = 0,
-        *,
-        lane: ModelLane | None = None,
-    ) -> _SummaryResult:
-        """Summarize one packed batch, subdividing on a token-window overflow.
-
-        The char budget that produced ``batch`` is only an estimate, so the model
-        call can overflow the real token window.  When a multi-block batch overflows,
-        it is split in HALF and each half summarized (recursing if a half still
-        overflows), then the two partials merged — binary subdivision, so an
-        over-window batch of N blocks costs ~log2(N) levels and a near-optimal number
-        of leaf calls, NOT N per-block calls (which on a wide rehydrated resume meant
-        hundreds of serial summaries).  A lone block that overflows even by itself is
-        head/tail-truncated progressively (halving the budget down to the floor, the
-        single-block analogue of the binary subdivision above) so it keeps as much as
-        the window allows; only if even the floor still overflows is the window too
-        small to compact anything and we bail irreducible.
-        """
-        # Cooperative cancellation: a cancel mid-compaction aborts here.  It raises
-        # GenerationCancelled (a BaseException), so _compact_messages' ``except
-        # Exception`` can't swallow it and the message-swap below never runs — the
-        # history is left untouched.  my_generation matters for the force-cancel
-        # orphan: a successor's claim REPLACES the cancel event, so the event arm
-        # alone would let an abandoned compaction keep issuing summary calls —
-        # the generation arm is what retires it at the next batch boundary.
-        self._check_cancelled(my_generation)
-        lane = lane or self._primary_lane()
-        try:
-            return self._summarize_once(system_prompt, "\n\n".join(batch), my_generation, lane=lane)
-        except Exception as e:
-            if not _is_ctx_overflow(e):
-                raise
-            if len(batch) > 1:
-                # Token-overflow despite the char budget: split the batch in HALF
-                # and summarize each (each half recurses + halves again if it still
-                # overflows), then merge.  Binary subdivision keeps each leaf as full
-                # as fits — a wide over-window batch costs ~log2(N) calls, not one
-                # model call per block.
-                mid = len(batch) // 2
-                left = self._summarize_batch(
-                    system_prompt, batch[:mid], depth, my_generation, lane=lane
-                )
-                right = self._summarize_batch(
-                    system_prompt, batch[mid:], depth, my_generation, lane=lane
-                )
-                return self._summarize_blocks(
-                    [left.text, right.text],
-                    depth=depth + 1,
-                    my_generation=my_generation,
-                    lane=lane,
-                )
-            # A lone block overflows by itself: the char budget over-estimated how
-            # many tokens it holds.  Shrink progressively — halve the truncation
-            # budget and retry, keeping as much of the message as the real window
-            # allows — mirroring the multi-block binary subdivision above rather than
-            # slamming straight to the 2 000-char floor (which would discard far more
-            # than the window actually forces).  Bail irreducible only once even the
-            # floor still overflows.
-            budget = max(self._MIN_SUMMARY_BUDGET_CHARS, len(batch[0]) // 2)
-            while True:
-                try:
-                    return self._summarize_once(
-                        system_prompt,
-                        self._truncate_block(batch[0], budget),
-                        my_generation,
-                        lane=lane,
-                    )
-                except Exception as e2:
-                    if not _is_ctx_overflow(e2):
-                        raise
-                    if budget <= self._MIN_SUMMARY_BUDGET_CHARS:
-                        raise _CompactionIrreducibleError from e2
-                    budget = max(self._MIN_SUMMARY_BUDGET_CHARS, budget // 2)
 
     # -- Coordinator handles across a compaction --------------------------------
     #
@@ -14800,7 +14621,9 @@ class ChatSession:
 
         Rows are whole handles, so truncation drops them at their boundary and
         names how many went: cutting head+tail through a list the way
-        :meth:`_truncate_block` does would leave a half-copied id, which is worse
+        :meth:`CompactionEngine.truncate_block
+        <turnstone.core.compaction.CompactionEngine.truncate_block>` does would leave a
+        half-copied id, which is worse
         than an absent one (it renders a call that can't resolve).  ``more``
         formats the count with an authoritative-source pointer, so the block is
         never the last word on what exists.
@@ -14860,6 +14683,13 @@ class ChatSession:
             return ""
         return prefix + tasks + children
 
+    def _next_compaction_id(self) -> int:
+        """Allocate a session-local id for one compaction attempt."""
+
+        with self._generation_lock:
+            self._compaction_seq += 1
+            return self._compaction_seq
+
     def _compact_messages(
         self,
         auto: bool = False,
@@ -14886,8 +14716,14 @@ class ChatSession:
         threshold, so a pct there would fabricate a trigger explanation
         contradicting the overflow notice printed a line above it.
         """
+        compaction_id = self._next_compaction_id()
         trigger = "auto" if auto else "manual"
-        start_payload: dict[str, Any] = {"phase": "start", "trigger": trigger}
+        start_payload: dict[str, Any] = {
+            "phase": "start",
+            "trigger": trigger,
+            "compaction_id": compaction_id,
+            "target": "workstream",
+        }
         if auto:
             start_payload["where"] = where
             if threshold_pct is not None:
@@ -14909,7 +14745,13 @@ class ChatSession:
         ):
             raise GenerationCancelled()
         try:
-            return self._compact_messages_impl(auto, preserve_tail, my_generation, carry_spill)
+            return self._compact_messages_impl(
+                auto,
+                preserve_tail,
+                my_generation,
+                carry_spill,
+                compaction_id=compaction_id,
+            )
         except ConversationPersistenceError:
             # The compaction state swap and successful END were already
             # accepted atomically with a pending marker row. Durability poison
@@ -14942,16 +14784,19 @@ class ChatSession:
                 trigger=trigger,
                 my_generation=my_generation,
                 emit_error=(trigger == "manual"),
+                compaction_id=compaction_id,
             )
             raise
 
     def _compaction_event(self, my_generation: int, payload: dict[str, Any]) -> int | None:
         """Emit one compaction lifecycle event stamped with its owning id.
 
-        ``compaction_id`` (the owning generation) ties every progress/end
-        event to the compaction that started it, and ``superseded`` marks
-        events from a generation that is no longer current (a
-        force-abandoned worker running out its last summary call).
+        ``compaction_id`` ties every progress/end event to the attempt that
+        started it; it is deliberately distinct from ``my_generation`` because
+        parallel task agents can compact concurrently and one generation can
+        compact more than once. ``my_generation`` remains the publication
+        owner, and ``superseded`` marks events from an owner that is no longer
+        current (a force-abandoned worker running out its last summary call).
         :meth:`SessionUIBase.on_compaction <turnstone.core.session_ui_base.SessionUIBase.on_compaction>`
         consumes ``superseded`` (never enqueued): a superseded event must
         not drive the activity-pill restore or animate a successor's card.
@@ -14959,15 +14804,13 @@ class ChatSession:
         events are never marked superseded (matching ``_check_cancelled``).
 
         Failed ends additionally carry ``notice`` — the single display-
-        policy site: renderers show the failure message only when it is
-        true, instead of each re-deriving suppression from reason/trigger/
-        superseded (the cross-runtime drift trap the old hand-synced
-        cli.py/conversation.js clauses documented).  Error-reason ends are
-        suppressed because :meth:`_compaction_bailed` already fired the one
-        red ``on_error`` row; cancelled-auto ends because the surrounding
-        send prints its own "[Generation cancelled]"; superseded ends
-        because nobody is waiting on a force-abandoned compaction and its
-        notice mid-turn reads as the LIVE work being cancelled.
+        policy site: renderers show the failure message only when it is true,
+        instead of each re-deriving suppression from reason/trigger/superseded.
+        Workstream error ends are suppressed because
+        :meth:`_compaction_bailed` already fired the one red ``on_error`` row.
+        A task-agent error has no unscoped error twin and therefore remains a
+        targeted notice for its nested card. Cancelled-auto and superseded ends
+        stay silent because their owners already expose the terminal state.
         """
         # Classification and emission are one generation publication.  Without
         # the shared lock, a force successor could claim after ``stale`` was
@@ -14982,33 +14825,52 @@ class ChatSession:
                 phase != "end" and (stale or self._cancel_event.is_set())
             ):
                 return None
+            raw_compaction_id = payload.get("compaction_id")
+            compaction_id = (
+                raw_compaction_id
+                if isinstance(raw_compaction_id, int) and not isinstance(raw_compaction_id, bool)
+                else my_generation
+            )
+            target = str(payload.get("target") or "workstream")
             event: dict[str, Any] = {
-                "compaction_id": my_generation,
-                "superseded": stale,
                 **payload,
+                "compaction_id": compaction_id,
+                "target": target,
+                "superseded": stale,
             }
-            if phase == "end" and not payload.get("ok"):
+            if target == "task_agent":
+                # SessionUIBase consumes this internal owner witness before
+                # fanout; it keeps reconnect snapshots exact when a provider
+                # reuses a task call id across force-successor generations.
+                event["_generation"] = my_generation
+            if not event.get("parent_call_id"):
+                event.pop("parent_call_id", None)
+            if phase == "end" and not payload.get("ok") and "notice" not in payload:
                 event["notice"] = (
                     not stale
-                    and payload.get("reason") != "error"
+                    and (payload.get("reason") != "error" or target == "task_agent")
                     and not (
                         payload.get("reason") == "cancelled" and payload.get("trigger") == "auto"
                     )
                 )
             # getattr-guarded like on_generation_claimed/on_aux_usage: a
-            # duck-typed SessionUI predating the hook must not hit an
+            # duck-typed SessionUI without the hook must not hit an
             # AttributeError that wedges every long session at its first
-            # auto-compaction.  This probe only catches DUCK-typed UIs — an
-            # explicit ``class MyUI(SessionUI)`` inherits the protocol
-            # member as a real method and never lands in the None arm, which
-            # is why the protocol default body renders the same classic
-            # lines itself (see SessionUI.on_compaction): both compat routes
-            # converge on render_compaction_event_as_info, policy
-            # single-sited.
+            # auto-compaction. This probe only catches duck-typed UIs. An
+            # explicit ``class MyUI(SessionUI)`` inherits the protocol member
+            # as a real method and never lands in the None arm, so the protocol
+            # default body renders the same foreground lines itself. Both paths
+            # converge on render_compaction_event_as_info, with policy kept in
+            # one place.
             emit = getattr(self.ui, "on_compaction", None)
             try:
                 if emit is None:
-                    # Pre-hook UIs get the classic info lines back (an
+                    # A UI without the targeted lifecycle cannot place task
+                    # progress under its parent card. Silence is safer than
+                    # misrepresenting it as a workstream-level compaction.
+                    if target != "workstream":
+                        return None
+                    # UIs without the hook get the original info lines (an
                     # auto-compaction must never swap history with zero
                     # announcement — the pre-1.8 lines reached every UI
                     # unconditionally).  Invoked for superseded END events too:
@@ -15017,7 +14879,7 @@ class ChatSession:
                     # ``on_info`` is getattr-guarded like the hook itself — the
                     # never-crash property is the floor; a UI with neither hook
                     # keeps compacting silently.  Deliberately NOT dual-emitted
-                    # for hook-aware UIs or SSE: pre-1.8 SSE/SDK clients that
+                    # for hook-aware UIs or SSE: older SSE/SDK clients that
                     # ignore unknown `compaction` events lose these lines — a
                     # documented 1.8 breaking change (CHANGELOG); dual emission
                     # would double-render on every current client.
@@ -15031,8 +14893,8 @@ class ChatSession:
                     return None
                 result = emit(event)
             except Exception:
-                # The single raise-proofing site for EVERY lifecycle emission
-                # (both compat routes, all phases): a raising duck-typed hook
+                # The single raise-proofing site for every lifecycle emission
+                # (both fallback paths, all phases): a raising duck-typed hook
                 # must degrade to a lost render, never to a lost EVENT —
                 # unguarded, a raising failed-END emit voided the
                 # exactly-one-end contract through the wrapper backstop
@@ -15061,6 +14923,7 @@ class ChatSession:
         trigger: str,
         my_generation: int,
         emit_error: bool = True,
+        compaction_id: int | None = None,
     ) -> bool:
         """Emit a failed-compaction ``end`` event and return ``False``.
 
@@ -15109,6 +14972,8 @@ class ChatSession:
                     "reason": reason,
                     "message": message,
                     "trigger": trigger,
+                    "compaction_id": (my_generation if compaction_id is None else compaction_id),
+                    "target": "workstream",
                 },
             )
         return False
@@ -15119,18 +14984,23 @@ class ChatSession:
         preserve_tail: int = 0,
         my_generation: int = 0,
         carry_spill: bool = False,
+        *,
+        compaction_id: int | None = None,
     ) -> bool:
         """Compact conversation history by summarizing it into a summary turn.
 
-        Summarizes the whole selection via :meth:`_summarize_blocks`, which packs
-        to the char-budget estimate and, when a batch still overflows the real token
-        window, binary-subdivides it (:meth:`_summarize_batch`) — so the summary call
+        Summarizes the whole selection through the shared
+        :class:`~turnstone.core.compaction.CompactionEngine`, which packs to the
+        char-budget estimate and, when a batch still overflows the real token
+        window, binary-subdivides it — so the summary call
         recovers from an under-estimate by chunking rather than overflowing, and the
         most-recent messages are no longer silently dropped.
 
         When auto=True (triggered by context limit), appends a continuation
         hint quoting the last user message — verbatim up to
-        :meth:`_carry_budget_chars` — so the model can resume seamlessly.
+        :meth:`CompactionEngine.carry_budget_chars
+        <turnstone.core.compaction.CompactionEngine.carry_budget_chars>` — so the model
+        can resume seamlessly.
 
         ``preserve_tail`` keeps the last N messages verbatim (re-appended after
         the summary) instead of summarizing them — used to keep an in-flight
@@ -15154,6 +15024,8 @@ class ChatSession:
         """
         # Presentation label derived from the one semantic flag — deriving
         # locally makes an auto=True/trigger="manual" drift impossible.
+        if compaction_id is None:
+            compaction_id = self._next_compaction_id()
         trigger = "auto" if auto else "manual"
         if len(self.messages) < 2:
             return self._compaction_bailed(
@@ -15161,6 +15033,7 @@ class ChatSession:
                 "Not enough messages to compact.",
                 trigger=trigger,
                 my_generation=my_generation,
+                compaction_id=compaction_id,
             )
 
         # Optionally keep the last ``preserve_tail`` messages verbatim — e.g. an
@@ -15194,13 +15067,14 @@ class ChatSession:
         # selection — not a fitting prefix — also fixes the latent drop of the
         # most-recent (unselected) messages.
         to_summarize_dicts = dicts_from_turns(to_summarize)
-        blocks = self._summary_blocks(to_summarize_dicts)
+        blocks = self._compaction_engine.summary_blocks(to_summarize_dicts)
         if not blocks:
             return self._compaction_bailed(
                 "not_enough_messages",
                 "Not enough messages to compact.",
                 trigger=trigger,
                 my_generation=my_generation,
+                compaction_id=compaction_id,
             )
 
         # Pin one semantic lane for the complete recursive transaction.  A
@@ -15209,6 +15083,22 @@ class ChatSession:
         # still abort the old client's in-flight transaction; failure leaves
         # history untouched, and the next compaction resolves the new lane.
         compaction_lane = self._primary_lane()
+
+        def _publish_summary_progress(progress: dict[str, Any]) -> None:
+            self._compaction_event(
+                my_generation,
+                {
+                    **progress,
+                    "compaction_id": compaction_id,
+                    "target": "workstream",
+                },
+            )
+
+        summary_runtime = self._build_summary_runtime(
+            compaction_lane,
+            my_generation=my_generation,
+            on_progress=_publish_summary_progress,
+        )
 
         def _thinking_start() -> None:
             try:
@@ -15223,21 +15113,25 @@ class ChatSession:
         ):
             raise GenerationCancelled()
         try:
-            summary_result = self._summarize_blocks(
+            summary_result = self._compaction_engine.summarize_blocks(
                 blocks,
-                my_generation=my_generation,
-                lane=compaction_lane,
+                summary_runtime,
             )
-        except _CompactionIrreducibleError:
+        except CompactionIrreducibleError:
             return self._compaction_bailed(
                 "irreducible",
                 "Messages too large to fit in summary context.",
                 trigger=trigger,
                 my_generation=my_generation,
+                compaction_id=compaction_id,
             )
         except Exception as e:
             return self._compaction_bailed(
-                "error", f"Compaction failed: {e}", trigger=trigger, my_generation=my_generation
+                "error",
+                f"Compaction failed: {e}",
+                trigger=trigger,
+                my_generation=my_generation,
+                compaction_id=compaction_id,
             )
         finally:
 
@@ -15262,6 +15156,7 @@ class ChatSession:
                 "Compaction produced an empty summary; keeping history.",
                 trigger=trigger,
                 my_generation=my_generation,
+                compaction_id=compaction_id,
             )
 
         # The verbatim carries: the wind-down spill and the continuation-hint
@@ -15291,7 +15186,9 @@ class ChatSession:
         task_lines, child_lines = self._coordinator_handle_rows()
         handles = bool(task_lines or child_lines)
         carries = (1 if spill_text else 0) + (1 if last_user_content else 0) + (1 if handles else 0)
-        carry_budget = self._carry_budget_chars(carries, compaction_lane) if carries else 0
+        carry_budget = (
+            self._compaction_engine.carry_budget_chars(summary_runtime, carries) if carries else 0
+        )
 
         summary = summary_result.text
 
@@ -15304,7 +15201,7 @@ class ChatSession:
         carry_truncated = False
         if spill_text:
             carry_truncated = len(spill_text) > carry_budget
-            summary += "\n\n## Wind-down (verbatim)\n" + self._truncate_block(
+            summary += "\n\n## Wind-down (verbatim)\n" + self._compaction_engine.truncate_block(
                 spill_text, carry_budget
             )
 
@@ -15315,7 +15212,9 @@ class ChatSession:
             # few-hundred-char clip amputates it.  Beyond the budget keep head
             # + tail around an honest marker.
             carry_truncated = carry_truncated or len(last_user_content) > carry_budget
-            last_user_content = self._truncate_block(last_user_content, carry_budget)
+            last_user_content = self._compaction_engine.truncate_block(
+                last_user_content, carry_budget
+            )
             summary += (
                 f"\n\n## Continue\n"
                 f"The user's last message was: {last_user_content}\n"
@@ -15497,6 +15396,8 @@ class ChatSession:
                             "phase": "end",
                             "ok": True,
                             "trigger": trigger,
+                            "compaction_id": compaction_id,
+                            "target": "workstream",
                             "before_tokens": before_tokens,
                             "after_tokens": after_tokens,
                             "summary": summary,
@@ -15523,6 +15424,8 @@ class ChatSession:
                         "phase": "end",
                         "ok": True,
                         "trigger": trigger,
+                        "compaction_id": compaction_id,
+                        "target": "workstream",
                         "before_tokens": before_tokens,
                         "after_tokens": after_tokens,
                         "summary": summary,
@@ -24278,25 +24181,37 @@ class ChatSession:
             return
         fn = getattr(self.ui, "on_agent_context", None)
         if fn is not None:
-            fn(
-                parent_call_id,
-                prompt_tokens,
-                context_window,
-                generation=generation,
-            )
+            try:
+                fn(
+                    parent_call_id,
+                    prompt_tokens,
+                    context_window,
+                    generation=generation,
+                )
+            except Exception:
+                # Context telemetry is advisory. A custom UI hook must not
+                # reclassify a completed model call or a committed compaction
+                # as failed after the provider/context state already changed.
+                log.debug(
+                    "session.agent_context.publish_failed ws=%s call_id=%s generation=%d",
+                    self._ws_id[:8],
+                    parent_call_id,
+                    generation,
+                    exc_info=True,
+                )
 
-    def _clear_agent_context(self, parent_call_id: str | None, *, generation: int) -> None:
+    def _clear_agent_transients(self, parent_call_id: str | None, *, generation: int) -> None:
         """Best-effort clear of generation-scoped task-agent reconnect state."""
         if not parent_call_id:
             return
-        fn = getattr(self.ui, "clear_agent_context", None)
+        fn = getattr(self.ui, "clear_agent_transients", None)
         if fn is not None:
             try:
                 fn(parent_call_id, generation=generation)
             except Exception:
                 # A custom UI hook must not suppress the task's authoritative
                 # terminal result. SessionUIBase's implementation is
-                # in-memory/infallible; this guard preserves the compatibility
+                # in-memory/infallible; this guard preserves the fault-isolation
                 # posture of every other optional task-agent UI hook.
                 log.debug(
                     "session.agent_context.cleanup_failed ws=%s call_id=%s generation=%d",
@@ -24306,9 +24221,9 @@ class ChatSession:
                     exc_info=True,
                 )
 
-    def _clear_agent_contexts_before_generation(self, generation: int) -> None:
+    def _clear_agent_transients_before_generation(self, generation: int) -> None:
         """Best-effort purge of reconnect state owned by retired workers."""
-        fn = getattr(self.ui, "clear_agent_contexts_before_generation", None)
+        fn = getattr(self.ui, "clear_agent_transients_before_generation", None)
         if fn is None:
             return
         try:
@@ -24345,134 +24260,16 @@ class ChatSession:
         The one format for sub-agent output clips — the in-loop 16k clip and the
         recall per-step cap — distinct from the token-budget-aware
         :meth:`_truncate_output`."""
-        if len(text) <= cap:
-            return text
-        return text[:cap] + f"\n\n... (truncated from {len(text)} chars)"
+        return _clip_agent_text(text, cap)
 
-    @staticmethod
-    def _iter_agent_tool_results(
-        agent_turns: list[Turn],
-    ) -> Iterator[tuple[ToolCall, Turn | None]]:
-        """Yield ``(tool_call, result_turn_or_None)`` for every sub-tool the
-        sub-agent issued, in order, pairing each call to its result FIFO per
-        call_id.  Parented runs mint session-unique ids
-        (``{parent}::r{run}s{step}::{provider_id}``, see :meth:`_run_agent`),
-        so for them this is a plain unique-key pairing; the FIFO queue stays as
-        honest pairing for id-colliding input a mint never touched (an
-        unparented run, or turns constructed directly), where last-wins would
-        collapse distinct calls onto one result.  Shared by
-        :meth:`_project_agent_steps` (recall) and :meth:`_cancel_ledger`
-        (cancel disposition)."""
-        pending: dict[str, collections.deque[Turn]] = {}
-        for t in agent_turns:
-            if t.role is Role.TOOL and t.tool_call_id:
-                pending.setdefault(t.tool_call_id, collections.deque()).append(t)
-        for t in agent_turns:
-            if t.role is not Role.ASSISTANT:
-                continue
-            for tc in t.tool_calls:
-                q = pending.get(tc.id)
-                yield tc, (q.popleft() if q else None)
+    def _stash_agent_steps(self, call_id: str | None, steps: list[dict[str, Any]]) -> None:
+        """Retain one already-bounded task recall projection when supported."""
 
-    @staticmethod
-    def _record_unstarted_agent_tools(
-        agent_turns: list[Turn],
-        started_tool_ids: list[str],
-    ) -> None:
-        """Close issued-but-never-started child calls with a NONE ledger row.
-
-        Task-agent tools execute sequentially.  A Stop can win while a call is
-        waiting for intent judging or human approval; that call and every later
-        sibling were never invoked, so labeling the first missing result as
-        in-flight UNKNOWN fabricates possible effects.  Started calls without a
-        result remain gaps.  A counter keeps direct/unparented tests honest when
-        a provider reuses a call id; parented production runs use minted ids.
-        """
-        remaining_started = collections.Counter(started_tool_ids)
-        for tool_call, result in list(ChatSession._iter_agent_tool_results(agent_turns)):
-            if result is not None:
-                if remaining_started[tool_call.id] > 0:
-                    remaining_started[tool_call.id] -= 1
-                continue
-            if remaining_started[tool_call.id] > 0:
-                remaining_started[tool_call.id] -= 1
-                continue
-            agent_turns.append(
-                Turn.tool(
-                    tool_call.id,
-                    "(cancelled before execution; no side effects)",
-                    is_error=True,
-                    effect_status=EffectStatus.NONE,
-                )
-            )
-
-    @staticmethod
-    def _project_agent_steps(agent_turns: list[Turn]) -> list[dict[str, Any]]:
-        """Project a finished sub-agent's trajectory into recall step items for
-        the task card — one per sub-tool call, matched to its result (FIFO per
-        call_id via :meth:`_iter_agent_tool_results`).
-
-        Reads the tool turn's payload directly rather than via ``Turn.text``,
-        which raises on a multimodal ``list[dict]`` result (the deferred-finding
-        landmine); a non-``str`` payload becomes a light placeholder so the
-        recall stays text-only and ``/history`` doesn't carry image bytes.  Each
-        step's output AND arguments are capped (:data:`_AGENT_STEP_OUTPUT_CAP`)
-        and the step COUNT (:data:`_AGENT_STEP_COUNT_CAP`); on overflow the most
-        RECENT steps are kept (a sub-agent's latest edits/writes matter more on
-        recall than its opening searches) behind an honest leading marker — so
-        the stash stays memory-bounded even for a 100+-tool agent and never
-        silently under-reports its step count."""
-        pairs = list(ChatSession._iter_agent_tool_results(agent_turns))
-        dropped = max(0, len(pairs) - _AGENT_STEP_COUNT_CAP)
-        # Build dicts only for the retained tail, not the dropped head.
-        tail = pairs[-_AGENT_STEP_COUNT_CAP:] if dropped else pairs
-        steps: list[dict[str, Any]] = []
-        if dropped:
-            # Leading marker naming how many earlier steps fell out — honest, and
-            # correct now that the RETAINED steps are the recent ones.
-            steps.append(
-                {
-                    "id": "",
-                    "name": "…",
-                    "arguments": "{}",
-                    "output": f"(+{dropped} earlier steps not retained)",
-                    "is_error": False,
-                }
-            )
-        for tc, res in tail:
-            output, is_error = "", False
-            if res is not None:
-                is_error = res.is_error
-                raw = (
-                    res.content[0].text
-                    if res.content and isinstance(res.content[0], TextBlock)
-                    else ""
-                )
-                output = raw if isinstance(raw, str) else "[non-text result]"
-            steps.append(
-                {
-                    "id": tc.id,
-                    "name": tc.name,
-                    # Clip arguments too: a write_file/edit_file call carries full
-                    # file content here, which the per-step output cap alone would
-                    # leave unbounded in the in-memory stash.
-                    "arguments": ChatSession._clip_with_count(tc.arguments, _AGENT_STEP_OUTPUT_CAP),
-                    "output": ChatSession._clip_with_count(output, _AGENT_STEP_OUTPUT_CAP),
-                    "is_error": is_error,
-                }
-            )
-        return steps
-
-    def _stash_agent_trajectory(self, call_id: str | None, agent_turns: list[Turn]) -> None:
-        """Retain a finished task agent's projected sub-trajectory for ``/history``
-        card recall (getattr-guarded → no-op on CLI / eval / fixtures).  Called
-        from ``_exec_task``'s ``finally`` so it captures the full record on
-        success and the partial one on cancel/error — both honest."""
         if not call_id:
             return
         fn = getattr(self.ui, "stash_agent_trajectory", None)
         if fn is not None:
-            fn(call_id, self._project_agent_steps(agent_turns))
+            fn(call_id, steps)
 
     def _run_agent(
         self,
@@ -24486,6 +24283,7 @@ class ChatSession:
         principal_id: str | None = None,
         origin_cancel_event: threading.Event | None = None,
         origin_generation: int = 0,
+        execution_journal: _TaskExecutionJournal | None = None,
     ) -> str:
         """Run one autonomous child under an independently abortable scope.
 
@@ -24494,12 +24292,12 @@ class ChatSession:
         without a registered provider-stream handle.
         """
         parent_event = self._cancel_event if origin_cancel_event is None else origin_cancel_event
+        journal = execution_journal or _TaskExecutionJournal(agent_turns)
         with self._registered_parallel_model_cancel_scope(
             parent_event,
             origin_generation,
         ) as cancel_scope:
             context_token = _active_task_agent_cancel_scope.set(cancel_scope)
-            started_tool_ids: list[str] = []
             try:
                 cancel_scope.check()
                 try:
@@ -24514,7 +24312,7 @@ class ChatSession:
                         principal_id=principal_id,
                         cancel_scope=cancel_scope,
                         origin_generation=origin_generation,
-                        started_tool_ids=started_tool_ids,
+                        execution_journal=journal,
                     )
                 except GenerationCancelled:
                     # Model-issued calls that never crossed their execute
@@ -24522,7 +24320,7 @@ class ChatSession:
                     # UNKNOWN. Fill those ledger rows before the parent builds
                     # its cancellation disposition; calls that did start and
                     # never returned deliberately remain gaps.
-                    self._record_unstarted_agent_tools(agent_turns, started_tool_ids)
+                    journal.materialize_unstarted(agent_turns)
                     raise
             finally:
                 _active_task_agent_cancel_scope.reset(context_token)
@@ -24540,7 +24338,7 @@ class ChatSession:
         *,
         cancel_scope: _ParallelModelCancelScope,
         origin_generation: int,
-        started_tool_ids: list[str],
+        execution_journal: _TaskExecutionJournal,
     ) -> str:
         """Run an autonomous agent loop.
 
@@ -24582,10 +24380,17 @@ class ChatSession:
         if auto_tools is None:
             auto_tools = TASK_AUTO_TOOLS
         max_tool_turns = self.agent_max_turns
+        # ``execution_journal`` is bounded cancellation/recall truth.
+        # ``context_turns`` is the bounded trajectory sent back to the model and
+        # may be replaced by compaction; ``agent_turns`` retains only raw turns
+        # since the latest replacement for direct-call diagnostics. The initial
+        # system/skill/delegation prefix is immutable controller context.
+        context_turns = list(agent_turns)
+        agent_prefix = tuple(agent_turns)
 
         # Resolve agent model: explicit per-call override wins, then the
-        # per-kind registry override (task_model), then the legacy single-
-        # knob agent_model, then the session's primary model.
+        # per-kind registry override (task_model), then the session-wide
+        # agent_model fallback, then the session's primary model.
         if agent_alias is not None:
             if self._registry is None or not self._registry.has_alias(agent_alias):
                 raise ValueError(f"Unknown agent_alias '{agent_alias}'")
@@ -24636,6 +24441,7 @@ class ChatSession:
         # invocation; the native lane carried here serves the WITHIN-RUN
         # reasoning continuity of the agent's own tool loop.
         same_lane = (lane.alias or "") == (primary_lane.alias or "")
+        agent_reasoning_effort = reasoning_effort or (self.reasoning_effort if same_lane else None)
         # Keep the initiating principal pinned for the whole sub-agent run,
         # but defer each credential mint until model_turn has acquired this
         # alias's admission slot.  A long queue can outlive a bearer token;
@@ -24643,7 +24449,13 @@ class ChatSession:
         # without consulting a later shared-workstream actor.
         cancel_scope.check()
         lane = self._lane_for_backend_auth_principal(lane, agent_principal)
-        agent_context_window = self._context_window_for_lane(lane) if parent_call_id else 0
+        agent_context_window = self._context_window_for_lane(lane)
+        context_estimator = PromptTokenEstimator(
+            measure=self._msg_text_chars,
+            tool_def_chars=serialized_tool_chars(tools),
+            image_tokens=self._IMAGE_TOKENS,
+        )
+        compaction_policy = self._compaction_policy(agent_context_window)
 
         def _api_call(
             turns: list[Turn],
@@ -24675,8 +24487,7 @@ class ChatSession:
                         tools=_tools,
                         max_tokens=self.max_tokens,
                         temperature=self.temperature if same_lane else None,
-                        reasoning_effort=reasoning_effort
-                        or (self.reasoning_effort if same_lane else None),
+                        reasoning_effort=agent_reasoning_effort,
                         mint=mint,
                         wire_id_map=wire_id_map,
                         cancel_ref=cancel_scope.cancel_ref,
@@ -24697,6 +24508,13 @@ class ChatSession:
                     # after its originating run was cancelled.
                     cancel_scope.check()
                     agent_usage = agent_result.usage
+                    if agent_usage is not None:
+                        context_estimator.observe(
+                            prompt_tokens=agent_usage.prompt_tokens,
+                            messages=turns,
+                            wire_messages=agent_result.wire_msgs,
+                            tool_def_chars=agent_result.tool_def_chars,
+                        )
                     if agent_usage is not None and parent_call_id:
                         published = self._publish_for_generation(
                             origin_generation,
@@ -24751,7 +24569,7 @@ class ChatSession:
             # therefore conservatively tracked as started/UNKNOWN until a
             # result establishes a tighter disposition.
             cancel_scope.check()
-            started_tool_ids.append(str(prepared.get("call_id") or ""))
+            execution_journal.mark_started(str(prepared.get("call_id") or ""))
             result: tuple[str, Any] = prepared["execute"](execute_item)
             return result
 
@@ -24766,6 +24584,309 @@ class ChatSession:
             )
             cancel_scope.check()
             return guarded
+
+        compaction_advised = False
+        # Cooperative soft compaction is admitted once per effect epoch.  A
+        # successful summary is not itself progress: if its irreducible prefix
+        # remains over soft, re-arming before another tool result creates an
+        # unbounded model -> summary -> model loop that never advances ``turn``.
+        tool_progress_epoch = 0
+        compacted_epoch: int | None = None
+        failed_compaction_signature: tuple[int, int, int, int] | None = None
+
+        def _context_signature(
+            prospective_turns: tuple[Turn, ...] = (),
+            *,
+            tool_def_chars: int | None = None,
+        ) -> tuple[int, int, int, int]:
+            request_turns = [*context_turns, *prospective_turns]
+            next_tool_chars = (
+                context_estimator.tool_def_chars if tool_def_chars is None else tool_def_chars
+            )
+            used = context_estimator.estimate_with_tool_defs(
+                request_turns,
+                tool_def_chars=next_tool_chars,
+            )
+            return len(context_turns), len(prospective_turns), next_tool_chars, used
+
+        def _task_compaction_event(
+            compaction_id: int,
+            payload: dict[str, Any],
+        ) -> None:
+            if not parent_call_id:
+                return
+            self._compaction_event(
+                origin_generation,
+                {
+                    **payload,
+                    "compaction_id": compaction_id,
+                    "target": "task_agent",
+                    "parent_call_id": parent_call_id,
+                },
+            )
+
+        def _agent_summary_runtime(
+            compaction_id: int,
+            *,
+            continuation_tool_def_chars: int | None = None,
+        ) -> SummaryRuntime:
+            prefix_tokens = context_estimator.tokens_for(agent_prefix)
+            tool_chars = (
+                context_estimator.tool_def_chars
+                if continuation_tool_def_chars is None
+                else continuation_tool_def_chars
+            )
+            tool_tokens = int(tool_chars / context_estimator.chars_per_token)
+            return self._build_summary_runtime(
+                lane,
+                my_generation=origin_generation,
+                context_window=agent_context_window,
+                chars_per_token=context_estimator.chars_per_token,
+                continuation_overhead_tokens=prefix_tokens + tool_tokens,
+                principal_id=agent_principal,
+                reasoning_effort=agent_reasoning_effort,
+                cancel_ref_factory=lambda: cancel_scope.cancel_ref,
+                check_cancelled=cancel_scope.check,
+                backoff_or_cancelled=cancel_scope.backoff_or_cancelled,
+                on_progress=functools.partial(_task_compaction_event, compaction_id),
+                use_session_temperature=same_lane,
+            )
+
+        def _compact_agent_context(
+            where: str,
+            *,
+            carry_spill: bool = False,
+            prospective_turns: tuple[Turn, ...] = (),
+            next_tool_def_chars: int | None = None,
+        ) -> bool:
+            """Summarize and atomically replace only this agent's model context."""
+
+            nonlocal compaction_advised, compacted_epoch, failed_compaction_signature
+            cancel_scope.check()
+            signature = _context_signature(
+                prospective_turns,
+                tool_def_chars=next_tool_def_chars,
+            )
+            if signature == failed_compaction_signature:
+                return False
+            # There must be work beyond the immutable harness prefix to reclaim.
+            if len(context_turns) <= len(agent_prefix):
+                failed_compaction_signature = signature
+                return False
+            compaction_advised = False
+            # The immutable controller prefix is reattached verbatim below, so
+            # summarize only the replaceable suffix. Including the task prompt
+            # in both places wastes the reclaimed budget and lets a paraphrase
+            # compete with the authoritative delegation contract.
+            blocks = self._compaction_engine.summary_blocks(
+                dicts_from_turns(context_turns[len(agent_prefix) :])
+            )
+            if not blocks:
+                failed_compaction_signature = signature
+                return False
+            compaction_id = self._next_compaction_id()
+            runtime = _agent_summary_runtime(
+                compaction_id,
+                continuation_tool_def_chars=next_tool_def_chars,
+            )
+            start_payload: dict[str, Any] = {
+                "phase": "start",
+                "trigger": "auto",
+                "where": where,
+            }
+            if where != "context overflow":
+                start_payload["pct"] = round(self.auto_compact_pct * 100)
+            if not self._publish_for_generation(
+                origin_generation,
+                functools.partial(_task_compaction_event, compaction_id, start_payload),
+                allow_cancelled=False,
+            ):
+                raise GenerationCancelled()
+
+            settled = False
+
+            def _settle(payload: dict[str, Any]) -> None:
+                nonlocal settled
+                if settled:
+                    return
+                # Mark first: the common emitter is raise-proof, but custom test
+                # doubles should not turn one attempted terminal edge into two.
+                settled = True
+                _task_compaction_event(compaction_id, payload)
+
+            try:
+                summary_result = self._compaction_engine.summarize_blocks(blocks, runtime)
+                if not summary_result.text.strip():
+                    failed_compaction_signature = signature
+                    _settle(
+                        {
+                            "phase": "end",
+                            "ok": False,
+                            "reason": "empty_summary",
+                            "message": "Task-agent context compaction returned an empty summary.",
+                            "trigger": "auto",
+                        }
+                    )
+                    self.ui.on_info(f"[{label}] context compaction returned an empty summary")
+                    return False
+
+                summary = summary_result.text
+                if carry_spill and context_turns:
+                    spill = context_turns[-1]
+                    spill_text = spill.text.strip() if spill.role is Role.ASSISTANT else ""
+                    if spill_text:
+                        carry_budget = self._compaction_engine.carry_budget_chars(runtime)
+                        summary += "\n\n## Wind-down (verbatim)\n" + (
+                            self._compaction_engine.truncate_block(spill_text, carry_budget)
+                        )
+
+                compacted = turns_from_dicts(
+                    [
+                        {
+                            "role": "user",
+                            "content": COMPACTION_SUMMARY_LABEL,
+                            "_source": COMPACTION_SOURCE,
+                        },
+                        {
+                            "role": "assistant",
+                            "content": summary,
+                            "_source": COMPACTION_SOURCE,
+                            "_provenance": summary_result.provenance.to_meta(),
+                        },
+                        {
+                            "role": "user",
+                            "content": NUDGE_TASK_COMPACTION_RESUME,
+                            "_source": "compaction_resume",
+                        },
+                    ]
+                )
+                cancel_scope.check()
+                replacement = [*agent_prefix, *compacted]
+                # Stage every fallible derivation before replacing either live
+                # trajectory. An unexpected estimator/provenance error therefore
+                # yields a failed END while leaving the old context intact.
+                context_estimator.invalidate()
+                next_tool_chars = (
+                    context_estimator.tool_def_chars
+                    if next_tool_def_chars is None
+                    else next_tool_def_chars
+                )
+                after_tokens = context_estimator.estimate_with_tool_defs(
+                    [*replacement, *prospective_turns],
+                    tool_def_chars=next_tool_chars,
+                )
+
+                context_turns[:] = replacement
+                # The bounded journal now owns cancellation/recall truth for
+                # every resolved pre-compaction call. Drop their raw
+                # assistant/native blocks, tool payloads, and provider-id restore
+                # entries referenced only by the discarded model context.
+                agent_turns[:] = list(agent_prefix)
+                wire_id_map.clear()
+                # Exact file contents have left the model context. Clear only
+                # this ContextVar-owned task set; siblings/parent are untouched.
+                self._current_read_files.clear()
+                failed_compaction_signature = None
+                compacted_epoch = tool_progress_epoch
+                if parent_call_id:
+                    published = self._publish_for_generation(
+                        origin_generation,
+                        functools.partial(
+                            self._paint_agent_context,
+                            parent_call_id,
+                            after_tokens,
+                            agent_context_window,
+                            generation=origin_generation,
+                        ),
+                        allow_cancelled=False,
+                    )
+                    if not published:
+                        raise GenerationCancelled()
+                _settle(
+                    {
+                        "phase": "end",
+                        "ok": True,
+                        "trigger": "auto",
+                        "before_tokens": signature[3],
+                        "after_tokens": after_tokens,
+                    }
+                )
+                return True
+            except CompactionIrreducibleError:
+                failed_compaction_signature = signature
+                _settle(
+                    {
+                        "phase": "end",
+                        "ok": False,
+                        "reason": "irreducible",
+                        "message": "Task-agent context could not be reduced.",
+                        "trigger": "auto",
+                    }
+                )
+                self.ui.on_info(f"[{label}] context compaction could not reduce the trajectory")
+                return False
+            except Exception as error:
+                failed_compaction_signature = signature
+                _settle(
+                    {
+                        "phase": "end",
+                        "ok": False,
+                        "reason": "error",
+                        "message": "Task-agent context compaction failed.",
+                        "trigger": "auto",
+                    }
+                )
+                log.warning(
+                    "task_agent.compaction_failed",
+                    label=label,
+                    where=where,
+                    error_type=type(error).__name__,
+                )
+                return False
+            except BaseException:
+                _settle(
+                    {
+                        "phase": "end",
+                        "ok": False,
+                        "reason": "cancelled",
+                        "message": "Task-agent context compaction cancelled.",
+                        "trigger": "auto",
+                    }
+                )
+                raise
+
+        def _maybe_compact_agent_context() -> None:
+            nonlocal compaction_advised
+            if len(context_turns) <= len(agent_prefix):
+                return
+            used = context_estimator.estimate(context_turns)
+            if compacted_epoch == tool_progress_epoch:
+                return
+            if compaction_policy.owed(used, advised=compaction_advised):
+                _compact_agent_context("mid-turn")
+            elif compaction_policy.over_soft(used):
+                context_turns.append(
+                    turn_from_dict(
+                        make_system_turn(
+                            "compaction_pending",
+                            format_nudge("compaction_pending"),
+                        )
+                    )
+                )
+                compaction_advised = True
+
+        def _api_call_with_compaction(
+            _tools: list[dict[str, Any]] | None = tools,
+        ) -> ModelTurnResult:
+            try:
+                return _api_call(context_turns, _tools=_tools)
+            except Exception as error:
+                if _is_ctx_overflow(error) and _compact_agent_context(
+                    "context overflow",
+                    next_tool_def_chars=serialized_tool_chars(_tools or []),
+                ):
+                    return _api_call(context_turns, _tools=_tools)
+                raise
 
         turn = 0
         # Mint tags for sub-tool ids.  ``run_seq`` is session-unique per
@@ -24822,8 +24943,9 @@ class ChatSession:
         mint: Callable[[str], str] | None = _mint_sub_id if parent_call_id else None
         while max_tool_turns < 0 or turn < max_tool_turns:
             cancel_scope.check()
+            _maybe_compact_agent_context()
             try:
-                result = _api_call(agent_turns)
+                result = _api_call_with_compaction()
             except Exception as e:
                 # Terminal API error: overflow, or any non-retryable error that
                 # escaped the retry loop above.  Salvage the sub-agent's partial work
@@ -24836,7 +24958,7 @@ class ChatSession:
                 # propagates past this ``except Exception``.
                 overflow = _is_ctx_overflow(e)
                 note = "context limit reached" if overflow else f"error ({type(e).__name__})"
-                salvage = last_assistant_text(agent_turns)
+                salvage = execution_journal.latest_assistant_text
                 if salvage:
                     self.ui.on_info(f"[{label}] {note}, returning partial work")
                     return _finish_synthesis(salvage)
@@ -24865,8 +24987,24 @@ class ChatSession:
             # (:func:`turnstone.core.model_turn.finalize_provider_blocks`).
             cancel_scope.check()
             agent_turns.append(result.turn)
+            context_turns.append(result.turn)
+            execution_journal.record_assistant(result.turn)
+            if result.usage is not None:
+                context_estimator.append_exact(
+                    result.turn,
+                    result.usage.completion_tokens,
+                )
 
             if not result.tool_calls:
+                if compaction_advised and _compact_agent_context(
+                    "cooperative wind-down",
+                    carry_spill=True,
+                ):
+                    # The committed summary replaced this no-tool turn. Do not
+                    # keep its provider-native payload alive through the resume
+                    # request merely because the loop local still points at it.
+                    del result
+                    continue
                 content = _non_blank_or(result.content, "(no output)")
                 self.ui.on_info(f"[{label} done] {len(content)} chars")
                 return _finish_synthesis(content)
@@ -24881,6 +25019,7 @@ class ChatSession:
                 # not only the execute path — so a guard-branch error's
                 # output_warning still nests under the task card.
                 self._note_agent_child(tc_dict["id"], parent_call_id)
+                execution_journal.register_child(tc_dict["id"])
 
                 # is_error for the recalled step: the guard / prepare / unknown
                 # branches produce explicit error text; the execute paths record
@@ -24890,6 +25029,7 @@ class ChatSession:
                 is_tool_error = False
                 child_effect_status: EffectStatus | None = None
                 cancelled_before_execution = False
+                prepared: dict[str, Any] | None = None
                 output: Any
                 # Guard 1: block recursive agent calls.
                 if tool_name == "task_agent":
@@ -24946,7 +25086,7 @@ class ChatSession:
                         # gate, exactly like the main loop.
                         agent_judge_cancel = self._evaluate_intent(
                             [prepared],
-                            conversation=agent_turns,
+                            conversation=context_turns,
                             agent_gate=True,
                             principal_id=agent_principal,
                             cancel_ref=cancel_scope.cancel_ref,
@@ -25029,6 +25169,12 @@ class ChatSession:
                         effect_status=child_effect_status,
                     )
                 )
+                journal_step = execution_journal.record_result(
+                    tc_dict["id"],
+                    "(tool result observed; output processing was interrupted)",
+                    is_error=is_tool_error,
+                    effect_status=child_effect_status,
+                )
                 if cancelled_before_execution:
                     raise GenerationCancelled()
 
@@ -25074,19 +25220,43 @@ class ChatSession:
                     is_error=is_tool_error,
                     effect_status=child_effect_status,
                 )
+                execution_journal.update_step(journal_step, output, is_error=is_tool_error)
+                context_turns.append(agent_turns[result_turn_index])
+                self._clear_agent_children(
+                    parent_call_id,
+                    child_ids={tc_dict["id"]},
+                )
+                execution_journal.release_child(tc_dict["id"])
+            # Successful compaction runs at the top of the next iteration.
+            # Drop the just-completed provider response and last tool locals
+            # before that summary/model call so the context swap is also a real
+            # reachability boundary for multimodal/native payloads.
+            del result, tc_dict, prepared, output
             turn += 1
+            tool_progress_epoch += 1
 
         # Exhausted tool turns — force a final synthesis response.
         cancel_scope.check()
         self.ui.on_info(f"[{label}] turn limit reached, requesting synthesis...")
-        agent_turns.append(
-            Turn.user(
-                "You have reached the tool call limit. "
-                "Provide your complete response now using "
-                "the information you have gathered so far."
-            )
+        synthesis_turn = Turn.user(
+            "You have reached the tool call limit. "
+            "Provide your complete response now using "
+            "the information you have gathered so far."
         )
-        result = _api_call(agent_turns, _tools=[])
+        if len(context_turns) > len(agent_prefix) and compaction_policy.over_soft(
+            context_estimator.estimate_with_tool_defs(
+                [*context_turns, synthesis_turn],
+                tool_def_chars=0,
+            )
+        ):
+            _compact_agent_context(
+                "turn-limit synthesis",
+                prospective_turns=(synthesis_turn,),
+                next_tool_def_chars=0,
+            )
+        agent_turns.append(synthesis_turn)
+        context_turns.append(synthesis_turn)
+        result = _api_call_with_compaction(_tools=[])
         cancel_scope.check()
         content = _non_blank_or(result.content, "(no output)")
         self.ui.on_info(f"[{label} done] {len(content)} chars")
@@ -25192,6 +25362,7 @@ class ChatSession:
                 skill_body = skill_body[:_MAX_SKILL_CONTENT]
             agent_turns.append(Turn.user(self._TASK_SKILL_CAPABILITY_PREAMBLE + skill_body))
         agent_turns.append(Turn.user(prompt))
+        execution_journal = _TaskExecutionJournal(agent_turns)
         self._begin_agent_scope()
         # Per-sub-agent file-read tracking.  COPY the parent's current set in (so
         # the agent can edit a file the parent already read for it — no spurious
@@ -25215,6 +25386,7 @@ class ChatSession:
                 principal_id=item.get("_principal_id"),
                 origin_cancel_event=item.get("_origin_cancel_event"),
                 origin_generation=origin_generation,
+                execution_journal=execution_journal,
             )
 
             # Self-report the task_agent's OWN result.  The parent run-loop only
@@ -25228,7 +25400,7 @@ class ChatSession:
                 # listener must observe either the active snapshot followed by
                 # this result, or no snapshot plus this result — never a
                 # synthetic active reading after the terminal replay.
-                self._clear_agent_context(call_id, generation=origin_generation)
+                self._clear_agent_transients(call_id, generation=origin_generation)
                 self._report_tool_result(call_id, "task_agent", result)
 
             if not self._publish_for_generation(
@@ -25239,23 +25411,21 @@ class ChatSession:
                 raise GenerationCancelled()
             return call_id, result
         except GenerationCancelled:
-            # Fold back an honest disposition built from the agent's own
-            # ledger.  ``agent_turns`` is mutated in place by
-            # ``_run_agent`` (it appends every assistant turn and tool
-            # result), so at this catch point it holds the full record of
-            # what the sub-agent did before cancel — including a partial
-            # result from a tool that was SIGKILL'd mid-flight.  The old
+            # Fold back an honest disposition from the bounded execution
+            # journal. It retains exact current-batch gaps and aggregate typed
+            # outcomes even after raw pre-compaction payloads were released,
+            # including a partial result from a tool SIGKILL'd mid-flight. The old
             # bare "(task interrupted by user)" string discarded all of
             # that and fabricated an *outcome*: downstream it read as
             # "nothing happened" and invited a re-dispatch / double-send.
             # See the cancellation appendix in HYPOTHESIS.md ("ρ may
             # fabricate the acknowledgment but must not fabricate the
             # outcome … unknown, never none").
-            disposition = self._cancelled_agent_disposition(agent_turns, "task")
+            disposition = execution_journal.cancelled_disposition("task")
 
             def _publish_cancelled() -> None:
-                self._clear_agent_context(call_id, generation=origin_generation)
-                status = self._cancelled_agent_status(agent_turns)
+                self._clear_agent_transients(call_id, generation=origin_generation)
+                status = execution_journal.cancelled_status()
                 receipt = _CancelledToolResult(
                     detail=disposition,
                     effect_status=status,
@@ -25308,7 +25478,7 @@ class ChatSession:
             msg = f"Task error: {e}"
 
             def _publish_error() -> None:
-                self._clear_agent_context(call_id, generation=origin_generation)
+                self._clear_agent_transients(call_id, generation=origin_generation)
                 self._report_tool_result(call_id, "task_agent", msg, is_error=True)
 
             self._publish_for_generation(
@@ -25331,172 +25501,23 @@ class ChatSession:
             _active_shell_owner.reset(shell_token)
             self._background_shells.reap(owner=shell_owner)
             self._end_agent_scope()
-            child_ids = {tc.id for tc, _result in self._iter_agent_tool_results(agent_turns)}
-            self._clear_agent_children(call_id, child_ids=child_ids)
+            self._clear_agent_children(
+                call_id,
+                child_ids=execution_journal.active_child_ids,
+            )
             # This is pure exact-owner cleanup, not publication. A retiring
             # predecessor must still drop its own reading after a force claim;
             # the generation stored beside the entry protects a successor that
             # reused the same public call id.
-            self._clear_agent_context(call_id, generation=origin_generation)
+            self._clear_agent_transients(call_id, generation=origin_generation)
 
             def _stash() -> None:
                 try:
-                    self._stash_agent_trajectory(call_id, agent_turns)
+                    self._stash_agent_steps(call_id, execution_journal.project_steps())
                 except Exception:
                     log.debug("task_agent.stash_failed call_id=%s", call_id, exc_info=True)
 
             self._publish_for_generation(origin_generation, _stash)
-
-    @staticmethod
-    def _cancel_effect_ledger(
-        agent_turns: list[Turn],
-    ) -> tuple[list[tuple[str, bool, EffectStatus | None]], int | None]:
-        """Read issued child calls, observed results, and typed effects.
-
-        Returns ``(name, was_answered, effect_status)`` in issue order plus
-        the first in-flight gap.  An answered UNKNOWN is distinct from a gap:
-        the controller received a result, but the child tool itself could not
-        establish whether its side effect landed.
-
-        ``_run_agent`` runs a turn's tool_calls sequentially (cancel raises at
-        the per-tool checkpoint, or mid-tool for a SIGKILL'd bash), so the first
-        gap is the call that was executing when cancel landed: everything before
-        it returned, everything after never started. (The LAST gap would invert
-        unknown/none on a multi-call turn.) Shared by the disposition string and
-        its typed status so the two can't disagree.
-
-        Pairs via :meth:`_iter_agent_tool_results`: parented runs carry minted
-        unique ids, and on un-minted id-colliding input (unparented / direct
-        construction) the FIFO still reads a half-answered colliding pair as
-        one answered + one in-flight gap, not (set-membership) both answered.
-        """
-        issued = [
-            (
-                (tc.name or "tool").strip(),
-                res is not None,
-                res.effect_status if res is not None else None,
-            )
-            for tc, res in ChatSession._iter_agent_tool_results(agent_turns)
-        ]
-        first_gap = next((i for i, (_n, ans, _status) in enumerate(issued) if not ans), None)
-        return issued, first_gap
-
-    @staticmethod
-    def _cancel_ledger(
-        agent_turns: list[Turn],
-    ) -> tuple[list[tuple[str, bool]], int | None]:
-        """Compatibility projection of :meth:`_cancel_effect_ledger`.
-
-        Existing recall/cancellation callers that only need answered-vs-missing
-        retain the compact pair shape; disposition and status use the typed
-        ledger directly.
-        """
-        issued, first_gap = ChatSession._cancel_effect_ledger(agent_turns)
-        return [(name, answered) for name, answered, _status in issued], first_gap
-
-    def _cancelled_agent_status(self, agent_turns: list[Turn]) -> EffectStatus:
-        """Typed twin of :meth:`_cancelled_agent_disposition`: ``none`` if the
-        agent never acted or every issued action is confirmed no-effect,
-        ``unknown`` if a tool was in flight when cancel landed (its effect
-        unobserved), else ``partial`` — at least one issued call returned a
-        durable or ordinary result, but the agent was stopped before finishing.
-        """
-        issued, first_gap = self._cancel_effect_ledger(agent_turns)
-        if not issued:
-            return EffectStatus.NONE
-        if first_gap is not None or any(
-            status is EffectStatus.UNKNOWN for _name, _answered, status in issued
-        ):
-            return EffectStatus.UNKNOWN
-        if all(
-            answered and status in (EffectStatus.NONE, EffectStatus.ROLLED_BACK)
-            for _name, answered, status in issued
-        ):
-            return EffectStatus.NONE
-        return EffectStatus.PARTIAL
-
-    def _cancelled_agent_disposition(self, agent_turns: list[Turn], label: str) -> str:
-        """Build an honest, deterministic disposition for a cancelled sub-agent.
-
-        A cancelled agent must not report a fabricated *outcome*.  The bare
-        "(interrupted)" string read downstream as *the task did not happen*
-        — which causes a double-send as readily as a dropped record causes
-        an orphan (cancellation appendix, HYPOTHESIS.md).  Instead we fold
-        back the agent's actual ledger: which tool actions completed, which
-        never started, and an explicit ``UNKNOWN`` flag on the in-flight
-        action — the FIRST issued call without a result.  ``_run_agent``
-        executes a turn's tool_calls sequentially, so on cancel everything
-        before the first gap completed, the gap itself was executing (its
-        side effect may or may not have landed, its result never observed),
-        and everything after it never ran.
-
-        Pure string assembly over the in-memory ``agent_turns`` — no
-        model call, because we are on the cancel path and the gate is
-        closed.  The owner (parent / coordinator) reads this to decide what,
-        if anything, to compensate.
-        """
-        issued, first_gap = self._cancel_effect_ledger(agent_turns)
-        if not issued:
-            return f"({label} cancelled by user before any action — no side effects)"
-
-        def _summ(names: list[str]) -> str:
-            counts: dict[str, int] = {}
-            for n in names:
-                counts[n] = counts.get(n, 0) + 1
-            return ", ".join(f"{n}×{c}" if c > 1 else n for n, c in counts.items())
-
-        parts = [f"({label} cancelled by user before completion)"]
-        answered = [entry for entry in issued if entry[1]]
-        completed = [
-            name
-            for name, _was_answered, status in answered
-            if status in (None, EffectStatus.COMMITTED)
-        ]
-        partial = [
-            name for name, _was_answered, status in answered if status is EffectStatus.PARTIAL
-        ]
-        no_effect = [
-            name for name, _was_answered, status in answered if status is EffectStatus.NONE
-        ]
-        rolled_back = [
-            name for name, _was_answered, status in answered if status is EffectStatus.ROLLED_BACK
-        ]
-        unresolved = [
-            name for name, _was_answered, status in answered if status is EffectStatus.UNKNOWN
-        ]
-        if completed:
-            parts.append("Completed before cancel: " + _summ(completed) + ".")
-        if partial:
-            parts.append("Partially completed before cancel: " + _summ(partial) + ".")
-        if no_effect:
-            parts.append("Confirmed no effect before cancel: " + _summ(no_effect) + ".")
-        if rolled_back:
-            parts.append("Completed and rolled back before cancel: " + _summ(rolled_back) + ".")
-        if unresolved:
-            parts.append(
-                "Results received with UNKNOWN effects before cancel: "
-                + _summ(unresolved)
-                + ". Those actions may have completed, partially executed, or caused "
-                "side effects; reconcile before re-running."
-            )
-        if first_gap is None:
-            # Every issued call returned a result — cancel landed between turns,
-            # so there is no in-flight boundary.  Typed UNKNOWN results above
-            # remain unresolved even though they were answered.
-            return "\n".join(parts)
-        boundary = issued[first_gap][0]
-        not_run = [
-            name for name, was_answered, _status in issued[first_gap + 1 :] if not was_answered
-        ]
-        parts.append(
-            f"In flight at cancel: {boundary} — outcome UNKNOWN. It may have "
-            "completed, partially executed, or caused side effects before the "
-            "agent was stopped; its result was never observed. Do not assume "
-            "it did or did not happen — reconcile before re-running."
-        )
-        if not_run:
-            parts.append("Not started (cancelled first): " + _summ(not_run) + ".")
-        return "\n".join(parts)
 
     def _audit_memory_event(
         self,

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -2762,6 +2762,19 @@ def make_events_handler(cfg: SessionEndpointConfig) -> Handler:
                                 }
                             )
                         }
+                    # A task compaction is transient parent-card state, just
+                    # like its context meter. Re-emit the latest lifecycle edge
+                    # so a refresh during a long recursive summary recreates
+                    # the nested progress card without inventing history.
+                    for agent_compaction in in_progress_snap.get("agent_compactions", []):
+                        yield {
+                            "data": json.dumps(
+                                {
+                                    **agent_compaction,
+                                    "ws_id": ws_id,
+                                }
+                            )
+                        }
                     # Surface the persisted ``last_error`` so a fresh
                     # connect to a workstream sitting in the error state
                     # shows WHY it failed (the ``error`` text bubble), not

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -574,6 +574,11 @@ class SessionUIBase:
         # when a provider reuses the public parent call id, and so force-abandon
         # can purge every reading owned by the retired generation at once.
         self._agent_contexts: dict[str, tuple[int, dict[str, Any]]] = {}
+        # Latest in-flight compaction lifecycle event for each running task
+        # agent. Stored beside context usage because both are transient,
+        # parent-keyed reconnect state and share the same generation cleanup.
+        # Value: (owner generation, compaction id, event payload).
+        self._agent_compactions: dict[str, tuple[int, int, dict[str, Any]]] = {}
         self._agent_contexts_lock = threading.Lock()
         # Recall store: a finished task agent's projected sub-trajectory (step
         # items: id/name/arguments/output/is_error), keyed by its (parent)
@@ -1276,8 +1281,8 @@ class SessionUIBase:
             self._agent_contexts[parent_call_id] = (generation, event)
         self._enqueue(event)
 
-    def clear_agent_context(self, parent_call_id: str, *, generation: int = 0) -> None:
-        """Drop one completed task agent's reconnect snapshot.
+    def clear_agent_transients(self, parent_call_id: str, *, generation: int = 0) -> None:
+        """Drop one completed task agent's transient reconnect state.
 
         Cleanup is exact-generation: a retiring predecessor whose public call
         id was reused cannot remove the successor's active reading.
@@ -1288,9 +1293,12 @@ class SessionUIBase:
             current = self._agent_contexts.get(parent_call_id)
             if current is not None and current[0] == generation:
                 del self._agent_contexts[parent_call_id]
+            compaction = self._agent_compactions.get(parent_call_id)
+            if compaction is not None and compaction[0] == generation:
+                del self._agent_compactions[parent_call_id]
 
-    def clear_agent_contexts_before_generation(self, generation: int) -> None:
-        """Drop every reading owned by a force-abandoned generation.
+    def clear_agent_transients_before_generation(self, generation: int) -> None:
+        """Drop every agent transient owned by a force-abandoned generation.
 
         A force successor may be claimed specifically because the retiring
         worker is wedged and will never reach its per-agent ``finally`` block.
@@ -1305,11 +1313,40 @@ class SessionUIBase:
             ]
             for parent_call_id in stale:
                 del self._agent_contexts[parent_call_id]
+            stale_compactions = [
+                parent_call_id
+                for parent_call_id, (owner_generation, _cid, _event) in (
+                    self._agent_compactions.items()
+                )
+                if owner_generation < generation
+            ]
+            for parent_call_id in stale_compactions:
+                del self._agent_compactions[parent_call_id]
+
+    def _snapshot_agent_transients(
+        self,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Atomically copy task-agent context and compaction reconnect state."""
+
+        with self._agent_contexts_lock:
+            contexts = [dict(event) for _generation, event in self._agent_contexts.values()]
+            compactions = [
+                dict(event)
+                for _generation, _compaction_id, event in self._agent_compactions.values()
+            ]
+        return contexts, compactions
 
     def _snapshot_agent_contexts(self) -> list[dict[str, Any]]:
-        """Copy active task-agent readings for fresh/truncated SSE replay."""
-        with self._agent_contexts_lock:
-            return [dict(event) for _generation, event in self._agent_contexts.values()]
+        """Copy active task-agent readings for focused callers/tests."""
+
+        contexts, _compactions = self._snapshot_agent_transients()
+        return contexts
+
+    def _snapshot_agent_compactions(self) -> list[dict[str, Any]]:
+        """Copy active task-agent compactions for fresh/truncated replay."""
+
+        _contexts, compactions = self._snapshot_agent_transients()
+        return compactions
 
     def on_agent_step(self, parent_call_id: str, item: dict[str, Any]) -> None:
         """Paint a sub-agent's auto-executed tool step as pending under its
@@ -1416,7 +1453,8 @@ class SessionUIBase:
 
         Returns ``(client_queue, snapshot_dict)`` where ``snapshot_dict``
         has keys ``content`` (str), ``reasoning`` (str), ``seq`` (int), and
-        ``agent_contexts`` (the active task-agent context events).
+        ``agent_contexts`` (active task-agent context events) and
+        ``agent_compactions`` (their active targeted compaction events).
         Caller checks for non-empty content / reasoning to decide
         whether to yield the event at all (empty snapshots are common
         between turns and on freshly-opened workstreams).
@@ -1434,11 +1472,13 @@ class SessionUIBase:
             with self._listeners_lock:
                 self._register_or_close_listener_locked(client_queue)
                 snap_seq = self._event_id
+        agent_contexts, agent_compactions = self._snapshot_agent_transients()
         snapshot = {
             "content": "".join(captured_content),
             "reasoning": "".join(captured_reasoning),
             "seq": snap_seq,
-            "agent_contexts": self._snapshot_agent_contexts(),
+            "agent_contexts": agent_contexts,
+            "agent_compactions": agent_compactions,
         }
         return client_queue, snapshot
 
@@ -1565,11 +1605,13 @@ class SessionUIBase:
                 buffered = list(self._event_buffer)
                 self._register_or_close_listener_locked(client_queue)
                 snap_seq = self._event_id
+        agent_contexts, agent_compactions = self._snapshot_agent_transients()
         snapshot: dict[str, Any] = {
             "content": "".join(captured_content),
             "reasoning": "".join(captured_reasoning),
             "seq": snap_seq,
-            "agent_contexts": self._snapshot_agent_contexts(),
+            "agent_contexts": agent_contexts,
+            "agent_compactions": agent_compactions,
         }
         if last_event_id < 0 or last_event_id > snap_seq:
             # Event ids start at 1, with cursor 0 reserved for the initial
@@ -4380,10 +4422,13 @@ class SessionUIBase:
         keeps a ``/history`` repaint and an SSE replay from double-rendering
         the result card.
 
-        Inside a task agent the events are dropped (same rule as
-        :meth:`on_info`): a sub-agent's compaction is progress chatter that
-        carries no ``call_id``, so it cannot nest under the task card and
-        must not paint a top-level compaction card on the pane.
+        ``target="workstream"`` owns the transcript card, activity latch, and
+        durable marker described above. ``target="task_agent"`` instead
+        carries ``parent_call_id`` and is retained as transient reconnect state
+        for that task card; it never touches the foreground activity pill or
+        becomes conversation history. A missing target is interpreted as
+        ``workstream`` so an event from an older node keeps its established
+        meaning.
 
         ``superseded`` (stamped by ``ChatSession._compaction_event``) marks
         events from a force-abandoned compaction whose generation a
@@ -4399,10 +4444,18 @@ class SessionUIBase:
         writes resume) without restoring — its saved pair predates the
         successor turn and would overwrite the live pill.
         """
+        payload = dict(payload)
+        generation = int(payload.pop("_generation", 0) or 0)
+        target = str(payload.get("target") or "workstream")
+        superseded = bool(payload.pop("superseded", False))
+        if target == "task_agent":
+            return self._on_task_agent_compaction(
+                payload,
+                generation=generation,
+                superseded=superseded,
+            )
         if _agent_scope_var.get() > 0:
             return None
-        payload = dict(payload)
-        superseded = bool(payload.pop("superseded", False))
         cid = int(payload.get("compaction_id") or 0)
         phase = payload.get("phase")
         if phase == "end":
@@ -4452,6 +4505,52 @@ class SessionUIBase:
         if superseded and phase != "end":
             return None
         return self._enqueue({"type": "compaction", **payload})
+
+    def _on_task_agent_compaction(
+        self,
+        payload: dict[str, Any],
+        *,
+        generation: int,
+        superseded: bool,
+    ) -> int | None:
+        """Reduce one parent-keyed task compaction and retain its live edge."""
+
+        parent_call_id = str(payload.get("parent_call_id") or "")
+        phase = str(payload.get("phase") or "")
+        raw_cid = payload.get("compaction_id")
+        if (
+            not parent_call_id
+            or phase not in {"start", "progress", "end"}
+            or not isinstance(raw_cid, int)
+            or isinstance(raw_cid, bool)
+        ):
+            return None
+        compaction_id = raw_cid
+        if superseded and phase != "end":
+            return None
+        if phase == "end":
+            payload["superseded"] = superseded
+
+        event = {"type": "compaction", **payload}
+        snapshot_event = {**event, "ws_id": self.ws_id}
+        with self._agent_contexts_lock:
+            current = self._agent_compactions.get(parent_call_id)
+            if phase in {"start", "progress"}:
+                if current is not None and (
+                    current[0] > generation
+                    or (current[0] == generation and current[1] > compaction_id)
+                ):
+                    return None
+                # Store before enqueue: a subscriber registering on the next
+                # instruction sees either this snapshot or this live event.
+                self._agent_compactions[parent_call_id] = (
+                    generation,
+                    compaction_id,
+                    snapshot_event,
+                )
+            elif current is not None and current[:2] == (generation, compaction_id):
+                del self._agent_compactions[parent_call_id]
+        return self._enqueue(event)
 
     def _release_compaction_latch_locked(self, *, restore: bool) -> bool:
         """Unlatch the compaction pill window; optionally restore the pair.

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -176,8 +176,8 @@ def _build_registry() -> dict[str, SettingDef]:
             "Max tokens for compaction summary",
             "session",
             min_value=0,
-            help="When conversation history is compacted (summarized to save space), this limits "
-            "how long the summary can be.",
+            help="When conversation or task-agent context is compacted (summarized to save "
+            "space), this limits how long the summary can be.",
         ),
         SettingDef(
             "session.auto_compact_pct",
@@ -187,9 +187,10 @@ def _build_registry() -> dict[str, SettingDef]:
             "session",
             min_value=0.1,
             max_value=1.0,
-            help="Automatically summarize older messages when the conversation fills this percentage "
-            "of the context window. For example, 0.8 means compact when 80% full. This prevents "
-            "conversations from hitting the context limit and losing information.",
+            help="Automatically summarize older messages when a conversation or task-agent context "
+            "fills this percentage of its model's context window. For example, 0.8 means compact "
+            "when 80% full. This prevents model calls from hitting the context limit and losing "
+            "information.",
         ),
         # -- tools ----------------------------------------------------------
         SettingDef(

--- a/turnstone/sdk/events.py
+++ b/turnstone/sdk/events.py
@@ -363,21 +363,29 @@ class CompactionEvent(ServerEvent):
     wait); ``end`` carries ``ok`` plus either the result
     (``before_tokens``/``after_tokens``/``summary``) or the failure
     ``reason``/``message`` — failure ends carry ``trigger`` too.  The
-    successful end's summary is also persisted as a compaction marker
-    row and replays from ``/history`` as a ``role="system"``,
-    ``source="compaction"`` entry.  ``compaction_id`` correlates every
-    event of one compaction run (0 from internal/legacy emitters).  End
+    ``target`` is ``"workstream"`` when the lifecycle owns the transcript
+    and durable marker. ``"task_agent"`` events instead carry
+    ``parent_call_id`` and are transient progress for that nested task; their
+    successful end omits ``summary``. Events without a target are workstream
+    events because that was the only compaction scope before targeted events
+    existed. The workstream successful end's summary is also
+    persisted as a compaction marker row and replays from ``/history`` as a
+    ``role="system"``, ``source="compaction"`` entry. ``compaction_id``
+    correlates every event of one attempt (0 from internal emitters). End
     events additionally carry ``superseded``: True marks a force-abandoned
     compaction retiring after a successor generation took over — clients
     should skip failure notices for those (an OK end's result still
-    stands; the history swap happened).  Failed ends carry ``notice``:
-    the emitter-computed display verdict — show ``message`` only when it
-    is True, instead of re-deriving suppression from
-    reason/trigger/superseded client-side.
+    stands; the history swap happened). Failed ends carry ``notice``: the
+    emitter-computed display verdict. Workstream errors use their paired typed
+    error and set it false; task-agent errors have no unscoped error twin and
+    set it true for the nested card. Clients show ``message`` only when notice
+    is true instead of re-deriving policy from reason/trigger/superseded.
     """
 
     type: str = "compaction"
     phase: str = ""
+    target: str = "workstream"
+    parent_call_id: str = ""
     compaction_id: int = 0
     superseded: bool = False
     notice: bool = False

--- a/turnstone/shared_static/conversation.css
+++ b/turnstone/shared_static/conversation.css
@@ -816,6 +816,21 @@
 .conv-agent-body {
   border-top: 1px solid var(--hair);
 }
+
+/* Task-agent compaction is transient controller progress, visible even while
+ * the (potentially huge) step body is collapsed. Reuse the shared progress
+ * card vocabulary but fit it to the nested card instead of a transcript row. */
+.conv-agent > .compaction-card {
+  margin: 0.35rem 0.55rem 0.5rem;
+  max-width: none;
+}
+.conv-agent-compaction-notice {
+  margin: 0.35rem 0.55rem 0.5rem;
+  color: var(--warn);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+}
 .conv-agent-body:empty {
   border-top: 0; /* no orphan hairline before the first step paints */
 }

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -127,15 +127,21 @@ export function buildCompactionCard(meta, summary) {
 // part-k-of-N progress event flips it determinate via
 // updateCompactionProgress.  The end event replaces the card with
 // buildCompactionCard (or a failure notice).
-export function buildCompactionProgressCard(isAuto) {
+export function buildCompactionProgressCard(isAuto, target) {
+  const taskTarget = target === "task_agent";
   const el = document.createElement("div");
   el.className = "msg compaction-card compaction-running";
   el.setAttribute("role", "status");
   el.setAttribute("data-ts-role", "compaction");
-  el.setAttribute("aria-label", "compacting context");
+  el.setAttribute(
+    "aria-label",
+    taskTarget ? "compacting task-agent context" : "compacting context",
+  );
   const header = document.createElement("div");
   header.className = "msg-compaction-header";
-  header.textContent = "compacting context…" + (isAuto ? " · auto" : "");
+  header.textContent =
+    (taskTarget ? "compacting task context…" : "compacting context…") +
+    (isAuto ? " · auto" : "");
   el.appendChild(header);
   const bar = document.createElement("div");
   bar.className = "msg-compaction-bar indeterminate";
@@ -145,7 +151,9 @@ export function buildCompactionProgressCard(isAuto) {
   el.appendChild(bar);
   const note = document.createElement("div");
   note.className = "msg-compaction-note";
-  note.textContent = "summarizing conversation…";
+  note.textContent = taskTarget
+    ? "summarizing task-agent context…"
+    : "summarizing conversation…";
   el.appendChild(note);
   return el;
 }
@@ -205,13 +213,17 @@ export function updateCompactionProgress(el, evt) {
 //   container      — the transcript element to append into
 //   renderedIds    — the pane's rendered-event-id Set (dedups the ok-end
 //                    card against the /history-projected marker row)
-//   onNotice(msg)  — render a non-error failure notice (info styling)
+//   onNotice(msg)  — render a lifecycle failure notice
 //   scroll(force)  — the pane's scroll-to-bottom
-// reason="error" ends render NO notice here: the backend pairs them with a
-// typed `error` event, which each pane's existing error handler styles red
-// (and which feeds the node's error metrics) — emitting here too would show
-// the message twice.
+//   append(node)   — optional placement override (task cards insert the
+//                    progress node outside their collapsible step body)
+//   renderResult   — false for transient task-agent compaction; its summary
+//                    is model context, not a transcript result card
+// Workstream reason="error" ends carry notice=false because the backend pairs
+// them with a typed `error` event. Task-agent errors have no unscoped twin and
+// carry notice=true; their pane hook renders the message inside the task card.
 export function applyCompactionEvent(holder, evt, hooks) {
+  const append = hooks.append || ((node) => hooks.container.appendChild(node));
   // Lifecycle ownership: events carry the backend's compaction_id and the
   // holder remembers which compaction painted the live card, so a stale
   // event — a force-abandoned compaction retiring after a successor
@@ -226,9 +238,12 @@ export function applyCompactionEvent(holder, evt, hooks) {
     String(evt.compaction_id) === holder.cid;
   if (evt.phase === "start") {
     if (holder.card) holder.card.remove();
-    holder.card = buildCompactionProgressCard(evt.trigger === "auto");
+    holder.card = buildCompactionProgressCard(
+      evt.trigger === "auto",
+      evt.target,
+    );
     holder.cid = evt.compaction_id != null ? String(evt.compaction_id) : null;
-    hooks.container.appendChild(holder.card);
+    append(holder.card);
     hooks.scroll(true);
     return;
   }
@@ -241,9 +256,9 @@ export function applyCompactionEvent(holder, evt, hooks) {
     // cosmetic, and threading trigger through the summarize stack for it
     // is disproportionate.
     if (!holder.card) {
-      holder.card = buildCompactionProgressCard(false);
+      holder.card = buildCompactionProgressCard(false, evt.target);
       holder.cid = evt.compaction_id != null ? String(evt.compaction_id) : null;
-      hooks.container.appendChild(holder.card);
+      append(holder.card);
     }
     updateCompactionProgress(holder.card, evt);
     hooks.scroll(false);
@@ -251,7 +266,7 @@ export function applyCompactionEvent(holder, evt, hooks) {
   }
   if (evt.phase === "end") {
     if (owns) resetCompactionHolder(holder);
-    if (evt.ok) {
+    if (evt.ok && hooks.renderResult !== false) {
       // The persisted marker row is stamped with THIS event's id, so
       // whichever of /history repaint or live/replayed event renders
       // first wins.  Rendered even for a non-owning end: a completed
@@ -274,9 +289,10 @@ export function applyCompactionEvent(holder, evt, hooks) {
       // cancelled / not_enough_messages / irreducible / empty_summary —
       // informational, not an error state.  Whether the message is shown
       // is the emitter's call: the backend stamps `notice` on failed ends
-      // (suppressing error-reason / superseded / cancelled-auto ends —
-      // see ChatSession._compaction_event, the single policy site), so
-      // this arm stays mechanical.  `owns` is the one pane-local clause
+      // (workstream errors use their typed-error twin; task errors use this
+      // nested notice; superseded and cancelled-auto ends stay silent — see
+      // ChatSession._compaction_event, the single policy site), so this arm
+      // stays mechanical. `owns` is the one pane-local clause
       // the emitter cannot compute — card ownership via compaction_id vs
       // holder.cid — and it guards a reachable divergence: a /resume
       // swaps sessions and restarts generation counters, so an abandoned

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -408,6 +408,10 @@ class Pane {
     // buffers that reading until _relinkAgentCards paints the row. Repeated
     // live/synthetic events replace one reading and update one badge.
     this._agentContexts = new Map();
+    // parent call id -> shared-reducer holder for a task agent's transient
+    // compaction progress. Parallel task agents compact independently, so one
+    // foreground holder cannot represent them.
+    this._agentCompactions = new Map();
     this._resizeObs = null;
     // Set when replay_truncated arrives mid-stream (refetching then would
     // detach the live bubble); consumed on the next idle edge.  Cleared by
@@ -759,6 +763,10 @@ class Pane {
   }
 
   handleCompactionEvent(evt) {
+    if ((evt.target || "workstream") === "task_agent") {
+      this._handleAgentCompaction(evt);
+      return;
+    }
     // Shared reducer (conversation.applyCompactionEvent) — one lifecycle
     // state machine for this pane and the coordinator viewer.  The dedup
     // set is the same one the system_turn path uses: the persisted marker
@@ -2218,6 +2226,12 @@ class Pane {
     // grace timer would escape buffered steps into the rebuilt pane.
     if (this._agentCards) this._agentCards.clear();
     if (this._agentContexts) this._agentContexts.clear();
+    if (this._agentCompactions) {
+      for (const holder of this._agentCompactions.values()) {
+        resetCompactionHolder(holder);
+      }
+      this._agentCompactions.clear();
+    }
     if (this._agentOrphans) {
       for (const entry of this._agentOrphans.values()) {
         if (entry.timer != null) clearTimeout(entry.timer);
@@ -2437,6 +2451,12 @@ class Pane {
           for (const [parentId, reading] of this._agentContexts.entries()) {
             if (reading.blockedByTerminalRow) {
               this._agentContexts.delete(parentId);
+            }
+          }
+          for (const [parentId, holder] of this._agentCompactions.entries()) {
+            if (holder.blockedByTerminalRow) {
+              resetCompactionHolder(holder);
+              this._agentCompactions.delete(parentId);
             }
           }
           this._attachRetryToLastAssistant();
@@ -4356,6 +4376,111 @@ class Pane {
   }
 
   // --- Task-agent card: nest a sub-agent's sub-tool steps under its row -----
+  _agentTransientRoute(parentId) {
+    const parentRow = this._toolRow(parentId);
+    const terminal = this._toolResultNodes.get(parentId);
+    if (!parentRow || !terminal || terminal.row !== parentRow) {
+      return { state: "current", row: parentRow };
+    }
+    // A fresh/truncated snapshot or live event can race a successor whose
+    // provider recycled the same public call id. While busy, hold the transient
+    // away from the earlier terminal occurrence; the next painted row relinks
+    // it. At idle there can be no successor, so the event is stale.
+    return this.busy
+      ? { state: "blocked", row: parentRow }
+      : { state: "drop", row: parentRow };
+  }
+
+  _handleAgentCompaction(evt) {
+    const parentId =
+      typeof evt.parent_call_id === "string" ? evt.parent_call_id : "";
+    if (!parentId) return;
+    let holder = this._agentCompactions.get(parentId);
+    const route = this._agentTransientRoute(parentId);
+    if (route.state === "drop") {
+      if (holder) resetCompactionHolder(holder);
+      this._agentCompactions.delete(parentId);
+      return;
+    }
+    if (!holder) {
+      // A terminal edge with no locally active attempt has no task-context
+      // result to render. In particular, do not manufacture an empty
+      // "0 steps · running" task card when a replay begins after start.
+      if (evt.phase === "end") return;
+      holder = { card: null, cid: null, pending: null };
+      this._agentCompactions.set(parentId, holder);
+    }
+    const pendingCid =
+      holder.pending && holder.pending.compaction_id != null
+        ? String(holder.pending.compaction_id)
+        : null;
+    const activeCid = holder.cid != null ? holder.cid : pendingCid;
+    const incomingCid =
+      evt.compaction_id != null ? String(evt.compaction_id) : null;
+    if (
+      evt.phase === "end" &&
+      activeCid != null &&
+      incomingCid != null &&
+      incomingCid !== activeCid
+    ) {
+      // The shared reducer also rejects this stale end. Return before the
+      // wrapper's terminal cleanup so it cannot delete the newer holder.
+      return;
+    }
+    holder.pending = evt;
+    if (route.state === "blocked") {
+      holder.blockedByTerminalRow = route.row;
+      if (evt.phase === "end") {
+        resetCompactionHolder(holder);
+        this._agentCompactions.delete(parentId);
+      }
+      return;
+    }
+    delete holder.blockedByTerminalRow;
+    const card = this._ensureAgentCard(parentId, true);
+    if (card) this._syncAgentCompaction(parentId, card);
+    if (evt.phase === "end") {
+      // _syncAgentCompaction consumes a visible end. If the parent row has not
+      // painted, there is no live task card to retire or historical result to
+      // render, so drop the buffered terminal edge too.
+      resetCompactionHolder(holder);
+      this._agentCompactions.delete(parentId);
+    }
+  }
+
+  _syncAgentCompaction(parentId, card) {
+    const holder = this._agentCompactions.get(parentId);
+    if (!holder || !holder.pending || holder.blockedByTerminalRow) return;
+    const evt = holder.pending;
+    holder.pending = null;
+    card.wrap.hidden = false;
+    if (evt.phase === "start") {
+      const prior = card.wrap.querySelector(".conv-agent-compaction-notice");
+      if (prior) prior.remove();
+    }
+    applyCompactionEvent(holder, evt, {
+      container: card.wrap,
+      renderedIds: this._renderedSystemEventIds,
+      renderResult: false,
+      // Keep progress visible when the step body is collapsed.
+      append: (node) => card.wrap.insertBefore(node, card.body),
+      // Keep a task-local failure inside its card. It has no unscoped typed
+      // error twin, and escaping it into the workstream transcript would
+      // misattribute a non-fatal nested controller failure to the parent turn.
+      onNotice: (message) => {
+        let notice = card.wrap.querySelector(".conv-agent-compaction-notice");
+        if (!notice) {
+          notice = document.createElement("div");
+          notice.className = "conv-agent-compaction-notice";
+          notice.setAttribute("role", "status");
+          card.wrap.insertBefore(notice, card.body);
+        }
+        notice.textContent = stripAnsi(message);
+      },
+      scroll: (force) => this.scrollToBottom(force),
+    });
+  }
+
   // Child events (tool_pending / approve_request) carry parent_call_id; route
   // them into the task_agent row's collapsible body.  tool_result /
   // tool_output_chunk / intent_verdict / output_warning need no special-casing
@@ -4462,6 +4587,7 @@ class Pane {
     if (card) {
       if (parentRow.contains(card.wrap)) {
         this._syncAgentContext(parentCallId, card);
+        this._syncAgentCompaction(parentCallId, card);
         return card;
       }
       if (!card.wrap.isConnected) {
@@ -4470,6 +4596,7 @@ class Pane {
         // so its already-rendered steps survive the upgrade.
         parentRow.appendChild(card.wrap);
         this._syncAgentContext(parentCallId, card);
+        this._syncAgentCompaction(parentCallId, card);
         return card;
       }
       // The cached card is still attached to a DIFFERENT (earlier) row — a
@@ -4485,6 +4612,7 @@ class Pane {
     this._agentCards.set(parentCallId, card);
     this._syncAgentToggleLabel(card);
     this._syncAgentContext(parentCallId, card);
+    this._syncAgentCompaction(parentCallId, card);
     return card;
   }
 
@@ -4554,25 +4682,16 @@ class Pane {
       return;
     }
 
-    // A synthetic fresh-connect snapshot can race the task's terminal result.
-    // History/replay records which exact latest row already owns a result; do
-    // not resurrect a running badge on that completed card.
-    const parentRow = this._toolRow(parentId);
-    const terminal = this._toolResultNodes.get(parentId);
-    if (parentRow && terminal && terminal.row === parentRow) {
-      if (!this.busy) {
-        this._agentContexts.delete(parentId);
-        return;
-      }
-      // The provider may recycle a parent call id on a later turn. Until that
-      // successor row paints, _toolRow still resolves the prior terminal row;
-      // retain the reading without attaching it there. _relinkAgentCards will
-      // consume it when a different row occurrence arrives. An idle/error edge
-      // drops it if no successor ever appears.
+    const route = this._agentTransientRoute(parentId);
+    if (route.state === "drop") {
+      this._agentContexts.delete(parentId);
+      return;
+    }
+    if (route.state === "blocked") {
       this._agentContexts.set(parentId, {
         promptTokens,
         contextWindow,
-        blockedByTerminalRow: parentRow,
+        blockedByTerminalRow: route.row,
       });
       return;
     }
@@ -4649,11 +4768,31 @@ class Pane {
     (items || []).forEach((it) => {
       if (!it || !it.call_id) return;
       paintedIds.push(it.call_id);
+      const row = this._toolRow(it.call_id);
+      const reading = this._agentContexts.get(it.call_id);
+      const compaction = this._agentCompactions.get(it.call_id);
+      if (
+        (reading && reading.blockedByTerminalRow === row) ||
+        (compaction && compaction.blockedByTerminalRow === row)
+      ) {
+        return;
+      }
+      if (reading && reading.blockedByTerminalRow) {
+        delete reading.blockedByTerminalRow;
+      }
+      if (compaction && compaction.blockedByTerminalRow) {
+        delete compaction.blockedByTerminalRow;
+      }
       if (
         (this._agentCards && this._agentCards.has(it.call_id)) ||
-        this._agentContexts.has(it.call_id)
+        this._agentContexts.has(it.call_id) ||
+        this._agentCompactions.has(it.call_id)
       ) {
-        this._ensureAgentCard(it.call_id, this._agentContexts.has(it.call_id));
+        this._ensureAgentCard(
+          it.call_id,
+          this._agentContexts.has(it.call_id) ||
+            this._agentCompactions.has(it.call_id),
+        );
       }
     });
     if (paintedIds.length) this._flushAgentOrphans(paintedIds);
@@ -4715,6 +4854,10 @@ class Pane {
       }
     }
     this._agentContexts.delete(callId);
+    if (this._agentCompactions && this._agentCompactions.has(callId)) {
+      resetCompactionHolder(this._agentCompactions.get(callId));
+      this._agentCompactions.delete(callId);
+    }
     let target = this._toolRow(callId);
     if (!target) {
       // A minted sub-agent child id ("<parent>::r{run}s{step}::<id>") whose row hasn't


### PR DESCRIPTION
## Summary

- extract a lifecycle-agnostic compaction policy, estimator, and recursive summary engine shared by foreground sessions and task agents
- give task agents soft warning nudges, hard compaction, cooperative wind-down, recursive overflow recovery, and post-compaction resume behavior
- retain cancellation and recall truth in a bounded execution journal while releasing replaced raw provider context
- extend the existing `compaction` lifecycle with `target`, `parent_call_id`, and attempt-scoped `compaction_id` fields
- render transient task compaction beneath the owning task card, including reconnect recovery, without persisting or exposing the private task summary
- update Python and TypeScript SDK contracts and the public documentation

## Lifecycle contract

- `target: "workstream"` owns the durable transcript checkpoint and result card
- `target: "task_agent"` requires `parent_call_id`, is transient, and never publishes or persists the private summary
- an omitted target continues to mean workstream, matching the only event meaning that existed before targeted compaction
- generation ownership and `compaction_id` prevent stale attempts from retiring successor UI state

## Review

The combined diff received independent bug, security, performance, and quality passes. Every concrete finding was routed to a separate verifier before remediation; all four final-tree closure passes were clean.

The review covered cancellation chronology, repeated soft/hard compaction, exactly-paired lifecycle events, reconnect ownership, recycled parent IDs, bounded journal memory, provider-native payload release, output-guard privacy, and SDK/UI contract parity.

Optional custom task-agent UI hook fault isolation is tracked separately in #1043. The existing `tools.agent_max_turns=-1` unlimited policy is unchanged.

## Validation

- `TURNSTONE_CONFIG=/dev/null pytest -q tests/ -m "not live and not e2e_recovery"` — 12,453 passed, 27 skipped, 17 deselected
- focused cancellation/session/compaction/reconnect matrix — 589 passed
- Ruff lint and format — clean
- mypy — clean across 251 source files
- JavaScript syntax checks — clean
- TypeScript typecheck — clean
- TypeScript SDK — 84 passed
- `git diff --check` — clean

MkDocs was not installed in the repository environment, so the documentation source was reviewed but a local MkDocs build was not run.

Follow-up to the task-agent context visibility work in #982.