### PR TITLE
fix(models): per-definition context windows, no bootstrap endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,13 @@
 # =============================================================================
 
 # -- LLM backend --------------------------------------------------------------
-# Optional: nodes boot without an LLM. Add real model backends from the console
-# UI (Models tab). These only set the bootstrap default a node starts with.
-# LLM_BASE_URL=http://host.docker.internal:8000/v1
+# Optional: nodes boot without an LLM and have no bootstrap endpoint. Add model
+# backends from the console UI (Models tab), each with its own URL and key. A
+# definition that leaves api_key empty falls back to the matching variable
+# below; a local server needs none.
 # OPENAI_API_KEY=dummy
-# ANTHROPIC_API_KEY=sk-ant-...     # set instead of OPENAI_API_KEY for Anthropic
+# ANTHROPIC_API_KEY=sk-ant-...     # for Anthropic definitions without a key
 # TURNSTONE_SEARXNG_URL=http://searxng:8080  # web_search backend (default: bundled service; set to an external SearxNG)
-# MODEL=                           # default model alias
 
 # -- Secrets ------------------------------------------------------------------
 # The dev stack defaults these to INSECURE values. Always set real ones for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,69 @@ frozen.
   addresses, and the `https://` requirement for per-user bearers is
   unchanged. A refusal names the remedy that actually applies to it.
 
+### Changed
+
+- **A model definition that leaves `api_key` empty on a local server**
+  (`openai-compatible` / `anthropic-compatible`) resolves its bearer the way
+  the server's own `--api-key` default used to: the SDK's environment
+  variable when set, otherwise a placeholder, so vLLM and llama.cpp
+  definitions keep working without an exported `OPENAI_API_KEY`. Commercial
+  providers keep the SDK environment-variable rule unchanged.
+- **`turnstone-doctor` resolves its own model the way a node does** — from
+  the database definitions and `[models.*]` — instead of seeding one from
+  `[api]` / `LLM_BASE_URL`, which a node no longer reads.
+- **A `[models.*]` entry that names neither `base_url` nor `provider`** is
+  skipped with a startup warning. It used to inherit the server's bootstrap
+  endpoint; without one, the default provider would send its prompts to the
+  commercial OpenAI API.
+
+### Removed
+
+- **`turnstone-server` no longer takes `--base-url`, `--api-key`,
+  `--provider`, or `--model`, and no longer reads `[api]` from
+  `config.toml`.** Model endpoints live in the console Models tab and in
+  `[models.*]` entries, each with its own `base_url` and `api_key`; a server
+  started with nothing configured boots with an empty registry and picks
+  models up live from the console. `compose.yaml` drops the `LLM_BASE_URL`
+  and `MODEL` variables, the Helm chart drops `llm.baseUrl` / `llm.provider`
+  (their environment variables were read by nothing), and the Terraform
+  module drops `llm_base_url`. A `config.toml` that still carries `[api]`
+  gets a startup warning naming the replacement. The `turnstone` CLI keeps
+  its flags.
+
 ### Fixed
 
+- **Context window auto-detection (#1052).** A model definition whose
+  `context_window` is `0` is now resolved per definition: from the
+  provider's capability table for Anthropic, OpenAI and xAI, and by asking
+  the definition's own endpoint for local servers and gateways (vLLM
+  `max_model_len`, llama.cpp `n_ctx_train`, and the `context_length`,
+  `context_window` or `max_context_length` that OpenRouter, Together,
+  Fireworks, Groq and Mistral report) — at startup and on every
+  hot-reload, identical
+  definitions sharing one probe; when a reload's probe fails, a definition
+  the running registry had detected on the same endpoint and model keeps
+  that window, so a backend mid-restart never shrinks live sessions. The
+  server, the console and the doctor resolve the same way. Previously every
+  such definition inherited the window the server had detected on its
+  bootstrap endpoint at boot — 32768 whenever `--model` was passed or that
+  endpoint was unreachable, and the wrong endpoint's number otherwise. A
+  definition that cannot be resolved — a model id the capability table does
+  not list (every Google model, which has no table), an unreachable or
+  silent endpoint — falls back to 32768 with a startup warning naming the
+  alias and the reason. Probes run concurrently under a five-second budget.
+  A definition created through the admin API without a `context_window` is
+  stored as auto-detect rather than a literal 32768. A local-server
+  definition without a `base_url` is refused at save time and skipped at
+  load time, and a `[models.*]` entry with `provider = "openai"` and no
+  `base_url` is skipped while the file still carries `[api] base_url`,
+  since it was written to inherit that endpoint. The console Detect button
+  no longer offers a commercial model's window for a local server, and when
+  the endpoint reports no window it fills the field with the 32768 the node
+  would otherwise use, and says so, so the operator corrects it before the
+  first call rather than finding it in the node log. Node
+  hot-reloads are serialised and keep the running registry when the load
+  fails.
 - **MCP OAuth discovery for servers and issuers with paths (#1061, #1063).**
   Protected-resource metadata is fetched from the RFC 9728 path-specific
   location first and the origin-level location second, in one candidate loop

--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ pip install turnstone
 # Terminal REPL
 turnstone --base-url http://localhost:8000/v1
 
-# Browser UI
-turnstone-server --port 8080 --base-url http://localhost:8000/v1
+# Browser UI — define models in the console Models tab, or in
+# ~/.config/turnstone/config.toml:
+#   [models.local]
+#   base_url = "http://localhost:8000/v1"
+#   model = "qwen3-32b"
+turnstone-server --port 8080
 
 # Cluster dashboard
 turnstone-console --port 8090
@@ -93,7 +97,7 @@ For PostgreSQL (recommended for production):
 ```bash
 export TURNSTONE_DB_BACKEND=postgresql
 export TURNSTONE_DB_URL="postgresql+psycopg://user:pass@localhost:5432/turnstone"
-turnstone-server --port 8080 --base-url http://localhost:8000/v1
+turnstone-server --port 8080
 ```
 
 ### Docker

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,8 +23,8 @@
 #
 # Bring your own LLM: nodes boot without one and show up in the console
 # immediately. Add model backends (OpenAI / Anthropic / local vLLM) from the
-# console UI's Models tab, or point LLM_BASE_URL / OPENAI_API_KEY (below) at an
-# OpenAI-compatible endpoint.
+# console UI's Models tab; OPENAI_API_KEY (below) backs definitions that leave
+# api_key empty (local servers need none).
 #
 # Fewer nodes (lighter machines):
 #     docker compose up postgres console caddy channel node-1 node-2 node-3
@@ -288,9 +288,6 @@ services:
         turnstone-server
         --host 0.0.0.0
         --port 8080
-        --base-url "$${LLM_BASE_URL}"
-        --api-key "$${OPENAI_API_KEY}"
-        $${MODEL:+--model $$MODEL}
         $${SKIP_PERMISSIONS:+--skip-permissions}
         $${MCP_CONFIG:+--mcp-config $$MCP_CONFIG}
     volumes:
@@ -300,13 +297,13 @@ services:
       TURNSTONE_JWT_SECRET: *jwt-secret
       TURNSTONE_DB_BACKEND: *db-backend
       TURNSTONE_DB_URL: *db-url
-      # Bootstrap LLM defaults — real backends are configured in the console UI.
-      LLM_BASE_URL: ${LLM_BASE_URL:-http://host.docker.internal:8000/v1}
+      # Model backends are configured in the console Models tab. A definition
+      # that leaves api_key empty falls back to this variable (local servers
+      # need none); so does a ${OPENAI_API_KEY} placeholder in a definition.
       OPENAI_API_KEY: ${OPENAI_API_KEY:-dummy}
       # web_search backend. Defaults to the bundled searxng service; point at an
       # external SearxNG by setting TURNSTONE_SEARXNG_URL in .env (empty disables).
       TURNSTONE_SEARXNG_URL: ${TURNSTONE_SEARXNG_URL:-http://searxng:8080}
-      MODEL: ${MODEL:-}
       MCP_CONFIG: ${MCP_CONFIG:-}
       SKIP_PERMISSIONS: ${SKIP_PERMISSIONS:-}
       TURNSTONE_NODE_ID: node-1

--- a/deploy/helm/turnstone/templates/NOTES.txt
+++ b/deploy/helm/turnstone/templates/NOTES.txt
@@ -30,9 +30,3 @@ Components deployed:
   - PostgreSQL (bitnami subchart)
 {{- end }}
 
-{{- if not .Values.llm.apiKey }}
-{{- if not .Values.llm.existingSecret }}
-
-WARNING: No LLM API key configured. Set llm.apiKey or llm.existingSecret in your values.
-{{- end }}
-{{- end }}

--- a/deploy/helm/turnstone/templates/configmap.yaml
+++ b/deploy/helm/turnstone/templates/configmap.yaml
@@ -15,7 +15,3 @@ data:
   TURNSTONE_CONSOLE_HOST: "0.0.0.0"
   TURNSTONE_CONSOLE_PORT: {{ .Values.console.service.port | quote }}
   TURNSTONE_POLL_INTERVAL: "5"
-  {{- if .Values.llm.baseUrl }}
-  TURNSTONE_LLM_BASE_URL: {{ .Values.llm.baseUrl | quote }}
-  {{- end }}
-  TURNSTONE_LLM_PROVIDER: {{ .Values.llm.provider | quote }}

--- a/deploy/helm/turnstone/values.yaml
+++ b/deploy/helm/turnstone/values.yaml
@@ -73,10 +73,10 @@ migrate:
   affinity: {}
   tolerations: []
 
-# -- LLM provider configuration
+# -- LLM API key (optional). Model backends are defined in the console
+# Models tab; a definition that leaves api_key empty falls back to the
+# OPENAI_API_KEY this feeds (a local server needs none).
 llm:
-  baseUrl: ""
-  provider: openai
   apiKey: ""
   existingSecret: ""
 

--- a/deploy/openshell/routes.yaml
+++ b/deploy/openshell/routes.yaml
@@ -12,8 +12,12 @@
 #     --inference-routes deploy/openshell/routes.yaml \
 #     ...
 #
-# Then start turnstone with:
-#   python3 -m turnstone.server --base-url https://inference.local
+# Then point a model definition at the proxy — in config.toml:
+#   [models.sandbox]
+#   base_url = "https://inference.local"
+#   model = "gpt-5"                       # the id the route below serves
+# (or the same fields in the console Models tab) — and start turnstone:
+#   python3 -m turnstone.server
 #
 # CUSTOMIZE: uncomment one of the provider blocks below.
 

--- a/deploy/openshell/turnstone-policy.yaml
+++ b/deploy/openshell/turnstone-policy.yaml
@@ -15,8 +15,9 @@
 #     --policy deploy/openshell/turnstone-policy.yaml \
 #     --inference-routes deploy/openshell/routes.yaml \
 #     --workdir /project \
-#     -- python3 -m turnstone.server --host 0.0.0.0 --port 8080 \
-#         --base-url https://inference.local
+#     -- python3 -m turnstone.server --host 0.0.0.0 --port 8080
+#   with a model definition whose base_url is https://inference.local
+#   (config.toml [models.*] or the console Models tab).
 #
 # Note: inference.local is intercepted by the OpenShell proxy before
 # network policy evaluation — no network_policies entry is needed for it.

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -37,6 +37,8 @@ uv pip install --python /opt/turnstone-venv 'turnstone @ git+https://github.com/
 #   …or from a local checkout:  uv pip install --python /opt/turnstone-venv /path/to/turnstone
 
 # 3. Secrets — match the cluster's JWT secret + DB credentials (kept out of env).
+#    Model backends and their API keys are configured in the console UI's
+#    Models tab (or as [models.*] entries here); the node has no bootstrap endpoint.
 install -d -m 750 -o turnstone -g turnstone /etc/turnstone
 cat > /etc/turnstone/config.toml <<'TOML'
 [auth]
@@ -44,9 +46,6 @@ jwt_secret = "<same secret as the cluster>"
 [database]
 backend = "postgresql"
 url = "postgresql+psycopg://turnstone:<password>@<compose-host-ip>:5432/turnstone"
-[api]
-base_url = "http://localhost:8000/v1"   # a real model backend is configured in the console UI
-api_key = "dummy"
 TOML
 chown turnstone:turnstone /etc/turnstone/config.toml
 chmod 600 /etc/turnstone/config.toml

--- a/deploy/systemd/turnstone-server.service
+++ b/deploy/systemd/turnstone-server.service
@@ -17,8 +17,9 @@ Type=exec
 User=turnstone
 Group=turnstone
 
-# Secrets live in config.toml — JWT secret, Postgres URL+password, LLM API key —
-# kept out of os.environ so a prompt-injected tool can't dump them via `env`.
+# Secrets live in config.toml — JWT secret, Postgres URL+password, and any
+# [models.*] API keys — kept out of os.environ so a prompt-injected tool can't
+# dump them via `env`. Model backends are otherwise configured in the console.
 Environment=TURNSTONE_CONFIG=/etc/turnstone/config.toml
 Environment=TURNSTONE_LOG_LEVEL=info
 

--- a/deploy/terraform/examples/aws-ecs-basic/main.tf
+++ b/deploy/terraform/examples/aws-ecs-basic/main.tf
@@ -23,7 +23,6 @@ module "turnstone" {
   image_repository = var.image_repository
   image_tag        = var.image_tag
 
-  llm_base_url   = var.llm_base_url
   openai_api_key = var.openai_api_key
 
   environment = var.environment

--- a/deploy/terraform/examples/aws-ecs-basic/terraform.tfvars.example
+++ b/deploy/terraform/examples/aws-ecs-basic/terraform.tfvars.example
@@ -6,10 +6,9 @@ vpc_id             = "vpc-0123456789abcdef0"
 private_subnet_ids = ["subnet-aaa111", "subnet-bbb222"]
 public_subnet_ids  = ["subnet-ccc333", "subnet-ddd444"]
 
-# LLM provider configuration.
-# For OpenAI: https://api.openai.com/v1
-# For a self-hosted vLLM instance: http://your-vllm-host:8000/v1
-llm_base_url   = "https://api.openai.com/v1"
+# LLM API key. Model backends (OpenAI, a self-hosted vLLM, ...) are defined
+# in the console Models tab; a definition that leaves api_key empty falls
+# back to this value.
 openai_api_key = "sk-..."
 
 # --- Optional ---

--- a/deploy/terraform/examples/aws-ecs-basic/variables.tf
+++ b/deploy/terraform/examples/aws-ecs-basic/variables.tf
@@ -31,13 +31,8 @@ variable "image_tag" {
   default     = "latest"
 }
 
-variable "llm_base_url" {
-  description = "Base URL for the LLM provider API."
-  type        = string
-}
-
 variable "openai_api_key" {
-  description = "API key for the LLM provider."
+  description = "API key used by model definitions that leave api_key empty."
   type        = string
   sensitive   = true
 }

--- a/deploy/terraform/modules/aws-ecs/main.tf
+++ b/deploy/terraform/modules/aws-ecs/main.tf
@@ -26,7 +26,6 @@ locals {
   common_env = [
     { name = "TURNSTONE_ENV", value = var.environment },
     { name = "TURNSTONE_DB_BACKEND", value = "postgresql" },
-    { name = "TURNSTONE_LLM_BASE_URL", value = var.llm_base_url },
   ]
 
   # Secrets pulled from Secrets Manager at container start.

--- a/deploy/terraform/modules/aws-ecs/variables.tf
+++ b/deploy/terraform/modules/aws-ecs/variables.tf
@@ -31,13 +31,8 @@ variable "image_tag" {
 
 # --- LLM Provider ---
 
-variable "llm_base_url" {
-  description = "Base URL for the LLM provider API (e.g. https://api.openai.com/v1)."
-  type        = string
-}
-
 variable "openai_api_key" {
-  description = "API key for the LLM provider. Stored in AWS Secrets Manager."
+  description = "API key used by model definitions that leave api_key empty. Stored in AWS Secrets Manager."
   type        = string
   sensitive   = true
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1173,11 +1173,11 @@ provider = "anthropic-compatible"
 base_url = "http://localhost:8000"   # no /v1 — the SDK appends /v1/messages
 api_key = "dummy"
 model = "deepseek-ai/DeepSeek-V4-Flash"
+context_window = 131072              # or 0 to ask the server at startup
 
 [models.vllm-claude.capabilities]
 supports_vision = true                    # multimodal checkpoints only
 supports_mid_conversation_system = true   # template-dependent
-context_window = 131072
 thinking_mode = "manual"                  # session effort knob drives the template toggle
 thinking_param = "enable_thinking"        # Qwen/Gemma key; "thinking" for Granite/DeepSeek
 ```
@@ -1301,8 +1301,14 @@ rows are never modified).
 
 **Lifecycle:**
 1. `load_model_registry()` loads DB model definitions (if storage available),
-   then overlays `[models.*]` from config.toml, then builds a `"default"` entry
-   from CLI `--base-url`/`--model`/`--api-key` args
+   then overlays `[models.*]` from config.toml. The CLI additionally builds a
+   `"default"` entry from its `--base-url`/`--model`/`--api-key` args when
+   nothing else defines a model; the server has no bootstrap endpoint. A
+   definition whose `context_window` is `0` is auto-detected per definition:
+   from the provider's capability table, or by asking the definition's own
+   endpoint (vLLM `max_model_len`, llama.cpp `n_ctx_train`, a gateway's
+   `context_length`), with `32768` and
+   a startup warning as the last resort
 2. The registry is passed to the session factory closure in both `cli.py` and
    `server.py`; each workstream resolves its model on creation
 3. `ModelRegistry.get_client()` lazily creates SDK client instances via

--- a/docs/diagrams/12-deployment.puml
+++ b/docs/diagrams/12-deployment.puml
@@ -79,8 +79,7 @@ pgbouncer --> postgres : transaction\npooling
 ' Environment variables
 note right of host
     **Environment Variables:**
-    * LLM_BASE_URL -- LLM endpoint
-    * OPENAI_API_KEY -- API key
+    * OPENAI_API_KEY -- API key for definitions without one
     * TURNSTONE_AUTH_TOKEN -- API auth
     * TURNSTONE_DB_URL -- PostgreSQL URL
     * POSTGRES_PASSWORD -- DB password

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -35,10 +35,11 @@ docker compose exec node-1 turnstone-admin create-user --username admin --name "
 
 ### Bring your own LLM
 
-Nodes boot **without** an LLM and appear in the console immediately. Add real
+Nodes boot **without** an LLM and appear in the console immediately. Add
 model backends (OpenAI, Anthropic, or a local/vLLM endpoint) from the console
-UI's **Models** tab. To set a node's bootstrap default instead, point
-`LLM_BASE_URL` / `OPENAI_API_KEY` at an OpenAI-compatible endpoint in `.env`.
+UI's **Models** tab, or as `[models.*]` entries in a node's `config.toml`. A
+definition that leaves `api_key` empty falls back to `OPENAI_API_KEY` from
+`.env`; a local server needs no key at all.
 
 ### Fewer nodes
 
@@ -77,9 +78,9 @@ jwt_secret = "dev-only-insecure-jwt-secret-change-me-for-real-deployments"
 backend = "postgresql"
 url = "postgresql+psycopg://turnstone:turnstone@localhost:5432/turnstone"
 
-[api]
+[models.local]
 base_url = "http://localhost:8000/v1"   # your local model endpoint
-api_key = "dummy"
+model = "qwen3-32b"
 ```
 
 Then start the server. The node identity isn't a secret, so it stays on the
@@ -178,11 +179,9 @@ overrides.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LLM_BASE_URL` | `http://host.docker.internal:8000/v1` | Bootstrap OpenAI-compatible API URL (real backends go in the UI) |
-| `OPENAI_API_KEY` | `dummy` | API key (`dummy` for local servers) |
+| `OPENAI_API_KEY` | `dummy` | API key used by model definitions that leave `api_key` empty, and by `${OPENAI_API_KEY}` placeholders in a definition |
 | `TURNSTONE_SEARXNG_URL` | `http://searxng:8080` | SearxNG URL for the `web_search` tool (local/vLLM models only; Anthropic/OpenAI use native search). Defaults to the bundled `searxng` service; set to an external instance's URL. To turn web search off, clear `tools.searxng_url` in the admin Settings tab. |
 | `SEARXNG_IMAGE_TAG` | `latest` | Tag for the bundled `searxng/searxng` image |
-| `MODEL` | — | Override the default model alias |
 
 ### Auth & database
 

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -38,9 +38,18 @@ openshell sandbox run \
   --policy deploy/openshell/turnstone-policy.yaml \
   --inference-routes deploy/openshell/routes.yaml \
   --workdir /path/to/project \
-  -- python3 -m turnstone.server --host 0.0.0.0 --port 8080 \
-      --base-url https://inference.local
+  -- python3 -m turnstone.server --host 0.0.0.0 --port 8080
 ```
+
+with a model definition that points at the proxy — in `config.toml`:
+
+```toml
+[models.sandbox]
+base_url = "https://inference.local"
+model = "gpt-5"          # the id the route serves
+```
+
+or the same fields in the console Models tab.
 
 The `inference.local` hostname is intercepted by the OpenShell proxy before
 network policy evaluation -- no network policy entry is needed for it.
@@ -190,12 +199,12 @@ routes:
     api_key_env: ANTHROPIC_API_KEY
 ```
 
-2. Start with `--inference-routes` and point turnstone at `inference.local`:
+2. Start with `--inference-routes` and point a model definition at
+   `inference.local` (`base_url = "https://inference.local"`):
 
 ```bash
 openshell sandbox run \
   --inference-routes deploy/openshell/routes.yaml \
-  --base-url https://inference.local \
   ...
 ```
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -256,7 +256,7 @@ connection, Redis, auth secrets, server bind address). These stay in
 
 | Category | Section | Where |
 |----------|---------|-------|
-| API credentials | `[api]` | config.toml / env |
+| API credentials (CLI only) | `[api]` | config.toml / env — the server takes endpoints from model definitions |
 | Database | `[database]` | config.toml / env |
 | Auth | `[auth]` | config.toml / env |
 | Console bind | `[console]` | config.toml / env |

--- a/tests/test_admin_calibrate_endpoint.py
+++ b/tests/test_admin_calibrate_endpoint.py
@@ -396,7 +396,7 @@ def test_calibrate_no_base_url_graceful(
 def _stub_probe(monkeypatch: pytest.MonkeyPatch, result: dict[str, Any]) -> None:
     monkeypatch.setattr(
         "turnstone.core.model_registry.probe_model_endpoint",
-        lambda provider, base_url, api_key, target_model="": dict(result),
+        lambda provider, base_url, api_key, target_model="", **_kw: dict(result),
     )
 
 

--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -32,6 +32,7 @@ from turnstone.console.server import (
     _refresh_coord_registry,
     admin_create_model_definition,
     admin_delete_model_definition,
+    admin_detect_model,
     admin_list_model_definitions,
     admin_model_auth_constraints,
     admin_model_reload,
@@ -978,6 +979,11 @@ def _make_client(
             Route(
                 "/v1/api/admin/model-definitions",
                 admin_create_model_definition,
+                methods=["POST"],
+            ),
+            Route(
+                "/v1/api/admin/model-definitions/detect",
+                admin_detect_model,
                 methods=["POST"],
             ),
             Route(
@@ -3987,3 +3993,154 @@ def test_every_mutable_column_probes_its_classification(
     )
     assert resp.status_code == 200, resp.text
     assert not storage.get_model_definition("probe-enabled-disarm")["enabled"]
+
+
+def test_create_without_context_window_stores_auto_detect(storage: SQLiteBackend) -> None:
+    """An API create that omits ``context_window`` must store the auto-detect
+    sentinel — a literal 32768 would be taken as an explicit choice and the
+    resolver would never look at the endpoint."""
+    _seed_model_def(storage, definition_id="m1", alias="seed", model="m")
+    client = _make_client(storage, _make_registry(alias="seed", model="m"))
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions",
+        json={
+            "alias": "local",
+            "model": "qwen3-32b",
+            "provider": "openai-compatible",
+            "base_url": "http://vllm.example:8000/v1",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    rows = {r["alias"]: r for r in storage.list_model_definitions()}
+    assert rows["local"]["context_window"] == 0
+
+
+def test_create_refuses_local_provider_without_base_url(storage: SQLiteBackend) -> None:
+    """A local-server definition without a base_url is fully knowable as
+    broken at save time — refuse it here rather than on a user's first turn."""
+    _seed_model_def(storage, definition_id="m1", alias="seed", model="m")
+    client = _make_client(storage, _make_registry(alias="seed", model="m"))
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions",
+        json={"alias": "local", "model": "qwen3-32b", "provider": "openai-compatible"},
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert "base_url" in resp.json()["error"]
+    assert storage.get_model_definition_by_alias("local") is None
+
+
+def test_update_refuses_clearing_base_url_on_local_provider(storage: SQLiteBackend) -> None:
+    _seed_model_def(storage, definition_id="m1", alias="local", model="m")
+    client = _make_client(storage, _make_registry(alias="local", model="m"))
+
+    resp = client.put("/v1/api/admin/model-definitions/m1", json={"base_url": ""})
+
+    assert resp.status_code == 400, resp.text
+    assert "base_url" in resp.json()["error"]
+    assert storage.get_model_definition("m1")["base_url"] == "http://localhost:8000/v1"
+
+
+def test_update_unrelated_field_on_legacy_row_without_base_url(storage: SQLiteBackend) -> None:
+    """A row that predates the save-time check can still be disabled or
+    renamed; only a request that chooses the endpoint is refused for it."""
+    _seed_model_def(storage, definition_id="m1", alias="legacy", model="m", base_url="")
+    client = _make_client(storage, _make_registry(alias="legacy", model="m"))
+
+    resp = client.put("/v1/api/admin/model-definitions/m1", json={"enabled": False})
+
+    assert resp.status_code == 200, resp.text
+    assert storage.get_model_definition("m1")["enabled"] is False
+
+
+def test_update_refuses_blanking_local_host_stored_as_openai(storage: SQLiteBackend) -> None:
+    """provider "openai" with a non-OpenAI host is a local server the loader
+    reclassifies at load time; blanking the host would retarget the row to
+    the commercial API."""
+    storage.create_model_definition(
+        "m2",
+        "vllm",
+        "qwen3-32b",
+        provider="openai",
+        base_url="http://vllm.example:8000/v1",
+        api_key="",
+        context_window=8192,
+        enabled=True,
+    )
+    client = _make_client(storage, _make_registry(alias="vllm", model="qwen3-32b"))
+
+    resp = client.put("/v1/api/admin/model-definitions/m2", json={"base_url": ""})
+
+    assert resp.status_code == 400, resp.text
+    assert storage.get_model_definition("m2")["base_url"] == "http://vllm.example:8000/v1"
+
+
+def test_detect_is_endpoint_only_for_local_providers(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Detect button must not offer a commercial model's window for a
+    local server that happens to serve that model id — the registry loader
+    applies the same rule, so the form and the runtime agree."""
+    _seed_model_def(storage, definition_id="m1", alias="seed", model="m")
+    client = _make_client(storage, _make_registry(alias="seed", model="m"))
+    seen: dict[str, object] = {}
+
+    def fake_probe(*args: object, **kwargs: object) -> dict[str, object]:
+        seen["args"] = args
+        seen.update(kwargs)
+        return {"reachable": True, "model_found": True, "context_window": None}
+
+    monkeypatch.setattr("turnstone.core.model_registry.probe_model_endpoint", fake_probe)
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions/detect",
+        json={
+            "provider": "openai-compatible",
+            "base_url": "http://vllm.example:8000/v1",
+            "model": "gpt-5.4",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert seen.get("static_table") is False
+    # No window reported: the form is told what the node would run with,
+    # so the operator corrects it before the first call.
+    assert resp.json()["fallback_context_window"] == 32768
+
+    resp = client.post(
+        "/v1/api/admin/model-definitions/detect",
+        json={"provider": "openai", "base_url": "https://api.openai.com/v1", "api_key": "k"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert seen.get("static_table") is True
+
+
+def test_detect_reports_fallback_only_when_reachable_and_silent(
+    storage: SQLiteBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_model_def(storage, definition_id="m1", alias="seed", model="m")
+    client = _make_client(storage, _make_registry(alias="seed", model="m"))
+    outcomes = iter(
+        [
+            {"reachable": True, "model_found": True, "context_window": 262144},
+            {"reachable": False, "context_window": None, "error": "connection refused"},
+        ]
+    )
+    monkeypatch.setattr(
+        "turnstone.core.model_registry.probe_model_endpoint",
+        lambda *a, **kw: dict(next(outcomes)),
+    )
+    body = {
+        "provider": "openai-compatible",
+        "base_url": "http://vllm.example:8000/v1",
+        "model": "qwen3-32b",
+    }
+
+    detected = client.post("/v1/api/admin/model-definitions/detect", json=body).json()
+    assert detected["context_window"] == 262144
+    assert "fallback_context_window" not in detected
+
+    down = client.post("/v1/api/admin/model-definitions/detect", json=body).json()
+    assert "fallback_context_window" not in down  # transient; nothing to correct yet

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -422,3 +422,27 @@ def test_set_config_path_overrides_env_var(tmp_path, monkeypatch):
     set_config_path(str(explicit_cfg))
 
     assert load_config("api") == {"base_url": "http://explicit"}
+
+
+def test_warn_migrated_settings_flags_api_section(tmp_path, caplog):
+    """The server no longer reads [api]; a file that still carries it gets a
+    warning naming the replacement (per-definition base_url / api_key)."""
+    import logging
+
+    _reset_cache()
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        """[api]
+base_url = "http://localhost:8000/v1"
+api_key = "k"
+"""
+    )
+    set_config_path(str(cfg))
+    with caplog.at_level(logging.WARNING):
+        config_mod.warn_migrated_settings()
+    # structlog renders the console line (template + positional_args repr)
+    # before the record reaches caplog, so match on pieces present either way.
+    text = " | ".join(f"{r.getMessage()} {r.args!r}" for r in caplog.records)
+    assert "has been removed and will be ignored" in text
+    assert "base_url" in text and "Models tab" in text
+    assert "api_key" in text and "OPENAI_API_KEY" in text

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -29,7 +29,6 @@ from turnstone.doctor import (
     _mask_secrets,
     _parse_config_sections,
     _primary_kind,
-    _read_api_creds,
     _redact_url_credentials,
     _relevant_env,
     _resolve_db_config,
@@ -604,12 +603,10 @@ class TestPreflightHelpers:
             'url = "postgresql://u:p@h/db"\n'
             '[api]\nbase_url = "http://localhost:8000/v1"\napi_key = "sk-test"\n'
         )
-        sections, db, api = _parse_config_sections(cfg)
+        sections, db = _parse_config_sections(cfg)
         assert "auth" in sections and "database" in sections and "api" in sections
         assert db["backend"] == "postgresql"
         assert db["url"] == "postgresql://u:p@h/db"
-        assert api["base_url"] == "http://localhost:8000/v1"
-        assert api["api_key"] == "sk-test"
 
     def test_discover_config_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(Path, "home", lambda: tmp_path / "fakehome")
@@ -620,7 +617,7 @@ class TestPreflightHelpers:
 
     def test_resolve_db_config_config_wins_over_env(self) -> None:
         cf = ConfigFileInfo(
-            path=Path("/x"), sections=["database"], db={"backend": "postgresql", "url": "u"}, api={}
+            path=Path("/x"), sections=["database"], db={"backend": "postgresql", "url": "u"}
         )
         out = _resolve_db_config([cf], {"TURNSTONE_DB_BACKEND": "sqlite"})
         assert out["backend"] == "postgresql"
@@ -637,7 +634,7 @@ class TestPreflightHelpers:
             '[database]\nbackend = "postgresql"\nsslmode = "verify-full"\n'
             'sslrootcert = "/c/ca.crt"\nsslcert = "/c/client.crt"\nsslkey = "/c/client.key"\n'
         )
-        _sections, db, _api = _parse_config_sections(cfg)
+        _sections, db = _parse_config_sections(cfg)
         assert db["sslmode"] == "verify-full"
         assert db["sslrootcert"] == "/c/ca.crt"
 
@@ -646,7 +643,6 @@ class TestPreflightHelpers:
             path=Path("/x"),
             sections=["database"],
             db={"backend": "postgresql", "url": "u", "sslmode": "verify-full"},
-            api={},
         )
         out = _resolve_db_config([cf], {"TURNSTONE_DB_SSLCERT": "/env/client.crt"})
         assert out["sslmode"] == "verify-full"  # config
@@ -681,49 +677,6 @@ class TestPreflightHelpers:
         urls = _derive_health_urls({})
         assert "http://localhost:8080/health" in urls
         assert "http://localhost:8090/health" in urls
-
-    def test_read_api_creds_reads_parsed_api_field(self, tmp_path: Path) -> None:
-        # perf-5: creds come from the already-parsed ConfigFileInfo.api (first
-        # non-empty wins) — the file is never re-opened (it doesn't even exist here).
-        cf = ConfigFileInfo(
-            path=tmp_path / "config.toml",
-            sections=["api"],
-            db={},
-            api={"base_url": "http://localhost:8000/v1", "api_key": "sk-cfg"},
-        )
-        profile = _make_profile(tmp_path, config_files=[cf])
-        base_url, api_key = _read_api_creds(profile, {})
-        assert base_url == "http://localhost:8000/v1"
-        assert api_key == "sk-cfg"
-
-    def test_read_api_creds_env_fallback(self, tmp_path: Path) -> None:
-        profile = _make_profile(tmp_path, config_files=[])
-        base_url, api_key = _read_api_creds(
-            profile, {"LLM_BASE_URL": "http://env/v1", "OPENAI_API_KEY": "sk-env"}
-        )
-        assert base_url == "http://env/v1"
-        assert api_key == "sk-env"
-
-    def test_read_api_creds_pair_from_single_source(self, tmp_path: Path) -> None:
-        # Two config files: the first defines only base_url, the second only
-        # api_key. The pair must come from ONE source (the first that defines
-        # either field) — never a base_url+api_key spliced across both files.
-        cf1 = ConfigFileInfo(
-            path=tmp_path / "a.toml",
-            sections=["api"],
-            db={},
-            api={"base_url": "http://endpoint-a/v1"},
-        )
-        cf2 = ConfigFileInfo(
-            path=tmp_path / "b.toml",
-            sections=["api"],
-            db={},
-            api={"api_key": "sk-from-b"},
-        )
-        profile = _make_profile(tmp_path, config_files=[cf1, cf2])
-        base_url, api_key = _read_api_creds(profile, {})
-        assert base_url == "http://endpoint-a/v1"
-        assert api_key == ""  # not spliced from the unrelated second file
 
     def test_detect_install_profile_classifies_compose(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -897,6 +850,51 @@ class TestResolveDoctorBrain:
 
 class TestResolveBrainIntegration:
     """End-to-end against an ephemeral SQLite DB seeded with one model."""
+
+    def test_reads_models_from_the_discovered_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A node's config.toml can live where the loader does not look on
+        its own (/etc/turnstone); doctor must read [models.*] from the file
+        its discovery pass found, exactly as that node does."""
+        import turnstone.core.config as config_mod
+        from turnstone.core.storage import init_storage, reset_storage
+
+        cfg = tmp_path / "etc-config.toml"
+        cfg.write_text(
+            """[models.local]
+base_url = "http://localhost:9/v1"
+model = "cfg-model"
+context_window = 8192
+"""
+        )
+        monkeypatch.setattr(config_mod, "_config_path", None)
+        monkeypatch.setattr(config_mod, "_cache", None)
+        # The ambient config (never this machine's ~/.config file) defines
+        # no models — only the CLI's [api] — so the discovered node file is
+        # the one consulted for [models.*].
+        ambient = tmp_path / "ambient.toml"
+        ambient.write_text(
+            """[api]
+base_url = "http://laptop:8000/v1"
+"""
+        )
+        monkeypatch.setenv("TURNSTONE_CONFIG", str(ambient))
+        db_path = str(tmp_path / "doctor-cfg.db")
+        reset_storage()
+        st = init_storage("sqlite", path=db_path, run_migrations=True)
+        try:
+            monkeypatch.setattr("turnstone.doctor._validate_connection", lambda llm: (True, ""))
+            profile = _make_profile(
+                tmp_path,
+                config_files=[ConfigFileInfo(path=cfg, sections=["models"], db={})],
+                db_config={"backend": "sqlite", "url": "", "path": db_path},
+            )
+            brain, verdict = resolve_doctor_brain(profile, st, "")
+            assert brain is not None, verdict.detail
+            assert brain.model == "cfg-model"
+        finally:
+            reset_storage()
 
     def test_resolves_seeded_model(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from turnstone.core.storage import init_storage, reset_storage

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 import threading
 from types import SimpleNamespace
 from typing import Any
@@ -26,6 +27,7 @@ from turnstone.core.model_registry import (
     load_model_registry,
 )
 from turnstone.core.model_turn import resolve_model_binding
+from turnstone.core.providers import list_known_models
 from turnstone.core.trajectory import Turn
 from turnstone.core.workstream import WorkstreamKind
 
@@ -438,12 +440,13 @@ class TestLoadModelRegistry:
         ):
             load_model_registry()
 
-    def test_config_context_window_zero_inherits_detected(self) -> None:
+    def test_config_context_window_zero_inherits_cli_window(self) -> None:
         """``context_window = 0`` in a [models.*] entry is the auto-detect
-        sentinel: it must inherit the CLI/detected window, not stay a literal 0
-        (which would zero every downstream budget — judge lowering, session
-        compaction).  The DB loader normalizes 0->inherit; the config path must
-        match it (``.get(k, 0) or context_window``, not ``.get(k, default)``)."""
+        sentinel: it must never stay a literal 0 (which would zero every
+        downstream budget — judge lowering, session compaction). A caller
+        that supplies a bootstrap window — the CLI's ``--context-window`` or
+        its own detection — is the resolution; the server passes 0 and the
+        per-definition chain pinned in TestContextWindowAutoDetect runs."""
         fake_cfg: dict[str, Any] = {
             "models": {
                 "local": {
@@ -451,6 +454,7 @@ class TestLoadModelRegistry:
                     "model": "local-model",
                     "context_window": 0,  # auto-detect
                 },
+                "claude": {"provider": "anthropic", "model": _ANTHROPIC_ID},
             },
             "model": {"default": "local"},
         }
@@ -459,10 +463,16 @@ class TestLoadModelRegistry:
                 base_url="http://localhost:8000/v1",
                 api_key="dummy",
                 model="local-model",
-                context_window=40_000,  # the CLI-detected window
+                context_window=40_000,  # the CLI's own bootstrap window
             )
         _, _, cfg, _ = reg.resolve("local")
         assert cfg.context_window == 40_000  # inherited, not the literal 0
+        # A capability-table provider is resolved from the table even in the
+        # CLI: the bootstrap window applies to local servers only.
+        from turnstone.core.providers import create_provider
+
+        expected = create_provider("anthropic").get_capabilities(_ANTHROPIC_ID).context_window
+        assert reg.get_config("claude").context_window == expected
 
     def test_fallback_from_config(self) -> None:
         fake_cfg: dict[str, Any] = {
@@ -4097,6 +4107,44 @@ class TestDetectModelTimeout:
 
 
 class TestExtractContextWindow:
+    def test_gateway_context_length(self) -> None:
+        """OpenRouter-style listings carry ``context_length`` at the top level
+        and under ``top_provider``; neither is vLLM's or llama.cpp's key."""
+        from turnstone.core.model_registry import _extract_context_window
+
+        m = MagicMock()
+        m.id = "openai/gpt-5.6-luna"
+        m.model_dump.return_value = {
+            "id": "openai/gpt-5.6-luna",
+            "context_length": 1_050_000,
+            "top_provider": {"context_length": 1_050_000, "max_completion_tokens": 128_000},
+        }
+        assert _extract_context_window(m, "openai") == 1_050_000
+
+        m.model_dump.return_value = {"id": "x", "top_provider": {"context_length": 200_000}}
+        assert _extract_context_window(m, "openai") == 200_000
+
+        m.model_dump.return_value = {"id": "x", "context_length": True, "top_provider": {}}
+        assert _extract_context_window(m, "openai") is None
+
+    @pytest.mark.parametrize(
+        ("card", "expected"),
+        [
+            ({"id": "x", "context_window": 131072, "max_completion_tokens": 8192}, 131072),
+            ({"id": "x", "max_context_length": 262144}, 262144),
+            ({"id": "x", "max_model_len": 65536, "context_length": 131072}, 65536),
+            ({"id": "x", "owned_by": "ollama"}, None),
+        ],
+        ids=["groq", "mistral", "vllm-wins-over-gateway-key", "ollama-reports-nothing"],
+    )
+    def test_provider_key_matrix(self, card: dict[str, Any], expected: int | None) -> None:
+        from turnstone.core.model_registry import _extract_context_window
+
+        m = MagicMock()
+        m.id = card["id"]
+        m.model_dump.return_value = card
+        assert _extract_context_window(m, "openai") == expected
+
     def test_vllm_max_model_len(self) -> None:
         from turnstone.core.model_registry import _extract_context_window
 
@@ -4518,3 +4566,834 @@ def test_control_bearing_alias_refuses_to_load() -> None:
             mr_module._normalize_auth_mode(
                 "gw" + chr(1), mode, "api://gw" if mode != "static" else "", ""
             )
+
+
+# ---------------------------------------------------------------------------
+# context_window = 0 → per-definition auto-detection (#1052)
+# ---------------------------------------------------------------------------
+
+
+def _rendered(record: logging.LogRecord) -> str:
+    """Message text plus its args, however structlog captured them.
+
+    Under the test configuration the record carries the console-rendered
+    line with ``positional_args=(...)`` appended and empty ``args``; under a
+    plain stdlib configuration the args are formatted into the message.
+    Concatenating both makes the substring checks below hold either way.
+    """
+    return f"{record.getMessage()} {record.args!r}"
+
+
+# Model ids the commercial tables know, whatever they hold today.
+_COMMERCIAL_ID = list_known_models("openai")[0]
+_ANTHROPIC_ID = list_known_models("anthropic")[0]
+
+
+def _probe_result(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "reachable": True,
+        "model_found": True,
+        "available_models": ["local-model"],
+        "context_window": 262144,
+        "server_type": "vllm",
+        "error": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestContextWindowAutoDetect:
+    """``0`` is the Models tab's auto-detect sentinel. It must resolve to a
+    real number per definition — never stay 0 (zeroes every downstream
+    budget) and never inherit whatever the node's bootstrap endpoint said,
+    because the node no longer has one."""
+
+    @staticmethod
+    def _local_cfg(**entry: Any) -> dict[str, Any]:
+        local: dict[str, Any] = {
+            "base_url": "http://localhost:8000/v1",
+            "model": "local-model",
+            "context_window": 0,
+        }
+        local.update(entry)
+        return {"models": {"local": local}}
+
+    def test_table_provider_resolves_offline(self) -> None:
+        from turnstone.core.providers import create_provider
+
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "claude": {
+                    "provider": "anthropic",
+                    "model": _ANTHROPIC_ID,
+                    "context_window": 0,
+                },
+                "gpt": {
+                    "provider": "openai",
+                    "base_url": "https://api.openai.com/v1",
+                    "model": _COMMERCIAL_ID,
+                },
+            }
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            patch("turnstone.core.model_registry.probe_model_endpoint") as probe,
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        probe.assert_not_called()
+        claude = reg.get_config("claude").context_window
+        gpt = reg.get_config("gpt").context_window
+        assert claude == create_provider("anthropic").get_capabilities(_ANTHROPIC_ID).context_window
+        assert gpt == create_provider("openai").get_capabilities(_COMMERCIAL_ID).context_window
+        assert claude > 0 and gpt > 0
+
+    def test_unlisted_commercial_model_falls_back_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A model id the table does not list gets the conservative fallback
+        and a warning — never the provider default, which can exceed the
+        real window (a 128k fine-tune budgeted at 200k hard-fails turns)."""
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "new": {
+                    "provider": "openai",
+                    "base_url": "https://api.openai.com/v1",
+                    "model": "ft:gpt-4o-mini-2024-07-18:acme::abc",
+                    "context_window": 0,
+                },
+                "gemini": {"provider": "google", "model": "gemini-3-something"},
+            }
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert reg.get_config("new").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert reg.get_config("gemini").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any(
+            "'new'" in _rendered(r) and "no capability entry" in _rendered(r)
+            for r in caplog.records
+        )
+        assert any("'gemini'" in _rendered(r) for r in caplog.records)
+
+    def test_explicit_value_is_taken_verbatim(self) -> None:
+        with (
+            patch(
+                "turnstone.core.model_registry.load_config",
+                return_value=self._local_cfg(context_window=131072),
+            ),
+            patch("turnstone.core.model_registry.probe_model_endpoint") as probe,
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        probe.assert_not_called()
+        assert reg.get_config("local").context_window == 131072
+
+    def test_local_detection_off_falls_back(self) -> None:
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint") as probe,
+        ):
+            reg = load_model_registry()
+        probe.assert_not_called()
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+
+    def test_local_probe_asks_the_definitions_own_endpoint(self) -> None:
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                return_value=_probe_result(),
+            ) as probe,
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        # Endpoint metadata only, on the loader's shorter budget, with the
+        # definition's own key (create_client supplies the local placeholder).
+        probe.assert_called_once_with(
+            "openai-compatible",
+            "http://localhost:8000/v1",
+            "",
+            target_model="local-model",
+            static_table=False,
+            timeout=mr_module._LOADER_PROBE_TIMEOUT,
+        )
+        assert reg.get_config("local").context_window == 262144
+
+    def test_local_probe_single_model_server_accepts_any_name(self) -> None:
+        """A one-model server is this model whatever it calls itself — the
+        common vLLM case where the served id is a path, not the alias name."""
+        result = _probe_result(model_found=False, available_models=["/models/qwen"])
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint", return_value=result),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert reg.get_config("local").context_window == 262144
+
+    def test_local_probe_multi_model_needs_a_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        result = _probe_result(model_found=False, available_models=["a", "b"])
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint", return_value=result),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any(
+            "'local'" in _rendered(r) and "not in the endpoint's model list" in _rendered(r)
+            for r in caplog.records
+        )
+
+    def test_local_probe_failure_warns_and_falls_back(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        result = _probe_result(reachable=False, context_window=None, error="connection refused")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint", return_value=result),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any(
+            "'local'" in _rendered(r) and "connection refused" in _rendered(r)
+            for r in caplog.records
+        )
+
+    def test_local_probe_runs_on_every_load(self) -> None:
+        """A backend restarted with a different window is picked up by the
+        next hot-reload — nothing is cached across loads."""
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                side_effect=[_probe_result(), _probe_result(context_window=16384)],
+            ) as probe,
+        ):
+            first = load_model_registry(detect_context_windows=True)
+            second = load_model_registry(detect_context_windows=True)
+        assert probe.call_count == 2
+        assert first.get_config("local").context_window == 262144
+        assert second.get_config("local").context_window == 16384
+
+    def test_local_probe_miss_is_retried_on_next_load(self) -> None:
+        down = _probe_result(reachable=False, context_window=None, error="down")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                side_effect=[down, _probe_result()],
+            ) as probe,
+        ):
+            first = load_model_registry(detect_context_windows=True)
+            second = load_model_registry(detect_context_windows=True)
+        assert probe.call_count == 2
+        assert first.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert second.get_config("local").context_window == 262144
+
+    def test_reload_probes_first_and_takes_a_new_window(self) -> None:
+        """A hot-reload asks the endpoint again, so a backend restarted with
+        a smaller window is picked up rather than served from the prior."""
+        running = ModelConfig(
+            alias="local",
+            base_url="http://localhost:8000/v1",
+            api_key="",
+            model="local-model",
+            provider="openai-compatible",
+            context_window=262144,
+            context_window_detected=True,
+        )
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                return_value=_probe_result(context_window=16384),
+            ) as probe,
+        ):
+            reg = load_model_registry(detect_context_windows=True, prior={"local": running})
+        probe.assert_called_once()
+        assert reg.get_config("local").context_window == 16384
+
+    def test_reload_keeps_the_detected_window_when_the_probe_misses(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A backend mid-restart during a hot-reload must not shrink live
+        sessions to the fallback: the definition keeps the window the running
+        registry detected, while endpoint and model are unchanged."""
+        running = ModelConfig(
+            alias="local",
+            base_url="http://localhost:8000/v1",
+            api_key="",
+            model="local-model",
+            provider="openai-compatible",
+            context_window=262144,
+            context_window_detected=True,
+        )
+        down = _probe_result(reachable=False, context_window=None, error="connection refused")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint", return_value=down),
+            caplog.at_level(logging.INFO),
+        ):
+            reg = load_model_registry(detect_context_windows=True, prior={"local": running})
+        kept = reg.get_config("local")
+        assert kept.context_window == 262144
+        assert kept.context_window_detected is True
+        assert any("keeping the previously detected" in _rendered(r) for r in caplog.records)
+        assert not any(
+            r.levelno >= logging.WARNING and "'local'" in _rendered(r) for r in caplog.records
+        )
+
+    def test_identical_definitions_share_one_probe(self) -> None:
+        cfg = self._local_cfg()
+        cfg["models"]["twin"] = dict(cfg["models"]["local"])
+        cfg["models"]["other"] = dict(cfg["models"]["local"], model="other-model")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=cfg),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                return_value=_probe_result(),
+            ) as probe,
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert probe.call_count == 2  # local + twin share; other is distinct
+        assert reg.get_config("local").context_window == 262144
+        assert reg.get_config("twin").context_window == 262144
+
+    @pytest.mark.parametrize(
+        "prior_window",
+        [mr_module.FALLBACK_CONTEXT_WINDOW, 8192],
+        ids=["prior-fallback", "prior-explicit"],
+    )
+    def test_prior_that_was_not_detected_is_not_carried_on_a_miss(self, prior_window: int) -> None:
+        """A prior fallback is not a resolution, and an explicit prior window
+        (the operator just switched the definition to auto-detect) is not
+        either: when the probe misses, neither is carried forward."""
+        previous = ModelConfig(
+            alias="local",
+            base_url="http://localhost:8000/v1",
+            api_key="",
+            model="local-model",
+            provider="openai-compatible",
+            context_window=prior_window,
+        )
+        down = _probe_result(reachable=False, context_window=None, error="connection refused")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint", return_value=down) as probe,
+        ):
+            reg = load_model_registry(detect_context_windows=True, prior={"local": previous})
+        probe.assert_called_once()
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+
+    def test_probe_exception_is_a_miss_not_a_crash(self, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                side_effect=RuntimeError("can't start new thread"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any("raised RuntimeError" in _rendered(r) for r in caplog.records)
+
+    def test_probe_miss_with_changed_model_does_not_carry_forward(self) -> None:
+        running = ModelConfig(
+            alias="local",
+            base_url="http://localhost:8000/v1",
+            api_key="",
+            model="previous-model",
+            provider="openai-compatible",
+            context_window=262144,
+            context_window_detected=True,
+        )
+        down = _probe_result(reachable=False, context_window=None, error="connection refused")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+            patch("turnstone.core.model_registry.probe_model_endpoint", return_value=down),
+        ):
+            reg = load_model_registry(detect_context_windows=True, prior={"local": running})
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+
+    def test_probe_is_bounded_by_its_deadline(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A probe that outlives its deadline is abandoned on its daemon
+        thread — boot and a console sync wait at most one probe budget,
+        whatever the endpoint (or the resolver) does."""
+        release = threading.Event()
+        workers: list[threading.Thread] = []
+
+        def slow_probe(*_a: Any, **_kw: Any) -> dict[str, Any]:
+            workers.append(threading.current_thread())
+            release.wait(5)
+            return _probe_result()
+
+        monkeypatch.setattr(mr_module, "_LOADER_PROBE_TIMEOUT", 0.05)
+        try:
+            with (
+                patch("turnstone.core.model_registry.load_config", return_value=self._local_cfg()),
+                patch("turnstone.core.model_registry.probe_model_endpoint", side_effect=slow_probe),
+                caplog.at_level(logging.WARNING),
+            ):
+                reg = load_model_registry(detect_context_windows=True)
+        finally:
+            release.set()
+            for worker in workers:
+                worker.join(5)
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any("did not answer within" in _rendered(r) for r in caplog.records)
+
+    def test_rerank_only_definition_is_not_probed(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A reranker has no chat window; it takes the fallback silently."""
+        cfg = self._local_cfg(capabilities={"supports_rerank": True})
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=cfg),
+            patch("turnstone.core.model_registry.probe_model_endpoint") as probe,
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        probe.assert_not_called()
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert not any("'local'" in _rendered(r) for r in caplog.records)
+
+    def test_dynamic_auth_lane_is_not_probed(self, caplog: pytest.LogCaptureFixture) -> None:
+        cfg = self._local_cfg(auth_mode="rfc8693_obo", obo_audience="api://gw")
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=cfg),
+            patch("turnstone.core.model_registry.probe_model_endpoint") as probe,
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        probe.assert_not_called()
+        assert reg.get_config("local").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any("per-call credential" in _rendered(r) for r in caplog.records)
+
+    def test_db_row_goes_through_the_same_chain(self) -> None:
+        from turnstone.core.providers import create_provider
+
+        storage = _MockStorage(
+            [
+                {
+                    "alias": "claude",
+                    "model": "claude-opus-4-6",
+                    "provider": "anthropic",
+                    "base_url": "",
+                    "api_key": "sk-db",
+                    "context_window": 0,
+                    "capabilities": "{}",
+                    "enabled": True,
+                },
+                {
+                    "alias": "local",
+                    "model": "local-model",
+                    "provider": "openai",
+                    "base_url": "http://localhost:8000/v1",
+                    "api_key": "",
+                    "context_window": 0,
+                    "capabilities": "{}",
+                    "enabled": True,
+                },
+            ]
+        )
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value={}),
+            patch(
+                "turnstone.core.model_registry.probe_model_endpoint",
+                return_value=_probe_result(),
+            ) as probe,
+        ):
+            reg = load_model_registry(storage=storage, detect_context_windows=True)
+        expected = create_provider("anthropic").get_capabilities("claude-opus-4-6").context_window
+        assert reg.get_config("claude").context_window == expected
+        assert reg.get_config("local").context_window == 262144
+        probe.assert_called_once()
+
+    def test_non_finite_context_window_is_treated_as_auto(self) -> None:
+        """TOML admits ``inf``; int() raises OverflowError, which must degrade
+        to auto-detect, not abort the load."""
+        assert mr_module._coerce_context_window(float("inf"), "x") == 0
+        assert mr_module._coerce_context_window(-5, "x") == 0
+        assert mr_module._coerce_context_window(True, "x") == 0
+        assert mr_module._coerce_context_window(131072.0, "x") == 131072
+
+    def test_invalid_context_window_is_treated_as_auto(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "claude": {
+                    "provider": "anthropic",
+                    "model": "claude-opus-4-6",
+                    "context_window": "lots",
+                }
+            }
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry()
+        assert reg.get_config("claude").context_window > 0
+        assert any("invalid context_window" in _rendered(r) for r in caplog.records)
+
+
+class TestLocalProviderPlaceholderKey:
+    """The server used to resolve ``--api-key or $OPENAI_API_KEY or "dummy"``
+    and hand the result to every definition with an empty key. That default
+    is gone, so ``create_client`` keeps the same precedence for local
+    providers — explicit key, then the SDK's env var, then the placeholder —
+    and the registry, the loader's probe and the console Detect button all
+    inherit it. Commercial providers stay on the SDK's own env-var rule."""
+
+    def test_openai_compatible_placeholder_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from turnstone.core.providers import LOCAL_PLACEHOLDER_API_KEY, create_client
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        client = create_client("openai-compatible", base_url="http://localhost:8000/v1", api_key="")
+        assert client.api_key == LOCAL_PLACEHOLDER_API_KEY
+
+    def test_openai_compatible_env_var_wins_over_placeholder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from turnstone.core.providers import create_client
+
+        monkeypatch.setenv("OPENAI_API_KEY", "s3cret")
+        client = create_client("openai-compatible", base_url="http://localhost:8000/v1", api_key="")
+        assert client.api_key == "s3cret"
+
+    def test_explicit_key_wins_over_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from turnstone.core.providers import create_client
+
+        monkeypatch.setenv("OPENAI_API_KEY", "s3cret")
+        client = create_client(
+            "openai-compatible", base_url="http://localhost:8000/v1", api_key="row-key"
+        )
+        assert client.api_key == "row-key"
+
+    def test_anthropic_compatible_placeholder_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from turnstone.core.providers import LOCAL_PLACEHOLDER_API_KEY, create_client
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        client = create_client("anthropic-compatible", base_url="http://localhost:8000", api_key="")
+        assert client.api_key == LOCAL_PLACEHOLDER_API_KEY
+
+    def test_commercial_provider_keeps_sdk_rule(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No placeholder for api.openai.com: with neither key nor env var the
+        SDK refuses, exactly as before."""
+        from turnstone.core.providers import create_client
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Exception, match="api_key"):
+            create_client("openai", base_url="https://api.openai.com/v1", api_key="")
+
+    def test_openai_compatible_requires_base_url(self) -> None:
+        """Without a base_url the SDK would default to the commercial API and
+        carry a local server's prompts there; refuse at construction, as the
+        anthropic-compatible arm already does."""
+        from turnstone.core.providers import create_client
+
+        with pytest.raises(ValueError, match="openai-compatible requires base_url"):
+            create_client("openai-compatible", base_url="", api_key="k")
+
+    def test_registry_passes_the_definition_key_through(self) -> None:
+        cfg = ModelConfig(
+            alias="m",
+            base_url="http://localhost:8000/v1",
+            api_key="",
+            model="x",
+            provider="openai-compatible",
+        )
+        reg = ModelRegistry(models={"m": cfg}, default="m")
+        with patch("turnstone.core.model_registry.create_client") as cc:
+            reg.get_client("m")
+        cc.assert_called_once_with(
+            "openai-compatible", base_url="http://localhost:8000/v1", api_key=""
+        )
+
+
+class TestProbeEndpointOnly:
+    """The loader's probe must never lift a commercial table window onto a
+    local server that happens to serve a commercial model id."""
+
+    @staticmethod
+    def _fake_client(model_id: str) -> MagicMock:
+        model = MagicMock()
+        model.id = model_id
+        model.model_dump.return_value = {"id": model_id, "owned_by": "llama.cpp"}
+        fast = MagicMock()
+        fast.models.list.return_value = MagicMock(data=[model])
+        client = MagicMock()
+        client.with_options.return_value = fast
+        return client
+
+    def test_static_table_off_reports_no_window(self) -> None:
+        with patch(
+            "turnstone.core.providers.create_client", return_value=self._fake_client(_COMMERCIAL_ID)
+        ):
+            probed = mr_module.probe_model_endpoint(
+                "openai-compatible",
+                "http://localhost:8000/v1",
+                "",
+                _COMMERCIAL_ID,
+                static_table=False,
+            )
+        assert probed["model_found"] is True
+        assert probed["context_window"] is None
+
+    def test_static_table_on_is_the_detect_button_behaviour(self) -> None:
+        from turnstone.core.providers import lookup_model_capabilities
+
+        with patch(
+            "turnstone.core.providers.create_client", return_value=self._fake_client(_COMMERCIAL_ID)
+        ):
+            probed = mr_module.probe_model_endpoint(
+                "openai-compatible", "http://localhost:8000/v1", "", _COMMERCIAL_ID
+            )
+        known = lookup_model_capabilities("openai", _COMMERCIAL_ID)
+        assert known is not None
+        assert probed["context_window"] == known["context_window"]
+
+    def test_gateway_listing_resolves_through_the_loader(self) -> None:
+        """A gateway definition (OpenRouter shape) with context_window = 0
+        gets the gateway's number from its own listing — no static table."""
+        model = MagicMock()
+        model.id = "openai/gpt-5.6-luna"
+        model.model_dump.return_value = {
+            "id": "openai/gpt-5.6-luna",
+            "context_length": 1_050_000,
+            "top_provider": {"context_length": 1_050_000},
+        }
+        fast = MagicMock()
+        fast.models.list.return_value = MagicMock(data=[model])
+        client = MagicMock()
+        client.with_options.return_value = fast
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "router": {
+                    "provider": "openai",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key": "k",
+                    "model": "openai/gpt-5.6-luna",
+                    "context_window": 0,
+                }
+            }
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            patch("turnstone.core.providers.create_client", return_value=client),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        router = reg.get_config("router")
+        assert router.provider == "openai-compatible"
+        assert router.context_window == 1_050_000
+        assert router.context_window_detected is True
+
+    def test_loader_probe_leaves_commercial_id_unresolved(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "gw": {
+                    "base_url": "http://localhost:8000/v1",
+                    "model": _COMMERCIAL_ID,
+                    "context_window": 0,
+                }
+            }
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            patch(
+                "turnstone.core.providers.create_client",
+                return_value=self._fake_client(_COMMERCIAL_ID),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(detect_context_windows=True)
+        assert reg.get_config("gw").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+        assert any("does not report a context window" in _rendered(r) for r in caplog.records)
+
+
+class TestEntryWithoutEndpoint:
+    """The server used to hand its own ``--base-url`` / ``[api]`` endpoint
+    down to every entry that named neither ``base_url`` nor ``provider``.
+    That endpoint is gone and the default provider without a base_url is
+    the commercial OpenAI API, so such an entry — almost certainly written
+    for a local server — is refused rather than retargeted. The CLI still
+    passes its own ``base_url`` and inherits as before."""
+
+    def test_server_load_skips_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "local": {"model": "qwen", "context_window": 8192},
+                "claude": {"provider": "anthropic", "model": "claude-opus-4-6"},
+            },
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry()
+        assert not reg.has_alias("local")
+        assert reg.has_alias("claude")  # a commercial provider needs no base_url
+        assert any(
+            "'local'" in _rendered(r) and "neither base_url nor provider" in _rendered(r)
+            for r in caplog.records
+        )
+
+    def test_empty_or_unset_base_url_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A base_url that resolves to nothing — an empty value or an unset
+        ${VAR} — would send the entry to the provider's public endpoint."""
+        monkeypatch.delenv("TURNSTONE_TEST_UNSET_URL", raising=False)
+        fake_cfg: dict[str, Any] = {
+            "models": {
+                "env": {"model": "qwen", "base_url": "${TURNSTONE_TEST_UNSET_URL}"},
+                "blank": {"model": "qwen", "base_url": ""},
+                "ok": {"model": "qwen", "base_url": "http://localhost:8000/v1"},
+            },
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry()
+        assert reg.list_aliases() == ["ok"]
+        assert sum("empty base_url" in _rendered(r) for r in caplog.records) == 2
+
+    def test_local_provider_without_base_url_is_skipped_in_both_branches(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An openai-compatible definition with no endpoint would fail on a
+        user's first turn; the loader refuses it, config entry or DB row."""
+        storage = _MockStorage(
+            [
+                {
+                    "alias": "row",
+                    "model": "qwen",
+                    "provider": "openai-compatible",
+                    "base_url": "",
+                    "api_key": "",
+                    "context_window": 8192,
+                    "capabilities": "{}",
+                    "enabled": True,
+                }
+            ]
+        )
+        fake_cfg: dict[str, Any] = {
+            "models": {"entry": {"model": "qwen", "provider": "openai-compatible"}},
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(storage=storage, allow_empty=True)
+        assert reg.list_aliases() == []
+        assert sum("without a base_url" in _rendered(r) for r in caplog.records) == 2
+
+    def test_db_row_with_unset_url_variable_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TURNSTONE_TEST_UNSET_URL", raising=False)
+        storage = _MockStorage(
+            [
+                {
+                    "alias": "row",
+                    "model": _COMMERCIAL_ID,
+                    "provider": "openai",
+                    "base_url": "${TURNSTONE_TEST_UNSET_URL}",
+                    "api_key": "",
+                    "context_window": 8192,
+                    "capabilities": "{}",
+                    "enabled": True,
+                }
+            ]
+        )
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value={}),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(storage=storage, allow_empty=True)
+        assert reg.list_aliases() == []
+        assert any("${VAR} is unset" in _rendered(r) for r in caplog.records)
+
+    def test_table_provider_entry_that_relied_on_api_section_loads_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Empty base_url is the normal shape for a commercial provider, so the
+        entry loads — but the log says it now targets the public endpoint."""
+        fake_cfg: dict[str, Any] = {
+            "api": {"base_url": "http://localhost:8000/v1"},
+            "models": {"claude": {"provider": "anthropic", "model": _ANTHROPIC_ID}},
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry()
+        assert reg.get_config("claude").base_url == ""
+        assert any(
+            "'claude'" in _rendered(r) and "public endpoint" in _rendered(r) for r in caplog.records
+        )
+
+    def test_openai_entry_that_relied_on_api_section_is_refused(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """provider = "openai" with no base_url is the commercial API. While the
+        file still carries [api] base_url the entry was written to inherit it,
+        so it is refused; without [api] the same entry is the commercial API."""
+        entry: dict[str, Any] = {"provider": "openai", "model": _COMMERCIAL_ID}
+        with (
+            patch(
+                "turnstone.core.model_registry.load_config",
+                return_value={
+                    "api": {"base_url": "http://localhost:8000/v1"},
+                    "models": {"m": entry},
+                },
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(allow_empty=True)
+        assert reg.list_aliases() == []
+        assert any("[api] base_url" in _rendered(r) for r in caplog.records)
+
+        with patch(
+            "turnstone.core.model_registry.load_config", return_value={"models": {"m": entry}}
+        ):
+            reg = load_model_registry()
+        assert reg.get_config("m").provider == "openai"
+        assert reg.get_config("m").base_url == ""
+
+    def test_cli_load_inherits_without_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        fake_cfg: dict[str, Any] = {
+            "models": {"local": {"model": "qwen", "context_window": 8192}},
+        }
+        with (
+            patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+            caplog.at_level(logging.WARNING),
+        ):
+            reg = load_model_registry(base_url="http://localhost:8000/v1")
+        assert reg.get_config("local").base_url == "http://localhost:8000/v1"
+        assert not any("neither base_url nor provider" in _rendered(r) for r in caplog.records)
+
+
+def test_unknown_provider_does_not_crash_the_load(caplog: pytest.LogCaptureFixture) -> None:
+    """A typo'd provider has always failed at first use, not at boot; the
+    window resolver must keep it that way."""
+    fake_cfg: dict[str, Any] = {
+        "models": {"typo": {"provider": "openia", "model": "gpt-5", "context_window": 0}}
+    }
+    with (
+        patch("turnstone.core.model_registry.load_config", return_value=fake_cfg),
+        caplog.at_level(logging.WARNING),
+    ):
+        reg = load_model_registry(detect_context_windows=True)
+    assert reg.get_config("typo").context_window == mr_module.FALLBACK_CONTEXT_WINDOW
+    assert any("not recognised" in _rendered(r) for r in caplog.records)

--- a/tests/test_provider_anthropic_compat.py
+++ b/tests/test_provider_anthropic_compat.py
@@ -380,25 +380,41 @@ class TestCompatFactory:
         assert create_provider("anthropic-compatible") is provider
 
     @patch("turnstone.core.providers._anthropic._ensure_anthropic")
-    def test_create_client_anthropic_compatible(self, mock_ensure: MagicMock) -> None:
-        """base_url forwards verbatim; empty api_key is omitted entirely."""
-        from turnstone.core.providers import create_client
+    def test_create_client_anthropic_compatible(
+        self, mock_ensure: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """base_url forwards verbatim. An empty api_key is omitted so the SDK
+        reads ANTHROPIC_API_KEY; when that is unset too, the local placeholder
+        is passed so the client still constructs (a local server needs no
+        bearer, and the SDK refuses to run with neither)."""
+        from turnstone.core.providers import LOCAL_PLACEHOLDER_API_KEY, create_client
 
         mock_anthropic_cls = MagicMock()
         mock_mod = MagicMock()
         mock_mod.Anthropic = mock_anthropic_cls
         mock_ensure.return_value = mock_mod
 
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "from-env")
         create_client("anthropic-compatible", base_url="http://vllm-host:8000", api_key="")
         mock_anthropic_cls.assert_called_once_with(base_url="http://vllm-host:8000")
 
+        mock_anthropic_cls.reset_mock()
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        create_client("anthropic-compatible", base_url="http://vllm-host:8000", api_key="")
+        mock_anthropic_cls.assert_called_once_with(
+            api_key=LOCAL_PLACEHOLDER_API_KEY, base_url="http://vllm-host:8000"
+        )
+
     @patch("turnstone.core.providers._anthropic._ensure_anthropic")
-    def test_create_client_strips_v1_suffix(self, mock_ensure: MagicMock) -> None:
+    def test_create_client_strips_v1_suffix(
+        self, mock_ensure: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A /v1-suffixed base_url (openai-compatible muscle memory) is
         normalized for the compat lane — the SDK appends /v1/... itself,
         so the verbatim URL would request /v1/v1/messages and 404."""
         from turnstone.core.providers import create_client
 
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "from-env")
         mock_anthropic_cls = MagicMock()
         mock_mod = MagicMock()
         mock_mod.Anthropic = mock_anthropic_cls

--- a/tests/test_server_node_models_metadata.py
+++ b/tests/test_server_node_models_metadata.py
@@ -296,13 +296,6 @@ def test_model_reload_endpoint_rewrites_models_metadata(monkeypatch, tmp_path):
     app_state = SimpleNamespace(
         registry=old_reg,
         health_registry=health_reg,
-        cli_model_args={
-            "base_url": "",
-            "api_key": "",
-            "model": "",
-            "context_window": 0,
-            "provider": "openai",
-        },
         config_store=None,
         node_id="node-a",
     )
@@ -360,13 +353,6 @@ def test_model_reload_cap_only_change_resizes_the_stable_gate(monkeypatch):
     original_gate = old_reg.get_admission("a")
     app_state = SimpleNamespace(
         registry=old_reg,
-        cli_model_args={
-            "base_url": "",
-            "api_key": "",
-            "model": "",
-            "context_window": 0,
-            "provider": "openai",
-        },
         config_store=None,
         node_id="",
     )
@@ -415,13 +401,6 @@ def test_model_reload_refuses_dynamic_auth_without_key(monkeypatch, tmp_path, ca
     app_state = SimpleNamespace(
         registry=old_reg,
         health_registry=HealthTrackerRegistry(),
-        cli_model_args={
-            "base_url": "",
-            "api_key": "",
-            "model": "",
-            "context_window": 0,
-            "provider": "openai",
-        },
         config_store=None,
         node_id="node-a",
         mcp_token_store=None,
@@ -455,13 +434,6 @@ def test_model_reload_maps_auth_config_error_to_422(monkeypatch, tmp_path):
     app_state = SimpleNamespace(
         registry=old_reg,
         health_registry=HealthTrackerRegistry(),
-        cli_model_args={
-            "base_url": "",
-            "api_key": "",
-            "model": "",
-            "context_window": 0,
-            "provider": "openai",
-        },
         config_store=None,
         node_id="node-a",
     )
@@ -490,13 +462,6 @@ def test_model_reload_maps_concurrency_config_error_to_422(monkeypatch, tmp_path
     old_reg = _registry(("a", "http://x"))
     app_state = SimpleNamespace(
         registry=old_reg,
-        cli_model_args={
-            "base_url": "",
-            "api_key": "",
-            "model": "",
-            "context_window": 0,
-            "provider": "openai",
-        },
         config_store=None,
         node_id="node-a",
     )
@@ -603,3 +568,67 @@ def test_heartbeat_write_awaits_before_shutdown_delete():
         "BEFORE delete_node_metadata_by_source(..., 'auto') so an in-flight "
         "set_node_metadata_bulk lands before the delete."
     )
+
+
+def test_model_reload_tolerates_the_last_definition_going_away(monkeypatch, tmp_path):
+    """Deleting the last enabled definition and syncing must reload to an
+    empty registry, not 500 and leave the stale one serving. The endpoint
+    passes ``allow_empty=True`` — the same posture as boot."""
+    from turnstone.core.storage._sqlite import SQLiteBackend
+    from turnstone.server import internal_model_reload
+
+    storage = SQLiteBackend(str(tmp_path / "reload-empty.db"))
+    old_reg = _registry(("a", "http://x"))
+    seen: dict[str, object] = {}
+
+    def fake_loader(**kw):
+        seen.update(kw)
+        return ModelRegistry({}, default="")
+
+    app_state = SimpleNamespace(
+        registry=old_reg,
+        health_registry=HealthTrackerRegistry(),
+        config_store=None,
+        node_id="node-a",
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=app_state))
+    monkeypatch.setattr("turnstone.core.model_registry.load_model_registry", fake_loader)
+    monkeypatch.setattr("turnstone.core.storage._registry.get_storage", lambda: storage)
+    monkeypatch.setattr("turnstone.server._broadcast_agent_tool_schema_refresh", lambda _s: None)
+
+    response = internal_model_reload(request)  # type: ignore[arg-type]
+    assert response.status_code == 200
+    assert seen.get("allow_empty") is True
+    assert seen.get("strict") is True
+    assert seen.get("detect_context_windows") is True
+    assert old_reg.list_aliases() == []
+
+
+def test_model_reload_keeps_running_registry_when_the_load_fails(monkeypatch, tmp_path):
+    """A storage read failure during a hot-reload (strict load) must answer
+    503 and leave the running registry untouched — never swap in an empty
+    or config-only registry over live aliases."""
+    from turnstone.core.storage._sqlite import SQLiteBackend
+    from turnstone.server import internal_model_reload
+
+    storage = SQLiteBackend(str(tmp_path / "reload-fail.db"))
+    old_reg = _registry(("a", "http://x"))
+
+    def failing_loader(**_kw):
+        raise RuntimeError("connection reset by pgbouncer")
+
+    app_state = SimpleNamespace(
+        registry=old_reg,
+        health_registry=HealthTrackerRegistry(),
+        config_store=None,
+        node_id="node-a",
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=app_state))
+    monkeypatch.setattr("turnstone.core.model_registry.load_model_registry", failing_loader)
+    monkeypatch.setattr("turnstone.core.storage._registry.get_storage", lambda: storage)
+
+    response = internal_model_reload(request)  # type: ignore[arg-type]
+    assert response.status_code == 503
+    assert b"registry load failed: RuntimeError" in response.body
+    assert b"pgbouncer" not in response.body  # detail stays in the node log
+    assert old_reg.list_aliases() == ["a"]

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -9,19 +9,20 @@
 #   2. $TURNSTONE_CONFIG env var
 #   3. ~/.config/turnstone/config.toml
 
-# --- LLM API (turnstone, node, eval) ---
+# --- LLM API (turnstone CLI, eval) ---
+# The server (node) does not read this section: its models come from the
+# console Models tab and the [models.*] entries below, each with its own
+# base_url and api_key.
 
 [api]
 # base_url = ""                # API endpoint; empty = binary default
 # api_key = ""                 # env: OPENAI_API_KEY or ANTHROPIC_API_KEY
 
-# --- Default Model (turnstone, node, eval) ---
+# --- Model routing and sampling (turnstone, node, eval) ---
 
 [model]
-# name = ""                    # Model ID; empty = provider default (gpt-5 / claude-sonnet-4)
 # temperature = 0.0            # 0 = provider default
 # reasoning_effort = ""        # "none", "minimal", "low", "medium", "high", "xhigh", "max"
-# context_window = 0           # 0 = auto-detect from provider capabilities
 # max_tokens = 0               # 0 = provider default
 #
 # Sub-agent routing (task_agent tool).  Falls back to agent_model when
@@ -37,13 +38,16 @@
 
 # --- Named Models (turnstone, node, eval) ---
 # Define model aliases with per-model overrides. Useful for local model
-# servers or mixing providers. Reference by name with --model flag.
+# servers or mixing providers. Route with [model].default / fallback above,
+# or per call through task_agent's model= argument.
 #
 # [models.local]
-# name = "llama-3-70b"
+# model = "llama-3-70b"
 # provider = "openai"
 # base_url = "http://localhost:8000/v1"
-# context_window = 8192
+# context_window = 0           # 0 = node asks the server at startup (vLLM,
+#                              # llama.cpp); set it when the server does not
+#                              # report one. The CLI applies its own window.
 # max_concurrency = 1          # Per-process generation cap for this alias; 0 = unlimited.
 #                              # For llama.cpp, start with its usable -np slot count.
 #
@@ -52,8 +56,9 @@
 # supports_web_search = false
 #
 # [models.claude]
-# name = "claude-opus-4-8"
-# provider = "anthropic"
+# model = "claude-opus-4-8"
+# provider = "anthropic"       # context_window omitted = provider capability table
+#                              # (Anthropic, OpenAI, xAI; Google needs a value)
 
 # --- Database (turnstone, node, console) ---
 

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -5477,7 +5477,7 @@ def _load_and_bootstrap_coord_subsystem(app: Starlette, storage: Any, config_sto
     coord_registry: Any | None = None
     try:
         try:
-            coord_registry = load_model_registry(storage=storage)
+            coord_registry = load_model_registry(storage=storage, detect_context_windows=True)
         except ValueError as exc:
             # No model rows configured.  Endpoint returns 503 with the
             # error text so admin sees remediation in the UI; the
@@ -12857,7 +12857,12 @@ def _refresh_coord_registry_locked(app_state: Any, storage: Any) -> None:
         # Without it, the loader degrades to a config.toml-only registry
         # and ``existing.reload()`` would silently drop every DB-sourced
         # alias.
-        new_registry = load_model_registry(storage=storage, strict=True)
+        new_registry = load_model_registry(
+            storage=storage,
+            strict=True,
+            detect_context_windows=True,
+            prior=existing.models,
+        )
     except ValueError as exc:
         # ModelRegistry.__init__ raises ValueError for several distinct
         # config issues — empty models, default/fallback/agent/task
@@ -12953,7 +12958,7 @@ def _maybe_bootstrap_coord_subsystem(app: Any, storage: Any) -> None:
         if getattr(app.state, "coord_mgr", None) is not None:
             return
         try:
-            coord_registry = load_model_registry(storage=storage)
+            coord_registry = load_model_registry(storage=storage, detect_context_windows=True)
         except ValueError as exc:
             # Still no usable rows (e.g. all disabled).  Surface the
             # reason via the same channel the lifespan path uses so
@@ -13214,9 +13219,18 @@ async def admin_create_model_definition(request: Request) -> JSONResponse:
             {"error": f"Unknown provider: {provider!r}"},
             status_code=400,
         )
+    from turnstone.core.providers import LOCAL_PROVIDERS
+
     base_url = str(body.get("base_url", "")).strip()
+    if provider in LOCAL_PROVIDERS and not base_url:
+        # Fully knowable at save time; without it the SDK client would target
+        # the provider's public endpoint (create_client refuses, but only on
+        # the first turn, as a per-user construction error).
+        return JSONResponse(
+            {"error": f"base_url is required for provider {provider!r}"}, status_code=400
+        )
     api_key = str(body.get("api_key", "")).strip()
-    ctx_raw = body.get("context_window", 32768)
+    ctx_raw = body.get("context_window", 0)  # omitted = auto-detect
     # json admits NaN/Infinity literals, which pass the isinstance check but
     # crash int(); refuse non-finite floats as invalid values instead.
     if isinstance(ctx_raw, float) and not math.isfinite(ctx_raw):
@@ -13457,6 +13471,25 @@ async def admin_update_model_definition(request: Request) -> JSONResponse:
         updates["provider"] = prov
     if "base_url" in body:
         updates["base_url"] = str(body["base_url"]).strip()
+    if "provider" in body or "base_url" in body:
+        # Only a request that chooses the endpoint is refused for it; an
+        # unrelated update (enabled, alias) to an older row still goes through.
+        from turnstone.core.providers import LOCAL_PROVIDERS
+
+        effective_provider = updates.get("provider", existing.get("provider", "openai"))
+        effective_base_url = updates.get("base_url", existing.get("base_url", ""))
+        stored_url = str(existing.get("base_url") or "")
+        # provider "openai" with a non-OpenAI host is a local server too — the
+        # loader reclassifies it at load time — so blanking that host would
+        # retarget the row to the commercial API.
+        was_local = bool(stored_url) and "api.openai.com" not in stored_url
+        if not effective_base_url and (
+            effective_provider in LOCAL_PROVIDERS or (effective_provider == "openai" and was_local)
+        ):
+            return JSONResponse(
+                {"error": f"base_url is required for provider {effective_provider!r}"},
+                status_code=400,
+            )
     if "api_key" in body:
         api_key = str(body["api_key"]).strip()
         # Sentinel "***" or empty string means "keep existing"
@@ -13888,10 +13921,29 @@ async def admin_detect_model(request: Request) -> JSONResponse:
     ):
         return JSONResponse({"error": "api_key is required"}, status_code=400)
 
+    from turnstone.core.providers import LOCAL_PROVIDERS
+
     loop = asyncio.get_running_loop()
     result = await loop.run_in_executor(
-        None, probe_model_endpoint, provider, base_url, api_key, model
+        None,
+        functools.partial(
+            probe_model_endpoint,
+            provider,
+            base_url,
+            api_key,
+            model,
+            # A local server serving a commercial model id must not be shown
+            # (and then saved with) that model's commercial window; the
+            # registry loader applies the same rule.
+            static_table=provider not in LOCAL_PROVIDERS,
+        ),
     )
+    if result.get("reachable") and result.get("context_window") is None:
+        # Tell the form what the node would run with, so the operator sees
+        # the number before the first call instead of in the node log.
+        from turnstone.core.model_registry import FALLBACK_CONTEXT_WINDOW
+
+        result["fallback_context_window"] = FALLBACK_CONTEXT_WINDOW
     return JSONResponse(result)
 
 

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -8488,6 +8488,25 @@ function detectModel() {
         if (parseInt(ctxInput.value, 10) === 0) {
           ctxInput.value = d.context_window;
         }
+      } else if (d.fallback_context_window) {
+        // The endpoint reports no window. Leaving 0 here would read as
+        // "auto-detect will handle it" while the node would silently run
+        // with the fallback; put that number in the field so it is seen
+        // and corrected before the first call.
+        const ctxInput = document.getElementById("model-ctx-window");
+        const filled = parseInt(ctxInput.value, 10) === 0;
+        if (filled) ctxInput.value = d.fallback_context_window;
+        resultDiv.appendChild(
+          _detectResultLine(
+            "\u26A0 Context window: this endpoint does not report one" +
+              (filled
+                ? " \u2014 set to " +
+                  d.fallback_context_window.toLocaleString() +
+                  " (what the node would use); enter the model's real size before saving"
+                : "; the node will use the value entered above"),
+            "yellow",
+          ),
+        );
       }
       if (d.server_type) {
         resultDiv.appendChild(

--- a/turnstone/core/config.py
+++ b/turnstone/core/config.py
@@ -369,10 +369,22 @@ def warn_migrated_settings() -> None:
 
     # Warn about removed settings whose config.toml keys are now ignored.
     # model.name → use model definitions (Models tab); model.context_window
-    # → set per-model in the Models tab (context_window column).
+    # → set per-model in the Models tab (context_window column); [api] →
+    # the server has no bootstrap endpoint, every model definition carries
+    # its own base_url and api_key (the CLI still reads [api]).
     removed_settings: dict[str, str] = {
         "model.name": "Use model definitions in the Models tab instead.",
         "model.context_window": "Set per-model in the Models tab instead.",
+        "api.base_url": (
+            "The server takes endpoints from model definitions; set base_url on "
+            "each [models.*] entry or in the Models tab (the turnstone CLI still "
+            "reads [api])."
+        ),
+        "api.api_key": (
+            "Set api_key on each [models.*] entry or in the Models tab; an empty "
+            "key falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY, and a local "
+            "server needs none."
+        ),
     }
     for key, guidance in removed_settings.items():
         section, config_key = key.split(".", 1)

--- a/turnstone/core/model_registry.py
+++ b/turnstone/core/model_registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import re
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -22,9 +23,28 @@ if TYPE_CHECKING:
 from turnstone.core.admission import ModelAdmission
 from turnstone.core.config import load_config
 from turnstone.core.log import get_logger
-from turnstone.core.providers import LLMProvider, create_client, create_provider
+from turnstone.core.providers import (
+    LOCAL_PROVIDERS,
+    LLMProvider,
+    create_client,
+    create_provider,
+)
 
 log = get_logger(__name__)
+
+# Window used when a model definition leaves ``context_window`` at 0 (the
+# Models tab's "auto-detect") and nothing can supply a number: the provider
+# has no capability table and its endpoint did not report one. Deliberately
+# conservative — an overestimate overflows the real window and hard-fails
+# the turn, an underestimate only compacts early.
+FALLBACK_CONTEXT_WINDOW = 32768
+
+# Per-endpoint budget for the startup / hot-reload window probe. Shorter than
+# the admin Detect button's 10 s: a reachable server answers ``/v1/models``
+# in milliseconds, and an unreachable one should not hold boot or a console
+# sync for long. Probes run concurrently, so this is also the wall-clock cost
+# of a load whose endpoints are all down.
+_LOADER_PROBE_TIMEOUT = 5.0
 
 
 @contextlib.contextmanager
@@ -263,7 +283,12 @@ class ModelConfig:
     base_url: str
     api_key: str = field(repr=False)
     model: str
-    context_window: int = 32768
+    context_window: int = FALLBACK_CONTEXT_WINDOW
+    # True when ``context_window`` came from this definition's own endpoint
+    # (auto-detect), so a hot-reload can keep it without asking again. An
+    # explicit, table or fallback window is never carried into a later
+    # auto-detect resolution.
+    context_window_detected: bool = False
     provider: str = "openai"
     capabilities: dict[str, Any] = field(default_factory=dict)
     source: str = ""  # "config", "db", or "" (CLI default)
@@ -1010,15 +1035,221 @@ def _resolve_openai_provider(provider: str, base_url: str) -> str:
     return provider
 
 
+def _coerce_context_window(raw: Any, alias: str) -> int:
+    """Read a definition's ``context_window``; garbage and negatives become 0."""
+    if raw is None or isinstance(raw, bool):
+        return 0
+    try:
+        value = int(raw)
+    except (TypeError, ValueError, OverflowError):
+        log.warning("Model '%s' has invalid context_window %r, auto-detecting", alias, raw)
+        return 0
+    return max(0, value)
+
+
+def _probe_context_window(cfg: ModelConfig) -> tuple[int | None, str]:
+    """Ask *cfg*'s own endpoint for its window.
+
+    Returns ``(window, note)`` on a hit — *note* is empty, or says the
+    number came from a single-model server whose served id differs from
+    the definition — and ``(None, why)`` on a miss. Endpoint metadata only
+    (vLLM ``max_model_len``, llama.cpp ``n_ctx_train``): the commercial
+    OpenAI table is never consulted for a local server, so a model served
+    under a commercial id cannot inherit that model's window.
+
+    The round trip runs on a daemon thread under a wall-clock deadline: the
+    SDK timeout bounds the socket phases, but a wedged resolver would pin a
+    non-daemon worker past process exit.
+    """
+    from turnstone.core.deadline import DeadlineExceededError, run_with_deadline
+
+    try:
+        result = run_with_deadline(
+            lambda: probe_model_endpoint(
+                cfg.provider,
+                cfg.base_url,
+                cfg.api_key,
+                target_model=cfg.model,
+                static_table=False,
+                timeout=_LOADER_PROBE_TIMEOUT,
+            ),
+            timeout=_LOADER_PROBE_TIMEOUT + 1.0,
+            poll=0.05,
+            thread_name="ctx-probe-io",
+        )
+    except DeadlineExceededError:
+        return None, f"the endpoint probe did not answer within {_LOADER_PROBE_TIMEOUT:.0f} s"
+    except Exception as exc:  # noqa: BLE001 - a probe failure is a miss, never a boot crash
+        return None, f"the endpoint probe raised {type(exc).__name__}"
+    if result.get("error"):
+        return None, f"the endpoint probe failed ({result['error']})"
+    ctx = result.get("context_window")
+    if not isinstance(ctx, int) or ctx <= 0:
+        return None, "the endpoint does not report a context window"
+    if result.get("model_found"):
+        return ctx, ""
+    # A single-model server is this model whatever it calls itself (vLLM
+    # often serves a path, not the alias name); on a multi-model endpoint
+    # the number must belong to this model.
+    listed = result.get("available_models") or []
+    if len(listed) == 1:
+        return ctx, f"single-model server, served as {listed[0]!r}"
+    return None, f"model {cfg.model!r} is not in the endpoint's model list"
+
+
+def _same_endpoint(a: ModelConfig, b: ModelConfig) -> bool:
+    return (a.provider, a.base_url.rstrip("/"), a.model) == (
+        b.provider,
+        b.base_url.rstrip("/"),
+        b.model,
+    )
+
+
+def _resolve_context_windows(
+    configs: dict[str, ModelConfig],
+    *,
+    detect: bool,
+    inherited: int = 0,
+    prior: Mapping[str, ModelConfig] | None = None,
+) -> dict[str, ModelConfig]:
+    """Replace every ``context_window == 0`` with an auto-detected window.
+
+    ``0`` is the Models tab's "auto-detect" sentinel. In order:
+
+    1. A definition with a capability-table provider (anthropic, openai,
+       xai) takes its table entry. Google publishes no table, so its
+       definitions need an explicit window.
+    2. A caller-supplied *inherited* window — the CLI's own bootstrap
+       detection or ``--context-window`` — applies to the local-server
+       definitions the CLI would otherwise probe.
+    3. A local-server definition is asked directly when *detect* is set —
+       one ``/v1/models`` round trip against its own endpoint, identical
+       definitions sharing one probe, concurrently on bounded daemon
+       threads — so a backend restarted with a different window is picked
+       up by the next hot-reload.
+    4. When that probe misses, a definition the registry being hot-reloaded
+       (*prior*) had detected from the same endpoint and model keeps that
+       window: a backend mid-restart cannot shrink live sessions. A prior
+       that was explicit, or a fallback, is not carried.
+    5. Anything still unresolved — an unlisted commercial id, a silent or
+       unreachable endpoint — gets :data:`FALLBACK_CONTEXT_WINDOW` and a
+       warning naming the alias and the reason. A rerank-only definition has
+       no chat window and takes the fallback silently.
+    """
+    from dataclasses import replace
+
+    from turnstone.core.providers import lookup_model_capabilities
+
+    unresolved: dict[str, str] = {}
+    to_probe: list[str] = []
+    for alias, cfg in list(configs.items()):
+        if cfg.context_window > 0:
+            continue
+        if cfg.capabilities.get("supports_rerank"):
+            configs[alias] = replace(cfg, context_window=FALLBACK_CONTEXT_WINDOW)
+            continue
+        if cfg.provider not in LOCAL_PROVIDERS:
+            try:
+                known = lookup_model_capabilities(cfg.provider, cfg.model)
+            except ValueError:
+                # An unrecognised provider string fails at first use, as it
+                # always has; the window must not turn it into a boot crash.
+                unresolved[alias] = f"provider {cfg.provider!r} is not recognised"
+                continue
+            if known is None:
+                # The provider default would be a guess that can exceed the
+                # real window and hard-fail turns; say so instead.
+                unresolved[alias] = f"{cfg.provider} has no capability entry for {cfg.model!r}"
+                continue
+            configs[alias] = replace(cfg, context_window=int(known["context_window"]))
+            continue
+        if inherited > 0:
+            configs[alias] = replace(cfg, context_window=inherited)
+            continue
+        if _is_dynamic_auth_mode(cfg.auth_mode):
+            unresolved[alias] = "the endpoint needs a per-call credential, so it is not probed"
+        elif not cfg.base_url:
+            unresolved[alias] = "the definition has no base_url"
+        elif not detect:
+            unresolved[alias] = "endpoint detection is off in this process"
+        else:
+            to_probe.append(alias)
+
+    if to_probe:
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Identical definitions (same endpoint, credential and model) share
+        # one round trip; each worker only waits on its own deadline-bounded
+        # daemon thread, so the pool drains within a few probe budgets
+        # however many endpoints are down.
+        by_identity: dict[tuple[str, str, str, str, str], list[str]] = {}
+        for alias in to_probe:
+            cfg = configs[alias]
+            key = (cfg.provider, cfg.base_url.rstrip("/"), cfg.api_key, cfg.auth_mode, cfg.model)
+            by_identity.setdefault(key, []).append(alias)
+        groups = list(by_identity.values())
+        with ThreadPoolExecutor(
+            max_workers=min(16, len(groups)), thread_name_prefix="ctx-probe"
+        ) as pool:
+            outcomes = list(
+                pool.map(_probe_context_window, [configs[aliases[0]] for aliases in groups])
+            )
+        for aliases, (ctx, note) in zip(groups, outcomes, strict=True):
+            for alias in aliases:
+                if ctx is None:
+                    unresolved[alias] = note
+                    continue
+                cfg = configs[alias]
+                configs[alias] = replace(cfg, context_window=ctx, context_window_detected=True)
+                log.info(
+                    "Model '%s': context_window %s (detected from %s%s)",
+                    alias,
+                    f"{ctx:,}",
+                    cfg.base_url,
+                    f"; {note}" if note else "",
+                )
+
+    for alias, why in unresolved.items():
+        cfg = configs[alias]
+        previous = prior.get(alias) if prior else None
+        if (
+            previous is not None
+            and previous.context_window_detected
+            and _same_endpoint(previous, cfg)
+        ):
+            configs[alias] = replace(
+                cfg, context_window=previous.context_window, context_window_detected=True
+            )
+            log.info(
+                "Model '%s': keeping the previously detected context_window %s (%s)",
+                alias,
+                f"{previous.context_window:,}",
+                why,
+            )
+            continue
+        emit = log.warning if detect else log.debug
+        emit(
+            "Model '%s': context_window is 0 (auto-detect) but %s — using %s until "
+            "context_window is set on the model definition",
+            alias,
+            why,
+            f"{FALLBACK_CONTEXT_WINDOW:,}",
+        )
+        configs[alias] = replace(configs[alias], context_window=FALLBACK_CONTEXT_WINDOW)
+    return configs
+
+
 def load_model_registry(
     base_url: str = "",
     api_key: str = "",
     model: str = "",
-    context_window: int = 32768,
+    context_window: int = 0,
     provider: str = "openai",
     storage: Any | None = None,
     strict: bool = False,
     allow_empty: bool = False,
+    detect_context_windows: bool = False,
+    prior: Mapping[str, ModelConfig] | None = None,
 ) -> ModelRegistry:
     """Build a ModelRegistry from CLI args, ``config.toml``, and database.
 
@@ -1029,8 +1260,9 @@ def load_model_registry(
        alias in-memory only — the DB rows are never modified.
     2. Database model definitions (``source="db"``), loaded when
        *storage* is provided.
-    3. CLI ``--base-url`` / ``--api-key`` / ``--model`` always create a
-       ``"default"`` entry.
+    3. The CLI's ``--base-url`` / ``--api-key`` / ``--model`` synthesize a
+       ``"default"`` entry when nothing else defines a model. The server
+       passes none of these: its models come from the DB and config.toml only.
     4. ``[model].default``, ``[model].fallback``, ``[model].agent_model``,
        ``[model].task_model``, ``[model].task_effort`` control routing.
        ``task_model`` overrides ``agent_model`` for the task sub-agent;
@@ -1050,12 +1282,25 @@ def load_model_registry(
     node boots and registers with no models yet, to be configured live via the
     admin panel.  The CLI leaves it False — a REPL with no model is unusable
     and there's no live panel to fix it.
+
+    ``context_window``: the CLI's bootstrap window. It sizes the synthesized
+    ``"default"`` entry and, when non-zero, every
+    local-server definition whose own ``context_window`` is ``0``. The
+    server passes ``0``, and ``0`` (the Models tab's "auto-detect") is then
+    resolved per definition by :func:`_resolve_context_windows` — from the
+    provider's capability table, from the registry being hot-reloaded
+    (``prior``), or from the definition's own endpoint when
+    ``detect_context_windows`` is set (server boot and hot-reload, console,
+    doctor). Callers that must not touch the network leave it False and
+    unresolved local definitions fall back to :data:`FALLBACK_CONTEXT_WINDOW`.
     """
     import json as _json
 
     cfg = load_config()
     models_section: dict[str, Any] = cfg.get("models", {})
     model_section: dict[str, Any] = cfg.get("model", {})
+    api_section = cfg.get("api")
+    api_base_url_present = isinstance(api_section, dict) and bool(api_section.get("base_url"))
 
     configs: dict[str, ModelConfig] = {}
 
@@ -1076,12 +1321,31 @@ def load_model_registry(
                 row_server_compat = caps.pop("server_compat", {})
                 if not isinstance(row_server_compat, dict):
                     row_server_compat = {}
-                row_base_url = _resolve_env_vars(row.get("base_url", ""))
+                raw_row_base_url = str(row.get("base_url") or "")
+                row_base_url = _resolve_env_vars(raw_row_base_url)
+                if raw_row_base_url and not row_base_url:
+                    # An unset ${VAR} would resolve to the provider's public
+                    # endpoint under a credential meant for the local server.
+                    log.warning(
+                        "Model '%s' has a base_url whose ${VAR} is unset — export it or "
+                        "set the URL in the Models tab; skipping",
+                        alias,
+                    )
+                    continue
                 row_provider = _resolve_openai_provider(row.get("provider", "openai"), row_base_url)
+                if row_provider in LOCAL_PROVIDERS and not row_base_url:
+                    # The console refuses this at save time; a row that predates
+                    # that check would only fail on a user's first turn.
+                    log.warning(
+                        "Model '%s' is a %s definition without a base_url — set it in "
+                        "the Models tab; skipping",
+                        alias,
+                        row_provider,
+                    )
+                    continue
                 row_model = row["model"]
-                # 0 = auto-detect: inherit CLI-detected context_window,
-                # same fallback chain as config.toml models
-                row_ctx = row.get("context_window", 0) or context_window
+                # 0 = auto-detect, resolved per definition below
+                row_ctx = _coerce_context_window(row.get("context_window"), alias)
                 # Per-model sampling overrides (None = use global default)
                 row_temperature = row.get("temperature")
                 row_max_tokens = row.get("max_tokens")
@@ -1139,7 +1403,31 @@ def load_model_registry(
         if not model_name:
             log.warning("Model entry '%s' has no model name, skipping", alias)
             continue
+        if not base_url and "base_url" not in entry and "provider" not in entry:
+            # No caller endpoint to inherit, and the default provider without
+            # a base_url is the commercial OpenAI API: an entry written for a
+            # local server would send its prompts there. Refuse it instead.
+            log.warning(
+                "Model '%s' names neither base_url nor provider — set base_url "
+                "(local server) or provider (commercial API) on the [models.%s] "
+                "entry; skipping it (a database definition of the same alias, "
+                "if any, stays in force)",
+                alias,
+                alias,
+            )
+            continue
         entry_base_url = _resolve_env_vars(entry.get("base_url", base_url))
+        if "base_url" in entry and not entry_base_url:
+            # Same hazard through the back door: an empty value or an unset
+            # ${VAR} would resolve to the provider's public endpoint.
+            log.warning(
+                "Model '%s' has an empty base_url (or its ${VAR} is unset) — set it "
+                "on the [models.%s] entry; skipping it (a database definition of "
+                "the same alias, if any, stays in force)",
+                alias,
+                alias,
+            )
+            continue
         # Per-model sampling overrides from config.toml — invalid values
         # are logged and treated as None (inherit global default).
         entry_temp: float | None = None
@@ -1178,6 +1466,53 @@ def load_model_registry(
         entry_server_compat = entry_caps.pop("server_compat", {})
         if not isinstance(entry_server_compat, dict):
             entry_server_compat = {}
+        entry_provider = _resolve_openai_provider(entry.get("provider", "openai"), entry_base_url)
+        if entry_provider in LOCAL_PROVIDERS and not entry_base_url:
+            log.warning(
+                "Model '%s' is a %s entry without a base_url — set it on the "
+                "[models.%s] entry; skipping",
+                alias,
+                entry_provider,
+                alias,
+            )
+            continue
+        if (
+            not base_url
+            and entry_provider == "openai"
+            and "base_url" not in entry
+            and api_base_url_present
+        ):
+            # provider = "openai" with no base_url is the commercial API. A
+            # file that still carries [api] base_url was written when such an
+            # entry inherited that endpoint; sending its prompts to the
+            # commercial API instead is the one outcome to refuse.
+            log.warning(
+                "Model '%s' names provider \"openai\" without a base_url while "
+                "config.toml still carries [api] base_url, which the server no "
+                "longer applies — set base_url on the [models.%s] entry (or drop "
+                "[api] if the commercial API is intended); skipping",
+                alias,
+                alias,
+            )
+            continue
+        if (
+            not base_url
+            and entry_provider not in LOCAL_PROVIDERS
+            and entry_provider != "openai"
+            and "base_url" not in entry
+            and api_base_url_present
+        ):
+            # Empty base_url is the normal shape for these providers (the
+            # SDK default), so the entry loads — but say where it now goes.
+            log.warning(
+                "Model '%s' (provider %s) has no base_url and config.toml still carries "
+                "[api] base_url, which the server no longer applies — the entry targets "
+                "the provider's public endpoint; set base_url on [models.%s] if a local "
+                "server was intended",
+                alias,
+                entry_provider,
+                alias,
+            )
         entry_auth_mode, entry_obo_audience, entry_obo_scopes = _normalize_auth_mode(
             alias,
             entry.get("auth_mode", "static"),
@@ -1189,13 +1524,9 @@ def load_model_registry(
             base_url=entry_base_url,
             api_key=_resolve_env_vars(entry.get("api_key", api_key)),
             model=model_name,
-            # 0 = auto-detect: inherit the CLI-detected context_window, matching
-            # the DB loader above.  ``.get(k, 0) or context_window`` (NOT
-            # ``.get(k, default)``) is load-bearing — an explicit
-            # ``context_window = 0`` must normalize to the inherited window, not
-            # stay a literal 0 that zeroes every downstream budget.
-            context_window=entry.get("context_window", 0) or context_window,
-            provider=_resolve_openai_provider(entry.get("provider", "openai"), entry_base_url),
+            # 0 = auto-detect, resolved per definition below
+            context_window=_coerce_context_window(entry.get("context_window"), alias),
+            provider=entry_provider,
             capabilities=entry_caps,
             source="config",
             temperature=entry_temp,
@@ -1214,7 +1545,7 @@ def load_model_registry(
     # into the public list — the LLM picks it in task_agent
     # ``model=`` and silently bypasses the operator's per-role
     # task_alias override (the "default" alias points at
-    # whatever LLM_BASE_URL was at boot, not at the configured default).
+    # whatever --base-url was at boot, not at the configured default).
     if not configs and model:
         configs["default"] = ModelConfig(
             alias="default",
@@ -1241,6 +1572,10 @@ def load_model_registry(
             "Add models in the admin panel; they load without a restart."
         )
         return ModelRegistry(models={}, default="")
+
+    configs = _resolve_context_windows(
+        configs, detect=detect_context_windows, inherited=context_window, prior=prior
+    )
 
     # Determine default alias
     default_alias = model_section.get("default", "default")
@@ -1387,12 +1722,23 @@ def _version_tuple(version_str: str) -> tuple[int, ...]:
     return tuple(int(p) for p in version_str.split("."))
 
 
+def _positive_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else None
+
+
 def _extract_context_window(model_obj: Any, provider: str) -> int | None:
     """Extract context window from a model object returned by ``/v1/models``.
 
-    Handles Anthropic and xAI (static capability tables), vLLM
-    (``max_model_len``), and llama.cpp (``meta.n_ctx_train``).
-    Returns ``None`` when not available.
+    Handles Anthropic and xAI (static capability tables) and the keys the
+    OpenAI-compatible servers and gateways put on a model card: vLLM, NIM
+    and SGLang (``max_model_len``); OpenRouter, Together and Fireworks
+    (``context_length``, OpenRouter also under ``top_provider``); Groq
+    (``context_window``); Mistral (``max_context_length``); llama.cpp
+    (``meta.n_ctx_train``). Ollama, LM Studio, LiteLLM and DeepSeek put
+    nothing on the OpenAI path, and neither do the cloud-hosted paths —
+    Azure OpenAI deployments, Bedrock's and Vertex AI's OpenAI-compatible
+    endpoints, OCI Generative AI, Databricks serving — so those definitions
+    need an explicit window. Returns ``None`` when not available.
     """
     if provider == "anthropic":
         from turnstone.core.providers._anthropic import AnthropicProvider
@@ -1403,14 +1749,20 @@ def _extract_context_window(model_obj: Any, provider: str) -> int | None:
 
         return lookup_grok_capabilities(model_obj.id).context_window
     model_data = model_obj.model_dump()
-    max_len = model_data.get("max_model_len")
-    if isinstance(max_len, int) and max_len > 0:
-        return max_len
+    for key in ("max_model_len", "context_length", "context_window", "max_context_length"):
+        found = _positive_int(model_data.get(key))
+        if found is not None:
+            return found
     meta = model_data.get("meta")
     if isinstance(meta, dict):
-        n_ctx = meta.get("n_ctx_train")
-        if isinstance(n_ctx, int) and n_ctx > 0:
-            return n_ctx
+        found = _positive_int(meta.get("n_ctx_train"))
+        if found is not None:
+            return found
+    top_provider = model_data.get("top_provider")
+    if isinstance(top_provider, dict):
+        found = _positive_int(top_provider.get("context_length"))
+        if found is not None:
+            return found
     return None
 
 
@@ -1433,9 +1785,8 @@ def detect_model(
     Calls ``log_fn`` for informational messages (defaults to ``print``).
 
     When *fatal* is ``True`` (default), raises ``SystemExit`` on failure.
-    When ``False``, returns ``(None, None)`` so the server can start in
-    degraded mode (useful for cluster deployments where the LLM backend
-    may not be available at startup).
+    When ``False``, returns ``(None, None)`` so the caller can carry on
+    without a bootstrap model.
     """
     try:
         # Use a short timeout for startup detection — the default OpenAI client
@@ -1478,13 +1829,22 @@ def probe_model_endpoint(
     base_url: str,
     api_key: str,
     target_model: str = "",
+    *,
+    static_table: bool = True,
+    timeout: float = 10.0,
 ) -> dict[str, Any]:
     """Stateless probe of a model endpoint.
 
     Creates a temporary SDK client, calls ``/v1/models``, and returns
     reachability status, available model IDs, detected context window,
-    and server type.  Used by the admin *Detect* button — never persists
-    state or stores the API key.
+    and server type.  Used by the admin *Detect* button and by the
+    registry's ``context_window = 0`` resolution — never persists state
+    or stores the API key.
+
+    *static_table* lets an OpenAI-compatible endpoint that reports no
+    window fall back to the commercial OpenAI table by model id; the
+    Detect button shows that number to a human, the registry loader
+    passes ``False`` so it is never applied to a local server unseen.
     """
     from turnstone.core.providers import create_client
 
@@ -1499,7 +1859,7 @@ def probe_model_endpoint(
     client = None
     try:
         client = create_client(provider, base_url=base_url, api_key=api_key)
-        fast = client.with_options(timeout=10.0, max_retries=0)
+        fast = client.with_options(timeout=timeout, max_retries=0)
         models = fast.models.list()
         if not models.data:
             result["reachable"] = True
@@ -1544,7 +1904,9 @@ def probe_model_endpoint(
             result["server_type"] = "anthropic-compatible"
         else:
             # OpenAI-compatible path
-            _detect_openai_compat(result, inspect_obj, inspect_id, base_url)
+            _detect_openai_compat(
+                result, inspect_obj, inspect_id, base_url, static_table=static_table
+            )
     except Exception as exc:
         err_msg = str(exc)
         if len(err_msg) > 500:
@@ -1561,6 +1923,8 @@ def _detect_openai_compat(
     model_obj: Any,
     model_id: str,
     base_url: str,
+    *,
+    static_table: bool = True,
 ) -> None:
     """Fill context_window and server_type for an OpenAI-compatible endpoint."""
 
@@ -1579,7 +1943,7 @@ def _detect_openai_compat(
         ctx = _extract_context_window(model_obj, "openai")
         if ctx is not None:
             result["context_window"] = ctx
-    if result["context_window"] is None:
+    if result["context_window"] is None and static_table:
         from turnstone.core.providers import lookup_model_capabilities
 
         known = lookup_model_capabilities("openai", model_id)

--- a/turnstone/core/providers/__init__.py
+++ b/turnstone/core/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from typing import Any
 
@@ -139,6 +140,17 @@ def create_provider(
     )
 
 
+# Providers whose models live on an operator-run server: no capability
+# table, the window comes from the endpoint, and a bearer is optional.
+LOCAL_PROVIDERS: frozenset[str] = frozenset({"openai-compatible", "anthropic-compatible"})
+
+# Bearer an SDK client is built with for a local provider when the
+# definition has no key and the SDK's environment variable is unset. vLLM /
+# llama.cpp ignore it unless started with an API key; the SDKs refuse to
+# construct with neither a key nor their env var.
+LOCAL_PLACEHOLDER_API_KEY = "dummy"
+
+
 def create_client(provider_name: str, *, base_url: str, api_key: str) -> Any:
     """Create an SDK client for the given provider.
 
@@ -147,11 +159,30 @@ def create_client(provider_name: str, *, base_url: str, api_key: str) -> Any:
     ``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``).  Passing an empty
     string would short-circuit the SDK's env-var check and raise a
     "Missing credentials" error even when the env var is set.
+
+    A local provider with neither a key nor the env var gets
+    :data:`LOCAL_PLACEHOLDER_API_KEY` so the client still constructs; a
+    commercial provider in that state fails the way the SDK dictates.
     """
     resolved_key: str | None = api_key if api_key else None
+    if resolved_key is None and provider_name in LOCAL_PROVIDERS:
+        env_name = (
+            "ANTHROPIC_API_KEY" if provider_name == "anthropic-compatible" else "OPENAI_API_KEY"
+        )
+        if not os.environ.get(env_name):
+            resolved_key = LOCAL_PLACEHOLDER_API_KEY
     if provider_name in ("openai", "openai-compatible", "google", "xai"):
         from openai import OpenAI
 
+        if provider_name == "openai-compatible" and not base_url:
+            # The lane targets an operator-run server; without a base_url the
+            # SDK would default to https://api.openai.com/v1 and send the
+            # prompts meant for that server to the commercial API. Same
+            # posture as the anthropic-compatible arm below.
+            raise ValueError(
+                "openai-compatible requires base_url (the server's /v1 root, "
+                "e.g. http://your-vllm-host:8000/v1)"
+            )
         if not base_url and provider_name == "google":
             from turnstone.core.providers._google import GOOGLE_DEFAULT_BASE_URL
 
@@ -203,7 +234,7 @@ def lookup_model_capabilities(provider: str, model: str) -> dict[str, Any] | Non
     """
     import dataclasses
 
-    if provider in ("openai-compatible", "anthropic-compatible"):
+    if provider in LOCAL_PROVIDERS:
         return None
     prov = create_provider(provider)
     caps = prov.get_capabilities(model)

--- a/turnstone/deploy/compose.yaml
+++ b/turnstone/deploy/compose.yaml
@@ -181,9 +181,6 @@ services:
         turnstone-server
         --host 0.0.0.0
         --port 8080
-        --base-url "$${LLM_BASE_URL}"
-        --api-key "$${OPENAI_API_KEY}"
-        $${MODEL:+--model $$MODEL}
         $${SKIP_PERMISSIONS:+--skip-permissions}
         $${MCP_CONFIG:+--mcp-config $$MCP_CONFIG}
     volumes:
@@ -193,13 +190,13 @@ services:
       TURNSTONE_JWT_SECRET: *jwt-secret
       TURNSTONE_DB_BACKEND: *db-backend
       TURNSTONE_DB_URL: *db-url
-      # Bootstrap LLM defaults — real backends are configured in the console UI.
-      LLM_BASE_URL: ${LLM_BASE_URL:-http://host.docker.internal:8000/v1}
+      # Model backends are configured in the console Models tab. A definition
+      # that leaves api_key empty falls back to this variable (local servers
+      # need none); so does a ${OPENAI_API_KEY} placeholder in a definition.
       OPENAI_API_KEY: ${OPENAI_API_KEY:-dummy}
       # web_search backend. Defaults to the bundled searxng service; point at an
       # external SearxNG by setting TURNSTONE_SEARXNG_URL in .env (empty disables).
       TURNSTONE_SEARXNG_URL: ${TURNSTONE_SEARXNG_URL:-http://searxng:8080}
-      MODEL: ${MODEL:-}
       MCP_CONFIG: ${MCP_CONFIG:-}
       SKIP_PERMISSIONS: ${SKIP_PERMISSIONS:-}
       TURNSTONE_NODE_ID: ${TURNSTONE_NODE_ID:-node-1}

--- a/turnstone/doctor.py
+++ b/turnstone/doctor.py
@@ -82,8 +82,6 @@ _RELEVANT_ENV_VARS: tuple[str, ...] = (
     "TURNSTONE_JWT_SECRET",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
-    "LLM_BASE_URL",
-    "MODEL",
     "TURNSTONE_HOST_IP",
     "TURNSTONE_CONSOLE_URL",
     "TURNSTONE_ACME_EXTERNAL_URL",
@@ -326,7 +324,6 @@ class ConfigFileInfo:
     path: Path
     sections: list[str]
     db: dict[str, str]  # backend/url/path from [database], if present (real values)
-    api: dict[str, str]  # base_url/api_key from [api], if present (real values)
 
 
 @dataclass
@@ -429,13 +426,13 @@ def _systemd_units() -> list[str]:
     return units
 
 
-def _parse_config_sections(path: Path) -> tuple[list[str], dict[str, str], dict[str, str]]:
+def _parse_config_sections(path: Path) -> tuple[list[str], dict[str, str]]:
     """Return (section names, [database] subset, [api] subset) for a config.toml."""
     try:
         with open(path, "rb") as fh:
             data = tomllib.load(fh)
     except (OSError, tomllib.TOMLDecodeError):
-        return [], {}, {}
+        return [], {}
     sections = sorted(k for k, v in data.items() if isinstance(v, dict))
     db: dict[str, str] = {}
     dbsec = data.get("database")
@@ -444,14 +441,7 @@ def _parse_config_sections(path: Path) -> tuple[list[str], dict[str, str], dict[
             v = dbsec.get(k)
             if v:
                 db[k] = str(v)
-    api: dict[str, str] = {}
-    apisec = data.get("api")
-    if isinstance(apisec, dict):
-        for k in ("base_url", "api_key"):
-            v = apisec.get(k)
-            if v:
-                api[k] = str(v)
-    return sections, db, api
+    return sections, db
 
 
 def _discover_config_files(project_dir: Path, env: dict[str, str]) -> list[ConfigFileInfo]:
@@ -478,8 +468,8 @@ def _discover_config_files(project_dir: Path, env: dict[str, str]) -> list[Confi
         if rp in seen:
             continue
         seen.add(rp)
-        sections, db, api = _parse_config_sections(rp)
-        out.append(ConfigFileInfo(path=rp, sections=sections, db=db, api=api))
+        sections, db = _parse_config_sections(rp)
+        out.append(ConfigFileInfo(path=rp, sections=sections, db=db))
     return out
 
 
@@ -974,58 +964,43 @@ def family_of(provider: str) -> str | None:
     return None
 
 
-def _read_api_creds(profile: InstallProfile, env: dict[str, str]) -> tuple[str, str]:
-    """Resolve (base_url, api_key) from config.toml [api] then env, for brain seeding.
-
-    Reads the ``[api]`` block already parsed into each ``ConfigFileInfo`` at
-    discovery time (the config files aren't re-opened). The pair is taken from the
-    *first* config file that defines either field, as a unit — so base_url and
-    api_key never get mixed across two different config sources (which would form
-    an endpoint/key pair that exists in no real config). Any field still missing
-    is then filled from the environment, matching Turnstone's config→env order.
-    """
-    base_url = api_key = ""
-    for cf in profile.config_files:
-        if cf.api.get("base_url") or cf.api.get("api_key"):
-            base_url = cf.api.get("base_url", "")
-            api_key = cf.api.get("api_key", "")
-            break
-    base_url = base_url or env.get("LLM_BASE_URL", "")
-    api_key = api_key or env.get("OPENAI_API_KEY", "") or env.get("ANTHROPIC_API_KEY", "")
-    return base_url, api_key
-
-
 def resolve_doctor_brain(
     profile: InstallProfile,
     storage: Any,
     storage_err: str,
     *,
-    env: dict[str, str] | None = None,
     validate: bool = True,
 ) -> tuple[_DoctorLLM | None, BackendVerdict]:
-    """Build doctor's LLM from the cluster's config (the first diagnostic).
+    """Build doctor's LLM from the cluster's model definitions (the first diagnostic).
 
     Returns (brain, verdict). ``brain`` is None when resolution fails, in which
     case ``verdict.detail`` explains why and the caller should fall back to
     interactive provider selection.
     """
-    env = dict(env if env is not None else os.environ)
     if storage is None:
         return None, BackendVerdict(False, f"storage unreachable: {storage_err}")
 
     try:
+        from turnstone.core.config import load_config, set_config_path
         from turnstone.core.config_store import ConfigStore
         from turnstone.core.model_registry import load_model_registry
 
         cs = ConfigStore(storage=storage, node_id="")
         alias = str(cs.get("model.default_alias", "") or "")
-        base_url, api_key = _read_api_creds(profile, env)
+        # The same sources a node uses — DB definitions overlaid with
+        # config.toml [models.*] — and nothing else: a node has no bootstrap
+        # endpoint, so doctor must not invent one from [api] or the env. When
+        # the config the loader resolves on its own defines no models, the
+        # node's may live where it does not look (/etc/turnstone under
+        # systemd, a project dir); the
+        # discovery pass found it, so read [models.*] from there.
+        if not load_config("models"):
+            for cf in profile.config_files:
+                if "models" in cf.sections:
+                    set_config_path(str(cf.path))
+                    break
         registry = load_model_registry(
-            base_url=base_url,
-            api_key=api_key,
-            model=env.get("MODEL", ""),
-            storage=storage,
-            allow_empty=True,
+            storage=storage, allow_empty=True, detect_context_windows=True
         )
         client, model_name, cfg, _ = registry.resolve(alias or None)
     except Exception as exc:  # noqa: BLE001 - any failure means "no usable model"
@@ -1618,7 +1593,7 @@ reachable from the console.
 - **Database unreachable**: nodes crash-loop or the console shows no nodes → check \
 `TURNSTONE_DB_URL`, the postgres container/port, and credentials.
 - **LLM backend down**: chats error or hang → use `check_llm_backend` against the \
-node's `LLM_BASE_URL`.
+base_url of the node's model definition (console Models tab).
 - **Port conflict**: a service won't bind → `check_port`.
 - **TLS / ACME**: browser cert errors → Caddy fronts the console with a local CA; \
 nodes enroll via the console's plain-HTTP ACME endpoint.

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4664,8 +4664,19 @@ def _apply_routing_overrides(registry: Any, cs: Any, app_state: Any) -> bool:
     return False
 
 
+# Serialises hot-reloads on this node. A reload may probe model endpoints for
+# several seconds; two overlapping console fan-outs would otherwise race to
+# install their snapshots and the older one could land last.
+_MODEL_RELOAD_LOCK = threading.Lock()
+
+
 def internal_model_reload(request: Request) -> JSONResponse:
     """POST /v1/api/_internal/model-reload — rebuild registry from DB + config."""
+    with _MODEL_RELOAD_LOCK:
+        return _internal_model_reload_locked(request)
+
+
+def _internal_model_reload_locked(request: Request) -> JSONResponse:
     from turnstone.core.model_registry import (
         DynamicAuthKeyError,
         ModelAuthConfigError,
@@ -4675,19 +4686,24 @@ def internal_model_reload(request: Request) -> JSONResponse:
     from turnstone.core.storage._registry import get_storage
 
     registry = getattr(request.app.state, "registry", None)
-    cli_args = getattr(request.app.state, "cli_model_args", None)
-    if registry is None or cli_args is None:
+    if registry is None:
         return JSONResponse({"status": "error", "reason": "no registry"}, status_code=503)
 
     storage = get_storage()
     try:
         new_registry = load_model_registry(
-            base_url=cli_args["base_url"],
-            api_key=cli_args["api_key"],
-            model=cli_args["model"],
-            context_window=cli_args["context_window"],
-            provider=cli_args["provider"],
             storage=storage,
+            # Deleting the last definition is a legitimate reload: the node
+            # keeps serving an empty registry until one is added.
+            allow_empty=True,
+            # A storage read failure must surface here, not degrade to a
+            # config-only (or empty) registry that then replaces every live
+            # alias — the same posture as the console's refresh.
+            strict=True,
+            detect_context_windows=True,
+            # A definition the running registry already resolved keeps its
+            # window; only new or changed definitions are probed.
+            prior=registry.models,
         )
     except (ModelAuthConfigError, ModelConcurrencyConfigError) as exc:
         # A row whose auth or concurrency fields violate registry validation,
@@ -4697,6 +4713,17 @@ def internal_model_reload(request: Request) -> JSONResponse:
         # refresh path catches the same row. Same structured 422 contract as
         # the bad-arguments arm below: the reason names the row and field.
         return JSONResponse({"status": "error", "reason": str(exc)}, status_code=422)
+    except Exception as exc:  # noqa: BLE001 - keep the running registry on any load failure
+        # Type name only: a storage error can carry the SQL, host or file
+        # path, and this reply is relayed to the console as-is.
+        log.warning("Model reload skipped, keeping the running registry", exc_info=True)
+        return JSONResponse(
+            {
+                "status": "error",
+                "reason": f"registry load failed: {type(exc).__name__} (see the node log)",
+            },
+            status_code=503,
+        )
     cs = getattr(request.app.state, "config_store", None)
     if cs is not None:
         cs.reload()  # Ensure latest settings from DB
@@ -5946,21 +5973,13 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent("""\
             Examples:
-              turnstone-server                            # auto-detect model, serve on :8080
+              turnstone-server                            # serve on :8080
               turnstone-server --port 3000                # custom port
-              turnstone-server --model kappa_20b_131k     # explicit model
               turnstone-server --skip-permissions          # auto-approve all tools
+
+            Models come from the console Models tab (database) and from
+            [models.*] entries in config.toml; each carries its own endpoint.
         """),
-    )
-    parser.add_argument(
-        "--base-url",
-        default="http://localhost:8000/v1",
-        help="OpenAI-compatible API base URL (default: http://localhost:8000/v1)",
-    )
-    parser.add_argument(
-        "--model",
-        default=None,
-        help="Model name (default: auto-detect from server)",
     )
     parser.add_argument(
         "--skill",
@@ -5968,21 +5987,10 @@ def main() -> None:
         help="Skill name (replaces default skills)",
     )
     parser.add_argument(
-        "--provider",
-        default="openai",
-        choices=["openai", "anthropic"],
-        help="LLM provider for the default model (default: openai)",
-    )
-    parser.add_argument(
         "--resume",
         default=None,
         metavar="WS",
         help="Resume a previous workstream by alias or ws_id",
-    )
-    parser.add_argument(
-        "--api-key",
-        default=None,
-        help="API key (default: $OPENAI_API_KEY, or 'dummy' for local servers)",
     )
     parser.add_argument(
         "--host",
@@ -6015,7 +6023,7 @@ def main() -> None:
     add_config_arg(parser)
     # Only load bootstrap sections from config.toml — all other settings
     # are managed by ConfigStore (database-backed) after storage init.
-    apply_config(parser, ["api", "server", "database"])
+    apply_config(parser, ["server", "database"])
     args = parser.parse_args()
 
     from turnstone.core.log import configure_logging_from_args
@@ -6082,57 +6090,20 @@ def main() -> None:
 
     prune_workstreams(retention_days=config_store.get("session.retention_days"), log_fn=print)
 
-    # Create client and detect model
-    provider_name = args.provider
-    api_key = (
-        args.api_key
-        or os.environ.get("ANTHROPIC_API_KEY" if provider_name == "anthropic" else "OPENAI_API_KEY")
-        or "dummy"
-    )
-    base_url = args.base_url
-    if provider_name == "anthropic" and base_url == "http://localhost:8000/v1":
-        base_url = "https://api.anthropic.com"
-    from turnstone.core.providers import create_client
-
-    client = create_client(provider_name, base_url=base_url, api_key=api_key)
-
-    cli_model = args.model
-    effective_model = cli_model or None
-    if effective_model:
-        model = effective_model
-        detected_ctx = None
-    else:
-        from turnstone.core.model_registry import detect_model
-
-        model, detected_ctx = detect_model(client, provider=provider_name, fatal=False)
-        if model is None:
-            # LLM backend unreachable — no CLI model specified.
-            # Set empty so load_model_registry skips the CLI "default"
-            # entry and relies on DB / config.toml models instead.
-            model = ""
-
-    # Use detected context window, fall back to 32768
-    if detected_ctx:
-        context_window = detected_ctx
-        log.info("Context window: %s (detected from backend)", f"{context_window:,}")
-    else:
-        context_window = 32768
-
-    # Build model registry (reads [models.*] + database model definitions)
+    # Build the model registry from the database model definitions and
+    # config.toml [models.*]. The server has no bootstrap endpoint of its own:
+    # every definition carries its endpoint, and one whose context_window is
+    # 0 is auto-detected against that endpoint here and again on hot-reload.
     from turnstone.core.model_registry import load_model_registry
     from turnstone.core.storage._registry import get_storage as _get_storage
 
     registry = load_model_registry(
-        base_url=base_url,
-        api_key=api_key,
-        model=model,
-        context_window=context_window,
-        provider=provider_name,
         storage=_get_storage(),
         # A node boots even with no models configured yet: it registers and
         # shows in the console, and models added in the admin panel hot-reload
         # in (internal_model_reload). Requests fail cleanly until then.
         allow_empty=True,
+        detect_context_windows=True,
     )
 
     # Apply runtime overrides from ConfigStore for default alias plus the
@@ -6222,10 +6193,11 @@ def main() -> None:
         )
 
     judge_config = _build_judge_config()
+    default_model_id = registry.get_config(registry.default).model if registry.default else ""
     if judge_config.enabled:
         log.info(
             "Judge: enabled (model=%s, threshold=%.2f)",
-            judge_config.model or model,
+            judge_config.model or default_model_id,
             judge_config.confidence_threshold,
         )
 
@@ -6604,8 +6576,8 @@ def main() -> None:
         ws.session.set_watch_runner(_watch_runner, wake_fn=_watch_fire_wake_fn(ws))
         log.info("Resumed workstream %s (%d messages)", target_id, len(ws.session.messages))
 
-    # Record detected model and judge status in metrics
-    _metrics.model = model
+    # Record the default model and judge status in metrics
+    _metrics.model = default_model_id
     _metrics.set_judge_enabled(judge_config.enabled if judge_config else False)
 
     # Auth config
@@ -6658,18 +6630,8 @@ def main() -> None:
     # Wire app ref so health callbacks can access app.state for metrics
     _app_ref[0] = app
 
-    # Store CLI model args for hot-reload (internal_model_reload reads these)
-    app.state.cli_model_args = {
-        "base_url": base_url,
-        "api_key": api_key,
-        "model": model,
-        "context_window": context_window,
-        "provider": provider_name,
-        "_user_specified_model": bool(effective_model),
-    }
-
     log.info("Server starting on http://%s:%s", args.host, args.port)
-    log.info("Model: %s", model)
+    log.info("Default model: %s", registry.default or "(none configured)")
     if registry.count > 1:
         others = [a for a in registry.list_aliases() if a != registry.default]
         log.info("Models: %s (default), %s", registry.default, ", ".join(others))


### PR DESCRIPTION
`turnstone-server` no longer takes `--base-url`, `--api-key`, `--provider` or `--model`, and no longer reads `[api]` from `config.toml`. Every model definition (console Models tab or `[models.*]`) carries its own endpoint; a node started with nothing configured boots with an empty registry and picks definitions up live. The Helm chart and the Terraform module already passed no bootstrap endpoint (their environment variables were read by nothing); compose, OpenShell, the systemd docs and the example config follow.

A definition whose `context_window` is `0` used to inherit the window the server detected on its bootstrap endpoint at boot: 32768 whenever `--model` was passed or that endpoint was unreachable, and the wrong endpoint's number otherwise. It is now resolved per definition:

- the capability table for Anthropic, OpenAI and xAI;
- a `/v1/models` probe of the definition's own endpoint for local servers and gateways, on a deadline-bounded daemon thread, identical definitions sharing one probe — reading vLLM `max_model_len`, llama.cpp `n_ctx_train`, and the `context_length`, `context_window` or `max_context_length` that OpenRouter, Together, Fireworks, Groq and Mistral report;
- when a hot-reload's probe fails, the window the running registry had detected for the same endpoint and model;
- otherwise 32768 with a warning naming the alias and the reason.

The console and the doctor resolve the same way. The console Detect button no longer offers a commercial model's window for a local server, and when the endpoint reports none it fills the field with the 32768 the node would use, and says so, so the operator corrects it before the first call.

Consequences handled in the same change:

- an empty `api_key` on a local provider resolves as the server's old default did (SDK env var, then a placeholder);
- a local-provider definition without a `base_url` is refused at save time and skipped at load time, and an openai-compatible client without one refuses to construct;
- a definition whose `base_url` resolves to nothing, or a `[models.*]` entry that relied on the bootstrap endpoint, is skipped rather than retargeted to the commercial API;
- node hot-reloads are serialised, load strictly and keep the running registry on failure;
- the admin API stores an omitted `context_window` as auto-detect;
- the doctor resolves its own model from the registry alone.

The `turnstone` CLI keeps its flags (#1085).

Closes #1052.

## Notes for review

- Verified live: OpenRouter detection (`openai/gpt-5.6-luna`, 1,050,000). The Groq, Mistral, Together and Fireworks keys come from their API shapes and are pinned in a unit matrix, not exercised against a live key.
- Not detectable on the OpenAI path, so these need an explicit window (the node warns, naming the alias): Ollama, LM Studio, LiteLLM, DeepSeek, Gemini's compat path, Azure deployments, Bedrock and Vertex compat endpoints, OCI, Databricks.
- llama.cpp reports the checkpoint's trained maximum, not the `-c` allocation; same as the old bootstrap detection.
- Declined from review: refusing Anthropic, xAI and Google entries that have no `base_url`. Empty is those providers' normal shape and the common CLI layout keeps `[api]` alongside them; the entry loads with a warning naming the public endpoint it now targets.
- Full CI-lane suite: 12982 passed, 28 skipped.
