### PR TITLE
feat(anthropic): onboard Claude Fable 5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
     # since about 0.95. Raise the floor when adopting fast mode, server-side fallbacks,
     # advisor, or mid-conversation tool changes, which need newer typed parameters.
     # Version 1 moves to HTTPX2 and removes Messages sampling kwargs, so migrate the
-    # provider boundary before removing the cap.
+    # provider boundary before removing the cap. Claude Fable 5.1 needs nothing typed
+    # either: its thinking block-binding control is typed only in the 1.x beta
+    # namespace and rides the plain thinking dict (verified on 0.116).
     "anthropic>=0.117,<1",
     "httpx>=0.28",
     # Direct because the provider boundary catches this exception family;

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2020,6 +2020,7 @@ class TestAnthropicHelpers:
         assert caps.supports_vision is True
         assert caps.supports_reasoning_replay is True
         assert caps.supports_mid_conversation_system is True
+        assert caps.thinking_prefix_bound is False
 
     def test_capabilities_fable_5_dated(self) -> None:
         from turnstone.core.providers._anthropic import AnthropicProvider
@@ -2030,6 +2031,38 @@ class TestAnthropicHelpers:
         assert caps.supports_temperature is False
         assert caps.thinking_display == "summarized"
         assert caps.supports_mid_conversation_system is True
+        # A dated fable-5 snapshot must not slide onto the fable-5-1 row.
+        assert caps.thinking_prefix_bound is False
+
+    def test_capabilities_fable_5_1(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-fable-5-1")
+        assert caps.context_window == 1000000
+        assert caps.max_output_tokens == 128000
+        assert caps.thinking_mode == "adaptive"
+        assert caps.supports_effort is True
+        assert caps.effort_levels == ("low", "medium", "high", "xhigh", "max")
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+        assert caps.supports_web_search is True
+        assert caps.supports_tool_search is True
+        assert caps.supports_vision is True
+        assert caps.supports_pdf is True
+        assert caps.supports_reasoning_replay is True
+        assert caps.supports_mid_conversation_system is True
+        assert caps.thinking_prefix_bound is True
+
+    def test_capabilities_fable_5_1_dated(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        caps = provider.get_capabilities("claude-fable-5-1-20260901")
+        assert caps.context_window == 1000000
+        assert caps.supports_temperature is False
+        assert caps.thinking_display == "summarized"
+        assert caps.thinking_prefix_bound is True
 
     def test_capabilities_opus_5(self) -> None:
         from turnstone.core.providers._anthropic import AnthropicProvider
@@ -6370,3 +6403,146 @@ def test_commercial_lanes_declare_server_parses_reasoning():
     ]:
         caps = create_provider(name).get_capabilities(model)
         assert caps.server_parses_reasoning is False, (name, model)
+
+
+# ===========================================================================
+# TestAnthropicThinkingPrefixBinding
+# ===========================================================================
+
+
+class TestAnthropicThinkingPrefixBinding:
+    """``thinking_prefix_bound`` rows opt into drop_block + the controls beta."""
+
+    _BETA = "thinking-binding-controls-2026-08-01"
+
+    def setup_method(self) -> None:
+        from turnstone.core.providers._anthropic import AnthropicProvider
+
+        self.provider = AnthropicProvider()
+
+    def _kwargs(self, model: str) -> dict[str, Any]:
+        caps = self.provider.get_capabilities(model)
+        return self.provider._build_thinking_and_kwargs(
+            caps=caps,
+            reasoning_effort="high",
+            extra_params=None,
+            max_tokens=8192,
+            temperature=None,
+            converted_msgs=[{"role": "user", "content": "hi"}],
+            system_prompt="",
+            model=model,
+            tools=None,
+        )
+
+    def test_fable_5_1_sends_drop_block_and_beta(self) -> None:
+        kwargs = self._kwargs("claude-fable-5-1")
+        assert kwargs["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+            "block_binding": {"prefix_mismatch_behavior": "drop_block"},
+        }
+        assert kwargs["extra_headers"] == {"anthropic-beta": self._BETA}
+
+    def test_fable_5_sends_neither(self) -> None:
+        kwargs = self._kwargs("claude-fable-5")
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert "extra_headers" not in kwargs
+
+    def test_caller_beta_header_is_joined_not_replaced(self) -> None:
+        from tests._wire_capture import RecordingClient
+
+        client = RecordingClient()
+        gen = self.provider.create_streaming(
+            client=client,
+            model="claude-fable-5-1",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=64,
+            extra_headers={"anthropic-beta": "other-beta-2026-01-01", "x-trace": "t1"},
+        )
+        gen.close()
+        headers = client.captured["payload"]["extra_headers"]
+        assert headers == {
+            "anthropic-beta": f"{self._BETA},other-beta-2026-01-01",
+            "x-trace": "t1",
+        }
+
+    def test_caller_beta_header_joins_case_insensitively(self) -> None:
+        from tests._wire_capture import RecordingClient
+
+        client = RecordingClient()
+        gen = self.provider.create_streaming(
+            client=client,
+            model="claude-fable-5-1",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=64,
+            extra_headers={"Anthropic-Beta": "other-beta-2026-01-01"},
+        )
+        gen.close()
+        headers = client.captured["payload"]["extra_headers"]
+        assert headers == {"anthropic-beta": f"{self._BETA},other-beta-2026-01-01"}
+
+    def test_caller_headers_pass_through_on_unbound_rows(self) -> None:
+        from tests._wire_capture import RecordingClient
+
+        client = RecordingClient()
+        gen = self.provider.create_streaming(
+            client=client,
+            model="claude-fable-5",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=64,
+            extra_headers={"x-trace": "t1"},
+        )
+        gen.close()
+        assert client.captured["payload"]["extra_headers"] == {"x-trace": "t1"}
+
+    def test_real_sdk_puts_control_on_the_wire(self) -> None:
+        """Drive the real SDK: the untyped control must reach the HTTP body
+        verbatim and the beta must land as a request header (the SDK
+        floor is below the release that types ``block_binding``)."""
+        import anthropic
+        import httpx
+
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["beta"] = request.headers.get("anthropic-beta")
+            captured["body"] = json.loads(request.content)
+            sse = (
+                "event: message_start\n"
+                'data: {"type":"message_start","message":{"id":"m","type":"message",'
+                '"role":"assistant","model":"claude-fable-5-1","content":[],'
+                '"stop_reason":null,"stop_sequence":null,'
+                '"usage":{"input_tokens":1,"output_tokens":0}}}\n\n'
+                "event: message_delta\n"
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn",'
+                '"stop_sequence":null},"usage":{"output_tokens":1}}\n\n'
+                "event: message_stop\n"
+                'data: {"type":"message_stop"}\n\n'
+            )
+            return httpx.Response(
+                200, headers={"content-type": "text/event-stream"}, content=sse.encode()
+            )
+
+        client = anthropic.Anthropic(
+            api_key="test-key",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+        try:
+            chunks = list(
+                self.provider.create_streaming(
+                    client=client,
+                    model="claude-fable-5-1",
+                    messages=[{"role": "user", "content": "hi"}],
+                    max_tokens=64,
+                )
+            )
+        finally:
+            client.close()
+        assert captured["beta"] == self._BETA
+        assert captured["body"]["thinking"] == {
+            "type": "adaptive",
+            "display": "summarized",
+            "block_binding": {"prefix_mismatch_behavior": "drop_block"},
+        }
+        finishes = [c.finish_reason for c in chunks if c.finish_reason]
+        assert finishes == ["stop"]

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -78,6 +78,11 @@ _WEB_SEARCH_TOOL_TYPE = "web_search_20250305"
 
 # Tool search: server-side BM25 tool discovery for deferred tools
 _TOOL_SEARCH_TOOL_TYPE = "tool_search_tool_bm25"
+# Beta value that unlocks ``thinking.block_binding`` (see
+# ``ModelCapabilities.thinking_prefix_bound``).  Sent as an
+# ``anthropic-beta`` request header, comma-joined with any value a caller
+# already put there.
+_THINKING_BINDING_BETA = "thinking-binding-controls-2026-08-01"
 
 # extra_params keys consumed internally (``_reasoning_params``) — never
 # forwarded to the wire ``extra_body``.  Keeps real-Anthropic request
@@ -140,6 +145,35 @@ _ANTHROPIC_COMPAT_DEFAULT = ModelCapabilities(
 )
 
 _ANTHROPIC_CAPABILITIES: dict[str, ModelCapabilities] = {
+    # Fable 5.1: the fable-5 surface (below) plus three documented breaking
+    # changes, of which only the last reaches this lane:
+    #   * forced tool choice (``tool_choice`` any/tool) is a 400 -- this lane
+    #     never sends ``tool_choice`` at all, so unreachable.
+    #   * thinking blocks are bound to the producing model -- a block the
+    #     target model cannot read is dropped server-side, unbilled, before
+    #     the prompt is priced; replay stays verbatim, nothing to strip.
+    #   * thinking blocks are bound to the conversation prefix -- see
+    #     ``thinking_prefix_bound``; the row opts into drop_block.
+    # Same tokenizer, limits, effort ladder (default high) and pricing tier
+    # as fable-5.  ``display: "summarized"`` also returns the model's
+    # between-tool-call progress notes as thinking text.
+    "claude-fable-5-1": ModelCapabilities(
+        context_window=1000000,
+        max_output_tokens=128000,
+        token_param="max_tokens",
+        thinking_mode="adaptive",
+        supports_effort=True,
+        effort_levels=("low", "medium", "high", "xhigh", "max"),
+        supports_web_search=True,
+        supports_tool_search=True,
+        supports_vision=True,
+        supports_pdf=True,
+        supports_temperature=False,
+        thinking_display="summarized",
+        supports_reasoning_replay=True,
+        supports_mid_conversation_system=True,
+        thinking_prefix_bound=True,
+    ),
     # Fable 5: same wire surface as opus-4-8 (adaptive-only thinking, no
     # sampling params, prefill rejected) with one extra constraint — an
     # explicit thinking={"type": "disabled"} is a 400 on this model; thinking
@@ -483,6 +517,8 @@ class AnthropicProvider:
             thinking_dict: dict[str, Any] = {"type": "adaptive"}
             if caps.thinking_display:
                 thinking_dict["display"] = caps.thinking_display
+            if caps.thinking_prefix_bound:
+                thinking_dict["block_binding"] = {"prefix_mismatch_behavior": "drop_block"}
             thinking_params = {"thinking": thinking_dict}
             if caps.supports_temperature:
                 temperature = 1.0  # Required with thinking
@@ -529,6 +565,9 @@ class AnthropicProvider:
             wire_extra = {k: v for k, v in extra_params.items() if k not in _INTERNAL_EXTRA_PARAMS}
             if wire_extra:
                 kwargs["extra_body"] = wire_extra
+
+        if "block_binding" in thinking_params.get("thinking", {}):
+            kwargs["extra_headers"] = {"anthropic-beta": _THINKING_BINDING_BETA}
 
         return kwargs
 
@@ -942,7 +981,9 @@ class AnthropicProvider:
             deferred_names,
         )
         if extra_headers:
-            kwargs["extra_headers"] = extra_headers
+            kwargs["extra_headers"] = _merge_extra_headers(
+                kwargs.get("extra_headers"), extra_headers
+            )
 
         refuse_aborted_request(cancel_ref)
         if request_metrics_ref is not None:
@@ -1299,6 +1340,25 @@ class AnthropicProvider:
             if isinstance(text, str) and text:
                 parts.append(text)
         return _join_reasoning_with_cap(parts)
+
+
+def _merge_extra_headers(wire: dict[str, str] | None, caller: dict[str, str]) -> dict[str, str]:
+    """Overlay caller headers on the wire-built ones.
+
+    Callers win on every header except ``anthropic-beta``, where both
+    sides carry independent beta values and the header is a comma-joined
+    list -- dropping either half would silently disable one feature.
+    """
+    merged = dict(wire or {})
+    for name, value in caller.items():
+        existing = next((k for k in merged if k.lower() == name.lower()), None)
+        if existing is not None and name.lower() == "anthropic-beta" and merged[existing]:
+            merged[existing] = f"{merged[existing]},{value}"
+            continue
+        if existing is not None:
+            del merged[existing]
+        merged[name] = value
+    return merged
 
 
 def _normalize_finish_reason(reason: str) -> str:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -618,6 +618,25 @@ class ModelCapabilities:
     # stop_reason AND no ``message_stop``), Responses (no terminal
     # ``response.completed``/``response.incomplete`` event).
     finish_reason_optional: bool = False
+    # Preserved thinking (claude-fable-5-1 / claude-mythos-5-1): a thinking
+    # block's signature records the conversation prefix that produced it
+    # (top-level ``system``, the ``tools`` set, every earlier message), and
+    # a replayed block whose prefix has since changed fails the API's
+    # conversation check.  Organizations created on or after 2026-08-31 are
+    # enforced -- the default there is a 400 on the whole request, retried
+    # bodies fail the same way.  Older organizations only record the
+    # mismatch until a request sets the control, which opts it in.  This
+    # harness has not been audited append-only (client-side compaction
+    # alone rewrites earlier turns), and the documented production
+    # setting is an explicit choice either way, so a
+    # row with this flag sends the ``thinking-binding-controls-2026-08-01``
+    # beta and ``thinking.block_binding.prefix_mismatch_behavior=
+    # "drop_block"``: the API drops the first mismatched block and every
+    # later one, the request proceeds, and the model re-plans without that
+    # reasoning (dropped blocks are unbilled).  Wire shape verified on SDK
+    # 0.116 through a mock transport -- the control is untyped below 1.x
+    # and rides the plain ``thinking`` dict.  Never set on a compat lane.
+    thinking_prefix_bound: bool = False
 
 
 # The session effort knob is ORDINAL — snapping must respect this order.


### PR DESCRIPTION
## Summary

- Adds the `claude-fable-5-1` row to the Anthropic capability matrix. Same surface as `claude-fable-5`: 1M context, 128K output, adaptive-only thinking with summarized display, effort `low`..`max`, no sampling params, web search, tool search, vision, PDF, reasoning replay, mid-conversation system messages.
- Of Fable 5.1's three breaking changes versus Fable 5, only conversation-bound thinking reaches this lane. Forced `tool_choice` is never sent by the Anthropic lane, and model-bound thinking blocks are dropped server-side and unbilled, so replay stays verbatim.
- New capability field `thinking_prefix_bound`. Organizations created on or after 2026-08-31 get a 400 when replayed thinking blocks predate an edit to the conversation prefix. Rows with the flag send the `thinking-binding-controls-2026-08-01` beta header plus `thinking.block_binding.prefix_mismatch_behavior="drop_block"`, the documented degrade mode. Caller-supplied `anthropic-beta` headers are comma-joined rather than replaced.
- SDK floor unchanged (`anthropic>=0.117,<1`). The block-binding control is typed only in the 1.x beta namespace; below 1.x it rides the plain `thinking` dict, which the SDK forwards verbatim.

## Verification

- New tests: capability rows (bare and dated, including the fable-5 prefix boundary), kwargs shape with and without the flag, header merge (join, case-insensitive join, pass-through), and a real-SDK boundary test that drives `create_streaming` through `anthropic.Anthropic` with an `httpx.MockTransport` and asserts the HTTP body and header.
- `ruff format`, `ruff check`, `mypy` clean on the changed files.
- Full suite: 12788 passed, 31 skipped.

## Not in this PR

- No rows for `claude-mythos-5`, `claude-mythos-preview`, or `claude-mythos-5-1` (Project Glasswing only). They still fall through to the Anthropic default row.
- No adoption of per-message effort, turn-scoped system messages, or `display: "updates"`. All three are beta and none is required for Fable 5.1 to work on this lane.
- No append-only audit of the harness. The drop_block control degrades instead of failing; an audit would reduce how often reasoning is dropped after compaction or a tool-set change.
