### PR TITLE
fix(deps): constrain Anthropic SDK below v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,14 @@ dependencies = [
     # Version 3 moves the default transport to HTTPX2. Keep major upgrades
     # deliberate because the stream retry boundary depends on that contract.
     "openai>=3,<4",
-    "anthropic>=0.117",  # tracks the release current at claude-opus-5 onboarding; hard runtime floor is still 0.105 (mid-conversation system blocks) — Opus 5 itself needs no new SDK surface (model ids are opaque strings; "refusal" has been in the StopReason literal since ~0.95). Raise this when adopting fast mode / server-side fallbacks / advisor / mid-conversation tool changes, which DO need newer typed params.
+    # 0.117 tracks the release current at Claude Opus 5 onboarding; the hard runtime
+    # floor remains 0.105 (mid-conversation system blocks). Opus 5 itself needs no new
+    # SDK surface: model IDs are opaque strings, and "refusal" has been in StopReason
+    # since about 0.95. Raise the floor when adopting fast mode, server-side fallbacks,
+    # advisor, or mid-conversation tool changes, which need newer typed parameters.
+    # Version 1 moves to HTTPX2 and removes Messages sampling kwargs, so migrate the
+    # provider boundary before removing the cap.
+    "anthropic>=0.117,<1",
     "httpx>=0.28",
     # Direct because the provider boundary catches this exception family;
     # OpenAI v3's transitive dependency alone is not an import contract.

--- a/uv.lock
+++ b/uv.lock
@@ -2680,7 +2680,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'test'", specifier = ">=3.9" },
     { name = "alembic", specifier = ">=1.14" },
     { name = "altair", specifier = ">=6.0" },
-    { name = "anthropic", specifier = ">=0.117" },
+    { name = "anthropic", specifier = ">=0.117,<1" },
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "croniter", specifier = ">=3.0" },
     { name = "cryptography", specifier = ">=48.0.1" },


### PR DESCRIPTION
## Summary

- constrain the Anthropic SDK to `anthropic>=0.117,<1` so fresh installations remain on the verified HTTPX transport contract
- retain the current 0.121.0 lock selection while documenting the HTTPX2 and Messages-parameter boundaries that require a deliberate v1 migration

Anthropic 1.0 switches its default transport from HTTPX to HTTPX2 and removes sampling parameters from the generated Messages method signatures. The existing Turnstone boundary tests reject v1 immediately because they inject an `httpx.Client`, and native plus compatible requests that forward `temperature` fail before reaching the wire.

## Validation

- 123 Anthropic and transport-boundary tests pass
- Ruff check passes for `turnstone` and `tests`
- Ruff format check passes for `turnstone` and `tests`
- mypy passes for all 251 source files
- `uv lock --check` passes
- fresh unlocked resolution selects Anthropic 0.125.0 and publishes `anthropic<1,>=0.117`
- dependency audit reports no known vulnerabilities (existing PYSEC-2025-183 exception retained)
