### PR TITLE
feat(truncation): exact-cap primitive, single-cut result fold, bounded captures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1324,20 +1324,136 @@ which can override the model before workstream creation.
 
 ### Tool Output Truncation
 
-Tool execution results (bash, read_file, search) are truncated by
-`_truncate_output()` when they exceed `tool_truncation` characters. Truncation
-preserves the first half and last half of the output, with a message in
-between:
+`turnstone.core.truncation` provides the policy-free truncation primitive used
+across tool results, judge projections, compaction blocks, task-agent/recall
+clips, skill guidance, web extraction/search snippets, reasoning display, and
+watch output. It returns both the bounded text and explicit source-coverage
+metadata (`original_chars`, `retained_chars`, `omitted_chars`); callers never
+infer loss by comparing rendered string lengths. Every positive cap includes
+the omission marker itself, and even a one-character cap emits an ellipsis
+instead of failing open through a `[-0:]` tail slice.
+
+The main tool-result path uses a head-and-tail projection bounded by
+`tool_truncation`:
 
 ```
 ... [N chars truncated — output exceeded LIMIT char limit] ...
 ```
 
-The default limit is 50% of the context window in characters (computed as
-`context_window * chars_per_token * 0.5`). For a 131K context window this is
-~262K characters. Override with `--tool-truncation <chars>`.
+When the limit could have held the output but its producer retained less than
+the whole, the marker says `M of O chars retained` instead of blaming a limit
+that was never exceeded.
 
-This truncation message is visible to the model, so it knows output was cut.
+In automatic mode every tool result uses at most 20% of the result batch's
+remaining model-input allowance: a batch of results must leave room for its
+siblings and for the model's own turn, and a result also travels the event
+stream as one server-sent event whose consumers bound event size. A tool whose
+formatter owns a degradation ladder (`search`, `inspect_workstream`) is handed
+an estimate of that cap up front, so the ladder degrades to a tier the fold
+admits whole instead of the fold head/tail-clipping what the formatter kept on
+purpose. The estimate is made before siblings in the batch and a mid-turn
+compaction can move the cap, so it sizes what an executor produces and never
+replaces the fold's own decision; inside a task agent it is the agent's own
+clip, and an estimate too small to carry a counted marker predicts compaction,
+so a ladder keeps its own budget there. A `bash_output` read is bounded the
+same way: it returns whole lines up to the estimate and leaves the rest unread
+for the next call, so a delta the fold has to cut, consuming its elided middle,
+is the exception rather than the rule, and an exhausted estimate reads at most
+one line. A filtered read scans a bounded span of the delta, at most eight
+times what it can return, so each call is bounded and still advances the
+cursor. A `bash_output` result the fold must admit at an exhausted allowance
+takes the guaranteed floor rather than the drop notice, because its delta was
+consumed in producing it and could never be re-read. When a `bash_output`
+delta is cut nonetheless, by the fold or by a task agent's clip, its marker
+also says that the consumed output cannot be re-read, unless the cap is too
+tight to carry both the notice and some source text. The allowance is measured
+after the existing prompt, response reserve, and safety margin; parallel
+siblings share one snapshot, then the running aggregate budget is debited after
+each result. An allowance too small to carry a counted marker (128 characters)
+takes the zero-budget doors instead of rendering a bare fragment that reads as
+complete: small results pass verbatim through the per-batch grace pool and the
+rest get the drop notice. A positive
+`--tool-truncation <chars>` override replaces the percentage default with one
+fixed cap, while the running remaining-context budget remains authoritative.
+Every automatic cap is also bounded by the session ceiling of 20% of the
+context window, and every cap, automatic or manual, by the `tools.truncation`
+maximum (16 Mi characters).
+
+The fold is the only place a main-session result is cut. Executors hand it
+their complete result, so the marker's omitted count is the producer's real
+size rather than the size of an earlier projection. The provisional copy an
+executor passes to `on_tool_result` is capped separately for display and never
+becomes model context.
+
+Executor streaming and `on_tool_result` are provisional display channels, not
+model context. The result fold applies context sizing and output guarding once,
+then uses one final scalar for the in-memory TOOL turn, the accepted live event,
+and the durable TOOL `content` column. Resume reconstructs that stored scalar
+without re-truncating it, so a model never receives a longer live bash result
+and a shorter impersonation of the same result after rehydration. A later
+compaction may replace the whole turn with an explicitly labeled summary; that
+is a different evidence transformation, not replay of the TOOL row.
+
+Streaming producers do not allocate their complete output before applying this
+policy. Foreground `bash` and `diff_file` retain half the session cap at each
+edge, and never less than a task agent's guard window, in a bounded
+prefix/suffix buffer, so the fold still cuts once at every size while a capture
+never holds more than a fold on that session could show: below the retention
+the executor hands over the
+complete output, and above it the retained edges together with the true
+character count, from which the fold renders once, so its marker reports
+omission against the real output rather than against an earlier rendering. The
+shell drains read both pipes in 64K-character chunks. Foreground bash captures
+stdout and stderr separately and presents stdout followed by the stderr lines,
+each prefixed once with `[stderr]`, joining the two captures as edges rather
+than as rendered text; one arrival-ordered capture would let a stderr record
+land inside an unfinished stdout line. A background shell bounds each logical
+line at half its buffer with a single-line marker, so a record stays one line
+for the cursor, the filter, and the `[stderr]` prefix and survives the lines
+that follow it; the fold's marker then counts against that bounded record. The
+truncation marker is visible to the
+model, so omitted content cannot impersonate complete evidence.
+
+Two more rules keep the cap honest end to end. Secret redaction can lengthen a
+cut result past its cap, so such a result is cut again at the drain's limit
+before folding: the guarded rendering is split at the drain's marker and its
+two edges re-render as edges, so the second cut never runs into the first
+marker, and the omitted count still includes the middle the drain removed. A
+result the guard left alone, one the drain admitted whole, or one whose text no
+longer locates the marker exactly once passes as the guard left it: what the
+guard produced is what the model sees, and the pre-send hard-compaction guard
+remains the backstop for a batch that grew past its allowance. The drain keeps
+only its renderings across the guard, so an executor's complete result is
+released once rendered rather than held across the guard's judge round trips.
+The output guard scans a bounded window of a task-agent child result that
+reaches past the child's clip, so a credential straddling the clip boundary is
+seen whole and redacted while a tool server never controls how much text the
+guard scans; a capture's window is rendered from its source in the head mode
+the clip uses, so the guard scans exactly the text the agent will receive. The
+window is itself clipped
+with the result's true size before the guard runs, so a redaction that shrinks
+it below the clip still leaves the result marked as cut, and the recall
+projection of the step carries that same size. Provider tool names are
+normalized before any of these policies are looked up.
+
+#### Surface-specific policies
+
+The renderer is shared where the operation is syntactic; the selection policy
+is not forced into one shape where doing so would discard semantics:
+
+| Surface | Policy | Why |
+|---|---|---|
+| tool results, including `bash`, `bash_output`, and `diff_file` | shared exact-cap head + tail; 20% of the batch's remaining input allowance in automatic mode | preserves setup and terminal disposition without letting one result crowd out its siblings or the model's turn; a result also rides the event stream as one bounded server-sent event |
+| task-agent/recall clips, skill guidance, watch/reasoning display | shared exact-cap head; a task agent's cut `bash_output` delta carries the consumed notice | these consumers operate on an ordered prefix and need an honest cutoff; watch polls compare by their head at the cap, so consecutive polls with the same head compare equal whatever the marker says |
+| judge argument fields | head of the budget plus a counted note that is extra to the budget | one budget is divided across many fields, so budgets smaller than the note are routine, and a field shown empty would read to the judge as an edit that replaces nothing |
+| compaction blocks | shared exact-cap 2/3 head + 1/3 tail | preserves more opening context while retaining the conclusion |
+| `search`, `inspect_workstream` | bespoke degradation ladder sized to the fold's cap, then the fold's cut as a backstop | generic head/tail would silently drop middle files or middle messages the formatter deliberately kept |
+| `web_search` snippets and `web_fetch` text | shared exact-cap head within surface-specific result/document budgets | search snippets and top-heavy pages are ordered prefixes; the web document share still scales with the pinned lane |
+| PDF extraction | context/capability document budget plus byte/page/worker limits; the isolated worker reports the true size and hands over its bounded prefix, and the parent renders the marker with the shared primitive (a zero allowance still returns the marker as a receipt of what was dropped) | the worker runs under `-E -P` with a deliberately minimal import path, so rendering in the parent keeps one copy of the primitive instead of a worker-side twin |
+| provider/transport streams | protocol token/byte/timeout limits | byte and token boundaries cannot be represented honestly as a character-slice policy |
+
+Thus “standardized truncation” means one exact-cap rendering and metadata
+contract, not one content-selection algorithm for unrelated evidence types.
 
 During the send loop the limit is additionally capped by the remaining
 context budget, and three guarantees apply when that budget reaches zero
@@ -1346,7 +1462,9 @@ context budget, and three guarantees apply when that budget reaches zero
 - **Structural floor** — orchestration handles (`spawn_workstream`,
   `spawn_batch`, `wait_for_workstream`, `tasks`) and error results are
   always admitted up to a guaranteed floor (2048 chars, head+tail beyond
-  it), because a lost `ws_id` or a masked failure wedges the session.
+  it), because a lost `ws_id` or a masked failure wedges the session; at
+  an exhausted allowance a `bash_output` delta takes the same floor because
+  it was consumed in producing it and could never be re-read.
 - **Small-result pass** — results at or under the floor pass verbatim,
   funded from a bounded per-batch grace pool (2× the floor) so a wide
   batch of small results cannot collectively bypass budget accounting;

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -283,6 +283,12 @@ Settings are addressed by dotted key (e.g. `memory.relevance_k`). Each has a
 declared type (`int`, `float`, `str`, `bool`), optional `min_value`/`max_value`
 range, optional `choices` list, and an `is_secret` flag.
 
+A stored value outside a setting's range is clamped to the nearest bound when
+settings load, with a warning, so a bound tightened by an upgrade never
+silently replaces an operator's choice with the default. Values of the wrong
+type or outside a `choices` list are skipped with a warning and the default
+applies.
+
 ---
 
 ## Storage

--- a/tests/test_background_shells.py
+++ b/tests/test_background_shells.py
@@ -12,6 +12,7 @@ Pure registry tests — no ChatSession.  Session wiring is covered in
 """
 
 import re
+import sys
 import threading
 import time
 
@@ -25,6 +26,7 @@ from tests._proc_helpers import poll_until as _wait_until
 # that monkeypatch module attributes (os.killpg, subprocess.Popen, ...).
 from turnstone.core import background_shells as bg_mod
 from turnstone.core.background_shells import (
+    _DRAIN_CHUNK_CHARS,
     BackgroundShellRegistry,
     FilterExecError,
     FilterTimeoutError,
@@ -118,6 +120,98 @@ def test_output_is_complete_once_completed(registry):
     assert _wait_status(shell, "completed")
     read = registry.read(shell.shell_id)
     assert [ln.strip() for ln in read.lines] == ["alpha", "beta"]
+
+
+def test_bounded_pipe_fragments_remain_one_logical_line(registry):
+    size = _DRAIN_CHUNK_CHARS + 137
+    shell = registry.spawn(
+        f"{sys.executable} -c \"import sys; sys.stdout.write('x' * {size} + '\\\\n')\""
+    )
+    assert _wait_status(shell, "completed")
+
+    read = registry.read(shell.shell_id)
+
+    assert read.new_line_count == 1
+    assert read.dropped_lines == 0
+    assert len(read.lines) == 1
+    assert read.lines[0] == "x" * size + "\n"
+
+
+def test_read_bounded_by_chars_consumes_only_the_returned_lines(registry):
+    shell = registry.spawn("printf 'aaaa\\nbbbb\\ncccc\\ndddd\\n'")
+    assert _wait_status(shell, "completed")
+
+    first = registry.read(shell.shell_id, max_chars=10)
+    assert first.lines == ["aaaa\n", "bbbb\n"]
+    assert first.new_line_count == 2 and first.unread_lines == 2
+
+    second = registry.read(shell.shell_id, max_chars=10)
+    assert second.lines == ["cccc\n", "dddd\n"]
+    assert second.unread_lines == 0
+
+    assert registry.read(shell.shell_id, max_chars=10).lines == []
+
+
+def test_read_bound_always_returns_one_line(registry):
+    shell = registry.spawn("printf 'a-long-line\\nshort\\n'")
+    assert _wait_status(shell, "completed")
+
+    read = registry.read(shell.shell_id, max_chars=3)
+
+    assert read.lines == ["a-long-line\n"]
+    assert read.unread_lines == 1
+
+
+def test_read_bound_with_filter_consumes_skipped_lines_before_the_cut(registry):
+    shell = registry.spawn("printf 'keep-1\\nskip\\nkeep-2\\nskip\\nkeep-3\\n'")
+    assert _wait_status(shell, "completed")
+
+    first = registry.read(shell.shell_id, filter_pattern="keep", max_chars=14)
+    assert first.lines == ["keep-1\n", "keep-2\n"]
+    assert first.new_line_count == 4 and first.unread_lines == 1
+
+    second = registry.read(shell.shell_id, filter_pattern="keep", max_chars=14)
+    assert second.lines == ["keep-3\n"]
+    assert second.new_line_count == 1 and second.unread_lines == 0
+
+
+def test_over_long_line_record_survives_the_lines_around_it(registry):
+    """A bounded line record is half the buffer, so it neither evicts every
+    earlier unread line on arrival nor is evicted by the line after it."""
+    registry._max_buffer_chars = 4096  # noqa: SLF001 - the spawn reads it
+    shell = registry.spawn(
+        "for i in $(seq 1 20); do echo line-$i; done; "
+        "head -c 10000 /dev/zero | tr '\\0' x; echo; echo after"
+    )
+    assert _wait_status(shell, "completed")
+
+    read = registry.read(shell.shell_id)
+
+    assert read.dropped_lines == 0
+    assert len(read.lines) == 22 and read.lines[-1] == "after\n"
+    record = read.lines[-2]
+    assert len(record) <= 2048 and record.count("\n") == 1
+    assert "line exceeded 2048 char limit" in record
+
+
+def test_filtered_bounded_read_scans_a_bounded_span(registry):
+    """A filtered read scans at most eight times what it can return, so each
+    call is bounded and still advances the cursor until the match arrives."""
+    shell = registry.spawn("for i in $(seq 1 2000); do echo noise-$i; done; echo match")
+    assert _wait_status(shell, "completed")
+
+    first = registry.read(shell.shell_id, filter_pattern="match", max_chars=400)
+    assert first.lines == []
+    assert 200 <= first.new_line_count <= 400
+    assert first.unread_lines == 2001 - first.new_line_count
+
+    reads = 1
+    read = first
+    while read.unread_lines and reads < 50:
+        read = registry.read(shell.shell_id, filter_pattern="match", max_chars=400)
+        reads += 1
+    assert read.lines == ["match\n"] and read.unread_lines == 0
+    assert 5 <= reads <= 12
 
 
 def test_leader_exit_reaps_backgrounded_grandchild(registry, tmp_path):
@@ -611,6 +705,36 @@ def test_filter_matches_only_within_line_cap_and_reports_clipping(registry):
     assert read.lines == []
     assert read.new_line_count == 1
     assert read.clipped_lines == 1
+
+
+def test_filter_does_not_gain_a_fresh_window_at_pipe_chunk_boundary(registry):
+    size = _DRAIN_CHUNK_CHARS + 64
+    shell = registry.spawn(
+        f"{sys.executable} -c \"import sys; sys.stdout.write('x' * {size} + 'needle\\\\n')\""
+    )
+    assert _wait_status(shell, "completed")
+
+    read = registry.read(shell.shell_id, filter_pattern="needle")
+
+    assert read.lines == []
+    assert read.new_line_count == 1
+    assert read.clipped_lines == 1
+
+
+def test_overlong_logical_line_is_bounded_and_signalled() -> None:
+    reg = BackgroundShellRegistry(max_buffer_chars=4096)
+    try:
+        shell = reg.spawn(f"{sys.executable} -c \"import sys; sys.stdout.write('x' * 20000)\"")
+        assert _wait_status(shell, "completed")
+
+        read = reg.read(shell.shell_id)
+
+        assert read.new_line_count == 1
+        assert len(read.lines) == 1
+        assert len(read.lines[0]) <= 4096
+        assert "chars truncated" in read.lines[0]
+    finally:
+        reg.close()
 
 
 def test_concurrent_reads_never_double_deliver(registry):

--- a/tests/test_bash_tool_background_hang.py
+++ b/tests/test_bash_tool_background_hang.py
@@ -9,13 +9,20 @@ EOF) bounded by ``tool_timeout`` and kills the whole session group on exit, so
 the call always returns and never leaks the background child.
 """
 
+import io
 import threading
 import time
 
 from tests._proc_helpers import kill_pid as _kill_pid
 from tests._proc_helpers import pid_alive as _pid_alive
 from tests._session_helpers import NullUI, make_session
+from turnstone.core.background_shells import (
+    _DRAIN_CHUNK_CHARS,
+    drain_pipe_lines,
+    drain_pipe_logical_lines,
+)
 from turnstone.core.trajectory import EffectStatus
+from turnstone.core.truncation import BoundedTextBuffer, ProjectedText
 
 
 def _run_in_thread(fn, timeout):
@@ -29,6 +36,135 @@ def _run_in_thread(fn, timeout):
     t.start()
     t.join(timeout)
     return (not t.is_alive()), box.get("result")
+
+
+def test_drain_bounds_a_single_line_before_callback() -> None:
+    source = "x" * (_DRAIN_CHUNK_CHARS * 3 + 17)
+    chunks: list[str] = []
+
+    drain_pipe_lines(io.StringIO(source), chunks.append)
+
+    assert "".join(chunks) == source
+    assert len(chunks) == 4
+    assert max(map(len, chunks)) <= _DRAIN_CHUNK_CHARS
+
+
+def test_logical_line_drain_delivers_whole_lines_across_chunks() -> None:
+    long_line = "e" * (_DRAIN_CHUNK_CHARS * 2 + 5)
+    source = f"{long_line}\nshort\n"
+    lines: list[str] = []
+
+    drain_pipe_logical_lines(io.StringIO(source), lines.append, max_line_chars=len(source))
+
+    assert lines == [f"{long_line}\n", "short\n"]
+
+
+def test_logical_line_drain_bounds_a_line_that_fits_one_chunk() -> None:
+    """The whole-line fast path honors the bound too: a line within it passes
+    verbatim, a longer one is the same bounded record a spanning line gets."""
+    lines: list[str] = []
+
+    drain_pipe_logical_lines(io.StringIO("bb\nccccc\n"), lines.append, max_line_chars=3)
+
+    assert lines[0] == "bb\n"
+    assert len(lines[1]) <= 3
+
+
+def test_logical_line_drain_keeps_an_over_long_line_one_record() -> None:
+    """An over-long line is bounded with a marker that carries no newline, so
+    the record is still one line for the cursor, the filter, and the prefix."""
+    lines: list[str] = []
+
+    drain_pipe_logical_lines(
+        io.StringIO("x" * 1000 + "\nshort\n"), lines.append, max_line_chars=200
+    )
+
+    assert len(lines) == 2 and lines[1] == "short\n"
+    record = lines[0]
+    assert len(record) <= 200
+    assert record.count("\n") == 1 and record.endswith("\n")
+    assert "chars truncated — line exceeded 200 char limit" in record
+
+
+def test_bounded_buffer_snapshots_never_lose_or_reorder_chunks() -> None:
+    """Snapshots race the producer: every chunk appended before a snapshot is
+    in it, and the final capture is the producer's exact stream."""
+    buffer = BoundedTextBuffer(1 << 20)
+    total = 100_000
+
+    def produce() -> None:
+        for i in range(total):
+            buffer.append(f"{i}\n")
+
+    producer = threading.Thread(target=produce)
+    producer.start()
+    seen = 0
+    while producer.is_alive():
+        snapshot = buffer.source()
+        assert snapshot.original_chars >= seen
+        seen = snapshot.original_chars
+    producer.join()
+
+    final = buffer.source()
+    expected = "".join(f"{i}\n" for i in range(total))
+    assert final.original_chars == len(expected)
+    assert final.prefix == expected
+
+
+def test_executor_capture_retention_is_half_the_session_cap_or_the_agent_window() -> None:
+    """Each edge retains half the session cap, rounded up, so the two edges
+    always cover the cap and a capture never holds more than a fold on that
+    session could show; and never less than a task agent's guard window."""
+    from turnstone.core.session import _AGENT_GUARD_WINDOW_CHARS
+
+    session = make_session()
+    session.tool_truncation = 100_001
+    assert session._executor_capture_chars() == 50_001
+
+    manual = make_session(tool_truncation=1000)
+    assert manual._executor_capture_chars() == _AGENT_GUARD_WINDOW_CHARS
+
+
+def test_foreground_stderr_long_line_gets_one_prefix():
+    """A stderr line spanning several drain chunks is one logical line and
+    therefore carries exactly one ``[stderr]`` prefix in the captured output."""
+    session = make_session(tool_timeout=30)
+    session.tool_truncation = 1 << 20
+    width = _DRAIN_CHUNK_CHARS * 2 + 5
+    command = f"head -c {width} /dev/zero | tr '\\0' e >&2; echo >&2; echo ok"
+
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=15,
+    )
+    assert finished, "_exec_bash did not return"
+    assert result is not None
+    _, output = result
+    assert output.count("[stderr]") == 1
+    assert "e" * width in output
+    assert "ok" in output
+
+
+def test_bounded_bash_capture_carries_true_size_through_a_smaller_fold_cut():
+    """Output beyond the executor retention keeps its edges and true size, so a
+    later, smaller fold cut reports omission against the command's real output."""
+    session = make_session(tool_timeout=30)
+    session.tool_truncation = 600
+    command = "head -c 100000 /dev/zero | tr '\\0' x"
+
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=15,
+    )
+    assert finished, "_exec_bash did not return"
+    assert result is not None
+    _, output = result
+    assert isinstance(output, ProjectedText)
+    assert output.source.original_chars == 100_000
+    fold = session._truncate_output_result(output, maximum_chars=150)
+    assert len(fold.text) <= 150
+    assert fold.original_chars == 100_000
+    assert f"[{100_000 - fold.retained_chars} chars truncated" in fold.text
 
 
 def test_backgrounded_child_does_not_hang_and_is_reaped(tmp_path):
@@ -132,7 +268,7 @@ def test_leaked_drain_stops_emitting_chunks_after_return(tmp_path):
     """A double-``setsid`` grandchild escapes the session-group kill and
     holds the stdout pipe open past the drain join (``bash.drain_leaked``)
     — the leaked drain thread must STOP forwarding chunks to the UI once
-    ``_exec_bash`` returns (the ``emit_done`` gate).  Without the gate,
+    ``_exec_bash`` returns (the ``capture_closed`` gate).  Without the gate,
     its lines land in later turns' panes: the UI batches per call_id,
     some providers reuse call_ids across turns, and the client grafts
     stray chunks under the completed row.
@@ -174,7 +310,7 @@ def test_leaked_drain_stops_emitting_chunks_after_return(tmp_path):
         # gate keeps forwarding ~10 lines/sec and still fails loudly.
         assert len(chunks) <= seen_at_return + 1, (
             "leaked drain thread kept forwarding chunks to the UI after "
-            "the tool returned — the emit_done gate is not holding"
+            "the tool returned — the capture_closed gate is not holding"
         )
     finally:
         deadline = time.monotonic() + 5
@@ -229,3 +365,67 @@ def test_popen_failure_reports_cleanly(monkeypatch):
     call_id, output = session._exec_bash({"call_id": "c1", "command": "echo hi"})
     assert call_id == "c1"
     assert "cannot fork" in output
+
+
+def test_foreground_stderr_beyond_retention_keeps_its_true_size():
+    """stderr is bounded by the same executor retention as stdout rather than
+    per line: one over-long stderr line reaches the fold with its edges, one
+    prefix, and the command's real size, so the fold's marker is honest."""
+    session = make_session(tool_timeout=30)
+    session.tool_truncation = 600
+    command = "head -c 100000 /dev/zero | tr '\\0' e >&2"
+
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=15,
+    )
+    assert finished, "_exec_bash did not return"
+    assert result is not None
+    _, output = result
+    assert isinstance(output, ProjectedText)
+    assert output.source.original_chars == 100_000 + len("[stderr] ")
+    assert output.count("[stderr]") == 1
+    fold = session._truncate_output_result(output, maximum_chars=150)
+    assert fold.original_chars == 100_000 + len("[stderr] ")
+    assert f"[{fold.original_chars - fold.retained_chars} chars truncated" in fold.text
+
+
+def test_stderr_never_lands_inside_a_long_stdout_line():
+    """A stdout line longer than one drain chunk must reach the model intact.
+    stderr is presented after stdout, never spliced into it by arrival order."""
+    session = make_session(tool_timeout=30)
+    session.tool_truncation = 1 << 20
+    width = _DRAIN_CHUNK_CHARS * 3 + 11
+    command = f"head -c {width} /dev/zero | tr '\\0' x; echo; echo warn >&2; echo tail"
+
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=15,
+    )
+    assert finished, "_exec_bash did not return"
+    assert result is not None
+    _, output = result
+    assert "x" * width + "\n" in output
+    assert output.index("tail") < output.index("[stderr] warn")
+    assert output.count("[stderr]") == 1
+
+
+def test_exit_code_note_keeps_a_lossy_capture_rerenderable():
+    """The exit-code note is appended to the projection, not to a flattened
+    string, so the fold still renders the failure from the true edges."""
+    session = make_session(tool_timeout=30)
+    session.tool_truncation = 600
+    command = "head -c 100000 /dev/zero | tr '\\0' x; exit 3"
+
+    finished, result = _run_in_thread(
+        lambda: session._exec_bash({"call_id": "c1", "command": command}),
+        timeout=15,
+    )
+    assert finished, "_exec_bash did not return"
+    assert result is not None
+    _, output = result
+    assert isinstance(output, ProjectedText)
+    assert output.endswith("[exit code: 3]")
+    fold = session._truncate_output_result(output, maximum_chars=150)
+    assert fold.text.endswith("[exit code: 3]")
+    assert fold.original_chars == 100_000 + len("\n[exit code: 3]")

--- a/tests/test_compaction_crossing.py
+++ b/tests/test_compaction_crossing.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests._session_helpers import make_session
+from turnstone.core.compaction import CompactionEngine
 from turnstone.core.session import COMPACTION_SOURCE, COMPACTION_SUMMARY_LABEL
 from turnstone.core.storage import get_storage
 from turnstone.core.trajectory import turns_from_dicts
@@ -86,6 +87,22 @@ def _carry_budget_chars(session, carries: int = 1) -> int:
 
 def _summary_output_tokens(session) -> int:
     return session._compaction_engine.summary_output_tokens(_summary_runtime(session))
+
+
+def test_summary_message_projection_is_honest_and_exact_cap() -> None:
+    source = "A" * 2500 + "Z" * 2500
+
+    rendered = CompactionEngine.format_message_for_summary(
+        {"role": "tool", "tool_call_id": "call-1", "content": source},
+        {"call-1": "bash"},
+    )
+
+    assert rendered is not None
+    prefix = "TOOL[bash]: "
+    assert rendered.startswith(prefix + "A")
+    assert rendered.endswith("Z")
+    assert len(rendered) <= len(prefix) + 2000
+    assert "truncated — 5,000 chars total" in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -65,6 +65,17 @@ class TestSet:
         with pytest.raises(ValueError, match="maximum"):
             store.set("tools.timeout", 9999)
 
+    def test_stored_value_above_a_tightened_maximum_is_clamped_on_load(self, storage):
+        """A bound tightened after the value was written clamps it with a
+        warning; it never silently reverts to the default."""
+        from turnstone.core.settings_registry import TOOL_TRUNCATION_MAX_CHARS
+
+        storage.upsert_system_setting("tools.truncation", str(TOOL_TRUNCATION_MAX_CHARS + 1))
+
+        store = ConfigStore(storage)
+
+        assert store.get("tools.truncation") == TOOL_TRUNCATION_MAX_CHARS
+
 
 # ---------------------------------------------------------------------------
 # set() + get() round-trips

--- a/tests/test_coordinator_tools.py
+++ b/tests/test_coordinator_tools.py
@@ -367,6 +367,28 @@ def test_inspect_exec_dispatches_to_client(coord_session):
     assert "child-x" in output
 
 
+def test_inspect_exec_sizes_the_formatter_to_the_fold_cap(coord_session):
+    """The tiered formatter is handed the cap the result fold will apply, so it
+    degrades to a tier the fold admits whole instead of the fold splicing a
+    marker into the middle of a tier that fit the formatter's own budget."""
+    sess, coord, _ui = coord_session
+    coord.inspect.return_value = {
+        "ws_id": "child-x",
+        "skill_id": "general",
+        "state": "idle",
+        "messages": [{"role": "assistant", "content": "m" * 2000} for _ in range(30)],
+    }
+    item = sess._prepare_tool(_tc("inspect_workstream", {"ws_id": "child-x", "message_limit": 30}))
+
+    with patch.object(sess, "_remaining_token_budget", return_value=2000):
+        _call_id, output = sess._exec_inspect_workstream(item)
+
+    cap = sess._tool_result_truncation_limit(batch_budget_tokens=2000)
+    assert len(output) <= cap
+    assert '"_tier":"full"' not in output
+    assert "chars truncated" not in output
+
+
 # ---------------------------------------------------------------------------
 # send_to_workstream
 # ---------------------------------------------------------------------------
@@ -1595,8 +1617,8 @@ def test_spawn_batch_evaluate_intent_truncates_long_messages(coord_session, monk
     children = item["func_args"]["children"]
     assert len(children) == 1
     msg = children[0]["initial_message"]
-    assert msg.startswith("x" * 300)
-    assert "200 of 500 chars omitted" in msg
+    assert msg.count("x") == 300
+    assert msg.endswith("…[200 of 500 chars omitted]")
 
 
 def test_spawn_batch_evaluate_intent_handles_empty_children_defensively(coord_session, monkeypatch):

--- a/tests/test_diff_truncation.py
+++ b/tests/test_diff_truncation.py
@@ -1,0 +1,83 @@
+"""Honest bounded diff output regressions."""
+
+from __future__ import annotations
+
+from tests._session_helpers import make_session
+from turnstone.core.truncation import ProjectedText
+
+
+def _write_pair(tmp_path, lines=1000):
+    before = tmp_path / "before.txt"
+    after = tmp_path / "after.txt"
+    before.write_text("".join(f"old-{i:04d}\n" for i in range(lines)))
+    after.write_text("".join(f"new-{i:04d}\n" for i in range(lines)))
+    return {
+        "call_id": "diff",
+        "path_a": str(before),
+        "path_b": str(after),
+        "content_b": None,
+        "context_lines": 3,
+    }
+
+
+def test_diff_executor_returns_the_complete_diff_within_the_retention(tmp_path) -> None:
+    """The executor never cuts a diff the retention can hold: the fold is the
+    single cut, and its marker reports the diff's real size."""
+    session = make_session()
+    session.tool_truncation = 60_000
+
+    _, output = session._exec_diff(_write_pair(tmp_path))
+
+    assert not isinstance(output, ProjectedText)
+    assert 20_000 < len(output) <= session._executor_capture_chars()
+    assert "chars truncated" not in output
+    assert "new-0999" in output
+    result = session._truncate_output_result(output, maximum_chars=300)
+    assert len(result.text) <= 300
+    assert result.original_chars == len(output)
+    assert "chars truncated" in result.text
+    assert "new-0999" in result.text
+
+
+def test_diff_streaming_retention_carries_true_size_through_a_smaller_fold_cut(
+    tmp_path,
+) -> None:
+    session = make_session()
+    session.tool_truncation = 600
+    retention = session._executor_capture_chars()
+
+    _, output = session._exec_diff(_write_pair(tmp_path, lines=4000))
+
+    # The executor's rendering is bounded and honest, and it still carries its
+    # source edges plus the true size.
+    assert isinstance(output, ProjectedText)
+    assert len(output) <= retention
+    assert output.source.original_chars > 2 * retention
+    assert "chars truncated" in output
+    assert "new-3999" in output
+    # A smaller fold cut renders from the edges, so its marker reports omission
+    # against the real diff rather than against the 300-character rendering.
+    fold = session._truncate_output_result(output, maximum_chars=150)
+    assert len(fold.text) <= 150
+    assert fold.original_chars == output.source.original_chars
+    assert fold.retained_chars + fold.omitted_chars == fold.original_chars
+    assert f"[{fold.omitted_chars} chars truncated" in fold.text
+    assert "new-3999" in fold.text
+
+
+def test_identical_diff_stays_explicit(tmp_path) -> None:
+    path = tmp_path / "same.txt"
+    path.write_text("same\n")
+    session = make_session()
+
+    _, output = session._exec_diff(
+        {
+            "call_id": "diff",
+            "path_a": str(path),
+            "path_b": str(path),
+            "content_b": None,
+            "context_lines": 3,
+        }
+    )
+
+    assert output == "(no differences)"

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1524,7 +1524,17 @@ class TestArgBudget:
 
         out = honest_truncate("A" * 5000, 1000)
         assert out.startswith("A" * 1000)
-        assert "4,000 of 5,000 chars omitted" in out
+        assert out.count("A") == 1000
+        assert out.endswith("…[4,000 of 5,000 chars omitted]")
+
+    def test_honest_truncate_keeps_the_count_at_budgets_below_the_note(self):
+        """Callers divide one budget across many fields, so a budget of a few
+        characters (or zero) is routine.  The counted note must survive it:
+        an empty field reads to the judge as an edit that replaces nothing."""
+        from turnstone.core.judge import honest_truncate
+
+        assert honest_truncate("A" * 50, 0) == "…[50 of 50 chars omitted]"
+        assert honest_truncate("A" * 50, 3) == "AAA…[47 of 50 chars omitted]"
 
     def test_arg_budget_scales_with_context_window_uncapped(self):
         """The judge-prompt budget scales with the real window and is NOT
@@ -1753,8 +1763,9 @@ class TestReadOnlyToolExecution:
         )
 
         assert requested == [32_769]
-        assert result[:32_768] == "x" * 32_768
-        assert result[32_768:].startswith("\n... (truncated")
+        assert len(result) <= 32_768
+        assert result.startswith("x")
+        assert "\n... (truncated" in result
 
     def test_list_directory_success(self, tmp_path):
         (tmp_path / "file_a.txt").touch()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -78,9 +78,14 @@ class TestExtractPdfText:
         assert extract_pdf_text(b"") == ""
 
     def test_character_cap_is_applied_inside_worker(self) -> None:
-        assert extract_pdf_text(_minimal_pdf("abcdefghij"), max_chars=4) == (
-            "abcd\n\n... [6 chars truncated] ...\n"
-        )
+        assert extract_pdf_text(_minimal_pdf("abcdefghij"), max_chars=4) == "abc…"
+
+    def test_character_marker_fits_inside_nontrivial_cap(self) -> None:
+        result = extract_pdf_text(_minimal_pdf("x" * 100), max_chars=64)
+
+        assert len(result) <= 64
+        assert result.startswith("x")
+        assert "chars truncated" in result
 
     def test_resource_exit_is_typed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class ResourceLimitedProcess:
@@ -138,6 +143,30 @@ class TestExtractPdfText:
         assert process.killed
 
 
+class TestTextHeaderProtocol:
+    def test_parent_renders_the_marker_from_the_worker_prefix(self) -> None:
+        assert extract_pdf_text(_minimal_pdf("abcdefghij"), max_chars=8) == "abcdefg…"
+
+    def test_zero_allowance_returns_the_marker_as_a_receipt(self) -> None:
+        result = extract_pdf_text(_minimal_pdf("abcdefghij"), max_chars=0)
+
+        assert result == "\n\n... [10 chars truncated] ...\n"
+
+    def test_marker_counts_the_true_size(self) -> None:
+        from turnstone.core.pdf import _render_pdf_text
+
+        text = _render_pdf_text("a" * 1000, 123456, 1000)
+
+        head, _, rest = text.partition("\n\n... [")
+        assert len(text) == 1000
+        assert int(rest.split(" ")[0]) == 123456 - len(head)
+
+    def test_short_worker_output_reads_as_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("turnstone.core.pdf._worker_bytes", lambda *a, **k: b"abc")
+
+        assert extract_pdf_text(_minimal_pdf("abcdefghij")) == ""
+
+
 class TestRasterizePdf:
     def test_renders_pages_to_png(self) -> None:
         pages = rasterize_pdf(_minimal_pdf("Hello PDF"))
@@ -159,7 +188,7 @@ class TestRasterizePdf:
 
 class TestPdfWorkerEnvelope:
     def test_text_character_ceiling_is_derived_from_output_bytes(self) -> None:
-        expected = (_pdf_worker.MAX_FILE_BYTES - _pdf_worker._TEXT_OUTPUT_MARKER_RESERVE_BYTES) // 4
+        expected = (_pdf_worker.MAX_FILE_BYTES - _pdf_worker._TEXT_OUTPUT_HEADER_RESERVE_BYTES) // 4
         assert expected == _pdf_worker.MAX_TEXT_CHARS
 
     def test_worker_retains_user_site_dependencies(

--- a/tests/test_provider_anthropic_reasoning.py
+++ b/tests/test_provider_anthropic_reasoning.py
@@ -81,6 +81,7 @@ class TestExtractReasoningText:
         blocks = [{"type": "thinking", "thinking": long_text, "signature": "s"}]
         result = anthropic.extract_reasoning_text(blocks)
         assert len(result) == _MAX_REASONING_DISPLAY_CHARS
+        assert "reasoning chars omitted from display" in result
 
     def test_just_under_cap_not_truncated(self, anthropic: AnthropicProvider) -> None:
         text = "y" * (_MAX_REASONING_DISPLAY_CHARS - 1)

--- a/tests/test_provider_openai_responses_reasoning.py
+++ b/tests/test_provider_openai_responses_reasoning.py
@@ -101,6 +101,7 @@ class TestExtractReasoningText:
         ]
         result = provider.extract_reasoning_text(blocks)
         assert len(result) == _MAX_REASONING_DISPLAY_CHARS
+        assert "reasoning chars omitted from display" in result
 
     def test_malformed_summary_entry_skipped(self, provider: OpenAIResponsesProvider) -> None:
         blocks = [

--- a/tests/test_recall_compaction_scope.py
+++ b/tests/test_recall_compaction_scope.py
@@ -186,6 +186,16 @@ class TestRecallExecScope:
         assert "(earlier in this conversation, compacted)" in own_line
         assert "(earlier in this conversation, compacted)" not in other_line
 
+    def test_long_history_hit_has_honest_exact_cap(self):
+        session = make_session(user_id="owner")
+        content = "x" * 5000
+        rows = [("2026-07-02T10:00:00", "ws-other", "user", content, None)]
+
+        _, output = self._run_recall(session, rows)
+
+        assert "history item truncated; 5,000 chars total" in output
+        assert "x" * 2000 not in output
+
 
 def test_resume_nudge_teaches_recall():
     """The model is told the summary is a digest and recall reaches the

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -33,8 +33,10 @@ from turnstone.core.model_turn import (
 from turnstone.core.session import (
     _IMAGE_EXTENSIONS,
     _IMAGE_SIZE_CAP,
+    _MAX_SKILL_CONTENT,
     _MEMORY_MIXED_BATCH_ERROR,
     ChatSession,
+    _clip_skill_content,
     _TaskExecutionJournal,
 )
 from turnstone.core.storage import get_storage
@@ -435,6 +437,12 @@ class TestTaskExec:
     task-agent identity), NEVER the skill; a ``skill=`` rides a distinct
     capability turn.  Operating guidance (one-shot, tool-use over narration,
     no follow-ups) always layers on top."""
+
+    def test_skill_clip_discloses_omitted_guidance_inside_cap(self) -> None:
+        clipped = _clip_skill_content("x" * (_MAX_SKILL_CONTENT + 1000))
+
+        assert len(clipped) <= _MAX_SKILL_CONTENT
+        assert "skill guidance truncated from" in clipped
 
     @staticmethod
     def _capture_exec_turns(session, item):
@@ -2434,9 +2442,10 @@ class TestEvaluateIntentProjection:
             "content": body,
         }
         fa = _project_func_args(item, budget=1000)
-        assert fa["content"].startswith("A" * 1000)
-        # honest about exactly how much was dropped
-        assert "4,000 of 5,000 chars omitted" in fa["content"]
+        # The budget is spent on source characters; the counted note is extra
+        # to it and exact about the source characters it displaced.
+        assert fa["content"].count("A") == 1000
+        assert fa["content"].endswith("…[4,000 of 5,000 chars omitted]")
 
     def test_edit_projection_marks_overflow_when_budget_exhausted(self) -> None:
         """A batch of huge edits collapses its tail to an honest count rather
@@ -3620,6 +3629,329 @@ class TestAgentOutputGuard:
 
             mock_eval.assert_not_called()
 
+    def test_agent_loop_marks_a_result_the_guard_shrank_below_the_clip(self):
+        """Redaction can shrink the guard window below the clip; the result
+        must still read as cut, with its true size, never as complete."""
+        from turnstone.core.judge import JudgeConfig
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+        from turnstone.core.session import _AGENT_GUARD_WINDOW_CHARS, _AGENT_TOOL_OUTPUT_CAP
+
+        session = _make_session(judge_config=JudgeConfig(output_guard=True))
+        client = replace_session_lane(session, provider=OpenAIChatCompletionsProvider()).client
+        body = "".join(chr(65 + i % 26) for i in range(3200))
+        block = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            + "\n".join(body[i : i + 64] for i in range(0, 3200, 64))
+            + "\n-----END RSA PRIVATE KEY-----\n"
+        )
+        huge = block * 9 + "y" * (_AGENT_GUARD_WINDOW_CHARS * 2)
+        landed: list[str] = []
+
+        client.chat.completions.create = scripted_chat_client(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "name": "read_file",
+                        "arguments": '{"path": "/tmp/test"}',
+                    }
+                ],
+                "finish_reason": "tool_calls",
+            },
+            {"content": "Done"},
+        )
+
+        def fake_prepare(tc_dict, **kwargs):
+            return {
+                "call_id": tc_dict["id"],
+                "func_name": "read_file",
+                "needs_approval": False,
+                "execute": lambda p: ("call_1", huge),
+            }
+
+        original_tool = Turn.tool
+
+        def recording_tool(call_id, content, *args, **kwargs):
+            if isinstance(content, str):
+                landed.append(content)
+            return original_tool(call_id, content, *args, **kwargs)
+
+        with (
+            patch.object(session, "_prepare_tool", side_effect=fake_prepare),
+            patch("turnstone.core.session.Turn.tool", side_effect=recording_tool),
+        ):
+            session._run_agent(
+                [Turn.user("test")],
+                tools=[{"type": "function", "function": {"name": "read_file"}}],
+                label="test",
+            )
+
+        result = [c for c in landed if "[REDACTED" in c][-1]
+        assert len(result) < _AGENT_TOOL_OUTPUT_CAP
+        assert "PRIVATE KEY-----" not in result
+        assert result.endswith(f"(truncated from {len(huge)} chars)")
+        assert result.count("truncated from") == 1
+
+    def test_agent_loop_bash_output_clip_carries_the_consumed_notice(self):
+        """A task agent's cut ``bash_output`` delta says the elided output was
+        consumed, like the main fold's marker does."""
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+        from turnstone.core.session import _AGENT_TOOL_OUTPUT_CAP, _BASH_OUTPUT_CONSUMED_NOTICE
+
+        session = _make_session()
+        client = replace_session_lane(session, provider=OpenAIChatCompletionsProvider()).client
+        delta = "bash_1 (running)\n" + "line\n" * _AGENT_TOOL_OUTPUT_CAP
+        landed: list[str] = []
+
+        client.chat.completions.create = scripted_chat_client(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "name": "bash_output",
+                        "arguments": '{"id": "bash_1"}',
+                    }
+                ],
+                "finish_reason": "tool_calls",
+            },
+            {"content": "Done"},
+        )
+
+        def fake_prepare(tc_dict, **kwargs):
+            return {
+                "call_id": tc_dict["id"],
+                "func_name": "bash_output",
+                "needs_approval": False,
+                "execute": lambda p: ("call_1", delta),
+            }
+
+        original_tool = Turn.tool
+
+        def recording_tool(call_id, content, *args, **kwargs):
+            if isinstance(content, str):
+                landed.append(content)
+            return original_tool(call_id, content, *args, **kwargs)
+
+        with (
+            patch.object(session, "_prepare_tool", side_effect=fake_prepare),
+            patch("turnstone.core.session.Turn.tool", side_effect=recording_tool),
+        ):
+            session._run_agent(
+                [Turn.user("test")],
+                tools=[{"type": "function", "function": {"name": "bash_output"}}],
+                label="test",
+            )
+
+        result = [c for c in landed if c.startswith("bash_1")][-1]
+        assert len(result) <= _AGENT_TOOL_OUTPUT_CAP
+        assert f"(truncated from {len(delta)} chars)" in result
+        assert _BASH_OUTPUT_CONSUMED_NOTICE in result
+
+    def _run_agent_bash_capture(self, session, capture, guard=None):
+        """Run one agent turn whose ``bash`` tool returns ``capture``; return
+        the tool-turn contents that landed and the texts the guard scanned."""
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+
+        client = replace_session_lane(session, provider=OpenAIChatCompletionsProvider()).client
+        landed: list[str] = []
+        scanned: list[str] = []
+        client.chat.completions.create = scripted_chat_client(
+            {
+                "tool_calls": [{"id": "call_1", "name": "bash", "arguments": '{"command": "x"}'}],
+                "finish_reason": "tool_calls",
+            },
+            {"content": "Done"},
+        )
+
+        def fake_prepare(tc_dict, **kwargs):
+            return {
+                "call_id": tc_dict["id"],
+                "func_name": "bash",
+                "needs_approval": False,
+                "execute": lambda p: ("call_1", capture),
+            }
+
+        def recording_guard(_call_id, text, *_args, **_kwargs):
+            scanned.append(text)
+            return (guard(text) if guard else text), None
+
+        original_tool = Turn.tool
+
+        def recording_tool(call_id, content, *args, **kwargs):
+            if isinstance(content, str):
+                landed.append(content)
+            return original_tool(call_id, content, *args, **kwargs)
+
+        with (
+            patch.object(session, "_prepare_tool", side_effect=fake_prepare),
+            patch.object(session, "_evaluate_output", side_effect=recording_guard),
+            patch("turnstone.core.session.Turn.tool", side_effect=recording_tool),
+        ):
+            session._run_agent(
+                [Turn.user("test")],
+                tools=[{"type": "function", "function": {"name": "bash"}}],
+                label="test",
+            )
+        return landed, scanned
+
+    def test_agent_guard_scans_the_text_the_clip_will_reveal(self):
+        """A capture's window is rendered from its source in the clip's head
+        mode before the guard runs, so the guard scans exactly what the agent
+        receives: a secret beyond the executor rendering's head but within the
+        clip's reach is redacted rather than revealed by the clip."""
+        from turnstone.core.judge import JudgeConfig
+        from turnstone.core.session import _AGENT_TOOL_OUTPUT_CAP
+        from turnstone.core.truncation import BoundedTextBuffer
+
+        session = _make_session()
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        buffer = BoundedTextBuffer(20_000)
+        buffer.append("a" * 12_000 + "SECRET-TOKEN" + "b" * 88_000)
+        capture = buffer.projected()
+        assert "SECRET-TOKEN" not in capture
+
+        landed, scanned = self._run_agent_bash_capture(
+            session, capture, guard=lambda text: text.replace("SECRET-TOKEN", "[REDACTED]")
+        )
+
+        result = [c for c in landed if c.startswith("a")][-1]
+        assert len(result) <= _AGENT_TOOL_OUTPUT_CAP
+        assert "SECRET-TOKEN" not in result
+        assert "[REDACTED]" in result
+        assert any("SECRET-TOKEN" in text for text in scanned)
+
+    def test_agent_receives_a_capture_its_window_can_hold_complete(self):
+        """A capture rendered at the executor's retention is re-rendered from
+        its source for the agent, so an output the guard window can hold
+        arrives complete rather than as the executor's bounded rendering."""
+        from turnstone.core.truncation import BoundedTextBuffer
+
+        session = _make_session()
+        buffer = BoundedTextBuffer(1000)
+        buffer.append("x" * 1500)
+        capture = buffer.projected()
+        assert "chars truncated" in capture
+
+        landed, _scanned = self._run_agent_bash_capture(session, capture)
+
+        assert [c for c in landed if c.startswith("x")][-1] == "x" * 1500
+
+    def test_agent_loop_guard_scans_a_bounded_window(self):
+        """The guard evaluates a bounded window of the result, never an
+        unbounded string a tool server controls."""
+        from turnstone.core.judge import JudgeConfig
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+        from turnstone.core.session import _AGENT_GUARD_WINDOW_CHARS, _AGENT_TOOL_OUTPUT_CAP
+
+        session = _make_session(judge_config=JudgeConfig(output_guard=True))
+        client = replace_session_lane(session, provider=OpenAIChatCompletionsProvider()).client
+        seen_lengths: list[int] = []
+
+        def recording_guard(_call_id, output, *_args, **_kwargs):
+            seen_lengths.append(len(output))
+            return output, None
+
+        with patch.object(session, "_evaluate_output", side_effect=recording_guard):
+            client.chat.completions.create = scripted_chat_client(
+                {
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "name": "read_file",
+                            "arguments": '{"path": "/tmp/test"}',
+                        }
+                    ],
+                    "finish_reason": "tool_calls",
+                },
+                {"content": "Done"},
+            )
+            huge = "x" * (_AGENT_TOOL_OUTPUT_CAP * 4)
+
+            def fake_prepare(tc_dict, **kwargs):
+                return {
+                    "call_id": tc_dict["id"],
+                    "func_name": "read_file",
+                    "needs_approval": False,
+                    "execute": lambda p: ("call_1", huge),
+                }
+
+            with patch.object(session, "_prepare_tool", side_effect=fake_prepare):
+                session._run_agent(
+                    [Turn.user("test")],
+                    tools=[{"type": "function", "function": {"name": "read_file"}}],
+                    label="test",
+                )
+
+        assert seen_lengths and max(seen_lengths) <= _AGENT_GUARD_WINDOW_CHARS
+
+    def test_agent_loop_guard_window_reaches_past_the_clip(self):
+        """A credential that straddles the clip boundary is seen whole by the
+        guard and redacted, while the clip marker still reports the result's
+        true size and the guard never scans more than its bounded window."""
+        from turnstone.core.judge import JudgeConfig
+        from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
+        from turnstone.core.session import _AGENT_GUARD_WINDOW_CHARS, _AGENT_TOOL_OUTPUT_CAP
+
+        session = _make_session(judge_config=JudgeConfig(output_guard=True))
+        client = replace_session_lane(session, provider=OpenAIChatCompletionsProvider()).client
+        token = "ghp_" + "a" * 36
+        huge = "x" * (_AGENT_TOOL_OUTPUT_CAP - 10) + token + "y" * (_AGENT_GUARD_WINDOW_CHARS * 3)
+        seen_lengths: list[int] = []
+        landed: list[str] = []
+        real_guard = session._evaluate_output
+
+        def recording_guard(call_id, output, *args, **kwargs):
+            seen_lengths.append(len(output))
+            return real_guard(call_id, output, *args, **kwargs)
+
+        with patch.object(session, "_evaluate_output", side_effect=recording_guard):
+            client.chat.completions.create = scripted_chat_client(
+                {
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "name": "read_file",
+                            "arguments": '{"path": "/tmp/test"}',
+                        }
+                    ],
+                    "finish_reason": "tool_calls",
+                },
+                {"content": "Done"},
+            )
+
+            def fake_prepare(tc_dict, **kwargs):
+                return {
+                    "call_id": tc_dict["id"],
+                    "func_name": "read_file",
+                    "needs_approval": False,
+                    "execute": lambda p: ("call_1", huge),
+                }
+
+            original_tool = Turn.tool
+
+            def recording_tool(call_id, content, *args, **kwargs):
+                if isinstance(content, str):
+                    landed.append(content)
+                return original_tool(call_id, content, *args, **kwargs)
+
+            with (
+                patch.object(session, "_prepare_tool", side_effect=fake_prepare),
+                patch("turnstone.core.session.Turn.tool", side_effect=recording_tool),
+            ):
+                session._run_agent(
+                    [Turn.user("test")],
+                    tools=[{"type": "function", "function": {"name": "read_file"}}],
+                    label="test",
+                )
+
+        assert seen_lengths and max(seen_lengths) <= _AGENT_GUARD_WINDOW_CHARS
+        clipped = [c for c in landed if c.startswith("x" * 100)]
+        assert clipped, landed
+        result = clipped[-1]
+        assert token not in result
+        assert "ghp_" not in result
+        assert f"(truncated from {len(huge)} chars)" in result
+
     def test_synthesis_only_path_is_guarded(self):
         """When the sub-agent emits text directly (no tool calls), the
         synthesis still flows through _evaluate_output.  This is the
@@ -4653,6 +4985,18 @@ class TestTaskExecutionJournalProjection:
         steps = _TaskExecutionJournal(turns).project_steps()
         assert steps[0]["output"] == "[non-text result]"
 
+    def test_update_step_keeps_the_producer_size(self):
+        from turnstone.core.session import _AGENT_STEP_OUTPUT_CAP, _TaskExecutionJournal
+
+        step = {"output": "", "is_error": False}
+        clipped = "a" * (_AGENT_STEP_OUTPUT_CAP + 500) + "\n\n... (truncated from 1000000 chars)"
+
+        _TaskExecutionJournal.update_step(step, clipped, is_error=False, original_chars=1_000_000)
+
+        assert step["output"].endswith("(truncated from 1000000 chars)")
+        assert step["output"].count("truncated from") == 1
+        assert len(step["output"]) <= _AGENT_STEP_OUTPUT_CAP
+
     def test_output_capped(self):
         from turnstone.core.session import _AGENT_STEP_OUTPUT_CAP
         from turnstone.core.trajectory import ToolCall, Turn
@@ -5424,6 +5768,59 @@ class TestEvaluateOutputLLMStage:
         # signal that the LLM cannot override.
         assert assessment is not None
         assert "credential_leak" in assessment.flags
+
+    def test_disabled_secret_redaction_never_claims_bytes_changed(self) -> None:
+        """Raw-by-policy output and every guard projection agree it stayed raw."""
+
+        from turnstone.core.judge import JudgeConfig
+
+        records: list[dict[str, object]] = []
+        warnings: list[dict[str, object]] = []
+
+        class _PolicyUI(NullUI):
+            def record_output_assessment(
+                self,
+                call_id,
+                assessment,
+                *,
+                tier="heuristic",
+                reasoning="",
+                judge_model="",
+                latency_ms=0,
+                confidence=0.0,
+            ):
+                del call_id, tier, reasoning, judge_model, latency_ms, confidence
+                records.append(dict(assessment))
+
+            def on_output_warning(self, call_id, assessment):
+                warnings.append({"call_id": call_id, **assessment})
+
+        session = _make_session(
+            judge_config=JudgeConfig(
+                output_guard=True,
+                output_guard_llm=False,
+                redact_secrets=False,
+            ),
+            ui=_PolicyUI(),
+        )
+        secret = "OPENAI_API_KEY=sk-proj-aaaaaaaaaaaaaaaaaaaa123456"
+
+        output, assessment = session._evaluate_output("call-raw", secret, "bash")
+
+        assert output == secret
+        assert assessment is not None
+        assert assessment.sanitized is None
+        assert records[0]["redacted"] is False
+        assert warnings[0]["redacted"] is False
+        guard_specs = [
+            spec
+            for spec in session._collect_advisories(assessment, "bash", False)
+            if spec[0] == "output_guard"
+        ]
+        assert len(guard_specs) == 1
+        _source, content, meta = guard_specs[0]
+        assert meta["redacted"] is False
+        assert "Credentials have been redacted" not in content
 
     def test_rate_limit_drops_excess_judge_calls(self) -> None:
         """sec-4: when the per-session token bucket is exhausted, the LLM
@@ -8823,6 +9220,18 @@ class TestMemoryAccessTouch:
 
 
 class TestMetacognitiveBuffers:
+    def test_interjection_marker_is_inside_declared_cap(self, tmp_db) -> None:
+        from turnstone.core.workstream import INTERJECTION_CAP_CHARS
+
+        session = _make_session()
+        cleaned, _priority, _msg_id = session.queue_message(
+            "x" * (INTERJECTION_CAP_CHARS + 100),
+            queue_msg_id="bounded-interjection",
+        )
+
+        assert len(cleaned) == INTERJECTION_CAP_CHARS
+        assert cleaned.endswith("…")
+
     """Nudges drain through advisory channels, not the system message."""
 
     def test_pending_buffers_initialised_empty(self, tmp_db):
@@ -11642,6 +12051,27 @@ class TestSearchOutputBudget:
         # so the final emission stays at or below ``_SEARCH_OUTPUT_BUDGET``
         # without needing ``_truncate_output`` as a backstop.
         assert len(out) <= _SEARCH_OUTPUT_BUDGET
+
+    def test_budget_argument_sizes_the_ladder(self):
+        """The executor hands the formatter the fold's cap, so the ladder
+        degrades to a tier the fold admits whole."""
+        from turnstone.core.session import _SEARCH_OUTPUT_BUDGET, _format_search_results
+
+        records = [(f, str(i), "x" * 60) for f in ("a.py", "b.py", "c.py") for i in range(200)]
+
+        out = _format_search_results(records, capped=False, budget=2_000)
+
+        assert len(out) <= 2_000
+        assert "600 matches across 3 files" in out
+
+        session = _make_session()
+        with (
+            patch.object(session, "_remaining_token_budget", return_value=2_000),
+            patch("turnstone.core.session._format_search_results", return_value="ok") as fmt,
+        ):
+            _run_exec_search(session, (b"a.py:1:hit\n", 0, b"", False))
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=2_000)
+        assert fmt.call_args.kwargs["budget"] == min(_SEARCH_OUTPUT_BUDGET, cap)
 
     def test_tier3_counts_only_when_too_many_files(self):
         """Thousands of files × matches → degrade to per-file counts."""

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -185,6 +185,12 @@ class TestValidateValueRange:
         with pytest.raises(ValueError, match="maximum"):
             validate_value("tools.timeout", 9999)  # max_value=3600
 
+    def test_clamp_range(self):
+        assert validate_value("tools.timeout", 9999, clamp_range=True) == 3600
+        assert validate_value("tools.timeout", 0, clamp_range=True) == 1
+        with pytest.raises(ValueError):
+            validate_value("tools.timeout", "not a number", clamp_range=True)
+
     def test_min_value_float(self):
         with pytest.raises(ValueError, match="minimum"):
             validate_value("model.temperature", -0.1)  # min_value=0.0

--- a/tests/test_sse_chunk_batching.py
+++ b/tests/test_sse_chunk_batching.py
@@ -153,7 +153,7 @@ def test_result_finishes_the_stream_and_drops_the_entry(wide_window: None) -> No
     on the wire and the per-call entry (window clock included) is
     dropped.  A chunk arriving AFTER the terminal — only reachable
     through the producer gate's one-line race, since ``_exec_bash``'s
-    ``emit_done`` stops the leaked drain thread at the source — simply
+    ``capture_closed`` stops the leaked drain thread at the source — simply
     re-buffers and emits, identical to pre-batching behaviour for the
     same line.  (The UI deliberately keeps NO closed-call ledger: keyed
     on call_id it would either discard a reusing provider's NEW stream

--- a/tests/test_tool_truncation.py
+++ b/tests/test_tool_truncation.py
@@ -3,14 +3,27 @@
 from __future__ import annotations
 
 import contextlib
+import re
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests._session_helpers import make_result
-from turnstone.core.session import ChatSession
+from turnstone.core.judge import JudgeConfig
+from turnstone.core.session import (
+    _AGENT_TOOL_OUTPUT_CAP,
+    _BASH_OUTPUT_CONSUMED_NOTICE,
+    _MIN_COUNTED_RESULT_CHARS,
+    _REPEAT_WARNING,
+    _TRUNCATION_FLOOR_CHARS,
+    ChatSession,
+    _active_task_agent_cancel_scope,
+    _bash_output_truncation_marker,
+)
 from turnstone.core.trajectory import Role, turns_from_dicts
+from turnstone.core.truncation import BoundedTextBuffer, ProjectedText, truncate_text
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -38,6 +51,82 @@ def session(tmp_db, mock_openai_client):
 
 
 class TestTruncateOutput:
+    def test_auto_limit_is_one_fifth_of_the_remaining_budget(self, session):
+        batch_budget_tokens = 1000
+        fifth = int(batch_budget_tokens * session._chars_per_token * 0.20)
+
+        assert (
+            session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens) == fifth
+        )
+        # The session ceiling still bounds the share.
+        session.tool_truncation = fifth // 2
+        assert (
+            session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+            == fifth // 2
+        )
+
+    def test_read_file_is_cut_once_by_the_fold_with_its_real_size(self, session, tmp_path):
+        """Executors hand the fold their complete result, so the fold's marker
+        reports the file's real size rather than an earlier projection's."""
+        path = tmp_path / "big.txt"
+        path.write_text("".join(f"line-{i:05d} {'x' * 40}\n" for i in range(600)))
+
+        _, output = session._exec_read_file(
+            {"call_id": "r1", "path": str(path), "offset": None, "limit": None}
+        )
+
+        assert len(output) > session.tool_truncation
+        assert "chars truncated" not in output
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=2000)
+        result = session._truncate_output_result(
+            output, remaining_budget_tokens=2000, maximum_chars=cap
+        )
+        assert len(result.text) <= cap
+        assert result.original_chars == len(output)
+        assert result.retained_chars + result.omitted_chars == len(output)
+        assert f"[{result.omitted_chars} chars truncated" in result.text
+        assert result.text.count("chars truncated") == 1
+
+    def test_operator_limit_replaces_the_automatic_share(self, session):
+        session._manual_tool_truncation = True
+        session.tool_truncation = 1234
+
+        assert session._tool_result_truncation_limit(batch_budget_tokens=100) == 1234
+
+    def test_allowance_below_the_counted_floor_takes_the_zero_budget_doors(self, session):
+        """A cap too small to carry a counted marker never renders a bare
+        fragment that reads as complete: the result is funded by the grace
+        floor when the drain grants it, and dropped with the notice otherwise."""
+        limit = session._tool_result_truncation_limit(batch_budget_tokens=1)
+        output = "longer than one character"
+
+        assert 0 <= limit < _MIN_COUNTED_RESULT_CHARS
+        funded = session._truncate_output_result(
+            output, remaining_budget_tokens=1, floor_chars=len(output), maximum_chars=limit
+        )
+        assert funded.text == output
+        dropped = session._truncate_output_result(
+            output, remaining_budget_tokens=1, maximum_chars=limit
+        )
+        assert "context budget exhausted" in dropped.text
+        assert "…" not in dropped.text
+
+    def test_manual_cap_below_the_counted_floor_is_the_operators_choice(self, session):
+        session.tool_truncation = 40
+        session._manual_tool_truncation = True
+
+        result = session._truncate_output_result(
+            "x" * 500, remaining_budget_tokens=10_000, maximum_chars=40
+        )
+
+        assert len(result.text) <= 40
+        assert "context budget exhausted" not in result.text
+        assert not session._allowance_is_exhausted(
+            "x" * 500, budget_tokens=10_000, maximum_chars=40
+        )
+        session._manual_tool_truncation = False
+        assert session._allowance_is_exhausted("x" * 500, budget_tokens=10_000, maximum_chars=40)
+
     def test_no_truncation_when_under_limit(self, session):
         result = session._truncate_output("short text")
         assert result == "short text"
@@ -46,7 +135,7 @@ class TestTruncateOutput:
         session.tool_truncation = 100
         big = "x" * 500
         result = session._truncate_output(big)
-        assert len(result) <= 200  # head + tail + marker
+        assert len(result) <= 100  # source edges + marker share the cap
         assert "chars truncated" in result
 
     def test_budget_aware_truncation(self, session):
@@ -55,15 +144,16 @@ class TestTruncateOutput:
         # Budget of 50 tokens = 200 chars
         big = "x" * 1000
         result = session._truncate_output(big, remaining_budget_tokens=50)
-        assert len(result) <= 400  # head + tail + marker
+        assert len(result) <= 200  # source edges + marker share the budget
         assert "chars truncated" in result
 
     def test_budget_takes_precedence_when_smaller(self, session):
         session.tool_truncation = 10_000
         session._chars_per_token = 4.0
-        # Budget of 25 tokens = 100 chars, smaller than tool_truncation
+        # Budget of 50 tokens = 200 chars, smaller than tool_truncation
         big = "x" * 500
-        result = session._truncate_output(big, remaining_budget_tokens=25)
+        result = session._truncate_output(big, remaining_budget_tokens=50)
+        assert len(result) <= 200
         assert "chars truncated" in result
 
     def test_empty_output_passes_at_any_budget(self, session):
@@ -112,7 +202,7 @@ class TestTruncateOutput:
         assert "chars truncated" in result
         assert result.startswith("A")
         assert result.endswith("Z")
-        assert len(result) <= _TRUNCATION_FLOOR_CHARS + 200  # + marker
+        assert len(result) <= _TRUNCATION_FLOOR_CHARS
 
     def test_floor_overrides_operator_cap(self, session):
         # The floor deliberately wins over a tiny operator-set cap:
@@ -347,6 +437,522 @@ def _policy(*, owed: bool = False, over_soft: bool = False, over_hard: bool = Fa
     )
 
 
+class TestAutomaticBashDrain:
+    def test_parallel_bash_results_share_one_remaining_budget_snapshot(self, session):
+        output = "BEGIN\n" + "middle\n" * 5000 + "END\n"
+        calls = [
+            {"id": "tc_b1", "function": {"name": "bash", "arguments": "{}"}},
+            {"id": "tc_b2", "function": {"name": "bash", "arguments": "{}"}},
+        ]
+        batch_budget_tokens = 4000
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_b1", output), ("tc_b2", output)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+        ):
+            session.send("go")
+
+        expected = session._tool_result_truncation_limit(
+            batch_budget_tokens=batch_budget_tokens,
+        )
+        first, second = _tool_turn_texts(session)
+        assert len(first) == expected
+        assert len(second) == expected
+        assert "chars truncated" in first
+        assert "chars truncated" in second
+
+    def test_whitespace_padded_tool_name_still_gets_the_bash_share(self, session):
+        """Dispatch strips a padded provider name; the fold's policy must too."""
+        output = "BEGIN\n" + "middle\n" * 5000 + "END\n"
+        calls = [{"id": "tc_b1", "function": {"name": "  bash\n", "arguments": "{}"}}]
+        batch_budget_tokens = 4000
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_b1", output)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+        ):
+            session.send("go")
+
+        (text,) = _tool_turn_texts(session)
+        assert len(text) == session._tool_result_truncation_limit(
+            batch_budget_tokens=batch_budget_tokens
+        )
+
+    def test_redaction_expansion_cannot_exceed_the_admitted_cap(self, session):
+        """A guard that lengthens a capped result is re-capped before the fold."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        assert session._judge_cfg is not None and session._judge_cfg.output_guard
+        output = "BEGIN\n" + "middle\n" * 5000 + "END\n"
+        calls = [{"id": "tc_b1", "function": {"name": "bash", "arguments": "{}"}}]
+        batch_budget_tokens = 4000
+
+        def expanding_guard(_call_id, text, *_args, **_kwargs):
+            return text + "[REDACTED:secret]" * 500, None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_b1", output)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=expanding_guard),
+        ):
+            session.send("go")
+
+        (text,) = _tool_turn_texts(session)
+        assert len(text) <= session._tool_result_truncation_limit(
+            batch_budget_tokens=batch_budget_tokens
+        )
+        assert "chars truncated" in text
+
+    def test_growth_of_whole_admitted_results_is_accepted(self, session):
+        """A result the drain admitted whole is what the guard produced, grown
+        or not: nothing small is cut for having grown or replaced by a notice
+        several times its size, and the batch may exceed its allowance by that
+        growth, which the pre-send guard absorbs."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        session._chars_per_token = 4.0
+        batch_budget_tokens = 160
+        allowance_chars = int(batch_budget_tokens * session._chars_per_token)
+        share = session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+        short = "PASSWORD=x\n" * 9
+        count = 6
+        calls = [
+            {"id": f"tc_{i}", "function": {"name": "read_file", "arguments": "{}"}}
+            for i in range(count)
+        ]
+        assert len(short) <= share and count * len(short) <= allowance_chars
+
+        def expanding_guard(_call_id, text, *_args, **_kwargs):
+            return text.replace("PASSWORD=x", "PASSWORD=[REDACTED:secret]"), None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [(f"tc_{i}", short) for i in range(count)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=expanding_guard),
+        ):
+            session.send("go")
+
+        texts = _tool_turn_texts(session)
+        expanded = short.replace("PASSWORD=x", "PASSWORD=[REDACTED:secret]")
+        assert texts == [expanded] * count
+        assert sum(len(t) for t in texts) > allowance_chars
+
+    def test_bash_output_notice_rides_the_fold_marker(self, session):
+        """A cut ``bash_output`` delta says, inside its cap, that the consumed
+        middle cannot be re-read; a tight cap keeps the ordinary marker."""
+        output = "BEGIN\n" + "middle\n" * 5000 + "END\n"
+        calls = [{"id": "tc_o1", "function": {"name": "bash_output", "arguments": "{}"}}]
+        batch_budget_tokens = 4000
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_o1", output)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+        ):
+            session.send("go")
+
+        (text,) = _tool_turn_texts(session)
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+        assert len(text) == cap
+        assert text.count("chars truncated") == 1
+        assert _BASH_OUTPUT_CONSUMED_NOTICE in text
+        assert text.startswith("BEGIN\n") and text.endswith("END\n")
+
+        tight = session._truncate_output_result(
+            output,
+            remaining_budget_tokens=4000,
+            maximum_chars=200,
+            marker_factory=_bash_output_truncation_marker,
+        )
+        assert len(tight.text) <= 200
+        assert tight.text.count("chars truncated") == 1
+        assert _BASH_OUTPUT_CONSUMED_NOTICE not in tight.text
+
+    def test_bash_output_marker_count_matches_the_cut_at_every_cap(self):
+        """The notice decision must not depend on the omitted count: a marker
+        whose length toggles with that count cannot settle in the primitive's
+        fixed point, and its count would lag the cut."""
+        for original in (224, 1000, 60000):
+            text = "x" * original
+            for limit in range(1, 700):
+                result = truncate_text(text, limit, marker_factory=_bash_output_truncation_marker)
+                assert len(result.text) <= limit
+                claimed = re.search(r"\[(\d+) chars truncated", result.text)
+                if claimed is not None:
+                    assert int(claimed.group(1)) == original - result.retained_chars, (
+                        original,
+                        limit,
+                    )
+
+    def test_lengthened_cut_result_is_recut_at_the_drain_marker(self, session):
+        """A cut rendering the guard lengthened past its cap is re-cut as two
+        edges around the drain's marker: one marker, within the cap, both
+        edges kept."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        secret = "PASSWORD=x\n" * 40
+        cut = "H" * 2500 + "T" * 2500
+        calls = [
+            {"id": "tc_s", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "tc_c", "function": {"name": "read_file", "arguments": "{}"}},
+        ]
+        batch_budget_tokens = 400
+
+        def guard(_call_id, text, *_args, **_kwargs):
+            if text.startswith("PASSWORD"):
+                return text.replace("PASSWORD=x", "PASSWORD=[REDACTED:secret]" * 3), None
+            shrunk_head = text.replace("H" * 100, "[REDACTED]", 1)
+            return shrunk_head[:-10] + "[REDACTED:api_key:" + "k" * 100 + "]", None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_s", secret), ("tc_c", cut)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=guard),
+        ):
+            session.send("go")
+
+        _, text = _tool_turn_texts(session)
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+        assert len(text) <= cap
+        assert text.count("chars truncated") == 1
+        assert text.startswith("[REDACTED]H")
+        assert text.endswith("k]")
+
+    def test_small_results_stay_whole_when_siblings_grow_at_an_exhausted_budget(self, session):
+        """Redaction growth of earlier results never costs later small results
+        their verbatim admission: what the drain admitted whole stays whole."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        secret = "PASSWORD=a\n" * 3
+        plain = "p" * 32
+        calls = [
+            {"id": f"tc_{i}", "function": {"name": "read_file", "arguments": "{}"}}
+            for i in range(4)
+        ]
+
+        def guard(_call_id, text, *_args, **_kwargs):
+            return text.replace("PASSWORD=a", "PASSWORD=[REDACTED:secret]"), None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_0", secret), ("tc_1", secret), ("tc_2", plain), ("tc_3", plain)],
+            _remaining_token_budget=MagicMock(return_value=40),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=guard),
+        ):
+            session.send("go")
+
+        texts = _tool_turn_texts(session)
+        assert texts[2] == plain and texts[3] == plain
+        assert all("context budget exhausted" not in t for t in texts)
+        assert "[REDACTED:secret]" in texts[0]
+
+    def test_a_whole_admitted_result_the_guard_lengthened_stays_whole(self, session):
+        """A small result admitted whole through the grace pool and then
+        lengthened by redaction is what the guard produced: it is not cut for
+        having grown."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        session._chars_per_token = 4.0
+        batch_budget_tokens = 210
+        allowance_chars = int(batch_budget_tokens * 4.0)
+        share = session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+        # Enough share-sized siblings to spend the drain's whole allowance, so
+        # the small result arrives at an exhausted budget and passes through
+        # the grace pool; the guard withholds the first sibling, which frees
+        # allowance for the replay.
+        fillers = -(-allowance_chars // share)
+        assert fillers * -(-share // 4) >= batch_budget_tokens
+        small = "k" * 100 + "sk-abc123"
+        calls = [
+            {"id": f"tc_{i}", "function": {"name": "read_file", "arguments": "{}"}}
+            for i in range(fillers + 1)
+        ]
+        results = [(f"tc_{i}", ("a" if i == 0 else "b") * share) for i in range(fillers)]
+        results.append((f"tc_{fillers}", small))
+
+        def guard(_call_id, text, *_args, **_kwargs):
+            if text.startswith("a"):
+                return "[withheld]", None
+            return text.replace("sk-abc123", "[REDACTED:api_key]"), None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            results,
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=guard),
+        ):
+            session.send("go")
+
+        texts = _tool_turn_texts(session)
+        assert texts[0] == "[withheld]"
+        assert texts[1:fillers] == ["b" * share] * (fillers - 1)
+        assert texts[-1] == "k" * 100 + "[REDACTED:api_key]"
+
+    def test_bash_output_result_takes_the_floor_at_an_exhausted_allowance(self, session):
+        """A ``bash_output`` delta was consumed in producing it, so at an
+        exhausted allowance it is cut to the guaranteed floor with its consumed
+        notice rather than replaced by a drop notice that invites a re-read."""
+        delta = "bash_1 (running)\n" + "line\n" * 2000
+        calls = [{"id": "tc_o1", "function": {"name": "bash_output", "arguments": "{}"}}]
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_o1", delta)],
+            _remaining_token_budget=MagicMock(return_value=0),
+            _compact_messages=MagicMock(return_value=False),
+        ):
+            session.send("go")
+
+        (text,) = _tool_turn_texts(session)
+        assert "context budget exhausted" not in text
+        assert len(text) <= _TRUNCATION_FLOOR_CHARS
+        assert text.count("chars truncated") == 1
+        assert _BASH_OUTPUT_CONSUMED_NOTICE in text
+
+    def test_bash_output_read_inside_a_task_agent_is_sized_to_the_agent_cap(self, session):
+        """A task agent's results are clipped to its own cap rather than folded,
+        so a read issued from one is bounded to that cap and leaves the rest
+        unread instead of consuming lines the agent can never see."""
+        session._chars_per_token = 4.0
+        shell = session._background_shells.spawn(
+            "for i in $(seq 1 400); do printf 'line-%03d-%s\\n' $i " + "y" * 50 + "; done"
+        )
+        deadline = time.monotonic() + 15
+        while shell.status == "running" and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert shell.status == "completed"
+
+        token = _active_task_agent_cancel_scope.set(object())  # type: ignore[arg-type]
+        try:
+            with patch.object(session, "_remaining_token_budget", return_value=100_000):
+                _, text = session._exec_bash_output({"call_id": "c1", "shell_id": shell.shell_id})
+        finally:
+            _active_task_agent_cancel_scope.reset(token)
+
+        assert len(text) <= _AGENT_TOOL_OUTPUT_CAP
+        assert "remain unread" in text
+        assert "line-001-" in text and "line-400-" not in text
+
+    def test_recut_never_splices_out_the_middle_the_drain_removed(self, session):
+        """When redaction grows a cut rendering's edges past the producer's own
+        size, the re-cut still counts the middle the drain removed instead of
+        treating the grown edges as the complete source and splicing them."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        session._chars_per_token = 4.0
+        batch_budget_tokens = 1000
+        share = session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+        # Five siblings leave the last result a budget below its share; the
+        # first is withheld by the guard, which frees allowance afterwards.
+        fillers = ["a" * share, *(["b" * share] * 3), "b" * (share // 2)]
+        secret = "PASSWORD=x\n" * 64
+        calls = [
+            {"id": f"tc_{i}", "function": {"name": "read_file", "arguments": "{}"}}
+            for i in range(len(fillers) + 1)
+        ]
+        results = [(f"tc_{i}", text) for i, text in enumerate(fillers)]
+        results.append((f"tc_{len(fillers)}", secret))
+
+        def guard(_call_id, text, *_args, **_kwargs):
+            if text.startswith("a"):
+                return "[withheld]", None
+            return text.replace("PASSWORD=x", "PASSWORD=[REDACTED:secret]" * 3), None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            results,
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=guard),
+        ):
+            session.send("go")
+
+        text = _tool_turn_texts(session)[-1]
+        drain_limit = share // 2
+        assert len(text) <= drain_limit
+        assert text.count("chars truncated") == 1
+        claimed = re.search(r"\[(\d+) chars truncated", text)
+        assert claimed is not None and int(claimed.group(1)) >= len(secret) - drain_limit
+
+    def test_recut_is_skipped_when_the_marker_is_not_unique(self, session):
+        """A rendering whose text no longer locates the drain's marker exactly
+        once (a one-character fallback marker the source also contains) passes
+        as the guard left it rather than being split at the wrong place."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        session.tool_truncation = 60
+        session._manual_tool_truncation = True
+        source = "token=SECRET … " + "x" * 200
+        calls = [{"id": "tc_e", "function": {"name": "read_file", "arguments": "{}"}}]
+
+        def guard(_call_id, text, *_args, **_kwargs):
+            return text.replace("SECRET", "[REDACTED:secret]"), None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_e", source)],
+            _remaining_token_budget=MagicMock(return_value=10_000),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=guard),
+        ):
+            session.send("go")
+
+        (text,) = _tool_turn_texts(session)
+        assert text.startswith("token=[REDACTED:secret] …")
+        assert text.count("…") == 2 and len(text) > 60
+
+    def test_bash_output_read_is_bounded_by_the_running_budget_in_manual_mode(self, session):
+        """An operator cap is uniform, but the fold still applies the running
+        allowance, so the read is bounded by both and never consumes lines the
+        fold would cut away."""
+        session._chars_per_token = 4.0
+        session.tool_truncation = 100_000
+        session._manual_tool_truncation = True
+        shell = session._background_shells.spawn(
+            "for i in $(seq 1 400); do printf 'line-%03d-%s\\n' $i " + "y" * 50 + "; done"
+        )
+        deadline = time.monotonic() + 15
+        while shell.status == "running" and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert shell.status == "completed"
+
+        with patch.object(session, "_remaining_token_budget", return_value=250):
+            _, text = session._exec_bash_output({"call_id": "c1", "shell_id": shell.shell_id})
+
+        assert len(text) <= 1000
+        assert "remain unread" in text
+        assert "line-001-" in text and "line-400-" not in text
+
+    def test_bounded_capture_never_passes_the_small_result_door(self, session):
+        """The zero-budget doors judge a result by its producer's size, so a
+        multi-megabyte capture whose rendering is small is not admitted as a
+        small result and does not spend the grace pool."""
+        buffer = BoundedTextBuffer(1000)
+        buffer.append("x" * 1_000_000)
+        capture = buffer.projected()
+        assert isinstance(capture, ProjectedText) and len(capture) <= 1000
+
+        assert session._allowance_is_exhausted(capture, budget_tokens=0, maximum_chars=2000)
+        assert session._admission_floor(
+            "bash", "tc", capture, exhausted=True, verbatim_pool=4096
+        ) == (0, 4096)
+        dropped = session._truncate_output_result(
+            capture, remaining_budget_tokens=0, exhausted=True
+        )
+        assert "context budget exhausted" in dropped.text
+        assert "1000000-char result" in dropped.text
+
+    def test_bash_output_read_leaves_what_the_fold_could_not_admit_unread(self, session):
+        """A delta larger than the fold's share is read in whole lines up to
+        that share; the rest stays readable instead of being consumed by the
+        cursor and cut away by the fold."""
+        session._chars_per_token = 4.0
+        shell = session._background_shells.spawn(
+            "for i in $(seq 1 400); do printf 'line-%03d-%s\\n' $i " + "y" * 50 + "; done"
+        )
+        deadline = time.monotonic() + 15
+        while shell.status == "running" and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert shell.status == "completed"
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=5000)
+
+        seen: list[str] = []
+        reads = 0
+        with patch.object(session, "_remaining_token_budget", return_value=5000):
+            while reads < 100:
+                reads += 1
+                _, text = session._exec_bash_output(
+                    {"call_id": f"c{reads}", "shell_id": shell.shell_id}
+                )
+                assert len(text) <= cap
+                assert _BASH_OUTPUT_CONSUMED_NOTICE not in text
+                seen.extend(re.findall(r"line-\d{3}-", text))
+                if "remain unread" not in text:
+                    break
+
+        assert 1 < reads < 100
+        assert seen == [f"line-{i:03d}-" for i in range(1, 401)]
+
+    def test_true_size_survives_redaction_of_a_bounded_capture(self, session):
+        """Redaction turns the rendering into a plain string; the replayed cut
+        must still report omission against the producer's true size."""
+        session._judge_config = JudgeConfig(output_guard=True, output_guard_llm=False)
+        buffer = BoundedTextBuffer(300)
+        buffer.append("PASSWORD=x\n" * 1000)
+        capture = buffer.projected()
+        assert isinstance(capture, ProjectedText)
+        calls = [{"id": "tc_b1", "function": {"name": "bash", "arguments": "{}"}}]
+        batch_budget_tokens = 200
+
+        def expanding_guard(_call_id, text, *_args, **_kwargs):
+            return text.replace("PASSWORD=x", "PASSWORD=[REDACTED:secret]"), None
+
+        with _send_with_tool_batch(
+            session,
+            calls,
+            [("tc_b1", capture)],
+            _remaining_token_budget=MagicMock(return_value=batch_budget_tokens),
+            _compact_messages=MagicMock(return_value=False),
+            _evaluate_output=MagicMock(side_effect=expanding_guard),
+        ):
+            session.send("go")
+
+        (text,) = _tool_turn_texts(session)
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=batch_budget_tokens)
+        assert len(text) <= cap
+        match = re.search(r"\[(\d+) chars truncated", text)
+        assert match is not None
+        assert int(match.group(1)) >= 11_000 - cap
+
+    def test_repeat_warning_on_a_plain_result_never_copies_the_whole_result(self, session):
+        """A plain result larger than the executor edges is projected to
+        bounded edges before the warning is appended, and the fold still
+        renders it with its true size."""
+        retention = session._executor_capture_chars()
+        big = "x" * (3 * retention)
+
+        warned = session._bounded_result(big) + _REPEAT_WARNING
+
+        assert isinstance(warned, ProjectedText)
+        assert len(warned) <= retention + len(_REPEAT_WARNING)
+        assert warned.source.original_chars == len(big) + len(_REPEAT_WARNING)
+        assert len(warned.source.prefix) == retention
+        assert session._bounded_result("short") == "short"
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=4000)
+        result = session._truncate_output_result(warned, maximum_chars=cap)
+        assert result.original_chars == len(big) + len(_REPEAT_WARNING)
+        assert "identical repeat" in result.text
+
+    def test_true_size_survives_the_repeat_warning(self, session):
+        """The repeat-call warning is appended without discarding the source."""
+        buffer = BoundedTextBuffer(300)
+        buffer.append("PASSWORD=x\n" * 1000)
+        warned = buffer.projected() + _REPEAT_WARNING
+
+        assert isinstance(warned, ProjectedText)
+        assert "identical repeat" in warned
+        cap = session._tool_result_truncation_limit(batch_budget_tokens=4000)
+        result = session._truncate_output_result(warned, maximum_chars=cap)
+        assert len(result.text) <= cap
+        assert result.original_chars == warned.source.original_chars
+        assert result.original_chars > 11_000
+        assert "identical repeat" in result.text
+        assert f"[{result.omitted_chars} chars truncated" in result.text
+
+
 _SPAWN_CALL = [
     {
         "id": "tc_spawn",
@@ -365,6 +971,27 @@ class TestZeroBudgetDrain:
         with _send_with_tool_batch(
             session,
             _SPAWN_CALL,
+            [("tc_spawn", _SPAWN_RESULT)],
+            _remaining_token_budget=MagicMock(return_value=0),
+            _compact_messages=MagicMock(return_value=False),
+        ):
+            session.send("go")
+
+        tool_texts = _tool_turn_texts(session)
+        assert any("ws-8f3a" in t for t in tool_texts)
+        assert not any("dropped" in t for t in tool_texts)
+
+    def test_padded_structural_name_keeps_its_floor(self, session):
+        """A whitespace-padded structural tool name must still be floored."""
+        padded = [
+            {
+                "id": "tc_spawn",
+                "function": {"name": " spawn_workstream ", "arguments": '{"name": "child"}'},
+            }
+        ]
+        with _send_with_tool_batch(
+            session,
+            padded,
             [("tc_spawn", _SPAWN_RESULT)],
             _remaining_token_budget=MagicMock(return_value=0),
             _compact_messages=MagicMock(return_value=False),
@@ -732,3 +1359,40 @@ class TestZeroBudgetDrain:
         assert any("ws-b1" in t and "ws-b2" in t for t in texts)
         assert any('"complete":true' in t for t in texts)
         assert not any("dropped" in t for t in texts)
+
+
+def test_tool_truncation_caps_never_exceed_what_retained_edges_can_render(session):
+    """Every cap is bounded by the settings maximum and by the session cap, and
+    the streaming executors retain half the session cap at each edge, so a
+    saturated capture renders any cap the fold applies without clamping."""
+    from turnstone.core.session import _auto_tool_truncation_chars
+    from turnstone.core.settings_registry import TOOL_TRUNCATION_MAX_CHARS
+    from turnstone.core.truncation import TextProjectionSource
+
+    for cap in (999, 1000, TOOL_TRUNCATION_MAX_CHARS):
+        session.tool_truncation = cap
+        assert 2 * session._executor_capture_chars() >= cap
+    assert _auto_tool_truncation_chars(1_000_000_000, 4.0) == TOOL_TRUNCATION_MAX_CHARS
+    assert _auto_tool_truncation_chars(10_000, 4.0) == 8_000
+    retention = 500
+    saturated = TextProjectionSource("a" * retention, "b" * retention, 50 * retention)
+    rendered = saturated.render(2 * retention)
+    assert rendered.limit_chars == 2 * retention
+    assert len(rendered.text) == 2 * retention
+
+
+def test_manual_tool_truncation_is_clamped_to_the_maximum(tmp_db, mock_openai_client):
+    from turnstone.core.settings_registry import TOOL_TRUNCATION_MAX_CHARS
+
+    session = ChatSession(
+        client=mock_openai_client,
+        model="test-model",
+        ui=MagicMock(),
+        instructions=None,
+        temperature=0.5,
+        tool_timeout=10,
+        context_window=10_000,
+        max_tokens=1_000,
+        tool_truncation=10 * TOOL_TRUNCATION_MAX_CHARS,
+    )
+    assert session.tool_truncation == TOOL_TRUNCATION_MAX_CHARS

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,318 @@
+"""Shared exact-cap truncation and bounded-capture regressions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from turnstone.core.truncation import (
+    BoundedTextBuffer,
+    ProjectedText,
+    TextProjectionSource,
+    join_projection_sources,
+    truncate_text,
+)
+
+
+@pytest.mark.parametrize("limit", range(0, 96))
+@pytest.mark.parametrize("mode", ["head", "head_tail"])
+def test_truncate_text_never_exceeds_exact_cap(
+    limit: int,
+    mode: Literal["head", "head_tail"],
+) -> None:
+    source = "A" * 137 + "Z" * 137
+    result = truncate_text(source, limit, mode=mode)
+
+    assert len(result.text) <= limit
+    assert result.original_chars == len(source)
+    assert result.retained_chars + result.omitted_chars == len(source)
+    assert result.truncated is True
+
+
+def test_one_character_limit_cannot_fail_open_via_negative_zero_slice() -> None:
+    result = truncate_text("secret output", 1)
+
+    assert result.text == "…"
+    assert result.retained_chars == 0
+    assert result.omitted_chars == len("secret output")
+
+
+def test_small_cap_preserves_source_around_compact_marker() -> None:
+    result = truncate_text("abcdefghij", 4)
+
+    assert result.text == "ab…j"
+    assert result.retained_chars == 3
+    assert result.omitted_chars == 7
+
+
+def test_marker_omitted_count_matches_retained_source() -> None:
+    result = truncate_text("A" * 500 + "Z" * 500, 120)
+
+    assert len(result.text) <= 120
+    assert f"[{result.omitted_chars} chars truncated" in result.text
+    assert result.text.startswith("A")
+    assert result.text.endswith("Z")
+
+
+def test_bounded_buffer_matches_in_memory_projection() -> None:
+    source = "".join(f"line-{i:05d}\n" for i in range(50_000))
+    buffer = BoundedTextBuffer(4096)
+    for start in range(0, len(source), 997):
+        buffer.append(source[start : start + 997])
+
+    buffered = buffer.render(2048)
+    direct = truncate_text(source, 2048)
+
+    assert buffered == direct
+    assert buffer.source().original_chars == len(source)
+
+
+def test_bounded_buffer_renders_a_larger_projection_from_its_edges() -> None:
+    buffer = BoundedTextBuffer(10)
+    buffer.append("x" * 100)
+
+    result = buffer.render(30)
+
+    assert result.text == "x" * 10 + "…" + "x" * 10
+    assert result.limit_chars == 30
+    assert result.omitted_chars == 80
+
+
+def test_bounded_buffer_coalesces_many_tiny_fragments() -> None:
+    source = "x\n" * 100_000
+    buffer = BoundedTextBuffer(8192)
+    for char in source:
+        buffer.append(char)
+
+    assert buffer.render(4096) == truncate_text(source, 4096)
+    # Object overhead is bounded by compaction rather than proportional to
+    # the producer's fragment count.
+    assert buffer._tail.tell() < 2 * 8192  # noqa: SLF001 - white-box memory regression
+
+
+def test_projection_survives_concatenation() -> None:
+    buf = BoundedTextBuffer(20)
+    buf.append("a" * 30 + "b" * 30)
+    projected = buf.projected()
+    assert isinstance(projected, ProjectedText)
+
+    wrapped = "[pre]" + projected + "[post]"
+
+    assert isinstance(wrapped, ProjectedText)
+    assert wrapped.startswith("[pre]") and wrapped.endswith("[post]")
+    assert wrapped.source.original_chars == 60 + len("[pre]") + len("[post]")
+    result = truncate_text(wrapped, 30)
+    assert result.original_chars == wrapped.source.original_chars
+    assert result.retained_chars + result.omitted_chars == result.original_chars
+    assert result.text.startswith("[pre]") and result.text.endswith("[post]")
+
+
+def test_asymmetric_edges_never_overdraw_one_side() -> None:
+    buf = BoundedTextBuffer(300)
+    buf.append("x" * 11_000)
+    wrapped = buf.projected() + "!" * 110
+
+    result = truncate_text(wrapped, 3_200)
+
+    assert len(result.text) <= 3_200
+    assert result.text.endswith("!" * 110)
+    assert result.original_chars == 11_110
+
+
+def test_known_original_size_survives_a_transformed_rendering() -> None:
+    cut = truncate_text("x" * 400, 200, original_chars=5_000)
+    assert len(cut.text) <= 200
+    assert cut.original_chars == 5_000
+    assert cut.retained_chars + cut.omitted_chars == 5_000
+    assert f"[{cut.omitted_chars} chars truncated" in cut.text
+
+    kept = truncate_text("x" * 30, 40, original_chars=5_000)
+    assert kept.text == "x" * 30
+    assert kept.original_chars == 5_000
+
+
+def test_bounded_buffer_keeps_a_single_copy_until_the_prefix_fills() -> None:
+    """An output that never exceeds the retention is held once: the prefix is
+    the whole output and serves as both edges, and a render at any limit still
+    matches the in-memory projection."""
+    buffer = BoundedTextBuffer(100)
+    for start in range(0, 60, 7):
+        buffer.append(("abcdefghij" * 6)[start : start + 7])
+    source = buffer.source()
+
+    assert source.prefix is source.suffix
+    assert source.original_chars == 60
+    assert buffer.render(100).text == "abcdefghij" * 6
+    assert buffer.render(30) == truncate_text("abcdefghij" * 6, 30)
+
+
+@pytest.mark.parametrize("piece", [1, 5, 20, 100, 101, 250])
+def test_bounded_buffer_edges_survive_an_exact_prefix_fill(piece: int) -> None:
+    """The suffix edge starts tracking the moment the prefix fills, including
+    when one append fills it exactly; the next append must not become the
+    whole suffix."""
+    text = "".join(chr(97 + i % 26) for i in range(230))
+    buffer = BoundedTextBuffer(100)
+    for start in range(0, len(text), piece):
+        buffer.append(text[start : start + piece])
+    source = buffer.source()
+
+    assert source.prefix == text[:100]
+    assert source.suffix == text[-100:]
+    assert source.original_chars == 230
+    assert buffer.render(80) == TextProjectionSource(text[:100], text[-100:], 230).render(80)
+
+
+@pytest.mark.parametrize(
+    ("first_len", "second_len", "separator"),
+    [(0, 50, "\n"), (50, 0, "\n"), (3, 120, "\n"), (120, 3, ""), (700, 700, "|"), (40, 40, "\n")],
+)
+def test_joined_sources_render_like_the_concatenated_document(
+    first_len: int, second_len: int, separator: str
+) -> None:
+    """Two bounded captures joined as edges render exactly as one in-memory
+    capture of ``first + separator + second`` would, at every limit."""
+    first = "".join(chr(97 + i % 26) for i in range(first_len))
+    second = "".join(chr(65 + i % 26) for i in range(second_len))
+    retention = 100
+    first_buffer, second_buffer = BoundedTextBuffer(retention), BoundedTextBuffer(retention)
+    first_buffer.append(first)
+    second_buffer.append(second)
+    document = first + separator + second
+    reference = TextProjectionSource(document[:retention], document[-retention:], len(document))
+
+    joined = join_projection_sources(
+        first_buffer.source(),
+        second_buffer.source(),
+        separator=separator,
+        retention_chars=retention,
+    )
+
+    assert joined.original_chars == len(document)
+    for limit in (0, 1, 50, 100, 200, len(document) + 5):
+        assert joined.render(limit) == reference.render(limit)
+
+
+def test_projected_text_copies_keep_their_source() -> None:
+    import copy
+    import pickle
+
+    projected = ProjectedText("abc…xyz", TextProjectionSource("abc", "xyz", 100))
+
+    # pickle round-trips an object this test built itself; no untrusted bytes.
+    clones = (copy.copy(projected), copy.deepcopy(projected), pickle.loads(pickle.dumps(projected)))
+    for clone in clones:
+        assert type(clone) is ProjectedText
+        assert clone == projected
+        assert clone.source == projected.source
+
+
+def test_result_marker_is_the_embedded_cut() -> None:
+    result = truncate_text("A" * 500 + "Z" * 500, 120)
+
+    head, marker, tail = result.text.partition(result.marker)
+    assert marker == result.marker
+    assert head == "A" * len(head) and tail == "Z" * len(tail)
+    assert len(head) + len(tail) == result.retained_chars
+    assert truncate_text("short", 120).marker == ""
+
+
+def test_short_edges_hand_their_leftover_to_the_other_edge() -> None:
+    result = TextProjectionSource("P" * 380, "S" * 580, 5000).render(1000)
+
+    assert len(result.text) == 1000
+    assert result.text.count("P") == 380
+    assert result.limit_chars == 1000
+    assert result.retained_chars + result.omitted_chars == 5000
+
+
+def test_edges_that_cannot_cover_a_small_source_still_mark_omission() -> None:
+    result = TextProjectionSource("P" * 7, "S" * 9, 63).render(200)
+
+    assert result.truncated
+    assert result.marker and result.marker in result.text
+    assert result.retained_chars == 16 and result.omitted_chars == 47
+
+
+def test_tail_only_projection_with_an_empty_prefix_renders() -> None:
+    result = TextProjectionSource("", "Y" * 6, 10).render(5, head_fraction=0.0)
+
+    assert len(result.text) <= 5
+    assert result.text.endswith("Y")
+    assert result.truncated
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_bounded_buffer_matches_a_reference_over_random_feeds(seed: int) -> None:
+    import random
+
+    rng = random.Random(seed)
+    for _ in range(150):
+        retention = rng.randint(0, 40)
+        buffer = BoundedTextBuffer(retention)
+        fed = ""
+        for _ in range(rng.randint(0, 12)):
+            size = rng.choice([0, 1, 3, 11, 41, 130])
+            chunk = "".join(rng.choice("abcdefgh") for _ in range(size))
+            buffer.append(chunk)
+            fed += chunk
+            source = buffer.source()
+            assert source.original_chars == len(fed)
+            if len(fed) <= retention:
+                assert source.prefix == fed and source.suffix == fed
+            else:
+                assert source.prefix == fed[:retention]
+                assert source.suffix == (fed[-retention:] if retention else "")
+
+
+def test_default_marker_says_retained_when_the_limit_was_not_exceeded() -> None:
+    """A limit the output would have fit under was not exceeded: the cut came
+    from a producer that retained less than the whole, and the marker says so
+    instead of blaming the limit."""
+    result = TextProjectionSource("a" * 500, "b" * 500, 1515).render(2048)
+
+    assert result.truncated
+    assert "exceeded" not in result.text
+    assert (
+        f"[{result.omitted_chars} chars truncated — {result.retained_chars} of 1515 chars retained]"
+    ) in result.text
+    assert truncate_text("x" * 3000, 1000).text.count("exceeded 1000 char limit") == 1
+
+
+def test_oversized_chunk_becomes_the_newest_edge_without_a_full_copy() -> None:
+    """A chunk larger than the retention is kept by its last retention alone,
+    so buffering never holds a copy proportional to the producer's chunk."""
+    buffer = BoundedTextBuffer(100)
+    buffer.append("p" * 10)
+    buffer.append("x" * 1_000_000)
+
+    assert buffer._tail.tell() <= 100  # noqa: SLF001 - white-box memory regression
+    source = buffer.source()
+    assert source.prefix == "p" * 10 + "x" * 90
+    assert source.suffix == "x" * 100
+    assert source.original_chars == 1_000_010
+
+
+def test_oversized_chunk_never_costs_a_transient_copy_of_itself() -> None:
+    """Whether the prefix is still filling or already frozen, appending a
+    chunk far larger than the retention allocates on the order of the
+    retention, never of the chunk."""
+    import tracemalloc
+
+    chunk = "x" * 8_000_000
+    buffer = BoundedTextBuffer(100)
+    buffer.append("p" * 10)
+    tracemalloc.start()
+    try:
+        buffer.append(chunk)
+        buffer.append(chunk)
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert peak < 100_000
+    source = buffer.source()
+    assert source.prefix == "p" * 10 + "x" * 90
+    assert source.suffix == "x" * 100
+    assert source.original_chars == 16_000_010

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -98,6 +98,46 @@ class TestValidateCondition:
 
 
 # ---------------------------------------------------------------------------
+# output cap
+# ---------------------------------------------------------------------------
+
+
+def test_capped_output_compares_equal_when_only_the_omitted_tail_grew():
+    """The default stop condition compares consecutive polls.  A growing log
+    whose first 64K is unchanged must still read as unchanged, so the cap's
+    marker cannot carry a count that differs from poll to poll."""
+    from turnstone.core.watch import (
+        _WATCH_TRUNCATION_MARKER,
+        MAX_OUTPUT_SIZE,
+        _bound_watch_output,
+    )
+
+    head = "L" * (MAX_OUTPUT_SIZE + 100)
+    first = _bound_watch_output(head + "x" * 100)
+    second = _bound_watch_output(head + "x" * 250)
+
+    assert first == second
+    assert first == head[:MAX_OUTPUT_SIZE] + _WATCH_TRUNCATION_MARKER
+    assert _bound_watch_output(head[:MAX_OUTPUT_SIZE]) == head[:MAX_OUTPUT_SIZE]
+    # Any overflow, including one smaller than the marker, takes the capped
+    # shape rather than passing whole.
+    for over in (1, len(_WATCH_TRUNCATION_MARKER)):
+        assert (
+            _bound_watch_output(head[: MAX_OUTPUT_SIZE + over])
+            == head[:MAX_OUTPUT_SIZE] + _WATCH_TRUNCATION_MARKER
+        )
+    # Polls compare by the head at the cap, so a previous poll persisted by an
+    # earlier release with a differently worded marker still compares equal.
+    legacy = head[:MAX_OUTPUT_SIZE] + f"\n[truncated at {MAX_OUTPUT_SIZE} bytes]"
+    fired, _ = evaluate_condition(None, first, 0, legacy)
+    assert not fired
+    fired, _ = evaluate_condition(None, first, 0, "L" * 10 + "x")
+    assert fired
+    fired, _ = evaluate_condition(None, second, 0, first)
+    assert not fired
+
+
+# ---------------------------------------------------------------------------
 # evaluate_condition
 # ---------------------------------------------------------------------------
 

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -11,6 +11,7 @@ from turnstone.core.web_search import (
     MCPSearchClient,
     SearXNGClient,
     _format_searxng,
+    _format_snippet,
     resolve_web_search_client,
 )
 
@@ -109,6 +110,13 @@ class TestFormatSearXNG:
         out = _format_searxng(data, "q")
         assert "No results for 'q'" in out
         assert "duckduckgo" in out and "google" in out
+
+    def test_long_snippet_has_honest_exact_cap(self):
+        snippet = _format_snippet("x" * 700)
+
+        assert len(snippet) <= 500
+        assert snippet.startswith("x")
+        assert "snippet chars omitted" in snippet
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -1130,7 +1130,10 @@ def main() -> None:
         "--tool-truncation",
         type=int,
         default=0,
-        help="Tool output truncation limit in chars, 0 for auto (50%% of context window) (default: 0)",
+        help=(
+            "Tool output truncation limit in chars, 0 for auto "
+            "(20%% of the remaining input budget per result) (default: 0)"
+        ),
     )
     parser.add_argument(
         "--tool-search",

--- a/turnstone/console/coordinator_client.py
+++ b/turnstone/console/coordinator_client.py
@@ -2208,10 +2208,10 @@ def _serialize_messages(
 # learns which tier it got via the ``_tier`` field in the response
 # (no API change to the coordinator tool).
 #
-# Budget chosen well under ``tool_truncation`` (typically 256 KB+) so
-# the head+tail safety net never fires for inspect_workstream — that
-# strategy silently drops middle messages, which is exactly the
-# pathology this formatter exists to avoid.
+# The executor passes the smaller of this budget and the cap the result
+# fold will apply, so the head+tail safety net never fires for a tier
+# that fit — that strategy silently drops middle messages, which is
+# exactly the pathology this formatter exists to avoid.
 
 _INSPECT_OUTPUT_BUDGET: int = 32_768
 # Per-message head/tail snip when Tier 2 needs to compress content.

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -9825,7 +9825,7 @@ async def admin_list_settings(request: Request) -> JSONResponse:
         row = stored.get(key)
         if row:
             try:
-                val = deserialize_value(key, row["value"])
+                val = deserialize_value(key, row["value"], clamp_range=True)
             except (ValueError, KeyError):
                 val = row["value"]
             info = {
@@ -14589,7 +14589,7 @@ async def admin_list_judge_settings(request: Request) -> JSONResponse:
         row = stored.get(key)
         if row:
             try:
-                val = deserialize_value(key, row["value"])
+                val = deserialize_value(key, row["value"], clamp_range=True)
             except (ValueError, KeyError):
                 val = row["value"]
             entry = {

--- a/turnstone/core/_pdf_worker.py
+++ b/turnstone/core/_pdf_worker.py
@@ -31,13 +31,15 @@ MAX_SOURCE_BYTES = 32 * 1024 * 1024
 MAX_TEXT_PAGES = 100
 # Keep the character ceiling derived from the fixed output-byte envelope rather
 # than from today's model context sizes. UTF-8 needs at most four bytes per
-# Unicode scalar; leave room for the truncation marker.
-_TEXT_OUTPUT_MARKER_RESERVE_BYTES = 1024
-MAX_TEXT_CHARS = (MAX_FILE_BYTES - _TEXT_OUTPUT_MARKER_RESERVE_BYTES) // 4
+# Unicode scalar; leave room for the size header.
+_TEXT_OUTPUT_HEADER_RESERVE_BYTES = 1024
+MAX_TEXT_CHARS = (MAX_FILE_BYTES - _TEXT_OUTPUT_HEADER_RESERVE_BYTES) // 4
 
 _TEXT_CHUNK_CHARS = 64 * 1024
 _WHITESPACE_RUN = re.compile(r"\s+|\S+")
-_RASTER_LENGTH = struct.Struct("!I")
+RASTER_LENGTH = struct.Struct("!I")
+# Text output: the true character count, then the bounded UTF-8 prefix.
+TEXT_LENGTH = struct.Struct("!Q")
 _RESOURCE_LIMIT_ERRNOS = frozenset(
     getattr(errno, name) for name in ("EFBIG", "ENOMEM", "ENOSPC", "EDQUOT") if hasattr(errno, name)
 )
@@ -181,10 +183,9 @@ def _extract_text(input_path: Path, output_path: Path, max_chars: int) -> None:
             total_len += len(marker)
             prefix_len = _append_prefix(prefix, prefix_len, marker, max_chars)
 
-        text = prefix.getvalue()
-        if total_len > max_chars:
-            text += f"\n\n... [{total_len - max_chars} chars truncated] ...\n"
-        encoded = text.encode("utf-8")
+        # The worker reports the true size and hands over the bounded prefix;
+        # the parent renders the omission marker with the shared primitive.
+        encoded = TEXT_LENGTH.pack(total_len) + prefix.getvalue().encode("utf-8")
         if len(encoded) > MAX_FILE_BYTES:
             raise _ResourceLimitError("text output exceeds byte cap")
         output_path.write_bytes(encoded)
@@ -195,19 +196,19 @@ def _extract_text(input_path: Path, output_path: Path, max_chars: int) -> None:
 
 
 def _write_raster_page(output: BinaryIO, png: bytes, written: int) -> int:
-    next_written = written + _RASTER_LENGTH.size + len(png)
+    next_written = written + RASTER_LENGTH.size + len(png)
     if next_written > MAX_FILE_BYTES:
         raise _ResourceLimitError("raster output exceeds byte cap")
-    output.write(_RASTER_LENGTH.pack(len(png)))
+    output.write(RASTER_LENGTH.pack(len(png)))
     output.write(png)
     return next_written
 
 
 def _write_raster_truncation(output: BinaryIO, written: int) -> None:
     """Write the terminal zero-length frame denoting omitted source pages."""
-    if written + _RASTER_LENGTH.size > MAX_FILE_BYTES:
+    if written + RASTER_LENGTH.size > MAX_FILE_BYTES:
         raise _ResourceLimitError("raster output exceeds byte cap")
-    output.write(_RASTER_LENGTH.pack(0))
+    output.write(RASTER_LENGTH.pack(0))
 
 
 def _rasterize(

--- a/turnstone/core/background_shells.py
+++ b/turnstone/core/background_shells.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from turnstone.core.log import get_logger
+from turnstone.core.truncation import BoundedTextBuffer
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -57,8 +58,9 @@ ShellStatus = Literal["running", "completed", "killed"]
 # Live (status == "running") shells per session.  A hard backstop against a
 # runaway loop of spawns on a multi-tenant node, not an operator knob.
 _DEFAULT_MAX_SHELLS = 8
-# Rolling per-shell buffer cap, in characters.  Oldest whole lines drop
-# first; the newest line always survives even if it alone exceeds the cap.
+# Rolling per-shell buffer cap, in characters.  The pipe drain bounds each
+# logical line to this size before insertion; oldest whole lines then drop
+# first, while the newest bounded line always survives.
 _DEFAULT_MAX_BUFFER_CHARS = 200_000
 # How long to wait for the drain threads after the group kill forces their
 # pipes to EOF.  A grandchild that double-``setsid``-escaped the group can
@@ -90,6 +92,16 @@ _MAX_EXITED_RECORDS = 32
 _MAX_FILTER_PATTERN_CHARS = 512
 _FILTER_MAX_LINE_CHARS = 4096
 _FILTER_TIMEOUT_S = 2.0
+# A filtered, bounded read hands the helper at most this many times the
+# characters it can return, so one call pays for one bounded pass and still
+# advances the cursor at least that far; the rest of the delta stays unread.
+_FILTER_SCAN_MULTIPLE = 8
+# A producer can emit an arbitrarily long line.  Iterating a text pipe by line
+# asks ``TextIOWrapper`` to allocate that whole line before the callback sees
+# it, defeating every downstream buffer cap.  Bounded ``readline`` chunks keep
+# the parent allocation finite while preserving ordinary newline-delimited
+# output exactly.
+_DRAIN_CHUNK_CHARS = 64 * 1024
 
 # Runs inside ``sys.executable -c``: reads {pattern, lines} as JSON on
 # stdin (lines already truncated parent-side), writes the MATCHING INDEXES
@@ -119,8 +131,11 @@ class FilterExecError(RuntimeError):
     """The filter helper process failed for a non-pattern reason."""
 
 
-def _filter_lines_bounded(pattern: re.Pattern[str], lines: list[str], shell_id: str) -> list[str]:
-    """Apply ``pattern`` per line with a wall-clock bound.
+def _filter_line_indexes_bounded(
+    pattern: re.Pattern[str], lines: list[str], shell_id: str
+) -> list[int]:
+    """Apply ``pattern`` per line with a wall-clock bound; return the indexes
+    of the matching lines, in order.
 
     A catastrophic-backtracking pattern would wedge the (auto-approved)
     tool call — the exact never-returns class #816 removed — and it cannot
@@ -221,11 +236,11 @@ def _filter_lines_bounded(pattern: re.Pattern[str], lines: list[str], shell_id: 
             "the filter could not be applied (helper returned malformed data); "
             "no output was consumed — retry, or read without a filter"
         ) from None
-    return [lines[i] for i in indexes if isinstance(i, int) and 0 <= i < len(lines)]
+    return [i for i in indexes if isinstance(i, int) and 0 <= i < len(lines)]
 
 
 def drain_pipe_lines(pipe: Any, on_line: Callable[[str], None]) -> None:
-    """Read ``pipe`` line-by-line until EOF, forwarding each to ``on_line``.
+    """Read ``pipe`` in newline-aware bounded chunks, forwarding each chunk.
 
     The drain half of the shared bash recipe (see :func:`spawn_group_leader`
     for the spawn half): both variants of the tool tolerate the same two
@@ -236,10 +251,64 @@ def drain_pipe_lines(pipe: Any, on_line: Callable[[str], None]) -> None:
     remaining output while reporting a clean success.)
     """
     try:
-        for line in pipe:
-            on_line(line)
+        while chunk := pipe.readline(_DRAIN_CHUNK_CHARS):
+            on_line(chunk)
     except (ValueError, OSError):
         log.debug("bash.drain_read_error", exc_info=True)
+
+
+def _line_omission_marker(omitted: int, _original: int, limit: int) -> str:
+    """The marker inside one bounded shell-line record.  It carries no newline,
+    so the record stays a single line for the cursor, the filter, and the
+    ``[stderr]`` prefix."""
+
+    return f" ... [{omitted} chars truncated — line exceeded {limit} char limit] ... "
+
+
+def drain_pipe_logical_lines(
+    pipe: Any,
+    on_line: Callable[[str], None],
+    *,
+    max_line_chars: int,
+) -> None:
+    """Drain bounded chunks while forwarding one bounded record per line.
+
+    ``TextIOWrapper.readline(size)`` returns continuation fragments when one
+    physical line exceeds ``size``.  Background-shell cursors and filters are
+    defined over logical lines, so those fragments must not independently
+    advance the cursor or receive fresh filter windows.  Reassembly itself is
+    bounded: an arbitrarily long newline-free producer is consumed in
+    :data:`_DRAIN_CHUNK_CHARS` pieces while :class:`BoundedTextBuffer` retains
+    only enough head/tail evidence to render ``max_line_chars`` characters and
+    an explicit omission marker, one without a newline so the record is still
+    one line.  A final line without its newline (EOF, or a read error
+    mid-line) is still delivered as one bounded record.
+
+    Foreground bash uses :func:`drain_pipe_lines` for both of its pipes: its
+    capture is bounded as a whole rather than per line, so the result fold
+    stays its single cut.
+    """
+
+    line_buffer: BoundedTextBuffer | None = None
+
+    def on_chunk(chunk: str) -> None:
+        nonlocal line_buffer
+        if line_buffer is None:
+            if chunk.endswith("\n") and len(chunk) <= max_line_chars:
+                # The common case: one chunk is one whole line within the
+                # bound.  Forward it as is; the bounded reassembly below is
+                # for lines that span chunks or exceed the bound.
+                on_line(chunk)
+                return
+            line_buffer = BoundedTextBuffer(max_line_chars)
+        line_buffer.append(chunk)
+        if chunk.endswith("\n"):
+            on_line(line_buffer.render(marker_factory=_line_omission_marker).text)
+            line_buffer = None
+
+    drain_pipe_lines(pipe, on_chunk)
+    if line_buffer is not None:
+        on_line(line_buffer.render(marker_factory=_line_omission_marker).text)
 
 
 def spawn_group_leader(
@@ -291,10 +360,13 @@ class ShellRead:
     """One delta read: lines since the previous read, plus shell state.
 
     ``lines`` is post-filter (what the caller shows); ``new_line_count`` is
-    the pre-filter delta size — the cursor advanced past all of them, so a
-    filtered-out line is consumed, never deferred to a later read.
-    ``dropped_lines`` counts lines lost to the buffer cap before they were
-    ever read (an explicit gap, not silence).
+    the pre-filter count of lines this read consumed — the cursor advanced
+    past all of them, so a filtered-out line is consumed, never deferred to
+    a later read.  A read bounded by ``max_chars`` consumes whole lines up
+    to the bound, scans a bounded span of the delta when filtering, and
+    leaves ``unread_lines`` for the next call.  ``dropped_lines`` counts
+    lines lost to the buffer cap before they were ever read (an explicit gap,
+    not silence).
     """
 
     shell_id: str
@@ -308,6 +380,7 @@ class ShellRead:
     # reads; the caller surfaces it so a "none matching" answer over
     # clipped evidence is never silent.
     clipped_lines: int = 0
+    unread_lines: int = 0
 
 
 class BackgroundShell:
@@ -378,7 +451,10 @@ class BackgroundShell:
             self._buffered_chars += len(line)
             self._total_lines += 1
             # Drop oldest whole lines past the cap, but always keep the
-            # newest — a single oversized line must not empty the buffer.
+            # newest.  Production drains bound one logical line to half the
+            # cap before this point, so a bounded record survives its
+            # neighbours; keeping the defensive len > 1 rule also makes direct
+            # callers degrade to one oversized record instead of no evidence.
             while self._buffered_chars > self._max_buffer_chars and len(self._buffer) > 1:
                 dropped = self._buffer.popleft()
                 self._buffered_chars -= len(dropped)
@@ -564,8 +640,13 @@ class BackgroundShellRegistry:
 
     @staticmethod
     def _drain(pipe: Any, shell: BackgroundShell, is_stderr: bool) -> None:
-        drain_pipe_lines(
-            pipe, lambda line: shell._append(f"[stderr] {line}" if is_stderr else line)
+        # One logical line is bounded to half the buffer, so the record of an
+        # over-long line neither evicts every unread line before it nor is
+        # evicted by the line after it.
+        drain_pipe_logical_lines(
+            pipe,
+            lambda line: shell._append(f"[stderr] {line}" if is_stderr else line),
+            max_line_chars=max(1, shell._max_buffer_chars // 2),
         )
 
     def _wait_for_exit(
@@ -657,7 +738,12 @@ class BackgroundShellRegistry:
             return [s for s in self._shells.values() if s.owner == owner]
 
     def read(
-        self, shell_id: str, *, owner: str | None = None, filter_pattern: str | None = None
+        self,
+        shell_id: str,
+        *,
+        owner: str | None = None,
+        filter_pattern: str | None = None,
+        max_chars: int | None = None,
     ) -> ShellRead:
         """Return output produced since the last read of ``shell_id``.
 
@@ -669,6 +755,14 @@ class BackgroundShellRegistry:
         :class:`UnknownShellError` outside the caller's scope, ``re.error``
         for a bad pattern, and :class:`FilterTimeoutError` for a pattern
         that blows the time bound (catastrophic backtracking).
+
+        ``max_chars`` bounds what is returned in whole lines (always at
+        least one) and then bounds what is consumed too: the cursor advances
+        only past the last returned line, so the rest of the delta stays
+        readable by the next call instead of being cut away by a consumer's
+        cap.  A filtered read scans a bounded span of the delta, at most
+        :data:`_FILTER_SCAN_MULTIPLE` times the bound, so each call is bounded
+        and still advances the cursor.
         """
         shell = self._get(shell_id, owner)
         pattern: re.Pattern[str] | None = None
@@ -684,23 +778,45 @@ class BackgroundShellRegistry:
         # each return the full delta as "new".
         with shell.read_serial:
             delta, gap, new_cursor, status, exit_code = shell._snapshot_delta()
-            clipped = 0
+            span = len(delta)
             if pattern is None:
-                shown = delta
+                candidates = list(range(span))
             else:
+                if max_chars is not None:
+                    scanned = 0
+                    for index, line in enumerate(delta):
+                        scanned += len(line)
+                        if index and scanned > _FILTER_SCAN_MULTIPLE * max_chars:
+                            span = index
+                            break
                 # Raises FilterTimeoutError / FilterExecError BEFORE the
                 # commit below — a failed filter consumes nothing.
-                shown = _filter_lines_bounded(pattern, delta, shell.shell_id)
-                clipped = sum(1 for ln in delta if len(ln) > _FILTER_MAX_LINE_CHARS)
-            shell._commit_cursor(new_cursor)
+                candidates = _filter_line_indexes_bounded(pattern, delta[:span], shell.shell_id)
+            consumed = span
+            shown: list[str] = []
+            shown_chars = 0
+            for index in candidates:
+                line = delta[index]
+                if max_chars is not None and shown and shown_chars + len(line) > max_chars:
+                    # The bound is met in whole lines: this line and the rest
+                    # of the delta stay unread for the next call.
+                    consumed = index
+                    break
+                shown.append(line)
+                shown_chars += len(line)
+            clipped = 0
+            if pattern is not None:
+                clipped = sum(1 for ln in delta[:consumed] if len(ln) > _FILTER_MAX_LINE_CHARS)
+            shell._commit_cursor(new_cursor - len(delta) + consumed)
         return ShellRead(
             shell_id=shell.shell_id,
             status=status,
             exit_code=exit_code,
             lines=shown,
-            new_line_count=len(delta),
+            new_line_count=consumed,
             dropped_lines=gap,
             clipped_lines=clipped,
+            unread_lines=len(delta) - consumed,
         )
 
     # -- Termination ---------------------------------------------------------

--- a/turnstone/core/compaction.py
+++ b/turnstone/core/compaction.py
@@ -18,6 +18,13 @@ from typing import Any
 
 from turnstone.core.model_turn import ModelTurnResult
 from turnstone.core.trajectory import Turn, TurnProvenance
+from turnstone.core.truncation import truncate_text
+
+
+def _compaction_marker(_omitted: int, original: int, _limit: int) -> str:
+    """Size marker for compaction projections: the total is what a summary needs."""
+
+    return f"\n…[truncated — {original:,} chars total]…\n"
 
 
 class CompactionIrreducibleError(Exception):
@@ -316,8 +323,14 @@ class CompactionEngine:
             role = f"TOOL[{tool_names.get(call_id, 'tool')}]"
         if not content:
             return None
-        if len(content) > 2000:
-            content = content[:1000] + "\n...[truncated]...\n" + content[-500:]
+
+        content = truncate_text(
+            content,
+            2000,
+            mode="head_tail",
+            head_fraction=2 / 3,
+            marker_factory=_compaction_marker,
+        ).text
         return f"{role}: {content}"
 
     def summary_blocks(self, messages: Sequence[dict[str, Any]]) -> list[str]:
@@ -393,15 +406,13 @@ class CompactionEngine:
     def truncate_block(block: str, budget: int) -> str:
         """Fit one oversized block head+tail around an honest size marker."""
 
-        if len(block) <= budget:
-            return block
-        marker = f"\n…[truncated — {len(block):,} chars total]…\n"
-        if budget <= len(marker):
-            return block[:budget]
-        keep = budget - len(marker)
-        head = (keep * 2) // 3
-        tail = keep - head
-        return block[:head] + marker + block[-tail:] if tail else block[:head] + marker
+        return truncate_text(
+            block,
+            budget,
+            mode="head_tail",
+            head_fraction=2 / 3,
+            marker_factory=_compaction_marker,
+        ).text
 
     def pack_blocks(self, blocks: Sequence[str], budget_chars: int) -> list[list[str]]:
         """Greedily pack ordered blocks without drops or oversized batches.

--- a/turnstone/core/config_store.py
+++ b/turnstone/core/config_store.py
@@ -50,6 +50,7 @@ class ConfigStore:
         self._storage = storage
         self._node_id = node_id
         self._cache: dict[str, Any] = {}
+        self._clamp_warned: set[str] = set()
         # Serialize the storage operation and its cache publication as one
         # mutation.  ``_lock`` stays short-lived so coherent snapshot readers
         # never wait on database I/O; writers always nest mutation -> state.
@@ -85,9 +86,23 @@ class ConfigStore:
             new_cache: dict[str, Any] = {}
             for key, json_val in raw.items():
                 try:
-                    new_cache[key] = deserialize_value(key, json_val)
+                    # A stored value outside the registry's range (a bound
+                    # tightened after the value was written) is clamped, never
+                    # silently replaced by the default.
+                    value = deserialize_value(key, json_val, clamp_range=True)
                 except (ValueError, KeyError):
                     log.warning("Skipping invalid setting: %s", key)
+                    continue
+                new_cache[key] = value
+                if key not in self._clamp_warned:
+                    try:
+                        deserialize_value(key, json_val)
+                    except ValueError:
+                        # Once per key per process: the row stays out of range
+                        # until an operator rewrites it, and every reload would
+                        # otherwise repeat the warning.
+                        self._clamp_warned.add(key)
+                        log.warning("Clamped out-of-range setting %s to %r", key, value)
             with self._lock:
                 self._cache = new_cache
                 self._version += 1

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -39,6 +39,7 @@ from turnstone.core.model_turn import (
     same_model_lane_binding,
 )
 from turnstone.core.trajectory import Turn
+from turnstone.core.truncation import truncate_text
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1088,10 +1089,16 @@ def honest_truncate(text: str, budget: int) -> str:
     as complete.  Reason-neutral, since the same helper bounds both the judge
     prompt (fit the window) and the verdict record (the OH CRAP backstop).
     """
-    if budget < 0:
-        budget = 0
+
+    budget = max(0, budget)
     if len(text) <= budget:
         return text
+    # The note is deliberately extra to the budget rather than fitted inside
+    # it.  Callers divide one budget across many fields, so budgets smaller
+    # than the note are routine there, and fitting the note inside such a
+    # budget would leave a bare ellipsis or nothing at all: a judge shown an
+    # empty field rules on an edit that "replaces nothing".  The overshoot is
+    # bounded by the note's own length.
     omitted = len(text) - budget
     return f"{text[:budget]}…[{omitted:,} of {len(text):,} chars omitted]"
 
@@ -2108,7 +2115,16 @@ class IntentJudge:
                         size_note = f", {total_bytes} bytes total"
                     except OSError:
                         size_note = ""
-                    return content[:_JUDGE_READ_LIMIT] + f"\n... (truncated{size_note})"
+
+                    def _read_marker(_omitted: int, _original: int, _limit: int) -> str:
+                        return f"\n... (truncated{size_note})"
+
+                    return truncate_text(
+                        content,
+                        _JUDGE_READ_LIMIT,
+                        mode="head",
+                        marker_factory=_read_marker,
+                    ).text
                 return content
 
             if name == "list_directory":

--- a/turnstone/core/pdf.py
+++ b/turnstone/core/pdf.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-import struct
 import subprocess
 import sys
 import tempfile
@@ -36,8 +35,11 @@ from turnstone.core._pdf_worker import (
     MAX_RASTER_PAGES,
     MAX_SOURCE_BYTES,
     MAX_TEXT_CHARS,
+    RASTER_LENGTH,
+    TEXT_LENGTH,
 )
 from turnstone.core.log import get_logger
+from turnstone.core.truncation import truncate_edges
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -46,7 +48,6 @@ log = get_logger(__name__)
 
 _MAX_WALL_SECONDS = 30.0
 _POLL_SECONDS = 0.05
-_RASTER_LENGTH = struct.Struct("!I")
 _PDF_WORKER_PATH = Path(__file__).with_name("_pdf_worker.py").resolve(strict=True)
 
 # Public safety ceiling for callers that layer a narrower presentation budget
@@ -203,6 +204,31 @@ def _worker_bytes(
             _PDF_WORKER_SLOT.release()
 
 
+def _pdf_text_marker(omitted: int, _original: int, _limit: int) -> str:
+    return f"\n\n... [{omitted} chars truncated] ...\n"
+
+
+def _render_pdf_text(prefix: str, total_chars: int, limit: int) -> str:
+    """Fit the worker's bounded prefix and an omission marker inside ``limit``.
+
+    A zero allowance still returns the marker: it is a receipt of what was
+    dropped rather than source text, and an empty result would read
+    downstream as a PDF with no text at all.
+    """
+
+    text = truncate_edges(
+        prefix=prefix,
+        suffix="",
+        original_chars=total_chars,
+        limit_chars=limit,
+        mode="head",
+        marker_factory=_pdf_text_marker,
+    ).text
+    if text or not total_chars:
+        return text
+    return _pdf_text_marker(total_chars, total_chars, limit)
+
+
 def extract_pdf_text(
     data: bytes,
     *,
@@ -223,7 +249,11 @@ def extract_pdf_text(
             ["--max-chars", str(limit)],
             check_cancelled=check_cancelled,
         )
-        return output.decode("utf-8")
+        if len(output) < TEXT_LENGTH.size:
+            raise _PdfInvalidError
+        (total_chars,) = TEXT_LENGTH.unpack_from(output)
+        prefix = output[TEXT_LENGTH.size :].decode("utf-8")
+        return _render_pdf_text(prefix, total_chars, limit)
     except (_PdfInvalidError, UnicodeDecodeError):
         log.warning("PDF text extraction failed")
         return ""
@@ -268,10 +298,10 @@ def rasterize_pdf(
         truncated = False
         offset = 0
         while offset < len(output):
-            if len(output) - offset < _RASTER_LENGTH.size:
+            if len(output) - offset < RASTER_LENGTH.size:
                 raise PdfWorkLimitError("PDF worker returned malformed raster data")
-            (length,) = _RASTER_LENGTH.unpack_from(output, offset)
-            offset += _RASTER_LENGTH.size
+            (length,) = RASTER_LENGTH.unpack_from(output, offset)
+            offset += RASTER_LENGTH.size
             # A zero-length terminal frame is the worker's explicit signal
             # that it observed another source page beyond ``page_limit``.
             if length == 0:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -17,6 +17,7 @@ from turnstone.core.streaming_text import (
     split_inline_reasoning,
     strip_blank_edge_lines,
 )
+from turnstone.core.truncation import truncate_text
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -855,9 +856,16 @@ def _join_reasoning_with_cap(parts: list[str]) -> str:
     if not parts:
         return ""
     joined = "\n".join(parts)
-    if len(joined) > MAX_REASONING_DISPLAY_CHARS:
-        return joined[:MAX_REASONING_DISPLAY_CHARS]
-    return joined
+
+    def _reasoning_marker(omitted: int, _original: int, _limit: int) -> str:
+        return f"\n… [{omitted:,} reasoning chars omitted from display]"
+
+    return truncate_text(
+        joined,
+        MAX_REASONING_DISPLAY_CHARS,
+        mode="head",
+        marker_factory=_reasoning_marker,
+    ).text
 
 
 def _lookup_capabilities(

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -19,6 +19,7 @@ import difflib
 import functools
 import hashlib
 import json
+import math
 import mimetypes
 import os
 import queue
@@ -219,6 +220,7 @@ from turnstone.core.session_worker import WorkerClaim, current_worker_claim
 from turnstone.core.settings_registry import (
     DEFAULT_APPROVAL_TIMEOUT_SECONDS,
     DEFAULT_AUTO_COMPACT_PCT,
+    TOOL_TRUNCATION_MAX_CHARS,
 )
 from turnstone.core.skill_field_validation import SKILL_RUNTIME_CONFIG_FIELDS
 from turnstone.core.skill_parser import MAX_SKILL_DESCRIPTION_LEN
@@ -267,6 +269,17 @@ from turnstone.core.trajectory import (
     turn_from_dict,
     turn_to_dict,
     turns_from_dicts,
+)
+from turnstone.core.truncation import (
+    BoundedTextBuffer,
+    ProjectedText,
+    TextProjectionSource,
+    TruncationMarker,
+    TruncationResult,
+    default_truncation_marker,
+    join_projection_sources,
+    source_chars,
+    truncate_text,
 )
 from turnstone.core.watch import WATCH_REMINDER_OPTIONAL_KEYS
 from turnstone.core.web import fetch_with_ssrf_guard, screen_url, strip_html
@@ -1122,11 +1135,17 @@ def _encode_image_data_uri(raw: bytes, mime: str) -> str:
 
 # Upper bound on total skill content injected into system messages
 _MAX_SKILL_CONTENT: int = 32768
+_RECALL_RESULT_CONTENT_CAP: int = 2000
 
 # Cap on a sub-agent tool's RAW output before it enters the trajectory (the
 # in-loop truncation in _run_agent) — bounds what the sub-agent's own model sees
 # on its next turn.  Distinct from (and larger than) the recall per-step cap.
 _AGENT_TOOL_OUTPUT_CAP: int = 16000
+# The output guard scans this much of a task-agent tool result before the
+# clip.  Wider than the clip so a credential straddling the clip boundary is
+# seen whole and redacted, yet bounded so a tool server never chooses how much
+# text the guard scans.
+_AGENT_GUARD_WINDOW_CHARS: int = 2 * _AGENT_TOOL_OUTPUT_CAP
 
 # Request-local attachment id used only inside one PDF-aware web fetch. The
 # transient turn is never persisted, so this needs request consistency rather
@@ -1153,12 +1172,95 @@ _AGENT_EFFECT_NAME_COUNT_CAP: int = 64
 _AGENT_OTHER_TOOL_NAMES = "<other tool names>"
 
 
-def _clip_agent_text(text: str, cap: int) -> str:
-    """Head-clip task-agent text with one honest truncation marker."""
+def _clip_skill_content(text: str) -> str:
+    """Bound injected skill guidance without impersonating completeness."""
 
-    if len(text) <= cap:
-        return text
-    return text[:cap] + f"\n\n... (truncated from {len(text)} chars)"
+    def _skill_marker(_omitted: int, original: int, _limit: int) -> str:
+        return f"\n\n... [skill guidance truncated from {original:,} chars]"
+
+    return truncate_text(
+        text,
+        _MAX_SKILL_CONTENT,
+        mode="head",
+        marker_factory=_skill_marker,
+    ).text
+
+
+def _clip_recall_content(text: str) -> str:
+    """Bound one recalled history row with an honest source-size marker."""
+
+    def _recall_marker(_omitted: int, original: int, _limit: int) -> str:
+        return f"... [history item truncated; {original:,} chars total]"
+
+    return truncate_text(
+        text,
+        _RECALL_RESULT_CONTENT_CAP,
+        mode="head",
+        marker_factory=_recall_marker,
+    ).text
+
+
+def _with_consumed_notice(marker: str, limit: int, *, widest: str) -> str:
+    """``marker`` plus the ``bash_output`` consumed notice when the cap leaves
+    room for both and some source text; a tighter cap keeps the plain honest
+    marker instead of a severed notice.
+
+    The decision is sized against ``widest``, the longest marker the factory
+    can produce for this result, never against ``marker`` itself: a factory
+    whose length toggles with the omitted count cannot settle in the
+    primitive's fixed point, and its count would lag the cut."""
+
+    body = marker.rstrip("\n")
+    with_notice = body + "\n" + _BASH_OUTPUT_CONSUMED_NOTICE + marker[len(body) :]
+    widest_with_notice = len(widest) + len(_BASH_OUTPUT_CONSUMED_NOTICE) + 1
+    if limit >= widest_with_notice + len(widest):
+        return with_notice
+    return marker
+
+
+def _bash_output_truncation_marker(omitted: int, original: int, limit: int) -> str:
+    """The fold marker for a cut ``bash_output`` delta."""
+
+    return _with_consumed_notice(
+        default_truncation_marker(omitted, original, limit),
+        limit,
+        widest=default_truncation_marker(original, original, limit),
+    )
+
+
+def _agent_truncation_marker(_omitted: int, original: int, _limit: int) -> str:
+    return f"\n\n... (truncated from {original} chars)"
+
+
+def _agent_bash_output_marker(omitted: int, original: int, limit: int) -> str:
+    marker = _agent_truncation_marker(omitted, original, limit)
+    return _with_consumed_notice(marker, limit, widest=marker)
+
+
+def _clip_agent_text(
+    text: str,
+    cap: int,
+    *,
+    original_chars: int | None = None,
+    tool_name: str = "",
+) -> str:
+    """Head-clip task-agent text with one honest truncation marker.
+
+    ``original_chars`` is the true size when ``text`` is already a bounded
+    slice of a larger result, so the marker still reports that size.  A cut
+    ``bash_output`` delta also says that its elided output was consumed."""
+
+    return truncate_text(
+        text,
+        cap,
+        mode="head",
+        marker_factory=(
+            _agent_bash_output_marker
+            if tool_name in _CONSUMED_RESULT_TOOLS
+            else _agent_truncation_marker
+        ),
+        original_chars=original_chars,
+    ).text
 
 
 def _bound_agent_identity(text: str, cap: int) -> str:
@@ -1168,7 +1270,7 @@ def _bound_agent_identity(text: str, cap: int) -> str:
         return text
     digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
     marker = f"…[{digest}]"
-    return text[: max(0, cap - len(marker))] + marker
+    return truncate_text(text, cap, mode="head", marker_factory=lambda *_: marker).text
 
 
 @dataclasses.dataclass(slots=True)
@@ -1335,11 +1437,25 @@ class _TaskExecutionJournal:
         )
 
     @staticmethod
-    def update_step(step: dict[str, Any] | None, output: Any, *, is_error: bool) -> None:
+    def update_step(
+        step: dict[str, Any] | None,
+        output: Any,
+        *,
+        is_error: bool,
+        original_chars: int | None = None,
+    ) -> None:
+        """Record a step's result.  ``original_chars`` is the producer's true
+        size when ``output`` is already a clipped rendering, so the recall
+        marker reports that size rather than the earlier clip's."""
+
         if step is None:
             return
-        raw_output = output if isinstance(output, str) else "[non-text result]"
-        step["output"] = _clip_agent_text(raw_output, _AGENT_STEP_OUTPUT_CAP)
+        if isinstance(output, str):
+            step["output"] = _clip_agent_text(
+                output, _AGENT_STEP_OUTPUT_CAP, original_chars=original_chars
+            )
+        else:
+            step["output"] = "[non-text result]"
         step["is_error"] = is_error
 
     def materialize_unstarted(self, agent_turns: list[Turn]) -> None:
@@ -1512,6 +1628,62 @@ _active_commit_origin_generation: contextvars.ContextVar[int] = contextvars.Cont
 # Tools exempt from consecutive-identical-call repeat detection: delta-cursor
 # readers whose repeated identical call is the documented polling pattern.
 _REPEAT_EXEMPT_TOOLS: frozenset[str] = frozenset({"bash_output"})
+_REPEAT_WARNING: str = (
+    "\n\n⚠ Warning: this is an identical repeat of a previous tool call. "
+    "The result is the same. Try a different approach."
+)
+
+
+# A JSON-shaped result starts with ``{`` or ``[`` after optional whitespace.
+# Matched in place: ``lstrip()`` on a ``str`` subclass copies the rendering.
+_LEADING_JSON_RE = re.compile(r"\s*[\[{]")
+
+
+# Automatic main-session tool-result share: one fifth of the batch's remaining
+# input allowance for every result, and one fifth of the context window as the
+# session ceiling every automatic cap stays under. No single result may take
+# more: a batch of results must leave room for its siblings and for the
+# model's own turn, and one result also rides the event stream as a single
+# server-sent event whose consumers bound event size. A tool whose formatter
+# owns a degradation ladder (search, inspect_workstream) is handed an estimate
+# of this cap up front so the ladder degrades to a tier the fold admits whole.
+# This is admission policy, not renderer policy: the result fold is the only
+# place a main-session result is cut, so its omission marker always reports
+# the producer's real output size.
+_TOOL_RESULT_SHARE: float = 0.20
+
+# Tools whose executor consumed the result's source in producing it, so a
+# dropped result could never be re-read: their cut carries the consumed
+# notice, and at an exhausted allowance they take the guaranteed floor instead
+# of the drop notice.
+_CONSUMED_RESULT_TOOLS: frozenset[str] = frozenset({"bash_output"})
+
+
+def _result_marker_factory(tool_name: str) -> TruncationMarker:
+    if tool_name in _CONSUMED_RESULT_TOOLS:
+        return _bash_output_truncation_marker
+    return default_truncation_marker
+
+
+# Carried by the marker that cuts a ``bash_output`` delta, in the main fold
+# and in a task agent's clip alike: unlike foreground bash (re-run to re-see),
+# the delta cursor has already consumed the elided output, and without saying
+# so a "no new output" follow-up reads as "nothing was missed".
+_BASH_OUTPUT_CONSUMED_NOTICE: str = (
+    "[the truncated output was consumed and cannot be re-read; use filter to narrow future reads]"
+)
+# Room the bounded ``bash_output`` read leaves under its cap for the result's
+# own header line, notes, and the unread footer.
+_BASH_OUTPUT_READ_RESERVE_CHARS: int = 256
+
+
+def _auto_tool_truncation_chars(context_window: int, chars_per_token: float) -> int:
+    """The automatic session-wide tool-result ceiling for one context window."""
+
+    return min(
+        int(context_window * chars_per_token * _TOOL_RESULT_SHARE),
+        TOOL_TRUNCATION_MAX_CHARS,
+    )
 
 
 # Tools whose results are orchestration *handles* — control-determining state
@@ -1537,6 +1709,12 @@ _STRUCTURAL_FLOOR_TOOLS: frozenset[str] = frozenset(
 # docs/architecture.md ("Tool Output Truncation") enumerates the floor
 # tools and these sizes in prose — keep it in sync when either changes.
 _TRUNCATION_FLOOR_CHARS: int = 2048
+# The smallest allowance at which a cut result still carries a counted
+# omission marker (~65 chars) and at least as much source as marker.  Below
+# it the exact-cap renderer can only produce a bare fragment ("x…") that reads
+# as a complete result, so such an allowance takes the zero-budget doors
+# instead: the grace pool for small results, the drop notice for the rest.
+_MIN_COUNTED_RESULT_CHARS: int = 128
 # Per-BATCH grace pool (chars) funding verbatim admission of small
 # NON-structural results at zero budget (denial notices, spawn acks —
 # destroying a result smaller than the ~310-char drop notice is a net
@@ -1732,8 +1910,10 @@ def _parse_search_records(stdout: bytes) -> list[tuple[str, str, str]]:
 def _format_search_results(
     records: list[tuple[str, str, str]],
     capped: bool,
+    *,
+    budget: int = _SEARCH_OUTPUT_BUDGET,
 ) -> str:
-    """Format match records with tiered degradation when output > budget.
+    """Format match records with tiered degradation when output > ``budget``.
 
     Tier 1: full ``path:line:content`` lines, stream-emitted with a running
     cost check that short-circuits as soon as the budget would be exceeded.
@@ -1764,7 +1944,7 @@ def _format_search_results(
         for lineno, content in matches:
             line = f"{path}:{lineno}:{content}"
             cost = len(line) + 1
-            if used + cost + len(summary) > _SEARCH_OUTPUT_BUDGET:
+            if used + cost + len(summary) > budget:
                 overflow = True
                 break
             chunks.append(line)
@@ -1775,7 +1955,7 @@ def _format_search_results(
         return "\n".join(chunks) + summary
 
     # Tier 2 header is added on return; budget for it up front so the
-    # final emission stays strictly within ``_SEARCH_OUTPUT_BUDGET`` and
+    # final emission stays strictly within ``budget`` and
     # ``_truncate_output``'s head+tail strategy never kicks in (that
     # strategy silently drops middle files alphabetically — exactly the
     # shape we're trying to avoid for search results).
@@ -1801,7 +1981,7 @@ def _format_search_results(
         80,
         sum(len(p) + len(ln) + len(c) + 3 for p, ln, c in sample) // max(1, len(sample)),
     )
-    estimated_k = max(1, _SEARCH_OUTPUT_BUDGET // max(1, files * (avg + 1)))
+    estimated_k = max(1, budget // max(1, files * (avg + 1)))
     # Iterate the ladder starting from the highest rung that's ≤ our
     # estimate. If the chosen K's actual emission doesn't fit (the
     # estimate ignored the header and over-counts compression from
@@ -1815,7 +1995,7 @@ def _format_search_results(
     for k in candidates:
         header = _tier2_header(k)
         # Budget for header + the "\n\n" separator on return.
-        body_budget = _SEARCH_OUTPUT_BUDGET - len(header) - 2
+        body_budget = budget - len(header) - 2
         chunks2: list[str] = []
         used2 = 0
         fit = True
@@ -1844,8 +2024,8 @@ def _format_search_results(
         tier3_header += " (raw output capped; counts may underreport.)"
     # Budget for header + the "\n\n" separator + the trailing
     # "(plus N more files)" line so the final emission stays within
-    # ``_SEARCH_OUTPUT_BUDGET`` even when the count list is enormous.
-    tier3_body_budget = _SEARCH_OUTPUT_BUDGET - len(tier3_header) - 2 - _SEARCH_TIER3_TAIL_RESERVE
+    # ``budget`` even when the count list is enormous.
+    tier3_body_budget = budget - len(tier3_header) - 2 - _SEARCH_TIER3_TAIL_RESERVE
     body_lines: list[str] = []
     body_used = 0
     shown = 0
@@ -2128,6 +2308,7 @@ _DOC_BUDGET_CHAR_CAP = 16_000
 _PDF_ATTACHMENT_CONTEXT_SHARE = 0.5
 _WEB_FETCH_DOCUMENT_CONTEXT_SHARE = 0.5
 _DOCUMENT_BUDGET_PLANNING_MARGIN_PCT = 0.01
+_WEB_FETCH_TEXT_CHAR_CAP = 10 * 1024 * 1024
 _PDF_CACHE_CAP_INDEPENDENT: Literal["independent"] = "independent"
 
 _WireContentPart = dict[str, Any] | list[dict[str, Any]]
@@ -3026,12 +3207,17 @@ class ChatSession:
         self._compaction_advised = False
         self.agent_max_turns = agent_max_turns
         self._chars_per_token = 4.0  # calibrated from API usage
-        # Tool output truncation: 0 means auto (50% of context_window in chars)
+        # Tool output truncation: 0 keeps the automatic ceiling of one fifth of
+        # the context window; the result fold further narrows automatic
+        # results to one fifth of its remaining input allowance. A positive
+        # operator override applies uniformly instead.
         self._manual_tool_truncation = tool_truncation > 0
         if tool_truncation > 0:
-            self.tool_truncation = tool_truncation
+            self.tool_truncation = min(tool_truncation, TOOL_TRUNCATION_MAX_CHARS)
         else:
-            self.tool_truncation = int(context_window * self._chars_per_token * 0.5)
+            self.tool_truncation = _auto_tool_truncation_chars(
+                context_window, self._chars_per_token
+            )
         self.show_reasoning = True
         self.debug = False
         self.auto_approve = False
@@ -5004,7 +5190,9 @@ class ChatSession:
                 self.context_window = new_cfg.context_window
                 # Recompute auto tool truncation for new context window.
                 if not self._manual_tool_truncation:
-                    self.tool_truncation = int(new_cfg.context_window * self._chars_per_token * 0.5)
+                    self.tool_truncation = _auto_tool_truncation_chars(
+                        new_cfg.context_window, self._chars_per_token
+                    )
         if binding_changed:
             # A generation-only rebind resolving the identical binding
             # stamps silently: recomposing and logging on every unrelated
@@ -5799,7 +5987,7 @@ class ChatSession:
         else:
             self._calibrated_msg_count = 0
         if not self._manual_tool_truncation:
-            self.tool_truncation = int(self.context_window * ratio * 0.5)
+            self.tool_truncation = _auto_tool_truncation_chars(self.context_window, ratio)
 
     def _invalidate_token_calibration_anchors(self) -> None:
         """Forget prompt-prefix counts after changing history or its prefix.
@@ -5949,6 +6137,85 @@ class ChatSession:
             raise GenerationCancelled()
         return compacted
 
+    def _tool_result_truncation_limit(self, *, batch_budget_tokens: int) -> int:
+        """Return the pre-context cap for one main-session tool result.
+
+        A positive operator ``tool_truncation`` override remains the single
+        uniform cap. In automatic mode every result receives one fifth of the
+        batch's remaining input allowance, under the session ceiling.
+        """
+
+        if self._manual_tool_truncation:
+            return self.tool_truncation
+        remaining_chars = max(0, int(max(0, batch_budget_tokens) * self._chars_per_token))
+        # A share too small to carry a counted marker is decided at admission:
+        # :meth:`_allowance_is_exhausted` routes such a result through the
+        # zero-budget doors rather than rendering a bare fragment.
+        return min(self.tool_truncation, int(remaining_chars * _TOOL_RESULT_SHARE))
+
+    def _executor_capture_chars(self) -> int:
+        """Characters a streaming executor retains at each edge of its output.
+
+        Half the session cap, rounded up, so the two edges together can render
+        any cap the result fold applies on this session and the fold stays the
+        single cut at every size while a capture never holds more than a fold
+        here could show; and never less than a task agent's guard window, so
+        an agent's head clip is never narrower than the window it was guarded
+        over.
+        """
+
+        return max((self.tool_truncation + 1) // 2, _AGENT_GUARD_WINDOW_CHARS)
+
+    def _bounded_result(self, output: str) -> str:
+        """``output`` with at most the executor retention held at each edge.
+
+        A plain result larger than the two edges is projected to the edges the
+        streaming executors keep, so controller text can be added to it
+        without copying the whole result; the fold still renders from those
+        edges with the true size.
+        """
+
+        retention = self._executor_capture_chars()
+        if isinstance(output, ProjectedText) or len(output) <= 2 * retention:
+            return output
+        return TextProjectionSource(output[:retention], output[-retention:], len(output)).projected(
+            retention
+        )
+
+    def _executor_cap_estimate(self) -> int:
+        """The cap an executor sizes its own output to before the fold sees it.
+
+        Inside a task agent that is the agent's own clip.  Otherwise it is the
+        fold's cap under the running allowance: an estimate, made before
+        siblings in the batch and a mid-turn compaction can move it, that an
+        executor uses to avoid producing what the fold could not admit, never
+        as the cap itself.  The fold still decides.
+        """
+
+        if _active_task_agent_cancel_scope.get() is not None:
+            return _AGENT_TOOL_OUTPUT_CAP
+        remaining = self._remaining_token_budget()
+        return min(
+            self._tool_result_truncation_limit(batch_budget_tokens=remaining),
+            int(remaining * self._chars_per_token),
+        )
+
+    def _formatter_budget(self, formatter_budget: int) -> int:
+        """The budget handed to a tool's own degradation ladder.
+
+        The ladder is sized to the fold's cap so it degrades to a tier the fold
+        admits whole rather than the fold head/tail-clipping what the ladder
+        kept on purpose.  An estimate too small to carry a counted marker
+        predicts a mid-turn compaction, not the cap the fold will apply after
+        it, so the ladder keeps its own budget there and the fold's doors
+        decide.
+        """
+
+        estimate = self._executor_cap_estimate()
+        if estimate < _MIN_COUNTED_RESULT_CHARS:
+            return formatter_budget
+        return min(formatter_budget, estimate)
+
     def _truncate_output(
         self,
         output: str,
@@ -5958,7 +6225,7 @@ class ChatSession:
         """Truncate tool output, keeping head + tail.
 
         The effective limit is the *minimum* of:
-        - ``self.tool_truncation`` (fixed cap, defaults to 50% of context)
+        - ``self.tool_truncation`` (fixed cap, defaults to 20% of context)
         - ``remaining_budget_tokens`` converted to chars (if provided)
 
         raised to at least ``floor_chars`` when given.  The floor is the
@@ -5990,35 +6257,169 @@ class ChatSession:
         (deliberate — see #883 discussion); re-running after compaction is
         the recovery path for read-only calls.
         """
+        return self._truncate_output_result(
+            output,
+            remaining_budget_tokens=remaining_budget_tokens,
+            floor_chars=floor_chars,
+        ).text
+
+    def _truncate_output_result(
+        self,
+        output: str,
+        remaining_budget_tokens: int | None = None,
+        floor_chars: int = 0,
+        maximum_chars: int | None = None,
+        *,
+        exhausted: bool = False,
+        original_chars: int | None = None,
+        marker_factory: TruncationMarker = default_truncation_marker,
+    ) -> TruncationResult:
+        """Structured twin of :meth:`_truncate_output`.
+
+        Callers that need to react to source loss must consume
+        :attr:`TruncationResult.truncated`; comparing rendered string lengths is
+        invalid because an honest omission marker can be longer than the source
+        fragment it replaces. ``maximum_chars`` lets the result-fold policy
+        narrow one surface without changing the session-wide operator cap.
+        ``exhausted`` is the admission's verdict that the allowance cannot
+        carry a counted marker (:meth:`_allowance_is_exhausted`), so the floor
+        or the drop notice applies instead of a bare fragment.
+        ``original_chars`` is the producer's true size when ``output`` is a
+        transformed rendering that no longer carries its own source.
+        """
+
+        limit = self.tool_truncation
+        if maximum_chars is not None:
+            limit = min(limit, max(0, int(maximum_chars)))
         if not output:
             # Nothing to truncate and nothing to account: an empty result
             # always passes.  Without this, a zero-budget batch would
             # replace a 0-char result with the ~310-char drop notice —
             # false ("none of it could be added") and net-negative.
-            return output
-        limit = self.tool_truncation
+            return TruncationResult("", 0, max(0, limit), 0)
         if remaining_budget_tokens is not None:
-            budget_chars = int(remaining_budget_tokens * self._chars_per_token)
-            limit = min(limit, budget_chars)
+            limit = min(limit, int(remaining_budget_tokens * self._chars_per_token))
+        if exhausted:
+            limit = 0
         limit = max(limit, floor_chars)
         if limit <= 0:
-            return (
+            produced = source_chars(output) if original_chars is None else original_chars
+            notice = (
                 f"Error: tool result dropped — context budget exhausted. The call ran "
-                f"and produced a {len(output)}-char result, but none of it could be "
+                f"and produced a {produced}-char result, but none of it could be "
                 f"added to the conversation. Do not assume the call failed and do not "
                 f"re-run side-effecting calls. Compact or wrap up; re-issue read-only "
                 f"calls afterwards if their output is still needed."
             )
-        if len(output) <= limit:
-            return output
-        half = limit // 2
-        omitted = len(output) - limit
-        return (
-            output[:half]
-            + f"\n\n... [{omitted} chars truncated — output exceeded "
-            + f"{limit} char limit] ...\n\n"
-            + output[-half:]
+            # The controller receipt is not source content and intentionally
+            # survives a zero-character source allowance (#883).  Metadata
+            # still records that no source character was retained.
+            return TruncationResult(notice, produced, 0, produced)
+        return truncate_text(
+            output,
+            limit,
+            mode="head_tail",
+            original_chars=original_chars,
+            marker_factory=marker_factory,
         )
+
+    def _admit_tool_result(
+        self,
+        tool_name: str,
+        tc_id: str,
+        output: str,
+        *,
+        budget_tokens: int,
+        maximum_chars: int,
+        verbatim_pool: int,
+    ) -> tuple[TruncationResult, int]:
+        """One result's admission into the batch: the exhaustion test, decided
+        once for the floor and the cut alike, its floor and the grace pool left
+        after funding it, then the cut."""
+
+        exhausted = self._allowance_is_exhausted(
+            output, budget_tokens=budget_tokens, maximum_chars=maximum_chars
+        )
+        floor, verbatim_pool = self._admission_floor(
+            tool_name, tc_id, output, exhausted=exhausted, verbatim_pool=verbatim_pool
+        )
+        truncation = self._truncate_output_result(
+            output,
+            remaining_budget_tokens=budget_tokens,
+            floor_chars=floor,
+            maximum_chars=maximum_chars,
+            exhausted=exhausted,
+            marker_factory=_result_marker_factory(tool_name),
+        )
+        return truncation, verbatim_pool
+
+    def _allowance_is_exhausted(
+        self, output: str, *, budget_tokens: int, maximum_chars: int
+    ) -> bool:
+        """Whether the allowance cannot carry ``output`` with a counted marker.
+
+        Below ``_MIN_COUNTED_RESULT_CHARS`` a cut result would render as a
+        bare fragment (``x…``) that reads as complete, so such an allowance is
+        treated the way a zero budget is: small results pass verbatim through
+        the grace pool and larger ones get the honest drop notice.  In
+        automatic mode the share-derived surface cap counts too; a manual cap
+        is the operator's choice and is never treated as exhausted.  Size is
+        the producer's, so a bounded capture's rendering never reads as small.
+        """
+
+        cap = int(max(0, budget_tokens) * self._chars_per_token)
+        if not self._manual_tool_truncation:
+            cap = min(cap, max(0, int(maximum_chars)))
+        return cap < _MIN_COUNTED_RESULT_CHARS and source_chars(output) > cap
+
+    def _admission_floor(
+        self,
+        tool_name: str,
+        tc_id: str,
+        output: str,
+        *,
+        exhausted: bool,
+        verbatim_pool: int,
+    ) -> tuple[int, int]:
+        """One result's guaranteed floor and the grace pool left after funding
+        it.  Shared by the drain and its post-guard replay so a result passes
+        the same doors in both passes.
+
+        Structural handles and error dispositions get the guaranteed floor:
+        neither may be zero-dropped (a lost ws_id stalls orchestration, a
+        masked failure reads as success — #883).  At an exhausted allowance
+        so does a result whose executor consumed its source in producing it
+        (a ``bash_output`` delta): dropped, it could never be re-read, so it
+        is cut to the floor with its consumed notice instead, while at a live
+        allowance its surface cap governs.  All three are DELIBERATELY
+        per-result, with NO aggregate cap (unlike the grace pool): capping
+        structural floors would re-open #883 for wide fan-outs (every
+        parallel spawn's handle is needed or its child orphans), and capping
+        error floors would mask failures behind a success-leaning notice —
+        inviting the blind re-runs #865/#866 exist to prevent.  Worst case is
+        bounded by the model's own batch width and lands on the pre-send
+        hard-compaction guard / ctx-overflow retry: one extra compaction
+        round-trip, traded for never losing a handle or a disposition.
+
+        The per-batch grace pool admits small NON-structural results verbatim
+        at an exhausted allowance by funding their own size as the floor,
+        until the pool is spent — bounding THIS door's collective admission
+        where an unconditioned small-pass would let N small results bypass
+        the per-output bookkeeping entirely.  The pool bounds only the
+        small-result door; the structural/error floors are per-result by
+        design (ruling above).
+        """
+
+        if tool_name in _STRUCTURAL_FLOOR_TOOLS or self._tool_error_flags.get(tc_id, False):
+            return _TRUNCATION_FLOOR_CHARS, verbatim_pool
+        if exhausted and tool_name in _CONSUMED_RESULT_TOOLS:
+            return _TRUNCATION_FLOOR_CHARS, verbatim_pool
+        # The producer's size, never a bounded capture's rendering: a
+        # multi-megabyte capture is not a small result.
+        size = source_chars(output)
+        if exhausted and size <= _TRUNCATION_FLOOR_CHARS and verbatim_pool >= size:
+            return size, verbatim_pool - size
+        return 0, verbatim_pool
 
     def request_title_refresh(
         self,
@@ -6565,7 +6966,9 @@ class ChatSession:
             max(1, int(self._msg_char_count(m) / self._chars_per_token)) for m in self.messages
         ]
         if not self._manual_tool_truncation:
-            self.tool_truncation = int(self.context_window * self._chars_per_token * 0.5)
+            self.tool_truncation = _auto_tool_truncation_chars(
+                self.context_window, self._chars_per_token
+            )
         resume_diagnostics = lane_diagnostics(self._primary_lane())
         log.info(
             "Resuming ws=%s: %d messages, provider=%s, model=%s",
@@ -6628,8 +7031,8 @@ class ChatSession:
             if bound_cfg is not None:
                 self.context_window = bound_cfg.context_window
                 if not self._manual_tool_truncation:
-                    self.tool_truncation = int(
-                        bound_cfg.context_window * self._chars_per_token * 0.5
+                    self.tool_truncation = _auto_tool_truncation_chars(
+                        bound_cfg.context_window, self._chars_per_token
                     )
                 bound_diagnostics = lane_diagnostics(self._primary_lane())
                 log.info(
@@ -7419,7 +7822,7 @@ class ChatSession:
             tpl = self._skill_content
             if len(tpl) > _MAX_SKILL_CONTENT:
                 log.warning("skill_content.truncated", length=len(tpl))
-                tpl = tpl[:_MAX_SKILL_CONTENT]
+                tpl = _clip_skill_content(tpl)
             if not self._skill_name:
                 # Default (always-on) skills: keep in the identity system prefix.
                 dev_parts.append("")
@@ -12733,9 +13136,19 @@ class ChatSession:
                     allow_cancelled=False,
                 ):
                     raise GenerationCancelled()
+                # The partial captured the raw result list; release it so the
+                # executors' complete outputs do not outlive their admission.
+                del apply_post_execute_advisories
 
                 # Map tool_call_id → tool name for logging
-                _tc_names = {c["id"]: c.get("function", {}).get("name", "") for c in tool_calls}
+                # Providers may pad a name with whitespace; dispatch strips it,
+                # so every result-policy lookup keyed by this map (structural
+                # floors, surface shares, the bash_output notice, guard audit
+                # rows) must see the same normalized name.
+                _tc_names = {
+                    c["id"]: str(c.get("function", {}).get("name", "") or "").strip()
+                    for c in tool_calls
+                }
                 # Tool arguments (JSON string) per call_id — threaded into the
                 # LLM judge so it can reason about output-vs-request plausibility.
                 _tc_args = {c["id"]: c.get("function", {}).get("arguments", "") for c in tool_calls}
@@ -12828,63 +13241,55 @@ class ChatSession:
                         # this window) — retrying cannot help, so burn the
                         # remaining attempts for this send.
                         zero_budget_compact_attempts = _ZERO_BUDGET_COMPACT_CAP_PER_SEND
-                _truncated: dict[str, str] = {}
-                # Per-batch grace pool: small NON-structural results are
-                # admitted verbatim at zero budget by funding their own
-                # size as the floor, until the pool is spent — bounding
-                # THIS door's collective admission where an unconditioned
-                # small-pass would let N small results bypass the
-                # per-output bookkeeping below entirely.  The pool bounds
-                # only the small-result door; the structural/error floors
-                # below are per-result by design (ruling at their site).
-                zero_budget_verbatim_pool = _ZERO_BUDGET_VERBATIM_POOL_CHARS
-                for tc_id, output in results:
-                    if isinstance(output, str):
-                        # Structural handles and error dispositions get the
-                        # guaranteed floor: neither may be zero-dropped (a
-                        # lost ws_id stalls orchestration, a masked failure
-                        # reads as success — #883).  ``_tool_error_flags``
-                        # is still populated here; the per-result loop
-                        # below pops it to build the persisted turn.
-                        # DELIBERATELY per-result, with NO aggregate cap
-                        # (unlike the grace pool): capping structural
-                        # floors would re-open #883 for wide fan-outs
-                        # (every parallel spawn's handle is needed or its
-                        # child orphans), and capping error floors would
-                        # mask failures behind a success-leaning notice —
-                        # inviting the blind re-runs #865/#866 exist to
-                        # prevent.  Worst case is bounded by the model's
-                        # own batch width and lands on the pre-send
-                        # hard-compaction guard / ctx-overflow retry: one
-                        # extra compaction round-trip, traded for never
-                        # losing a handle or a disposition.
-                        _floor = (
-                            _TRUNCATION_FLOOR_CHARS
-                            if (
-                                _tc_names.get(tc_id, "") in _STRUCTURAL_FLOOR_TOOLS
-                                or self._tool_error_flags.get(tc_id, False)
+                # Surface percentages derive from one post-compaction snapshot
+                # so parallel siblings have the same nominal cap. The running
+                # ``truncation_budget`` below is still debited after every
+                # result and remains the aggregate hard backstop.
+                batch_truncation_budget = truncation_budget
+                # Per-result admission records for the post-guard re-cut: the
+                # drain's rendering and its coverage.  The executor's complete
+                # result is released here rather than held across the guard's
+                # judge round trips.
+                _admissions: dict[str, TruncationResult] = {}
+                maximum = self._tool_result_truncation_limit(
+                    batch_budget_tokens=batch_truncation_budget
+                )
+
+                def _admit_batch(
+                    names: dict[str, Any],
+                    cap: int,
+                    admissions: dict[str, TruncationResult],
+                ) -> None:
+                    # A helper so no executor result outlives its admission
+                    # in a loop variable while the guard's judge round trips
+                    # run.
+                    nonlocal results, truncation_budget
+                    verbatim_pool = _ZERO_BUDGET_VERBATIM_POOL_CHARS
+                    admitted: list[tuple[str, Any]] = []
+                    for tc_id, output in results:
+                        if isinstance(output, str):
+                            # ``_tool_error_flags`` is still populated here;
+                            # the per-result loop below pops it to build the
+                            # persisted turn.
+                            truncation, verbatim_pool = self._admit_tool_result(
+                                names.get(tc_id, ""),
+                                tc_id,
+                                output,
+                                budget_tokens=truncation_budget,
+                                maximum_chars=cap,
+                                verbatim_pool=verbatim_pool,
                             )
-                            else 0
-                        )
-                        if (
-                            _floor == 0
-                            and truncation_budget <= 0
-                            and len(output) <= _TRUNCATION_FLOOR_CHARS
-                            and zero_budget_verbatim_pool >= len(output)
-                        ):
-                            _floor = len(output)
-                            zero_budget_verbatim_pool -= len(output)
-                        truncated = self._truncate_output(
-                            output,
-                            remaining_budget_tokens=truncation_budget,
-                            floor_chars=_floor,
-                        )
-                        _truncated[tc_id] = truncated
-                        truncation_budget = max(
-                            0,
-                            truncation_budget - int(len(truncated) / self._chars_per_token),
-                        )
-                results = [(tc_id, _truncated.get(tc_id, output)) for tc_id, output in results]
+                            admissions[tc_id] = truncation
+                            truncation_budget = max(
+                                0,
+                                truncation_budget
+                                - math.ceil(len(truncation.text) / self._chars_per_token),
+                            )
+                            output = truncation.text
+                        admitted.append((tc_id, output))
+                    results = admitted
+
+                _admit_batch(_tc_names, maximum, _admissions)
 
                 # Pre-evaluate the guard stage concurrently when LLM is
                 # enabled and there are multiple string outputs (perf-2).
@@ -12958,6 +13363,43 @@ class ChatSession:
                     # here rather than fold into its successor's trajectory.
                     self._check_cancelled(my_generation)
                     guarded_results.append((_ri, tc_id, output, assessment))
+
+                # Redaction can lengthen a cut result past its cap: a short
+                # secret becomes a longer marker.  Such a result is cut again
+                # at the drain's limit by splitting the guarded rendering at
+                # the drain's marker and re-rendering the two edges, so the
+                # second cut never runs into the first marker and the omitted
+                # count still includes the middle the drain removed.  A result
+                # the guard left alone, one the drain admitted whole, or one
+                # whose text no longer locates the marker exactly once passes
+                # as the guard left it: what the guard produced is what the
+                # model sees, and the pre-send hard-compaction guard remains
+                # the backstop for a batch that grew past its allowance.
+                recut: list[tuple[int, str, Any, OutputAssessment | None]] = []
+                for _ri, tc_id, output, assessment in guarded_results:
+                    rendered = _admissions.get(tc_id)
+                    if (
+                        rendered is not None
+                        and isinstance(output, str)
+                        and rendered.truncated
+                        and rendered.limit_chars > 0
+                        and len(output) > rendered.limit_chars
+                        and output.count(rendered.marker) == 1
+                    ):
+                        head, _marker, tail = output.partition(rendered.marker)
+                        output = (
+                            TextProjectionSource(
+                                head, tail, len(head) + len(tail) + rendered.omitted_chars
+                            )
+                            .render(
+                                rendered.limit_chars,
+                                marker_factory=_result_marker_factory(_tc_names.get(tc_id, "")),
+                            )
+                            .text
+                        )
+                    recut.append((_ri, tc_id, output, assessment))
+                guarded_results = recut
+                _admissions.clear()
 
                 def _fold_tool_batch(
                     fold_results: list[tuple[int, str, Any, Any]],
@@ -16739,6 +17181,12 @@ class ChatSession:
         # follow attribute access below without re-asserting succeeded.
         llm = llm_verdict if (llm_verdict is not None and llm_verdict.succeeded) else None
         wants_redaction = heuristic.sanitized is not None and jc is not None and jc.redact_secrets
+        if not wants_redaction:
+            # ``sanitized`` means "redaction was applied" to every consumer
+            # below (audit rows, the acted assessment, the returned text), so
+            # a redacted copy the configuration declines is dropped here, at
+            # the one producer, rather than gated at each consumer.
+            heuristic = dataclasses.replace(heuristic, sanitized=None)
 
         # Persistence — one row per (call_id, tier).  Heuristic row when it
         # has signal; the LLM row carries the judge's OWN verdict on success
@@ -17174,7 +17622,12 @@ class ChatSession:
         # shared bound — the /send defer-fidelity check refuses fold-ins
         # that could hit this truncation).
         if len(cleaned) > INTERJECTION_CAP_CHARS:
-            cleaned = cleaned[:INTERJECTION_CAP_CHARS] + "..."
+            cleaned = truncate_text(
+                cleaned,
+                INTERJECTION_CAP_CHARS,
+                mode="head",
+                marker_factory=lambda _omitted, _original, _limit: "…",
+            ).text
         # Full UUID hex (128 bits) rather than a truncated prefix — this id is
         # the ``send_id`` tracking token threaded through the turn, so the wide
         # space keeps the birthday bound comfortable.
@@ -20463,18 +20916,14 @@ class ChatSession:
                 # any different signature breaks a streak, so an exempt call
                 # interleaved between identical bash calls must keep those
                 # bash calls from reading as consecutive.
-                exempt = tc["function"]["name"] in _REPEAT_EXEMPT_TOOLS
-                raw = tc["function"]["name"] + ":" + tc["function"]["arguments"]
+                exempt = str(tc["function"]["name"] or "").strip() in _REPEAT_EXEMPT_TOOLS
+                raw = str(tc["function"]["name"] or "").strip() + ":" + tc["function"]["arguments"]
                 sig = hashlib.sha256(raw.encode()).hexdigest()
-                is_json = output.lstrip().startswith(("{", "["))
+                is_json = _LEADING_JSON_RE.match(output) is not None
                 if self._repeat_detector.record(sig) and not exempt:
                     _repeat_detected = True
                     if not is_json:
-                        output += (
-                            "\n\n⚠ Warning: this is an identical repeat of a "
-                            "previous tool call. The result is the same. "
-                            "Try a different approach."
-                        )
+                        output = self._bounded_result(output) + _REPEAT_WARNING
                         results[i] = (tc_id, output)
                     # The operator-context system turn after the tool batch
                     # carries the operator-visible signal; the tool-name
@@ -21000,7 +21449,10 @@ class ChatSession:
         }
 
     def _exec_inspect_workstream(self, item: dict[str, Any]) -> tuple[str, str]:
-        from turnstone.console.coordinator_client import _format_inspect_tiered
+        from turnstone.console.coordinator_client import (
+            _INSPECT_OUTPUT_BUDGET,
+            _format_inspect_tiered,
+        )
 
         call_id = item["call_id"]
         ws_id = item["ws_id"]
@@ -21017,13 +21469,17 @@ class ChatSession:
         # Tiered output: full → compact (head/tail-snipped messages) →
         # skeleton (counts + last-assistant preview).  First tier that
         # fits the budget wins; the LLM sees a ``_tier`` field on every
-        # non-error response.  ``_truncate_output`` remains the safety
-        # net for the (rare) skeleton-exceeds-budget case — guarding
-        # against a single-field blowup we didn't anticipate.
-        output = _format_inspect_tiered(result)
+        # non-error response.  The budget is the smaller of the formatter's
+        # own and the fold's cap (``_formatter_budget``), so the tier chosen
+        # is one the fold admits whole; the fold's generic head/tail cut,
+        # which would splice a marker into the JSON, remains the safety net
+        # for the (rare) skeleton-exceeds-budget case.
+        output = _format_inspect_tiered(
+            result, budget=self._formatter_budget(_INSPECT_OUTPUT_BUDGET)
+        )
         desc = f"{result.get('state', '?')} ({len(result.get('messages', []))} msgs)"
         self._report_tool_result(call_id, "inspect_workstream", desc)
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     def _prepare_send_to_workstream(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         if self._coord_client is None:
@@ -21399,7 +21855,7 @@ class ChatSession:
                 " (truncated — more may exist; re-run with a narrower filter or larger limit)"
             )
         self._report_tool_result(call_id, "list_workstreams", summary)
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     def _prepare_list_nodes(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         if self._coord_client is None:
@@ -21486,7 +21942,7 @@ class ChatSession:
         if truncated:
             summary += " (truncated — narrow filters or raise limit)"
         self._report_tool_result(call_id, "list_nodes", summary)
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     # -- skills tool ----------------------------------------------------------
     #
@@ -21762,7 +22218,7 @@ class ChatSession:
             else json.dumps(result, separators=(",", ":"), default=str)
         )
         self._report_tool_result(call_id, "skills", summary)
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     @staticmethod
     def _skills_tags_text(raw: Any) -> str:
@@ -21853,7 +22309,7 @@ class ChatSession:
         projected["readonly"] = bool(row.get("readonly"))
         output = json.dumps(projected, separators=(",", ":"), default=str)
         self._report_tool_result(call_id, "skills", f"got {name}")
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     # -- load -------------------------------------------------------------------
 
@@ -23001,7 +23457,7 @@ class ChatSession:
             summary = action
         is_error = "error" in result
         self._report_tool_result(call_id, "tasks", summary, is_error=is_error)
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     def _prepare_wait_for_workstream(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
         """Thin pass-through to ``CoordinatorClient.wait_for_workstream``.
@@ -23180,7 +23636,7 @@ class ChatSession:
                 "resolved": resolved_count,
             },
         )
-        return call_id, self._truncate_output(output)
+        return call_id, output
 
     def _emit_wait_event(self, event_type: str, payload: dict[str, Any]) -> None:
         """Fan out a ``wait_*`` SSE event via the session UI.
@@ -23574,8 +24030,13 @@ class ChatSession:
             mcp_error = True
             self.ui.on_error(output)
 
-        output = self._truncate_output(output)
-        self._report_tool_result(call_id, func_name, output, is_error=mcp_error, status=mcp_status)
+        self._report_tool_result(
+            call_id,
+            func_name,
+            self._truncate_output(output),
+            is_error=mcp_error,
+            status=mcp_status,
+        )
         return call_id, output
 
     @staticmethod
@@ -23665,8 +24126,9 @@ class ChatSession:
             mcp_error = True
             self.ui.on_error(output)
 
-        output = self._truncate_output(output)
-        self._report_tool_result(call_id, "read_resource", output, is_error=mcp_error)
+        self._report_tool_result(
+            call_id, "read_resource", self._truncate_output(output), is_error=mcp_error
+        )
         return call_id, output
 
     def _prepare_use_prompt(self, call_id: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -23762,8 +24224,9 @@ class ChatSession:
             mcp_error = True
             self.ui.on_error(output)
 
-        output = self._truncate_output(output)
-        self._report_tool_result(call_id, "use_prompt", output, is_error=mcp_error)
+        self._report_tool_result(
+            call_id, "use_prompt", self._truncate_output(output), is_error=mcp_error
+        )
         return call_id, output
 
     # -- Execute methods (do the work, report output via UI) -------------------
@@ -23776,15 +24239,49 @@ class ChatSession:
         cancel = self._cancel_event
         call_id, command = item["call_id"], item["command"]
         timeout = item.get("timeout") or self.tool_timeout
+        # stdout and stderr are captured separately and presented as stdout
+        # followed by the stderr lines: with one arrival-ordered capture a
+        # stderr record could land inside an unfinished stdout line.  Each
+        # capture retains bounded edges, and the two are joined as edges too,
+        # so the fold still cuts once against the command's true output size.
+        retention = self._executor_capture_chars()
+        stdout_capture = BoundedTextBuffer(retention)
+        stderr_capture = BoundedTextBuffer(retention)
+        # One gate closes the capture.  Set in the ``finally`` below, it turns
+        # late drain callbacks into discard-only drains (neither buffered nor
+        # forwarded to the UI) once this execution closure ends, so an escaped
+        # grandchild cannot mutate a result, grow memory, or emit into later
+        # turns after return; the pipe still drains and the child never blocks
+        # on a full pipe.  Bound before the ``try`` so the finally's ``.set()``
+        # cannot raise ``UnboundLocalError`` on a failed spawn.
+        capture_closed = threading.Event()
+
+        def _captured_output() -> str:
+            out, err = stdout_capture.source(), stderr_capture.source()
+            if err.original_chars == 0:
+                source = out
+            elif out.original_chars == 0:
+                source = err
+            else:
+                source = join_projection_sources(
+                    out, err, separator="\n", retention_chars=retention
+                )
+            # Below the retention this is the complete output.  Above it, a
+            # lossy rendering keeps its source edges attached so the fold
+            # renders once against the true size; stripping would hand back a
+            # plain string and lose them.
+            text = source.projected(retention)
+            if isinstance(text, ProjectedText):
+                return text
+            return text.strip()
+
         try:
             # Pre-bind so the ``finally`` can't raise ``UnboundLocalError``
-            # and mask the real error if the spawn below fails.  The chunk
-            # gate pre-binds with them — its .set() runs in the same
-            # finally, and setting it when no drain ever started is a
-            # harmless no-op.
+            # and mask the real error if the spawn below fails.
             proc: subprocess.Popen[str] | None = None
+            pgid: int | None = None
             script_path: str | None = None
-            emit_done = threading.Event()
+            group_kill_attempted = False
             try:
                 from turnstone.core.env import scrubbed_env
 
@@ -23798,6 +24295,7 @@ class ChatSession:
                 )
                 with self._procs_lock:
                     self._active_procs.add(proc)
+
                 # Drain stdout and stderr in background threads.  Reading the
                 # pipes to EOF in the foreground is unsafe: a command that
                 # backgrounds a long-lived child (``server &``) leaks the pipe
@@ -23806,41 +24304,41 @@ class ChatSession:
                 # timeout defeated once the tracked ``bash`` has exited.  Instead
                 # we wait on the tracked process bounded by ``timeout`` and tear
                 # down its whole session group on exit, reaping any such survivor.
-                stdout_parts: list[str] = []
-                stderr_lines: list[str] = []
-
-                # End-of-stream tolerance lives in the shared
-                # ``drain_pipe_lines`` (the drain half of the recipe both
-                # bash variants share); only the sinks differ — stdout also
-                # streams to the UI.
+                # End-of-stream tolerance lives in the shared chunk drain
+                # (the drain half of the recipe both bash variants share).
+                # stdout also streams to the UI; stderr receives one
+                # ``[stderr]`` prefix per line, placed at each line start, so
+                # a line spanning several chunks is still prefixed once.
                 #
-                # ``emit_done`` gates the UI half only: once set (after the
-                # join window, before ANY report path), the drain callback
-                # stops forwarding lines to the UI but keeps collecting
-                # ``stdout_parts`` so the pipe always drains and the child
-                # never blocks on a full pipe.  Without the gate, a drain
-                # thread that outlives its join (``bash.drain_leaked``
-                # below — a double-``setsid`` grandchild holding stdout
-                # open) keeps emitting into LATER turns: the UI batches
-                # chunks per call_id, some local providers REUSE call_ids
-                # across turns, and the client grafts stray chunks under
-                # the completed row.  The execution closure is the one
-                # identity that id reuse can't confuse, so the leak is
-                # closed here at the source rather than with a UI-side
-                # closed-call ledger (which per-turn resets or LRU churn
-                # would silently re-open).  Residual race: a line already
-                # past the check when the event sets — at most one line,
-                # equivalent to the pre-batching behaviour.  (The event is
-                # pre-bound next to ``proc`` above so the finally's .set()
-                # can't UnboundLocalError on a failed spawn.)
-                def _on_stdout(line: str) -> None:
-                    stdout_parts.append(line)
-                    if emit_done.is_set():
+                # Without the gate, a drain thread that outlives its join
+                # (``bash.drain_leaked`` below — a double-``setsid`` grandchild
+                # holding stdout open) keeps emitting into LATER turns: the UI
+                # batches chunks per call_id, some local providers REUSE
+                # call_ids across turns, and the client grafts stray chunks
+                # under the completed row.  The execution closure is the one
+                # identity that id reuse can't confuse, so the leak is closed
+                # here at the source rather than with a UI-side closed-call
+                # ledger (which per-turn resets or LRU churn would silently
+                # re-open).  Residual race: a line already past the check when
+                # the event sets — at most one line, equivalent to the
+                # pre-batching behaviour.
+                def _on_stdout(chunk: str) -> None:
+                    if capture_closed.is_set():
                         return
+                    stdout_capture.append(chunk)
                     try:
-                        self.ui.on_tool_output_chunk(call_id, line)
+                        self.ui.on_tool_output_chunk(call_id, chunk)
                     except Exception:
                         log.debug("UI callback error during tool output", exc_info=True)
+
+                stderr_at_line_start = True
+
+                def _on_stderr(chunk: str) -> None:
+                    nonlocal stderr_at_line_start
+                    text = f"[stderr] {chunk}" if stderr_at_line_start else chunk
+                    stderr_at_line_start = chunk.endswith("\n")
+                    if not capture_closed.is_set():
+                        stderr_capture.append(text)
 
                 assert proc.stdout is not None and proc.stderr is not None
                 stdout_thread = threading.Thread(
@@ -23851,7 +24349,7 @@ class ChatSession:
                 )
                 stderr_thread = threading.Thread(
                     target=drain_pipe_lines,
-                    args=(proc.stderr, stderr_lines.append),
+                    args=(proc.stderr, _on_stderr),
                     name=f"bash-drain-err-{call_id}",
                     daemon=True,
                 )
@@ -23885,6 +24383,7 @@ class ChatSession:
                 # Terminate the whole session group on every exit path: reaps a
                 # backgrounded child that would otherwise leak (ports, PIDs) or
                 # hold the output pipe open, and forces the drain threads to EOF.
+                group_kill_attempted = True
                 with contextlib.suppress(OSError, ProcessLookupError):
                     os.killpg(pgid, signal.SIGKILL)
 
@@ -23913,14 +24412,21 @@ class ChatSession:
                 # still forwarding chunks past its own result (the exact
                 # cross-turn grafting the gate exists to prevent).  On the
                 # normal path this is the same post-join position.
-                emit_done.set()
+                capture_closed.set()
+                if pgid is not None and not group_kill_attempted:
+                    # An exception after spawn but before the ordinary group
+                    # teardown (for example thread exhaustion) must not leave
+                    # the command or a background descendant running.
+                    with contextlib.suppress(OSError, ProcessLookupError):
+                        os.killpg(pgid, signal.SIGKILL)
                 if proc is not None:
                     with self._procs_lock:
                         self._active_procs.discard(proc)
                 # ``spawn_group_leader`` already unlinked on a failed fork —
                 # ``script_path`` stays None on that path.
                 if script_path is not None:
-                    os.unlink(script_path)
+                    with contextlib.suppress(OSError):
+                        os.unlink(script_path)
 
             if timed_out.is_set():
                 raise subprocess.TimeoutExpired(cmd="bash", timeout=timeout)
@@ -23933,26 +24439,25 @@ class ChatSession:
                 # unobserved: record outcome UNKNOWN and
                 # mark it an error, not a clean empty success — a destructive
                 # command killed here must not read as "did not run" on
-                # replay.  Keep whatever partial stdout we captured.
-                partial = "".join(stdout_parts).strip()
+                # replay. Keep whatever bounded output we captured.
+                partial = _captured_output()
                 msg = (
                     "Cancelled by user. Outcome UNKNOWN — the command was "
                     "stopped mid-execution; it may have run partially or had "
                     "side effects. Do not assume it did not run."
                 )
                 if partial:
-                    msg += "\n\nPartial output before cancel:\n" + self._truncate_output(partial)
+                    # Concatenation keeps a capture's source: a projection
+                    # extends its edges, so the fold still renders from them.
+                    msg = msg + "\n\nPartial output before cancel:\n" + partial
                 self._report_tool_result(
-                    call_id, "bash", msg, is_error=True, status=EffectStatus.UNKNOWN
+                    call_id,
+                    "bash",
+                    self._truncate_output(msg),
+                    is_error=True,
+                    status=EffectStatus.UNKNOWN,
                 )
                 return call_id, msg
-
-            output = "".join(stdout_parts)
-            if stderr_lines:
-                tagged = "".join(f"[stderr] {line}" for line in stderr_lines)
-                output += ("\n" if output else "") + tagged
-            output = output.strip()
-            output = self._truncate_output(output)
 
             # With stop_on_error, any non-zero exit is a real failure (set -e
             # killed the script).  Without it, exit code 1 is often benign
@@ -23961,10 +24466,16 @@ class ChatSession:
                 bash_error = proc.returncode != 0
             else:
                 bash_error = proc.returncode not in (0, 1)
+            output = _captured_output()
             if proc.returncode != 0:
-                output += f"\n[exit code: {proc.returncode}]"
+                output = output + f"\n[exit code: {proc.returncode}]"
 
-            self._report_tool_result(call_id, "bash", output, is_error=bash_error)
+            self._report_tool_result(
+                call_id,
+                "bash",
+                self._truncate_output(output),
+                is_error=bash_error,
+            )
 
             return call_id, output if output else "(no output)"
 
@@ -23973,14 +24484,18 @@ class ChatSession:
             # mid-flight kill as the cooperative-cancel branch above, so its
             # side effects are equally unobserved.  Read UNKNOWN, never a flat
             # failure that invites a blind re-run (HYPOTHESIS.md effect-record
-            # appendix: unknown, never none).  Keep any partial stdout captured
+            # appendix: unknown, never none). Keep any bounded output captured
             # before the kill, exactly as the cancel path does.
             msg = f"Command timed out after {timeout}s. {TIMEOUT_OUTCOME_CLAUSE}"
-            partial = "".join(stdout_parts).strip()
+            partial = _captured_output()
             if partial:
-                msg += "\n\nPartial output before timeout:\n" + self._truncate_output(partial)
+                msg = msg + "\n\nPartial output before timeout:\n" + partial
             self._report_tool_result(
-                call_id, "bash", msg, is_error=True, status=EffectStatus.UNKNOWN
+                call_id,
+                "bash",
+                self._truncate_output(msg),
+                is_error=True,
+                status=EffectStatus.UNKNOWN,
             )
             return call_id, msg
         except Exception as e:
@@ -24035,9 +24550,20 @@ class ChatSession:
         """Delta read of a background shell: only output since the last read."""
         call_id, shell_id = item["call_id"], item["shell_id"]
         filter_arg = item.get("filter")
+        # Read whole lines up to what the consumer will admit, the fold's cap
+        # or a task agent's own clip, leaving the rest unread for the next
+        # call: a delta the consumer has to cut has already been consumed past
+        # the cut.  The cap is an estimate that siblings in the batch or a
+        # mid-turn compaction can move, so the fold's marker with its consumed
+        # notice and, at an exhausted allowance, the guaranteed floor remain
+        # the backstops; an exhausted estimate reads at most one line.
+        read_cap = self._executor_cap_estimate()
         try:
             read = self._background_shells.read(
-                shell_id, owner=_active_shell_owner.get(), filter_pattern=filter_arg
+                shell_id,
+                owner=_active_shell_owner.get(),
+                filter_pattern=filter_arg,
+                max_chars=max(0, read_cap - _BASH_OUTPUT_READ_RESERVE_CHARS),
             )
         except UnknownShellError as e:
             msg = f"Error: {e}"
@@ -24086,18 +24612,16 @@ class ChatSession:
             parts.append(f"{read.new_line_count} new line(s), none matching the filter.")
         else:
             parts.append("No new output since the last read.")
-        full = "\n".join(parts)
-        output = self._truncate_output(full)
-        if len(output) < len(full):
-            # Unlike foreground bash (re-run to re-see), the delta cursor has
-            # already consumed the elided middle — say so, or a "no new
-            # output" follow-up reads as "nothing was missed".
-            output += (
-                "\n[the truncated middle was consumed and cannot be re-read; "
-                "use filter to narrow future reads]"
+        if read.unread_lines:
+            parts.append(
+                f"[{read.unread_lines} more line(s) remain unread; call bash_output again "
+                "to continue]"
             )
-        self._report_tool_result(call_id, "bash_output", output)
-        return call_id, output
+        full = "\n".join(parts)
+        # The result fold applies the context cap once and, when it has to cut
+        # this delta, appends the consumed-middle notice inside that cap.
+        self._report_tool_result(call_id, "bash_output", self._truncate_output(full))
+        return call_id, full
 
     def _exec_kill_shell(self, item: dict[str, Any]) -> tuple[str, str]:
         """Kill a background shell's whole process group."""
@@ -24225,7 +24749,6 @@ class ChatSession:
         for i, line in enumerate(lines, start=start):
             numbered.append(f"{i:>4}\t{line.rstrip()}")
         output = "\n".join(numbered)
-        output = self._truncate_output(output)
 
         desc = f"{len(lines)} lines"
         if offset is not None or limit is not None:
@@ -24436,8 +24959,13 @@ class ChatSession:
                 self._report_tool_result(call_id, "search", "all matches malformed", is_error=True)
                 return call_id, _SEARCH_ALL_TRUNCATED_MSG
 
-            output = _format_search_results(records, capped)
-            output = self._truncate_output(output)  # belt-and-suspenders
+            # The ladder is sized to the fold's cap (``_formatter_budget``)
+            # so it degrades to a tier the fold admits whole instead of the
+            # fold head/tail-clipping middle files the formatter kept on
+            # purpose.
+            output = _format_search_results(
+                records, capped, budget=self._formatter_budget(_SEARCH_OUTPUT_BUDGET)
+            )
 
             match_count = len(records)
             desc = f"{match_count} matches"
@@ -24489,18 +25017,17 @@ class ChatSession:
             lines_a, lines_b = lines_b, lines_a
             path_a, label_b = label_b, path_a
 
-        # Stream diff with early cutoff to avoid large allocations
-        max_chars = self.tool_truncation or 262_144
-        chunks: list[str] = []
-        total_chars = 0
+        # Stream the generated diff through the shared bounded edge buffer so
+        # a huge diff is never materialized whole.  The two retained edges
+        # together cover any cap the result fold can apply, so the fold stays
+        # the single truncation point and its marker reports the diff's real
+        # size.
+        diff_buffer = BoundedTextBuffer(self._executor_capture_chars())
         line_count = 0
         for line in difflib.unified_diff(lines_a, lines_b, fromfile=path_a, tofile=label_b, n=ctx):
             line_count += 1
-            if total_chars < max_chars:
-                chunks.append(line)
-                total_chars += len(line)
-        output = "".join(chunks) if chunks else "(no differences)"
-        output = self._truncate_output(output)
+            diff_buffer.append(line)
+        output = diff_buffer.projected() if line_count else "(no differences)"
         desc = f"{line_count} diff lines" if line_count else "identical"
         self._report_tool_result(call_id, "diff_file", desc)
         return call_id, output
@@ -24629,14 +25156,6 @@ class ChatSession:
         fn = getattr(self.ui, "end_agent_scope", None)
         if fn is not None:
             fn()
-
-    @staticmethod
-    def _clip_with_count(text: str, cap: int) -> str:
-        """Head-clip ``text`` to ``cap`` chars with a uniform truncation marker.
-        The one format for sub-agent output clips — the in-loop 16k clip and the
-        recall per-step cap — distinct from the token-budget-aware
-        :meth:`_truncate_output`."""
-        return _clip_agent_text(text, cap)
 
     def _stash_agent_steps(self, call_id: str | None, steps: list[dict[str, Any]]) -> None:
         """Retain one already-bounded task recall projection when supported."""
@@ -25554,9 +26073,37 @@ class ChatSession:
                 if cancelled_before_execution:
                     raise GenerationCancelled()
 
-                # Output guard: evaluate before truncation so the guard
-                # sees full output (credentials split by truncation would
-                # evade detection).  Agent outputs are always str.
+                # Executors hand back their complete result.  The guard scans
+                # a bounded window of it that reaches past the clip below, so
+                # a credential straddling the clip boundary is seen whole and
+                # redacted, while a tool server never controls how much text
+                # the guard scans.  The true size is kept for the clip marker.
+                # Agents operate autonomously; they can refine their queries
+                # if the clip loses important detail.
+                original_chars: int | None = None
+                if isinstance(output, str):
+                    original_chars = (
+                        output.source.original_chars
+                        if isinstance(output, ProjectedText)
+                        else len(output)
+                    )
+                    if isinstance(output, ProjectedText) or len(output) > _AGENT_GUARD_WINDOW_CHARS:
+                        # A capture arrives as a rendering with its source
+                        # attached: render the window from that source here,
+                        # in the head mode the clip below uses, so the guard
+                        # scans exactly the text the agent will receive and
+                        # nothing the clip could reveal afterwards.  The
+                        # window carries the marker from the start: should
+                        # redaction shrink it below the clip, the result still
+                        # reads as cut, with its true size.
+                        output = _clip_agent_text(
+                            output,
+                            _AGENT_GUARD_WINDOW_CHARS,
+                            original_chars=original_chars,
+                            tool_name=tool_name,
+                        )
+
+                # Output guard on the window.  Agent outputs are always str.
                 cancel_scope.check()
                 if self._judge_cfg and self._judge_cfg.output_guard and isinstance(output, str):
                     output, _ = self._evaluate_output(
@@ -25568,12 +26115,13 @@ class ChatSession:
                         principal_id=agent_principal,
                         cancel_ref=cancel_scope.cancel_ref,
                     )
-
-                # Truncate large tool outputs to avoid blowing context limits.
-                # Agents operate autonomously; they can refine their queries
-                # if truncation loses important detail.
                 if isinstance(output, str) and len(output) > _AGENT_TOOL_OUTPUT_CAP:
-                    output = self._clip_with_count(output, _AGENT_TOOL_OUTPUT_CAP)
+                    output = _clip_agent_text(
+                        output,
+                        _AGENT_TOOL_OUTPUT_CAP,
+                        original_chars=original_chars,
+                        tool_name=tool_name,
+                    )
 
                 # NOTE: for a vision tool result ``output`` is a list[dict] of
                 # inline content parts (read_file on an image).  It lowers back
@@ -25596,7 +26144,9 @@ class ChatSession:
                     is_error=is_tool_error,
                     effect_status=child_effect_status,
                 )
-                execution_journal.update_step(journal_step, output, is_error=is_tool_error)
+                execution_journal.update_step(
+                    journal_step, output, is_error=is_tool_error, original_chars=original_chars
+                )
                 context_turns.append(agent_turns[result_turn_index])
                 self._clear_agent_children(
                     parent_call_id,
@@ -25735,7 +26285,7 @@ class ChatSession:
                     agent="task",
                     skill=skill_data.get("name", ""),
                 )
-                skill_body = skill_body[:_MAX_SKILL_CONTENT]
+                skill_body = _clip_skill_content(skill_body)
             agent_turns.append(Turn.user(self._TASK_SKILL_CAPABILITY_PREAMBLE + skill_body))
         agent_turns.append(Turn.user(prompt))
         execution_journal = _TaskExecutionJournal(agent_turns)
@@ -26220,9 +26770,7 @@ class ChatSession:
             lines = []
             for ts, sid, role, content, tool_name in conv_rows:
                 label = f"{role}({tool_name})" if tool_name else role
-                text = (content or "")[:2000]
-                if content and len(content) > 2000:
-                    text += f"... ({len(content)} chars total)"
+                text = _clip_recall_content(content or "")
                 own = " (earlier in this conversation, compacted)" if sid == self._ws_id else ""
                 lines.append(f"[{ts} {sid}]{own} {label}: {text}")
             header = f"Conversations ({len(conv_rows)} matches"
@@ -26233,8 +26781,7 @@ class ChatSession:
         else:
             output = f"No conversation history found for '{query}'."
 
-        output = self._truncate_output(output)
-        self._report_tool_result(call_id, "recall", output)
+        self._report_tool_result(call_id, "recall", self._truncate_output(output))
         return call_id, output
 
     # -- Notify tool -----------------------------------------------------------
@@ -26890,9 +27437,6 @@ class ChatSession:
                 text = resp.text
                 if "html" in ct:
                     text = strip_html(text)
-                # Cap decoded text at 10,485,760 characters.
-                if len(text) > 10 * 1024 * 1024:
-                    text = text[: 10 * 1024 * 1024]
 
         except httpx.HTTPStatusError as e:
             msg = f"Error: fetch failed: HTTP {e.response.status_code}"
@@ -27080,9 +27624,21 @@ class ChatSession:
         )
         if max_content <= 0:
             return _no_document_budget()
-        if len(text) > max_content:
-            # Prefer the beginning — page content is usually top-heavy.
-            text = text[:max_content] + f"\n\n... [{len(text) - max_content} chars truncated] ...\n"
+
+        def _web_text_marker(omitted: int, _original: int, limit: int) -> str:
+            return (
+                f"\n\n... [{omitted:,} page chars truncated at {limit:,}-char extraction cap] ...\n"
+            )
+
+        # Prefer the beginning — page content is usually top-heavy. Apply the
+        # fixed decode backstop and lane-scaled document share in one honest
+        # projection so neither stage can silently hide a second cutoff.
+        text = truncate_text(
+            text,
+            min(max_content, _WEB_FETCH_TEXT_CHAR_CAP),
+            mode="head",
+            marker_factory=_web_text_marker,
+        ).text
 
         extraction_turns = [
             Turn.system(extraction_system),
@@ -27311,8 +27867,7 @@ class ChatSession:
             self._report_tool_result(call_id, "web_search", msg, is_error=True)
             return call_id, msg
 
-        output = self._truncate_output(output)
-        self._report_tool_result(call_id, "web_search", output)
+        self._report_tool_result(call_id, "web_search", self._truncate_output(output))
         return call_id, output
 
     def handle_command(
@@ -27592,7 +28147,9 @@ class ChatSession:
                 if cfg is not None:
                     self.context_window = cfg.context_window
                     if not self._manual_tool_truncation:
-                        self.tool_truncation = int(cfg.context_window * self._chars_per_token * 0.5)
+                        self.tool_truncation = _auto_tool_truncation_chars(
+                            cfg.context_window, self._chars_per_token
+                        )
                     # Re-resolve the sampling knobs for the new alias through
                     # the SAME shared resolvers session_factory uses, so
                     # switching away from a model with overrides doesn't leak

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -1087,7 +1087,7 @@ class SessionUIBase:
 
         Late chunks from a LEAKED drain thread (past its join timeout,
         ``bash.drain_leaked``) are gated at the PRODUCER — the
-        ``emit_done`` event in ``_exec_bash``'s stdout closure — not
+        ``capture_closed`` gate in ``_exec_bash``'s stdout closure — not
         here: the execution closure is the one identity that call_id
         reuse across turns can't confuse, whereas a UI-side
         closed-call ledger keyed on call_id would either discard a

--- a/turnstone/core/settings_registry.py
+++ b/turnstone/core/settings_registry.py
@@ -44,6 +44,12 @@ DEFAULT_AUTO_COMPACT_PCT = 0.8
 # approval batches cannot drift.
 DEFAULT_APPROVAL_TIMEOUT_SECONDS = 0
 
+# The largest tool-result cap any surface may request. ``turnstone.core.session``
+# sizes its streaming executors' edge retention from this value (half of it at
+# each edge), so every cap up to it renders faithfully from retained edges; a
+# larger cap could only be honored for outputs that were held whole.
+TOOL_TRUNCATION_MAX_CHARS = 16 * 1024 * 1024
+
 
 def _build_registry() -> dict[str, SettingDef]:
     """Build the settings registry from declarative definitions."""
@@ -219,9 +225,10 @@ def _build_registry() -> dict[str, SettingDef]:
             "tools.truncation",
             "int",
             0,
-            "Tool output truncation limit in chars (0 = auto, 50% of context window)",
+            "Tool output truncation limit in chars (0 = auto: 20% of the remaining input budget per result)",
             "tools",
             min_value=0,
+            max_value=TOOL_TRUNCATION_MAX_CHARS,
             help="Limits how much output from a tool (e.g. a long command result) gets sent back "
             "to the model. Prevents large outputs from consuming the entire context window.",
         ),
@@ -990,10 +997,12 @@ def validate_key(key: str) -> SettingDef:
     return defn
 
 
-def validate_value(key: str, raw_value: Any) -> Any:
+def validate_value(key: str, raw_value: Any, *, clamp_range: bool = False) -> Any:
     """Coerce and validate *raw_value* against the setting definition.
 
-    Returns the typed value.  Raises ValueError on invalid input.
+    Returns the typed value.  Raises ValueError on invalid input, except that
+    with ``clamp_range`` a numeric value outside the declared range is clamped
+    to the nearest bound instead.
     """
     defn = validate_key(key)
 
@@ -1036,19 +1045,15 @@ def validate_value(key: str, raw_value: Any) -> Any:
         raise ValueError(f"Cannot convert {raw_value!r} to {defn.type} for {key}") from exc
 
     # Range validation
-    if typed is not None:
-        if (
-            defn.min_value is not None
-            and isinstance(typed, (int, float))
-            and typed < defn.min_value
-        ):
-            raise ValueError(f"{key}: {typed} < minimum {defn.min_value}")
-        if (
-            defn.max_value is not None
-            and isinstance(typed, (int, float))
-            and typed > defn.max_value
-        ):
-            raise ValueError(f"{key}: {typed} > maximum {defn.max_value}")
+    if typed is not None and isinstance(typed, (int, float)):
+        if defn.min_value is not None and typed < defn.min_value:
+            if not clamp_range:
+                raise ValueError(f"{key}: {typed} < minimum {defn.min_value}")
+            typed = type(typed)(defn.min_value)
+        if defn.max_value is not None and typed > defn.max_value:
+            if not clamp_range:
+                raise ValueError(f"{key}: {typed} > maximum {defn.max_value}")
+            typed = type(typed)(defn.max_value)
 
     # Choices validation
     if defn.choices is not None and typed not in defn.choices:
@@ -1062,10 +1067,10 @@ def serialize_value(value: Any) -> str:
     return json.dumps(value)
 
 
-def deserialize_value(key: str, json_str: str) -> Any:
+def deserialize_value(key: str, json_str: str, *, clamp_range: bool = False) -> Any:
     """JSON-decode and type-coerce against registry."""
     raw = json.loads(json_str)
     defn = SETTINGS.get(key)
     if defn is None:
         return raw  # Unknown key — return raw
-    return validate_value(key, raw)
+    return validate_value(key, raw, clamp_range=clamp_range)

--- a/turnstone/core/truncation.py
+++ b/turnstone/core/truncation.py
@@ -1,0 +1,466 @@
+"""Honest, exact-cap text truncation primitives.
+
+The mechanics in this module are deliberately policy-free.  Callers choose
+whether a head or head-and-tail projection is useful, and may supply
+surface-specific marker wording, but all of them receive the same guarantees:
+
+* the returned text never exceeds the requested positive character limit;
+* truncation is reported structurally instead of inferred from string length;
+* tiny limits cannot fail open (notably Python's ``text[-0:]`` trap); and
+* streaming producers can retain bounded edges without first allocating their
+  complete output; and
+* a lossy rendering can carry its source edges along, so a later cut reports
+  omission against the true size instead of against the earlier rendering.
+
+Context-exhaustion policy remains in :class:`turnstone.core.session.ChatSession`:
+its zero-budget receipt intentionally replaces source text with a controller
+error that may be longer than the zero-character source allowance.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+TruncationMode = Literal["head", "head_tail"]
+TruncationMarker = Callable[[int, int, int], str]
+
+
+def default_truncation_marker(omitted: int, original: int, limit: int) -> str:
+    """The canonical general-purpose tool-output omission marker.
+
+    An output larger than the limit exceeded it.  One the limit could have
+    held was cut only because its producer retained less than the whole, and
+    the marker says so instead of blaming a limit that was never exceeded.
+    """
+
+    if original > limit:
+        return f"\n\n... [{omitted} chars truncated — output exceeded {limit} char limit] ...\n\n"
+    return (
+        f"\n\n... [{omitted} chars truncated — {original - omitted} of {original} chars "
+        "retained] ...\n\n"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class TruncationResult:
+    """One bounded text projection and explicit source-coverage metadata.
+
+    ``marker`` is the omission marker this rendering embedded, empty when it
+    embedded none (nothing was omitted, or an already-cut rendering was
+    reported against its true size), so a consumer that transforms the
+    rendering can still find the cut and re-project the edges around it.
+    """
+
+    text: str
+    original_chars: int
+    limit_chars: int
+    omitted_chars: int
+    marker: str = ""
+
+    @property
+    def retained_chars(self) -> int:
+        return self.original_chars - self.omitted_chars
+
+    @property
+    def truncated(self) -> bool:
+        return self.omitted_chars > 0
+
+
+@dataclass(frozen=True, slots=True)
+class TextProjectionSource:
+    """Retained source edges plus the true size they were cut from.
+
+    A producer that cannot hold its complete output keeps ``prefix`` and
+    ``suffix`` and counts the rest.  Every later consumer renders from these
+    edges, so each projection reports omission against ``original_chars``
+    rather than against an earlier rendering.
+    """
+
+    prefix: str
+    suffix: str
+    original_chars: int
+
+    def render(
+        self,
+        limit_chars: int,
+        *,
+        mode: TruncationMode = "head_tail",
+        head_fraction: float = 0.5,
+        marker_factory: TruncationMarker = default_truncation_marker,
+    ) -> TruncationResult:
+        return truncate_edges(
+            prefix=self.prefix,
+            suffix=self.suffix,
+            original_chars=self.original_chars,
+            limit_chars=limit_chars,
+            mode=mode,
+            head_fraction=head_fraction,
+            marker_factory=marker_factory,
+        )
+
+    def projected(
+        self,
+        limit_chars: int,
+        *,
+        mode: TruncationMode = "head_tail",
+        head_fraction: float = 0.5,
+        marker_factory: TruncationMarker = default_truncation_marker,
+    ) -> str:
+        """Render, keeping this source attached whenever the rendering is lossy."""
+
+        result = self.render(
+            limit_chars,
+            mode=mode,
+            head_fraction=head_fraction,
+            marker_factory=marker_factory,
+        )
+        if not result.truncated:
+            return result.text
+        return ProjectedText(result.text, self)
+
+
+class ProjectedText(str):
+    """A rendered projection that still carries its rerenderable source.
+
+    It reads as the plain rendering for every consumer that only wants text.
+    :func:`truncate_text` renders from the attached source instead, so a second
+    cut reports omission against the true size rather than the first cut.
+    Concatenation with plain text extends the matching edge, so controller
+    text added before or after a rendering never discards its source; the
+    other operand contributes its rendering only.
+    """
+
+    source: TextProjectionSource
+
+    def __new__(cls, text: str, source: TextProjectionSource) -> ProjectedText:
+        projected = super().__new__(cls, text)
+        projected.source = source
+        return projected
+
+    def __getnewargs__(self) -> tuple[str, TextProjectionSource]:  # type: ignore[override]
+        # ``str`` reconstructs a subclass through ``cls(text)`` when copied or
+        # pickled; that call would lack ``source``.  Copies keep it instead.
+        return (str(self), self.source)
+
+    def __add__(self, other: str, /) -> ProjectedText:
+        source = self.source
+        tail = str(other)
+        return ProjectedText(
+            str(self) + tail,
+            TextProjectionSource(
+                source.prefix, source.suffix + tail, source.original_chars + len(tail)
+            ),
+        )
+
+    def __radd__(self, other: str, /) -> ProjectedText:
+        source = self.source
+        head = str(other)
+        return ProjectedText(
+            head + str(self),
+            TextProjectionSource(
+                head + source.prefix, source.suffix, source.original_chars + len(head)
+            ),
+        )
+
+
+def source_chars(text: str) -> int:
+    """The producer's size behind ``text``: its source's when it carries one,
+    otherwise its own length."""
+
+    if isinstance(text, ProjectedText):
+        return text.source.original_chars
+    return len(text)
+
+
+def _split_retained(
+    retained: int,
+    *,
+    prefix_chars: int,
+    suffix_chars: int,
+    mode: TruncationMode,
+    head_fraction: float,
+) -> tuple[int, int]:
+    """Divide ``retained`` source characters between the two edges.
+
+    An edge shorter than its share hands the leftover to the other edge, so
+    asymmetric edges still fill the allowance as far as they reach.
+    """
+
+    if mode == "head":
+        return min(retained, prefix_chars), 0
+    if mode != "head_tail":  # pragma: no cover - type checkers constrain callers.
+        raise ValueError(f"unknown truncation mode: {mode!r}")
+    fraction = min(1.0, max(0.0, float(head_fraction)))
+    head_floor = 1 if fraction > 0 else 0
+    head_chars = min(retained, max(head_floor, int(retained * fraction + 0.5)))
+    tail_chars = retained - head_chars
+    if head_chars > prefix_chars:
+        head_chars = prefix_chars
+        tail_chars = min(retained - head_chars, suffix_chars)
+    elif tail_chars > suffix_chars:
+        tail_chars = suffix_chars
+        head_chars = min(retained - tail_chars, prefix_chars)
+    return head_chars, tail_chars
+
+
+def truncate_edges(
+    *,
+    prefix: str,
+    suffix: str,
+    original_chars: int,
+    limit_chars: int,
+    mode: TruncationMode = "head_tail",
+    head_fraction: float = 0.5,
+    marker_factory: TruncationMarker = default_truncation_marker,
+) -> TruncationResult:
+    """Project a source from already-retained edges.
+
+    The edges are used as far as they reach: a producer that retained fewer
+    characters than the limit allows still gets an honest marker, and the
+    omitted count always includes the marker's own cost.  Digit-width changes
+    can alter the marker length (999 -> 1,000 omitted), so the marker and the
+    split are iterated to a fixed point.  A custom marker whose length never
+    settles still fits the limit; only its omitted count may lag one pass.
+    This lower-level form lets streaming producers share the exact same
+    rendering logic as :func:`truncate_text`.
+    """
+
+    limit = max(0, int(limit_chars))
+    original = max(0, int(original_chars))
+    edge_chars = len(prefix) + len(suffix)
+    if original <= limit and original <= edge_chars:
+        # The edges meet or overlap: the complete source is recoverable.
+        if len(prefix) >= original:
+            text = prefix[:original]
+        else:
+            text = prefix + suffix[edge_chars - original :]
+        return TruncationResult(text, original, limit, 0)
+    if limit == 0:
+        return TruncationResult("", original, 0, original)
+
+    def split(retained: int) -> tuple[int, int]:
+        return _split_retained(
+            retained,
+            prefix_chars=len(prefix),
+            suffix_chars=len(suffix),
+            mode=mode,
+            head_fraction=head_fraction,
+        )
+
+    omitted = original
+    marker = marker_factory(omitted, original, limit)
+    head_chars, tail_chars = split(max(0, limit - len(marker)))
+    for _ in range(12):
+        next_omitted = original - head_chars - tail_chars
+        next_marker = marker_factory(next_omitted, original, limit)
+        if next_omitted == omitted and next_marker == marker:
+            break
+        omitted, marker = next_omitted, next_marker
+        head_chars, tail_chars = split(max(0, limit - len(marker)))
+    else:
+        marker = marker_factory(original - head_chars - tail_chars, original, limit)
+        head_chars, tail_chars = split(max(0, limit - len(marker)))
+
+    if len(marker) > limit or head_chars + tail_chars <= 0:
+        # Fall back to the smallest honest marker instead of spending a
+        # moderate-but-marker-too-small cap entirely on one ellipsis.  Prefix
+        # and/or suffix plus ``…`` still signals incompleteness; at a true
+        # one-character cap the marker necessarily consumes the whole budget.
+        marker = "…"[:limit]
+        head_chars, tail_chars = split(max(0, limit - len(marker)))
+        if head_chars + tail_chars == 0:
+            return TruncationResult(marker, original, limit, original, marker)
+
+    head = prefix[:head_chars]
+    tail = suffix[len(suffix) - tail_chars :] if tail_chars else ""
+    return TruncationResult(
+        head + marker + tail, original, limit, original - head_chars - tail_chars, marker
+    )
+
+
+def truncate_text(
+    text: str,
+    limit_chars: int,
+    *,
+    mode: TruncationMode = "head_tail",
+    head_fraction: float = 0.5,
+    marker_factory: TruncationMarker = default_truncation_marker,
+    original_chars: int | None = None,
+) -> TruncationResult:
+    """Return an honestly marked projection no longer than ``limit_chars``.
+
+    ``original_chars`` lets a caller that transformed an earlier lossy
+    rendering (redaction, an inserted notice) keep reporting omission against
+    the producer's true size once the edges can no longer be re-rendered.  It
+    is ignored when ``text`` still carries its source.
+    """
+
+    if isinstance(text, ProjectedText):
+        return text.source.render(
+            limit_chars,
+            mode=mode,
+            head_fraction=head_fraction,
+            marker_factory=marker_factory,
+        )
+    if original_chars is not None and original_chars > len(text):
+        limit = max(0, int(limit_chars))
+        if len(text) <= limit:
+            return TruncationResult(text, original_chars, limit, original_chars - len(text))
+        return truncate_edges(
+            prefix=text,
+            suffix=text,
+            original_chars=original_chars,
+            limit_chars=limit,
+            mode=mode,
+            head_fraction=head_fraction,
+            marker_factory=marker_factory,
+        )
+    return truncate_edges(
+        prefix=text,
+        suffix=text,
+        original_chars=len(text),
+        limit_chars=limit_chars,
+        mode=mode,
+        head_fraction=head_fraction,
+        marker_factory=marker_factory,
+    )
+
+
+def join_projection_sources(
+    first: TextProjectionSource,
+    second: TextProjectionSource,
+    *,
+    separator: str = "",
+    retention_chars: int,
+) -> TextProjectionSource:
+    """Edges of ``first + separator + second`` built from the parts' edges.
+
+    Each part must retain at least ``min(its size, retention_chars)``
+    characters at both edges, which is what a :class:`BoundedTextBuffer` of
+    that retention guarantees.  The joined source retains ``retention_chars``
+    at each edge and reports the concatenation's true size, so two bounded
+    captures can be presented as one document without either being rendered
+    first.
+    """
+
+    retention = max(0, int(retention_chars))
+    total = first.original_chars + len(separator) + second.original_chars
+    if first.original_chars >= retention:
+        prefix = first.prefix[:retention]
+    else:
+        prefix = (first.prefix + separator + second.prefix)[:retention]
+    if second.original_chars >= retention:
+        suffix = second.suffix[-retention:] if retention else ""
+    else:
+        joined_tail = first.suffix + separator + second.suffix
+        suffix = joined_tail[-retention:] if retention else ""
+    return TextProjectionSource(prefix, suffix, total)
+
+
+class BoundedTextBuffer:
+    """Thread-safe streaming text accumulator retaining bounded source edges.
+
+    The oldest edge is written once and frozen when it fills.  The newest edge
+    accumulates in one buffer that is compacted to its last retention whenever
+    it holds twice that, so the buffer keeps at most about three retentions of
+    text however much the producer writes (about four while a compaction
+    copies), and tiny producer fragments coalesce inside it, so bounded
+    character retention also means bounded object overhead.
+    """
+
+    def __init__(self, retention_chars: int) -> None:
+        self._retention = max(0, int(retention_chars))
+        self._prefix: io.StringIO | None = io.StringIO()
+        self._prefix_text = ""
+        self._tail = io.StringIO()
+        self._total_chars = 0
+        self._lock = threading.Lock()
+
+    def append(self, text: str) -> None:
+        if not text:
+            return
+        with self._lock:
+            self._total_chars += len(text)
+            retention = self._retention
+            start = 0
+            if self._prefix is not None:
+                room = retention - self._prefix.tell()
+                if len(text) < room:
+                    # The prefix still holds the complete output with room to
+                    # spare: an output that never exceeds the retention is
+                    # stored exactly once.
+                    self._prefix.write(text)
+                    return
+                # The prefix just filled.  From here on the tail tracks the
+                # newest edge, and it starts as the prefix itself.
+                self._prefix.write(text[:room])
+                self._prefix_text = self._prefix.getvalue()
+                self._prefix = None
+                self._tail.write(self._prefix_text)
+                start = room
+            if len(text) - start >= retention:
+                # The rest of this chunk alone is the whole newest edge: keep
+                # its last retention without ever copying the rest of the
+                # chunk, so a chunk far larger than the retention costs no
+                # transient copy of itself.
+                self._tail = io.StringIO()
+                self._tail.write(text[len(text) - retention :])
+                return
+            self._tail.write(text[start:])
+            if self._tail.tell() >= 2 * retention:
+                kept = self._tail.getvalue()
+                self._tail = io.StringIO()
+                self._tail.write(kept[len(kept) - retention :])
+
+    def source(self) -> TextProjectionSource:
+        """Snapshot the retained edges and the true size behind them."""
+
+        with self._lock:
+            total = self._total_chars
+            if self._prefix is not None:
+                # Nothing was ever dropped: the prefix is the whole output and
+                # serves as both edges without a second copy.
+                prefix = self._prefix.getvalue()
+                return TextProjectionSource(prefix, prefix, total)
+            tail = self._tail.getvalue()
+            return TextProjectionSource(
+                self._prefix_text, tail[len(tail) - self._retention :], total
+            )
+
+    def render(
+        self,
+        limit_chars: int | None = None,
+        *,
+        mode: TruncationMode = "head_tail",
+        head_fraction: float = 0.5,
+        marker_factory: TruncationMarker = default_truncation_marker,
+    ) -> TruncationResult:
+        """Render the retained edges; the default limit is the retention."""
+
+        return self.source().render(
+            self._retention if limit_chars is None else limit_chars,
+            mode=mode,
+            head_fraction=head_fraction,
+            marker_factory=marker_factory,
+        )
+
+    def projected(
+        self,
+        limit_chars: int | None = None,
+        *,
+        mode: TruncationMode = "head_tail",
+        head_fraction: float = 0.5,
+        marker_factory: TruncationMarker = default_truncation_marker,
+    ) -> str:
+        """Render, keeping the source attached whenever the rendering is lossy."""
+
+        return self.source().projected(
+            self._retention if limit_chars is None else limit_chars,
+            mode=mode,
+            head_fraction=head_fraction,
+            marker_factory=marker_factory,
+        )

--- a/turnstone/core/watch.py
+++ b/turnstone/core/watch.py
@@ -33,7 +33,22 @@ MAX_WATCHES_PER_WS = 5
 MIN_INTERVAL = 10  # seconds
 MAX_INTERVAL = 86_400  # 24 hours
 DEFAULT_MAX_POLLS = 100
-MAX_OUTPUT_SIZE = 65_536  # truncate stored/dispatched output at 64 KB
+MAX_OUTPUT_SIZE = 65_536  # truncate stored/dispatched output at 64K characters
+# A capped rendering is the head at the cap followed by this marker, and polls
+# compare by that head alone (``evaluate_condition``), so a growing log with an
+# unchanged head still reads as unchanged, and a previous poll persisted by an
+# earlier release with a differently worded marker compares equal too.
+_WATCH_TRUNCATION_MARKER = f"\n[truncated at {MAX_OUTPUT_SIZE} chars]"
+
+
+def _bound_watch_output(output: str) -> str:
+    """``output`` whole, or its head at the cap followed by the fixed marker."""
+
+    if len(output) <= MAX_OUTPUT_SIZE:
+        return output
+    return output[:MAX_OUTPUT_SIZE] + _WATCH_TRUNCATION_MARKER
+
+
 # Cap on delivery re-attempts for a fire whose workstream can't be
 # reached (evicted + transiently unrestorable — all restore slots busy).
 # On exhaustion the held reminder is dropped and one poll is charged to
@@ -167,7 +182,8 @@ def evaluate_condition(
     Returns ``(fired, reason)`` where *fired* is ``True`` when the watch
     should report a result and *reason* is a human-readable explanation.
     """
-    changed = output != prev_output
+    # Compare by the head at the cap: the marker after it is not evidence.
+    changed = prev_output is None or output[:MAX_OUTPUT_SIZE] != prev_output[:MAX_OUTPUT_SIZE]
 
     if expr is None:
         # Default: fire on any change (skip first poll where prev is None)
@@ -695,9 +711,9 @@ class WatchRunner:
         # Run command
         output, exit_code = self._run_command(sanitize_command(command))
 
-        # Truncate to avoid unbounded storage / context window usage
-        if len(output) > MAX_OUTPUT_SIZE:
-            output = output[:MAX_OUTPUT_SIZE] + f"\n[truncated at {MAX_OUTPUT_SIZE} bytes]"
+        # Bound storage and context use with the fixed-shape rendering that
+        # consecutive polls, and earlier releases' stored polls, compare by.
+        output = _bound_watch_output(output)
 
         # Evaluate condition
         fired, reason = evaluate_condition(stop_on, output, exit_code, prev_output)

--- a/turnstone/core/web_search.py
+++ b/turnstone/core/web_search.py
@@ -22,6 +22,7 @@ import httpx
 
 from turnstone.core.log import get_logger
 from turnstone.core.mcp_crypto import is_user_scoped_auth
+from turnstone.core.truncation import truncate_text
 
 if TYPE_CHECKING:
     from turnstone.core.mcp_client import MCPClientManager
@@ -33,6 +34,23 @@ log = get_logger(__name__)
 # before the caller's ``max_results`` slice. bm25.py defines the same cap
 # independently (kept separate so bm25 stays httpx-free) — keep the two in sync.
 _RERANK_POOL = 50
+_RESULT_SNIPPET_CHARS = 500
+
+
+def _format_snippet(value: Any) -> str:
+    """Return one honestly bounded search-result evidence snippet."""
+
+    text = str(value or "").strip()
+
+    def _snippet_marker(omitted: int, _original: int, _limit: int) -> str:
+        return f"\n… [{omitted:,} snippet chars omitted]"
+
+    return truncate_text(
+        text,
+        _RESULT_SNIPPET_CHARS,
+        mode="head",
+        marker_factory=_snippet_marker,
+    ).text
 
 
 class WebSearchClient(Protocol):
@@ -124,9 +142,9 @@ def _format_searxng(
 
     # Infoboxes (Wikipedia/Wikidata side panels). One is plenty of context.
     for box in data.get("infoboxes") or []:
-        content = (box.get("content") or "").strip()
+        content = _format_snippet(box.get("content"))
         if content:
-            parts.append(content[:500])
+            parts.append(content)
             break
 
     results = data.get("results") or []
@@ -137,7 +155,7 @@ def _format_searxng(
         for i, r in enumerate(results[:max_results], 1):
             title = r.get("title", "")
             url = r.get("url", "")
-            content = (r.get("content") or "")[:500]
+            content = _format_snippet(r.get("content"))
             lines.append(f"{i}. [{title}]({url})\n   {content}")
         parts.append("\n".join(lines))
 

--- a/turnstone/tools/bash_output.json
+++ b/turnstone/tools/bash_output.json
@@ -1,6 +1,6 @@
 {
   "name": "bash_output",
-  "description": "Read new output from a background shell started with bash(run_in_background=true). Returns only output produced since your previous bash_output call for that shell, plus its status (running / completed / killed) and exit code once it has exited. Stderr lines are prefixed with [stderr]. Poll this to monitor a long-running process. In the main session a system notice announces when the shell exits, so you do not need to poll a shell you are merely waiting on; inside a task agent there is no notice — poll before you finish.",
+  "description": "Read new output from a background shell started with bash(run_in_background=true). Returns only output produced since your previous bash_output call for that shell, plus its status (running / completed / killed) and exit code once it has exited. Stderr lines are prefixed with [stderr]. A read returns whole lines up to what fits the context allowance; lines beyond that stay unread and the result says how many remain, so call again to continue. If a read is nonetheless cut, the elided portion was consumed and cannot be re-read; use filter to narrow future reads. Poll this to monitor a long-running process. In the main session a system notice announces when the shell exits, so you do not need to poll a shell you are merely waiting on; inside a task agent there is no notice — poll before you finish.",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Summary

Replaces the ad-hoc slice-plus-marker truncation sites with one policy-free primitive, `turnstone.core.truncation`, and makes the result fold the single place a main-session tool result is cut.

- **Exact-cap primitive.** Every cap includes its marker, loss is reported structurally (`original_chars`, `omitted_chars`, the embedded `marker`), a one-character cap emits an ellipsis instead of failing open, and streaming producers retain bounded head and tail edges (`BoundedTextBuffer`, `ProjectedText`) instead of materializing their complete output. A marker for an output the limit could have held says how much its producer retained rather than blaming the limit.
- **Single cut, honest size.** Executors hand the fold their complete result or a projection carrying the true size, so the omission marker reports the producer's real output. Foreground `bash` and `diff_file` retain half the session cap at each edge (never less than a task agent's guard window); stdout and stderr are captured separately and joined as edges.
- **One fifth across the board.** In automatic mode every tool result receives 20% of the batch's remaining input allowance, and the session ceiling is 20% of the context window. Tools whose formatter owns a degradation ladder (`search`, `inspect_workstream`) are handed an estimate of that cap up front; `bash_output` reads whole lines up to it and leaves the rest unread for the next call. An allowance too small to carry a counted marker takes the zero-budget doors, judged by the producer's size.
- **Redaction after the cut.** A cut result the guard lengthened past its cap is re-cut at the drain's limit by splitting at the drain's marker, so the second cut never runs into the first and the omitted count still includes the removed middle. Task-agent results are guarded over a window rendered from the capture's source in the clip's head mode, so the guard scans exactly the text the agent receives.
- **Surfaces.** Compaction blocks, web search snippets, web fetch text, skill and recall clips, the interjection cap, and reasoning display share the contract. Watch output keeps the head-at-cap plus a count-free marker and polls compare by that head. The isolated PDF worker reports the true size and hands over its bounded prefix through a header the parent imports. A stored setting outside a range the registry has since tightened is clamped on load, logged once per key, and shown clamped in the admin listing.

### Operator-visible changes

- `tools.truncation` automatic mode is now 20% of the remaining input budget per result (help text updated); the ceiling is 20% of the context window.
- A `bash_output` read returns whole lines up to the fold's cap and reports how many lines remain unread; a cut delta says its consumed output cannot be re-read.
- Out-of-range stored settings are clamped with a warning instead of reverting to the default.

## Review

Four local review rounds plus an external review with sign-off; every confirmed finding was fixed and the mechanisms that kept drawing findings (the post-guard replay ledger, the bash_output hold, the per-tool policy table) were deleted in favour of simpler rules. Design notes stay local.

## Test plan

- Full suite: 12,862 passed, 0 failed, 27 skipped (`-m "not live and not e2e_recovery"`).
- `ruff check`, `ruff format --check`, and `mypy` (pinned 2.3.0) clean.
- `scripts/recovery_e2e.py` (all 26 browser-level SSE recovery scenarios against a real node with headless Chrome): every verdict `RECOVERY-READY`, exit 0.
- New tests cover the primitive (fuzzed against a reference buffer, transient-allocation bound), the fold's doors, the re-cut, the task-agent guard window, bounded `bash_output` reads, shell line records, the filtered read span, the watch head comparison, the PDF header protocol, and the settings clamp.
