### PR TITLE
feat(console): Scheduled as a third kind on the dashboard launcher (#1090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ that minor, so the current stable line never has two independently writable
 branches. Earlier stable lines (`stable/1.7`, `stable/1.6`, `stable/1.5`) are
 frozen.
 
+## [Unreleased]
+
+### Added
+
+- **Scheduled tasks from the dashboard (#1090).** The console launcher's kind
+  toggle gains **Scheduled** next to Coordinator and Interactive, shown to
+  callers with `admin.schedules`. It takes the interactive field set plus a
+  When builder (Daily / Weekly / Monthly / Interval / Once / Cron with a live
+  next-runs read-out) and stores the schedule for the scheduler to dispatch;
+  a confirmation names the first run. The admin schedule shelf and the
+  launcher now share one timing builder; its "next runs" read-out shows each
+  run in the browser's local zone, and the shelf's NEXT RUN column now
+  converts the server's UTC time to local time instead of relabelling it.
+
 ## [1.8.2]
 
 Turnstone 1.8.2 moves model endpoints entirely into model definitions and

--- a/docs/console.md
+++ b/docs/console.md
@@ -407,8 +407,10 @@ workstream rows, and tab state glyphs synchronized.
 ### Workstream launcher
 
 The landing-page composer starts a workstream with an optional initial task and
-attachments. When the caller can create both kinds, a Coordinator / Interactive
-toggle selects the target kind. Its options include:
+attachments. A Coordinator / Interactive / Scheduled toggle selects the target
+kind; each option appears only when the caller holds its permission
+(`admin.coordinator`, `workstreams.create`, `admin.schedules`), and the toggle
+is hidden when only one kind is available. Its options include:
 
 - **Node placement** — "Least loaded" picks the reachable node with the most
   headroom, or "Specific node" pins the create to a node from the live list.
@@ -424,6 +426,20 @@ Interactive launches additionally expose node strategy / node selection.
 Submitting uses `POST /v1/api/cluster/workstreams/new`; coordinator launches use
 the console's coordinator create surface. A toast confirms the committed
 create, while SSE updates the dashboard and opens the resulting pane.
+
+**Scheduled** launches store a schedule instead of starting anything: the
+scheduler later dispatches the task as an interactive workstream (see
+[Scheduled Tasks](#scheduled-tasks)). The kind carries the interactive field
+set, including node placement, and reveals a **When** builder between the
+kind toggle and the composer with Daily / Weekly / Monthly / Interval / Once /
+Cron modes and a live "next runs" read-out. Recurring times are entered in
+UTC (the cron has no zone); a one-shot takes local time; the read-out and the
+confirmation show each run in the browser's local zone. The task text becomes the
+schedule's initial message and is required; the Name option, when empty, is
+derived from the task's first line. Judge model and attachments do not apply,
+so the kind hides them. Submitting uses `POST /v1/api/admin/schedules`; a
+confirmation beneath the composer names the first run, and the schedule is
+then managed under Admin › Schedules.
 
 Files require a non-empty initial task so the first turn consumes the staged
 attachments. The console shell does not currently expose a fork action; use the
@@ -547,6 +563,12 @@ to create the initial admin user and receive a JWT in one step. See
 ## Scheduled Tasks
 
 The console includes a background **TaskScheduler** daemon that creates workstreams on a timed basis via HTTP proxy to target nodes. It supports cron-based recurring schedules and one-shot `at` schedules.
+
+Schedules are created and managed under Admin › Schedules, and can also be
+created from the dashboard launcher's Scheduled kind (see
+[Workstream launcher](#workstream-launcher)). Both surfaces share one timing
+builder; the admin shelf additionally offers a description, auto-approve,
+notification targets and the pool / all target modes.
 
 ### Architecture
 

--- a/tests/_js_harness_helpers.py
+++ b/tests/_js_harness_helpers.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
+import subprocess
+import tempfile
 from typing import TYPE_CHECKING
 
 import pytest
@@ -185,6 +188,24 @@ globalThis.triggerResize = (target) => {
 
 def has_node() -> bool:
     return shutil.which("node") is not None
+
+
+def run_node_source(source: str, *, timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    """Run ``source`` as an ES module under node and return the process.
+
+    The one home for the write-temp-file / run / unlink plumbing the
+    slice-and-run suites share (a sliced console function plus ``throw``
+    checks); skips the test when node is absent.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
+        f.write(source)
+        tmp = f.name
+    try:
+        return subprocess.run(["node", tmp], capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        pytest.skip("node binary not available on PATH")
+    finally:
+        os.unlink(tmp)
 
 
 # Module-level ``pytestmark = node_skip`` in each harness suite — the node

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -10,14 +10,13 @@ manual testing.
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from tests._js_harness_helpers import slice_braced_block
+from tests._js_harness_helpers import run_node_source, slice_braced_block
 from tests._js_harness_helpers import strip_js_comments as _strip_js_comments
 
 _APP_JS = Path(__file__).resolve().parent.parent / "turnstone/ui/static/app.js"
@@ -756,6 +755,9 @@ _CONSOLE_ADMIN_JS = Path(__file__).resolve().parent.parent / "turnstone/console/
 _CONSOLE_GOVERNANCE_JS = (
     Path(__file__).resolve().parent.parent / "turnstone/console/static/governance.js"
 )
+_CONSOLE_SCHEDULE_BUILDER_JS = (
+    Path(__file__).resolve().parent.parent / "turnstone/console/static/schedule_builder.js"
+)
 
 
 _UNSAFE_CODE_SINK_LINT_TARGETS = [
@@ -768,6 +770,7 @@ _UNSAFE_CODE_SINK_LINT_TARGETS = [
     ("turnstone/console/static/admin.js", _CONSOLE_ADMIN_JS),
     ("turnstone/console/static/governance.js", _CONSOLE_GOVERNANCE_JS),
     ("turnstone/console/static/app.js", _CONSOLE_APP_JS),
+    ("turnstone/console/static/schedule_builder.js", _CONSOLE_SCHEDULE_BUILDER_JS),
 ]
 
 
@@ -906,7 +909,6 @@ def test_capability_bool_lift_agrees_with_the_backend_coercion() -> None:
     Cases are generated FROM the Python table, so a spelling added on one
     side and not the other fails here rather than in the field.
     """
-    import tempfile
 
     from turnstone.core.model_turn import _CAPABILITY_BOOL_STRINGS
 
@@ -938,15 +940,7 @@ def test_capability_bool_lift_agrees_with_the_backend_coercion() -> None:
     ]
     harness = table.group(0) + chr(10) + fn.group(0) + chr(10) + chr(10).join(checks)
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
-        f.write(harness)
-        tmp = f.name
-    try:
-        proc = subprocess.run(["node", tmp], capture_output=True, text=True, timeout=15)
-    except FileNotFoundError:
-        pytest.skip("node binary not available on PATH")
-    finally:
-        os.unlink(tmp)
+    proc = run_node_source(harness)
     assert proc.returncode == 0, (
         f"_capBool disagrees with the backend coercion.  stderr={proc.stderr!r}"
     )
@@ -1380,6 +1374,7 @@ _SWEPT_BUNDLES = [
     _REPO_ROOT / "turnstone/console/static/admin.js",
     _REPO_ROOT / "turnstone/console/static/governance.js",
     _REPO_ROOT / "turnstone/console/static/app.js",
+    _REPO_ROOT / "turnstone/console/static/schedule_builder.js",
 ]
 
 # The const-reassign analysis below is pure text — module vs script semantics
@@ -1719,7 +1714,6 @@ def test_redact_credentials_runtime_smoke() -> None:
     directories.  The ``redact_credentials.js`` source file is imported
     by absolute path so resolution is unambiguous.
     """
-    import tempfile
 
     mod_path = _REDACT_CREDENTIALS_JS.resolve()
     harness = (
@@ -1788,20 +1782,7 @@ def test_redact_credentials_runtime_smoke() -> None:
         + "if (up !== 'POSTGRESQL+PSYCOPG2://user:[REDACTED:password]@db/app') "
         + "throw new Error('uppercase scheme conn redact failed: ' + up);\n"
     )
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as f:
-        f.write(harness)
-        tmp = f.name
-    try:
-        proc = subprocess.run(
-            ["node", tmp],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-    except FileNotFoundError:
-        pytest.skip("node binary not available on PATH")
-    finally:
-        os.unlink(tmp)
+    proc = run_node_source(harness)
     assert proc.returncode == 0, (
         f"redactCredentials runtime smoke failed.  stdout={proc.stdout!r} stderr={proc.stderr!r}"
     )
@@ -3079,6 +3060,87 @@ def test_dashboard_paints_project_and_persona_from_cache_synchronously() -> None
     # The hint is seeded synchronously inside _paintProjectPicker (asserted there).
 
 
+def test_console_schedule_name_from_task() -> None:
+    """The Scheduled kind names a schedule from the task when the Name option
+    is empty: first line, whitespace collapsed, cut at 60 code points with an
+    ellipsis.  Driven through node like the builder helpers, because an
+    off-by-one or a surrogate split here mislabels every launcher-made
+    schedule (a lone surrogate would 500 the create)."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    cut = re.search(r"const _SCHEDULE_NAME_CUT_CHARS = \d+;", body)
+    assert cut, "the derived-name cut must be a named constant"
+    fn = cut.group(0) + chr(10) + _slice_top_level_fn(body, "function _scheduleNameFromTask(")
+    cases = [
+        ("Check disk usage", "Check disk usage"),
+        ("First line\nsecond line", "First line"),
+        ("a   b\t c", "a b c"),
+        ("x" * 60, "x" * 60),
+        ("x" * 61, "x" * 59 + "\u2026"),
+        # A space landing at the cut is trimmed before the ellipsis.
+        ("x" * 58 + " " + "y" * 10, "x" * 58 + "\u2026"),
+        # An astral character spanning the cut stays whole (code points, not
+        # UTF-16 units).
+        ("x" * 58 + "\U0001f600" + "y" * 5, "x" * 58 + "\U0001f600" + "\u2026"),
+    ]
+    checks = [
+        f"if (_scheduleNameFromTask({json.dumps(task)}) !== {json.dumps(want)}) "
+        f"throw new Error('case ' + {json.dumps(task[:20])});"
+        for task, want in cases
+    ]
+    proc = run_node_source(fn + chr(10) + chr(10).join(checks))
+    assert proc.returncode == 0, f"_scheduleNameFromTask disagrees: stderr={proc.stderr!r}"
+
+
+def test_console_over_cap_counts_code_points_with_a_cheap_short_circuit() -> None:
+    """The launcher's caps count code points like the server, but only box a
+    string into an array once its UTF-16 length is already over the cap — a
+    UTF-16 length under the cap can never exceed it in code points."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function _overCap(")
+    astral = "\U0001f600"
+    cases = [
+        ("x" * 10, 10, False),
+        ("x" * 11, 10, True),
+        (astral * 10, 10, False),  # 20 UTF-16 units, 10 code points: under
+        (astral * 11, 10, True),
+        ("x" * 9 + astral, 10, False),
+        ("", 10, False),
+    ]
+    checks = [
+        f"if (_overCap({json.dumps(text)}, {cap}) !== {json.dumps(want)}) "
+        f"throw new Error('case ' + {json.dumps(text[:8])} + ' cap ' + {cap});"
+        for text, cap, want in cases
+    ]
+    proc = run_node_source(fn + chr(10) + chr(10).join(checks))
+    assert proc.returncode == 0, f"_overCap disagrees: stderr={proc.stderr!r}"
+
+
+def test_console_next_launcher_kind() -> None:
+    """The kind toggle's arrow-key step: the neighbour in the available list,
+    wrapping at either end, and an end of the list when the active kind is no
+    longer offered (a permission refresh mid-session)."""
+    body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
+    fn = _slice_top_level_fn(body, "function _nextLauncherKind(")
+    three = ["coordinator", "interactive", "scheduled"]
+    cases = [
+        (("coordinator", three, False), "interactive"),
+        (("scheduled", three, False), "coordinator"),
+        (("coordinator", three, True), "scheduled"),
+        (("interactive", three, True), "coordinator"),
+        (("interactive", ["interactive"], False), "interactive"),
+        (("coordinator", ["interactive", "scheduled"], False), "interactive"),
+        (("coordinator", ["interactive", "scheduled"], True), "scheduled"),
+        (("coordinator", [], False), "coordinator"),
+    ]
+    checks = [
+        f"if (_nextLauncherKind({json.dumps(cur)}, {json.dumps(avail)}, {json.dumps(back)}) "
+        f"!== {json.dumps(want)}) throw new Error({json.dumps(f'{cur} {avail} {back}')});"
+        for (cur, avail, back), want in cases
+    ]
+    proc = run_node_source(fn + chr(10) + chr(10).join(checks))
+    assert proc.returncode == 0, f"_nextLauncherKind disagrees: stderr={proc.stderr!r}"
+
+
 def test_console_launcher_paints_project_and_persona_from_cache_synchronously() -> None:
     """FOUC fix (console launcher composer): the project + persona wrappers route
     through the _paintHomeFromCache chokepoint — sync paint from the warm cache,
@@ -3088,7 +3150,9 @@ def test_console_launcher_paints_project_and_persona_from_cache_synchronously() 
     kind-default revert: _populateHomePersonaDropdown must fall back to
     defaultPersona(kind) when the previous pick is no longer a valid choice (the
     interactive/coordinator persona shelves are disjoint), or a kind toggle
-    silently degrades the picker to a bare placeholder."""
+    silently degrades the picker to a bare placeholder.  The kind goes through
+    _launcherPersonaKind: a schedule dispatches an interactive workstream, so the
+    Scheduled kind draws from the interactive shelf."""
     body = _CONSOLE_APP_JS.read_text(encoding="utf-8")
     proj_fn = _slice_top_level_fn(body, "function _refreshAndPopulateProjects(")
     assert re.search(
@@ -3104,8 +3168,11 @@ def test_console_launcher_paints_project_and_persona_from_cache_synchronously() 
     assert '_restorePick("persona"' in pop, (
         "the persona populate must restore a still-valid pick via _restorePick"
     )
-    assert "defaultPersona(_launcherKind)" in pop, (
+    assert "defaultPersona(_launcherPersonaKind())" in pop, (
         "the persona populate must revert to the kind default when the pick is gone"
+    )
+    assert "personaChoices(_launcherPersonaKind())" in pop, (
+        "the persona choices must come from the kind's persona shelf"
     )
     proj_pop = _slice_top_level_fn(body, "function _populateHomeProjectDropdown(")
     assert '_restorePick("project"' in proj_pop, (
@@ -3709,7 +3776,6 @@ def test_memory_description_editor_defers_normalization_to_server() -> None:
 
 
 def test_memory_health_refresh_lifecycle() -> None:
-    import tempfile
 
     governance = _CONSOLE_GOVERNANCE_JS.read_text(encoding="utf-8")
     admin = _CONSOLE_ADMIN_JS.read_text(encoding="utf-8")
@@ -3799,15 +3865,7 @@ function loadMemoryIndexHealth(force) {load_health}
   process.exitCode = 1;
 }});
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".mjs", delete=False) as handle:
-        handle.write(script)
-        path = handle.name
-    try:
-        proc = subprocess.run(["node", path], capture_output=True, text=True, timeout=15)
-    except FileNotFoundError:
-        pytest.skip("node binary not available on PATH")
-    finally:
-        os.unlink(path)
+    proc = run_node_source(script)
     assert proc.returncode == 0, proc.stderr
 
 

--- a/tests/test_composer_paste_text_js.py
+++ b/tests/test_composer_paste_text_js.py
@@ -55,6 +55,12 @@ check(converted instanceof File, "above-threshold text did not convert");
 check(converted.name === "pasted-text.txt", "filename drifted");
 check(converted.type === "text/plain", "MIME drifted");
 check(converted.size === 2001, "byte size drifted");
+check(paste.isPastedTextFile(converted) === true, "synthesized file not recognised");
+check(
+  paste.isPastedTextFile(new File(["x"], "real.txt", { type: "text/plain" })) === false,
+  "a real file mistaken for a paste",
+);
+check(paste.isPastedTextFile(null) === false, "null mistaken for a paste");
 check(
   (await converted.text()) === convertedText,
   "file content did not round-trip",

--- a/tests/test_schedule_api.py
+++ b/tests/test_schedule_api.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from starlette.responses import Response
 
 from turnstone.console.server import (
+    SCHEDULE_MESSAGE_MAX_CHARS,
+    SCHEDULE_NAME_MAX_CHARS,
     admin_create_schedule,
     admin_delete_schedule,
     admin_get_schedule,
@@ -598,3 +600,47 @@ class TestPreviewSchedule:
             json={"schedule_type": "cron", "cron_expr": "0 6 * * *"},
         )
         assert all(t.endswith("+00:00") for t in resp.json()["next"])
+
+
+def test_message_cap_is_mirrored_by_the_console_ui() -> None:
+    """The launcher's client-side cap and the admin shelf's textarea maxlength
+    carry the server's number.  The number only: the launcher counts code
+    points like the server, while an HTML maxlength can only count UTF-16
+    units, so the semantics are allowed to differ at the edge."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    app = (root / "turnstone/console/static/app.js").read_text(encoding="utf-8")
+    index = (root / "turnstone/console/static/index.html").read_text(encoding="utf-8")
+    assert f"const _SCHEDULE_TASK_MAX_CHARS = {SCHEDULE_MESSAGE_MAX_CHARS};" in app
+    assert f'maxlength="{SCHEDULE_MESSAGE_MAX_CHARS}"' in index
+    assert f"const _SCHEDULE_NAME_MAX_CHARS = {SCHEDULE_NAME_MAX_CHARS};" in app
+    assert f'maxlength="{SCHEDULE_NAME_MAX_CHARS}"' in index
+
+
+def test_create_keeps_the_capped_message_length(client) -> None:
+    resp = client.post(
+        "/v1/api/admin/schedules",
+        json={
+            "name": "long",
+            "schedule_type": "cron",
+            "cron_expr": "0 6 * * *",
+            "initial_message": "x" * (SCHEDULE_MESSAGE_MAX_CHARS + 10),
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["initial_message"]) == SCHEDULE_MESSAGE_MAX_CHARS
+
+
+def test_create_keeps_the_capped_name_length(client) -> None:
+    resp = client.post(
+        "/v1/api/admin/schedules",
+        json={
+            "name": "n" * (SCHEDULE_NAME_MAX_CHARS + 10),
+            "schedule_type": "cron",
+            "cron_expr": "0 6 * * *",
+            "initial_message": "task",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["name"]) == SCHEDULE_NAME_MAX_CHARS

--- a/tests/test_schedule_builder_js.py
+++ b/tests/test_schedule_builder_js.py
@@ -1,0 +1,387 @@
+"""Behavioral tests for the schedule "When" builder's pure helpers
+(``turnstone/console/static/schedule_builder.js``): compile, describe,
+reverse-parse and the time formatters, driven through ``node``.
+
+Both the admin schedule shelf and the dashboard launcher's Scheduled kind
+compile their timing through these, so the arithmetic is pinned once here.
+The DOM instance (template cloning, event wiring, preview fetches) is
+browser-verified only: the node harness has no template / cloneNode.  The
+id transform the instance scoping rests on is a pure function (``scopedId``)
+and is pinned here; ``test_shell_js.py`` pins that the constructor routes
+every id / for / aria-labelledby through it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests._js_harness_helpers import node_skip
+
+_ROOT = Path(__file__).resolve().parent.parent
+_BUILDER_JS = _ROOT / "turnstone/console/static/schedule_builder.js"
+
+pytestmark = node_skip
+
+_HARNESS = """
+const vm = require('vm');
+global.window = global;
+global.document = { getElementById: () => null, createElement: () => ({}) };
+vm.runInThisContext(%(src)s);
+const SB = global.TurnstoneScheduleBuilder;
+const out = (%(expr)s);
+process.stdout.write(JSON.stringify(out === undefined ? null : out));
+"""
+
+
+def _eval(expr: str, tz: str = "UTC") -> Any:
+    """Evaluate ``expr`` with the builder loaded as ``SB`` under the ``tz``
+    local time (UTC by default so the datetime-local conversions are
+    deterministic; a named zone for the tests that prove the conversion)."""
+    harness = _HARNESS % {
+        "src": json.dumps(_BUILDER_JS.read_text(encoding="utf-8")),
+        "expr": expr,
+    }
+    result = subprocess.run(
+        ["node", "-e", harness],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+        env={**os.environ, "TZ": tz},
+    )
+    return json.loads(result.stdout)
+
+
+def _compile(**state: Any) -> dict[str, Any]:
+    return _eval(f"SB.compileSchedule(Object.assign(SB.defaultState(), {json.dumps(state)}))")
+
+
+def _describe(tz: str = "UTC", **state: Any) -> str:
+    return _eval(f"SB.describeSchedule(Object.assign(SB.defaultState(), {json.dumps(state)}))", tz)
+
+
+# ---------------------------------------------------------------------------
+# compileSchedule — builder state -> wire fields
+# ---------------------------------------------------------------------------
+
+
+def test_default_state_compiles_to_daily_0600() -> None:
+    assert _compile() == {"schedule_type": "cron", "cron_expr": "0 6 * * *", "at_time": ""}
+
+
+def test_daily_uses_the_chosen_time() -> None:
+    assert _compile(mode="daily", dailyTime="09:30")["cron_expr"] == "30 9 * * *"
+
+
+def test_daily_blank_time_falls_back_to_0600() -> None:
+    """A cleared <input type=time> reads as the default, never as NaN fields."""
+    assert _compile(mode="daily", dailyTime="")["cron_expr"] == "0 6 * * *"
+
+
+def test_weekly_sorts_days_numerically() -> None:
+    out = _compile(mode="weekly", weeklyTime="07:15", weeklyDays=[5, 1, 3])
+    assert out["cron_expr"] == "15 7 * * 1,3,5"
+
+
+def test_weekly_requires_a_day() -> None:
+    assert _compile(mode="weekly", weeklyDays=[]) == {"error": "Select at least one day"}
+
+
+def test_monthly_day_and_time() -> None:
+    assert _compile(mode="monthly", monthlyDom=15, monthlyTime="07:00")["cron_expr"] == (
+        "0 7 15 * *"
+    )
+
+
+@pytest.mark.parametrize("dom", [0, 32, "", "abc", "15.5"])
+def test_monthly_rejects_an_impossible_day(dom: Any) -> None:
+    assert _compile(mode="monthly", monthlyDom=dom) == {"error": "Day of month must be 1-31"}
+
+
+def test_interval_hours_and_minutes() -> None:
+    assert _compile(mode="interval", intervalEvery=4, intervalUnit="hours")["cron_expr"] == (
+        "0 */4 * * *"
+    )
+    assert _compile(mode="interval", intervalEvery="15", intervalUnit="minutes")["cron_expr"] == (
+        "*/15 * * * *"
+    )
+
+
+@pytest.mark.parametrize("every", [0, -1, "", "x", "4.5", "1e1.5"])
+def test_interval_rejects_less_than_one_or_a_fraction(every: Any) -> None:
+    """A number input reports "4.5" as its value even though its step is 1;
+    the builder refuses it rather than truncating to a cadence the read-out
+    never named."""
+    assert _compile(mode="interval", intervalEvery=every) == {
+        "error": "Interval must be a whole number, at least 1"
+    }
+
+
+def test_interval_accepts_an_exponent_form_as_the_whole_number_it_is() -> None:
+    assert _compile(mode="interval", intervalEvery="1e1", intervalUnit="hours")["cron_expr"] == (
+        "0 */10 * * *"
+    )
+    assert _describe(mode="interval", intervalEvery="1e1", intervalUnit="hours") == (
+        "every 10 hours, restarting at midnight"
+    )
+
+
+def test_interval_step_is_bounded_by_the_cron_field() -> None:
+    """ "*/90" in the minute field matches minute 0 only (hourly) and "0 */30"
+    in the hour field matches hour 0 only (daily); croniter accepts both, so
+    the builder refuses them instead of storing a schedule that fires on a
+    different cadence than the one described."""
+    assert _compile(mode="interval", intervalEvery=59, intervalUnit="minutes")["cron_expr"] == (
+        "*/59 * * * *"
+    )
+    assert _compile(mode="interval", intervalEvery=60, intervalUnit="minutes") == {
+        "error": "Minutes interval must be 1-59"
+    }
+    assert _compile(mode="interval", intervalEvery=90, intervalUnit="minutes") == {
+        "error": "Minutes interval must be 1-59"
+    }
+    assert _compile(mode="interval", intervalEvery=23, intervalUnit="hours")["cron_expr"] == (
+        "0 */23 * * *"
+    )
+    for every in (24, 30):
+        assert _compile(mode="interval", intervalEvery=every, intervalUnit="hours") == {
+            "error": "Hours interval must be 1-23 (Daily runs once a day)"
+        }
+
+
+def test_once_compiles_local_time_to_an_offset_bearing_at_time() -> None:
+    out = _compile(mode="once", atLocal="2026-09-08T10:00")
+    assert out == {"schedule_type": "at", "cron_expr": "", "at_time": "2026-09-08T10:00:00+00:00"}
+
+
+@pytest.mark.parametrize("at", ["", "not-a-date"])
+def test_once_requires_a_parseable_date(at: str) -> None:
+    assert _compile(mode="once", atLocal=at) == {"error": "Pick a date and time"}
+
+
+def test_cron_mode_trims_the_raw_expression() -> None:
+    assert _compile(mode="cron", cron="  0 9 * * MON-FRI ")["cron_expr"] == "0 9 * * MON-FRI"
+
+
+def test_cron_mode_requires_an_expression() -> None:
+    assert _compile(mode="cron", cron="   ") == {"error": "Cron expression is required"}
+
+
+def test_unknown_mode_is_an_error_not_an_interval() -> None:
+    assert _compile(mode="hourly") == {"error": "Unknown schedule mode"}
+
+
+# ---------------------------------------------------------------------------
+# describeSchedule — the read-out header
+# ---------------------------------------------------------------------------
+
+
+def test_descriptions() -> None:
+    assert _describe() == "every day at 06:00 UTC"
+    assert _describe(mode="daily", dailyTime="9:5") == "every day at 09:05 UTC"
+    assert _describe(mode="weekly", weeklyDays=[5, 1]) == "every Mon, Fri at 06:00 UTC"
+    assert _describe(mode="weekly", weeklyDays=[]) == "no days selected"
+    assert _describe(mode="monthly", monthlyDom=12) == "monthly on day 12 at 06:00 UTC"
+    assert _describe(mode="interval") == "every 4 hours"
+    assert _describe(mode="once") == "one time"
+
+
+def test_interval_description_says_how_an_uneven_step_restarts() -> None:
+    """A step that divides its field is a true cadence; one that does not
+    restarts at the field boundary ("*/7" hours fires 00, 07, 14, 21, then
+    00) and the read-out says so.  A blank or out-of-range step (which
+    compile refuses) gets the plain phrase, never a claim."""
+    even = [(15, "minutes"), (30, "minutes"), (1, "minutes"), (4, "hours"), (12, "hours")]
+    for n, unit in even:
+        assert _describe(mode="interval", intervalEvery=n, intervalUnit=unit) == (
+            f"every {n} {unit}"
+        )
+    for n, unit in [(7, "minutes"), (45, "minutes")]:
+        assert _describe(mode="interval", intervalEvery=n, intervalUnit=unit) == (
+            f"every {n} {unit}, restarting each hour"
+        )
+    for n, unit in [(5, "hours"), (7, "hours")]:
+        assert _describe(mode="interval", intervalEvery=n, intervalUnit=unit) == (
+            f"every {n} {unit}, restarting at midnight"
+        )
+    assert _describe(mode="interval", intervalEvery="", intervalUnit="hours") == "every ? hours"
+    # The read-out names the step compile will use, never the raw text.
+    assert _describe(mode="interval", intervalEvery="4.5", intervalUnit="hours") == "every ? hours"
+    assert _describe(mode="monthly", monthlyDom="15.5") == "monthly on day ? at 06:00 UTC"
+    assert _describe(mode="interval", intervalEvery=90, intervalUnit="minutes") == (
+        "every 90 minutes"
+    )
+    assert _describe(mode="once", atLocal="2026-09-08T10:00") == (
+        "once at Tue 2026-09-08 10:00 UTC"
+    )
+    assert _describe(mode="once", atLocal="2026-09-08T10:00", tz="America/New_York") == (
+        "once at Tue 2026-09-08 10:00 EDT"
+    )
+    assert _describe(mode="cron") == "custom cron"
+
+
+# ---------------------------------------------------------------------------
+# cronToScheduleMode / stateFromSaved — edit mode reverse-parse
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_parse_recognises_every_builder_shape() -> None:
+    parse = "SB.cronToScheduleMode(%s)"
+    assert _eval(parse % '"30 9 * * *"') == {"mode": "daily", "h": 9, "min": 30}
+    assert _eval(parse % '"0 6 * * 1,5"') == {"mode": "weekly", "h": 6, "min": 0, "days": [1, 5]}
+    assert _eval(parse % '"0 7 15 * *"') == {"mode": "monthly", "h": 7, "min": 0, "dom": 15}
+    assert _eval(parse % '"0 */4 * * *"') == {"mode": "interval", "every": 4, "unit": "hours"}
+    assert _eval(parse % '"*/15 * * * *"') == {"mode": "interval", "every": 15, "unit": "minutes"}
+
+
+def test_reverse_parse_maps_cron_sunday_7_to_0() -> None:
+    assert _eval('SB.cronToScheduleMode("0 6 * * 7")')["days"] == [0]
+
+
+def test_reverse_parse_falls_back_to_cron_mode() -> None:
+    for expr in ("0 9 * * MON-FRI", "*/5 8-18 * * *", "", "garbage"):
+        assert _eval(f"SB.cronToScheduleMode({json.dumps(expr)})") == {"mode": "cron"}
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "30 9 * * *",
+        "0 6 * * 1,5",
+        "0 7 15 * *",
+        "0 */4 * * *",
+        "*/15 * * * *",
+        # The bound's own edges, still inside: open in Interval, round-trip.
+        "0 */23 * * *",
+        "*/59 * * * *",
+    ],
+)
+def test_builder_shapes_round_trip_through_edit(expr: str) -> None:
+    """Open a saved builder-made schedule for edit, save unchanged: same cron,
+    and the raw expression is carried so Cron mode never shows an empty box."""
+    state = _eval(f'SB.stateFromSaved("cron", {json.dumps(expr)}, "")')
+    assert state["mode"] != "cron" and state["cron"] == expr
+    out = _eval(f'SB.compileSchedule(SB.stateFromSaved("cron", {json.dumps(expr)}, ""))')
+    assert out["cron_expr"] == expr
+
+
+@pytest.mark.parametrize("expr", ["*/60 * * * *", "*/90 * * * *", "0 */24 * * *", "0 */30 * * *"])
+def test_saved_out_of_range_step_opens_in_cron_mode_unchanged(expr: str) -> None:
+    """croniter accepts these, so they can be stored (by the Cron escape
+    hatch or an API client) and must stay editable: the reverse-parse falls
+    through to Cron mode with the expression intact, and saving unchanged
+    keeps it — the builder refuses to CREATE such a step, never to keep one."""
+    state = _eval(f'SB.stateFromSaved("cron", {json.dumps(expr)}, "")')
+    assert state["mode"] == "cron" and state["cron"] == expr
+    out = _eval(f'SB.compileSchedule(SB.stateFromSaved("cron", {json.dumps(expr)}, ""))')
+    assert out == {"schedule_type": "cron", "cron_expr": expr, "at_time": ""}
+
+
+def test_unrecognised_cron_opens_in_cron_mode_with_the_raw_text() -> None:
+    state = _eval('SB.stateFromSaved("cron", "0 9 * * MON-FRI", "")')
+    assert state["mode"] == "cron" and state["cron"] == "0 9 * * MON-FRI"
+    assert _eval('SB.compileSchedule(SB.stateFromSaved("cron", "0 9 * * MON-FRI", ""))') == {
+        "schedule_type": "cron",
+        "cron_expr": "0 9 * * MON-FRI",
+        "at_time": "",
+    }
+
+
+def test_saved_at_time_round_trips() -> None:
+    state = _eval('SB.stateFromSaved("at", "", "2026-09-08T10:00:00+00:00")')
+    assert state["mode"] == "once" and state["atLocal"] == "2026-09-08T10:00"
+    assert state["cron"] == "", "a one-shot carries no cron"
+    out = _eval('SB.compileSchedule(SB.stateFromSaved("at", "", "2026-09-08T10:00:00+00:00"))')
+    assert out["at_time"] == "2026-09-08T10:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# Time formatters
+# ---------------------------------------------------------------------------
+
+
+def test_format_local_reads_a_suffix_less_server_time_as_utc() -> None:
+    """next_run comes back "YYYY-MM-DDTHH:MM:SS" with no offset: it is UTC,
+    never browser-local, and the read-out shows it in the operator's zone."""
+    assert _eval('SB.formatLocal("2026-09-08T06:00:00")') == "Tue 2026-09-08 06:00 UTC"
+    assert _eval('SB.formatLocal("2026-09-08T06:00:00+00:00")') == "Tue 2026-09-08 06:00 UTC"
+    ny = "America/New_York"  # UTC-4 in September
+    assert _eval('SB.formatLocal("2026-09-08T06:00:00")', ny) == "Tue 2026-09-08 02:00 EDT"
+    assert _eval('SB.formatLocal("2026-09-08T06:00:00+00:00")', ny) == "Tue 2026-09-08 02:00 EDT"
+
+
+def test_format_local_crosses_the_day_line() -> None:
+    assert _eval('SB.formatLocal("2026-09-08T02:00:00")', "America/New_York") == (
+        "Mon 2026-09-07 22:00 EDT"
+    )
+
+
+def test_format_local_converts_a_negative_offset() -> None:
+    assert _eval('SB.formatLocal("2026-09-08T06:00:00-05:00")') == "Tue 2026-09-08 11:00 UTC"
+
+
+def test_format_local_echoes_the_unparseable() -> None:
+    assert _eval('SB.formatLocal("soon")') == "soon"
+
+
+def test_runs_message_kind() -> None:
+    """An unmet compile is a hint until the mode is edited or a submit is
+    refused on it; a clean compile has no message."""
+    kind = "SB.runsMessageKind(%s, %s)"
+    assert _eval(kind % ('{error: "Select at least one day"}', "false")) == "hint"
+    assert _eval(kind % ('{error: "Select at least one day"}', "true")) == "err"
+    assert _eval(kind % ('{schedule_type: "cron", cron_expr: "0 6 * * *"}', "false")) is None
+    assert _eval(kind % ('{schedule_type: "cron", cron_expr: "0 6 * * *"}', "true")) is None
+
+
+def test_relative_to_now_buckets() -> None:
+    now = "Date.parse('2026-09-08T06:00:00Z')"
+    rel = "SB.relativeToNow(%s, %s)"
+    assert _eval(rel % ('"2026-09-11T06:00:00"', now)) == "in 3d"
+    assert _eval(rel % ('"2026-09-08T07:30:00"', now)) == "in 2h"
+    assert _eval(rel % ('"2026-09-08T06:30:00"', now)) == "in 30m"
+    assert _eval(rel % ('"2026-09-08T05:00:00"', now)) == "now"
+    assert _eval(rel % ('"soon"', now)) == ""
+
+
+def test_utc_to_local_datetime() -> None:
+    assert _eval('SB.utcToLocalDatetime("2026-09-08T06:00:00+00:00")') == "2026-09-08T06:00"
+    assert _eval('SB.utcToLocalDatetime("")') == ""
+    assert _eval('SB.utcToLocalDatetime("not a time")') == "not a time"
+
+
+def test_utc_to_local_datetime_reads_a_suffix_less_server_time_as_utc() -> None:
+    """The admin list's NEXT RUN cell: next_run arrives with no offset and is
+    UTC, so a browser four hours behind sees 02:00, not 06:00 relabelled."""
+    tz = "America/New_York"  # UTC-4 in September
+    assert _eval('SB.utcToLocalDatetime("2026-09-08T06:00:00")', tz) == "2026-09-08T02:00"
+    assert _eval('SB.utcToLocalDatetime("2026-09-08T06:00:00+00:00")', tz) == ("2026-09-08T02:00")
+
+
+def test_once_round_trips_across_a_non_utc_browser() -> None:
+    """Edit a saved one-shot in New York: the picker shows local time and
+    compiles back to the same UTC instant."""
+    tz = "America/New_York"
+    state = _eval('SB.stateFromSaved("at", "", "2026-09-08T10:00:00+00:00")', tz)
+    assert state["atLocal"] == "2026-09-08T06:00"
+    out = _eval('SB.compileSchedule(SB.stateFromSaved("at", "", "2026-09-08T10:00:00+00:00"))', tz)
+    assert out["at_time"] == "2026-09-08T10:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# scopedId — the instance-scoping transform every cloned id goes through
+# ---------------------------------------------------------------------------
+
+
+def test_scoped_id_replaces_the_template_prefix_only() -> None:
+    assert _eval('SB.scopedId("when-seg", "when2-")') == "when2-seg"
+    assert _eval('SB.scopedId("when-time-daily", "when1-")') == "when1-time-daily"
+    # Outside the template vocabulary: untouched (no double prefix, no mangling).
+    assert _eval('SB.scopedId("sch-name", "when1-")') == "sch-name"
+    assert _eval('SB.scopedId("when1-seg", "when2-")') == "when1-seg"

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from tests._js_harness_helpers import strip_js_comments
+from tests._js_harness_helpers import slice_braced_block, strip_js_comments
 
 _ROOT = Path(__file__).resolve().parent.parent
 _SHARED = _ROOT / "turnstone/shared_static"
@@ -246,9 +246,7 @@ def test_console_launcher_routes_by_kind() -> None:
     (the rail covers it).  Pins the console-JS convention for the new logic."""
     app = _CONSOLE_APP.read_text(encoding="utf-8")
     assert "function _setLauncherKind" in app and "_launcherKind" in app
-    assert "function _hasInteractivePermission" in app, (
-        "launcher must scope-gate the interactive kind"
-    )
+    assert 'perm: "workstreams.create"' in app, "launcher must scope-gate the interactive kind"
     assert 'kind === "interactive"' in app, "submitHomeCoord must branch by kind"
     assert "function _createInteractive" in app, "the interactive create path must exist"
     assert '"/v1/api/cluster/workstreams/new"' in app, (
@@ -320,8 +318,9 @@ def test_console_launcher_node_strategy() -> None:
     assert "function _populateLauncherNodes" in app, (
         "the specific-node picker must populate from the live cluster snapshot"
     )
-    assert 'opts.node_strategy === "node"' in app, (
-        "interactive create must pin to the chosen node only under the Specific strategy"
+    resolver = slice_braced_block(app, app.index("function _resolveNodePlacement("))
+    assert resolver and 'opts.node_strategy !== "node"' in resolver, (
+        "creates must pin to the chosen node only under the Specific strategy"
     )
     composer = (_SHARED / "composer.js").read_text(encoding="utf-8")
     assert "Composer.prototype.setPlaceholder" in composer, (
@@ -367,6 +366,202 @@ def test_console_launcher_interactive_create_carries_attachments() -> None:
     assert "_createWorkstreamFetchOpts(body, files)" in interactive, (
         "_createInteractive must build its create body via the shared helper"
     )
+
+
+def test_console_launcher_scheduled_kind() -> None:
+    """#1090: the dashboard launcher carries a third kind, Scheduled — a
+    schedule the console's scheduler later dispatches as an interactive
+    workstream.  Pins the radio + its scope gate, the kind list the toggle
+    walks (no two-kind ternary cycle), the interactive field set minus judge
+    model + attachments, the When builder mounted from the shared template,
+    and the submit branch posting the schedule create."""
+    app = _CONSOLE_APP.read_text(encoding="utf-8")
+    index = _CONSOLE_INDEX.read_text(encoding="utf-8")
+    assert 'id="kind-scheduled"' in index, "the third kind radio must be in the toggle"
+    assert 'id="launcher-when"' in index and 'id="launcher-when-mount"' in index, (
+        "the When builder needs its section + mount under the composer"
+    )
+    assert 'id="schedule-when-template"' in index, "the builder markup must be a template"
+    assert '<script src="/static/schedule_builder.js"></script>' in index
+    assert index.index("/static/schedule_builder.js") < index.index('src="/static/admin.js"'), (
+        "the builder script must load before its classic consumers"
+    )
+    for fragment in ('kind: "scheduled"', 'id: "kind-scheduled"', 'perm: "admin.schedules"'):
+        assert fragment in app, f"the kind list must carry the Scheduled entry ({fragment})"
+    # The registry is the one place a kind's permission is named: the gate is
+    # derived from `perm`, and the named helpers read the registry.
+    assert "return _consoleHasPermission(k.perm);" in app, (
+        "each kind's gate must be derived from its registry perm"
+    )
+    assert '_consoleHasPermission(_launcherPerm("coordinator"))' in app, (
+        "_hasCoordPermission must read the registry, not restate the string"
+    )
+    assert "function _hasSchedulePermission" not in app, (
+        "no per-kind permission helper beside the registry (the gate is derived)"
+    )
+    # One permission gate for every kind, driven by the registry.
+    submit = slice_braced_block(app, app.index("function submitHomeCoord("))
+    assert submit and 'showToast((entry ? entry.perm : kind) + " permission required")' in submit
+    assert "_consoleHasPermission(" not in submit, (
+        "submit must not hardcode a per-kind permission check beside the registry"
+    )
+    # Success bookkeeping: the typed name belongs to the schedule just made,
+    # and a composer the user has moved on from is left alone.
+    create = slice_braced_block(app, app.index("function _createSchedule("))
+    assert create and '_homeCoordComposer.setOptionValue("name", "")' in create
+    assert "const submittedKind = _launcherKind;" in create
+    assert "_launcherKind !== submittedKind" in create
+    # Ctrl/Cmd+Enter submits from anywhere in the panel — the When block too.
+    assert 'const panel = document.getElementById("coord-composer-panel");' in app, (
+        "the keyboard submit must cover the whole launcher panel, not just the composer"
+    )
+    for gone in (
+        '? _launcherKind === "interactive"',
+        'const map = {\n    "kind-coordinator": "coordinator",',
+    ):
+        assert gone not in app, f"two-kind hardcoding {gone!r} must be gone (the list walks)"
+    assert "function _launcherPersonaKind" in app, (
+        "Scheduled must draw personas from the interactive shelf"
+    )
+    assert "function _createSchedule" in app and 'kind === "scheduled"' in app, (
+        "submitHomeCoord must branch to the schedule create"
+    )
+    assert 'authFetch("/v1/api/admin/schedules", {' in app
+    assert "_launcherWhen.compile()" in app, "the create must compile timing via the builder"
+    for creator in ("function _createInteractive(", "function _createSchedule("):
+        body = slice_braced_block(app, app.index(creator))
+        assert body and "_resolveNodePlacement(opts)" in body, (
+            f"{creator} must resolve node placement through the shared resolver"
+        )
+        assert 'opts.node_strategy === "node"' not in body, (
+            f"{creator} must not restate the placement rule beside the resolver"
+        )
+    assert "function _scheduleNameFromTask" in app, "an empty Name derives from the task"
+    assert 'setOptionFieldVisible("judge_model", !scheduled)' in app
+    fields = slice_braced_block(app, app.index("function _applyLauncherFields("))
+    assert fields and "setAttachVisible(!scheduled)" in fields, (
+        "the paperclip must be hidden through the composer's API"
+    )
+    assert "attachBtn.hidden" not in fields, (
+        "the kind switch must not poke the composer's attach button directly"
+    )
+    stage = slice_braced_block(app, app.index("function _homeStageFile("))
+    assert stage and 'if (_launcherKind === "scheduled") {' in stage, (
+        "_homeStageFile must refuse attachments in the Scheduled kind"
+    )
+    # A large paste is synthesized into a File by the composer; refusing it
+    # keeps the text inline, which is right for a schedule's task — so that
+    # case must stay silent while a real drop still gets the message.
+    assert "paste.isPastedTextFile(file)" in stage, (
+        "the Scheduled refusal must recognise a pasted-text file and stay silent for it"
+    )
+    paste_mod = (_SHARED / "composer_paste_text.js").read_text(encoding="utf-8")
+    assert "export function isPastedTextFile(file)" in paste_mod
+    assert "isPastedTextFile,\n" in paste_mod, "the window bridge must expose isPastedTextFile"
+    assert 'if (v.judge_model && _launcherKind !== "scheduled")' in app, (
+        "the options summary must not claim a judge model the Scheduled kind drops"
+    )
+    assert 'aria-controls="launcher-when"' in index, (
+        "the Scheduled radio must name the When region it reveals"
+    )
+    assert index.index('id="launcher-when"') < index.index('id="home-coord-composer-mount"'), (
+        "the When block must precede the composer (required input before the action)"
+    )
+    # One owner for the message row: kind switch and submit clear it, the
+    # schedule create confirms through it, and the confirmation is inline
+    # (nothing opens, so a toast would evaporate before the time is read).
+    assert "function _homeShowMessage" in app
+    create = slice_braced_block(app, app.index("function _createSchedule("))
+    assert create and 'Manage it under Admin › Schedules.", true)' in create
+    # The confirmation is the inline row; a toast only stands in when the
+    # user has already switched kinds while the create was in flight.
+    assert create.count("showToast(") == 1 and create.index(
+        "_launcherKind !== submittedKind"
+    ) < create.index("showToast("), (
+        "the schedule confirmation is the inline message row; a toast only for a moved-on user"
+    )
+    assert "_launcherWhen.showErrors()" in create, (
+        "a refused compile must flag the builder's untouched-mode hint as an error"
+    )
+    # Files staged before the switch are refused at submit, ahead of the
+    # files-need-a-task guard whose advice could never resolve the refusal.
+    assert submit and submit.index('kind === "scheduled" && files.length > 0') < submit.index(
+        "Add a message to send with this attachment."
+    ), "the Scheduled attachment refusal must precede the files-need-a-task guard"
+    composer = (_SHARED / "composer.js").read_text(encoding="utf-8")
+    for api in ("Composer.prototype.setSendLabel", "Composer.prototype.setAttachVisible"):
+        assert api in composer, f"the composer must expose {api} for the launcher"
+    assert re.search(r'setSendLabel\(\s*scheduled \? "Schedule" : "Start"', app), (
+        "the send button must read Schedule in the Scheduled kind"
+    )
+
+
+def test_admin_schedule_shelf_uses_shared_builder() -> None:
+    """#1090: the admin shelf's Runs builder moved to schedule_builder.js so the
+    launcher can share it.  The shelf keeps a mount + the footer read-out; the
+    in-file compile / reverse-parse / preview copies are gone."""
+    admin = _CONSOLE_ADMIN.read_text(encoding="utf-8")
+    index = _CONSOLE_INDEX.read_text(encoding="utf-8")
+    builder = (_ROOT / "turnstone/console/static/schedule_builder.js").read_text(encoding="utf-8")
+    assert 'id="sch-when-mount"' in index, "the shelf mounts the builder"
+    assert 'id="sch-seg"' not in index and "data-sch-pane" not in index, (
+        "the shelf's inline builder markup must be gone (it lives in the template)"
+    )
+    assert "new window.TurnstoneScheduleBuilder.ScheduleBuilder(" in admin
+    for method in (
+        "_schWhen.reset()",
+        "_schWhen.preview()",
+        "_schWhen.apply(",
+        "_schWhen.compile()",
+    ):
+        assert method in admin, f"the shelf must route {method} through the builder"
+    for gone in (
+        "function _schCompile",
+        "function _cronToScheduleMode",
+        "function _schApplyTiming",
+        "function _schPreview(",
+        "function _schFmtUtc",
+        "function _localToUtcIso",
+        "function _utcToLocalDatetime",
+    ):
+        assert gone not in admin, f"{gone!r} must not survive in admin.js"
+    assert "window.TurnstoneScheduleBuilder = {" in builder
+    assert 'const TEMPLATE_ID = "schedule-when-template"' in builder
+    assert '"/v1/api/admin/schedules/preview"' in builder
+    assert "seq !== self._previewSeq" in builder, "a superseded preview must be dropped"
+    # Every id-bearing attribute of the cloned template goes through scopedId
+    # (the pure transform test_schedule_builder_js.py pins), so two instances
+    # can share a page with their labels still pointing at their own inputs.
+    for wiring in (
+        "el.id = scopedId(el.id, prefix)",
+        'el.setAttribute("for", scopedId(el.getAttribute("for"), prefix))',
+        'scopedId(el.getAttribute("aria-labelledby"), prefix)',
+    ):
+        assert wiring in builder, f"instance scoping must route {wiring!r} through scopedId"
+    assert "_schWhen.showErrors()" in admin, (
+        "a refused shelf submit must flag the builder's untouched-mode hint as an error"
+    )
+
+
+def test_schedule_when_template_ids_carry_the_instance_prefix() -> None:
+    """scopedId rewrites only ids beginning with ``when-``; an id (or a
+    ``for`` / ``aria-labelledby`` reference) added to the template without
+    it would collide between the shelf's and the launcher's instances with no
+    runtime signal, so the contract is pinned here.  The template element's
+    own id is outside the cloned content and exempt."""
+    index = _CONSOLE_INDEX.read_text(encoding="utf-8")
+    start = index.index('<template id="schedule-when-template">') + len(
+        '<template id="schedule-when-template">'
+    )
+    block = index[start : index.index("</template>", start)]
+    refs = re.findall(r'(?:\bid|\bfor|aria-labelledby)="([^"]+)"', block)
+    assert len(refs) >= 14, "the template lost its ids"
+    bad = [r for r in refs if not r.startswith("when-")]
+    assert not bad, f"template ids / references must carry the when- prefix: {bad}"
+    # No defaults in the markup: reset() on mount writes defaultState() into
+    # every control, so a value here would be a second, dead source of truth.
+    assert 'aria-pressed="true"' not in block, "the template must not pre-press a segment"
+    assert not re.search(r'<input[^>]*\svalue="', block), "template inputs carry no default value"
 
 
 def test_pane_persists_meta_for_rehydrate() -> None:

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -247,6 +247,11 @@ _VALID_NODE_ID = re.compile(r"^[a-zA-Z0-9._-]+$")
 _VALID_WS_ID_RE = re.compile(r"^[a-f0-9]{1,64}$")
 _VALID_CREATE_WS_ID_RE = re.compile(r"^[a-f0-9]{32}$")
 _MAX_ROUTE_RESUME_LEN = 256
+# The schedule API keeps this many characters (code points) of a task's
+# initial message and of its name.  The console launcher and the admin shelf
+# mirror the values; tests/test_schedule_api.py keeps them in step.
+SCHEDULE_MESSAGE_MAX_CHARS = 4096
+SCHEDULE_NAME_MAX_CHARS = 256
 _GENERATED_WS_ID_COLLISION_RETRY_CAP = 3
 
 # Client timeout for the REST proxy pool (BOTH constructions: startup and
@@ -6735,14 +6740,14 @@ async def admin_create_schedule(request: Request) -> JSONResponse:
     if isinstance(body, JSONResponse):
         return body
 
-    name = str(body.get("name", "")).strip()[:256]
+    name = str(body.get("name", "")).strip()[:SCHEDULE_NAME_MAX_CHARS]
     description = str(body.get("description", "")).strip()[:1024]
     schedule_type = str(body.get("schedule_type", "")).strip()
     cron_expr = str(body.get("cron_expr", "")).strip()[:256]
     at_time = str(body.get("at_time", "")).strip()[:64]
     target_mode = str(body.get("target_mode", "auto")).strip()[:256]
     model = str(body.get("model", "")).strip()[:128]
-    initial_message = str(body.get("initial_message", "")).strip()[:4096]
+    initial_message = str(body.get("initial_message", "")).strip()[:SCHEDULE_MESSAGE_MAX_CHARS]
     auto_approve = bool(body.get("auto_approve", False))
     raw_tools = body.get("auto_approve_tools", [])
     auto_approve_tools = raw_tools if isinstance(raw_tools, list) else []
@@ -6875,7 +6880,7 @@ async def admin_update_schedule(request: Request) -> JSONResponse:
 
     updates: dict[str, Any] = {}
     if "name" in body:
-        updates["name"] = str(body["name"]).strip()[:256]
+        updates["name"] = str(body["name"]).strip()[:SCHEDULE_NAME_MAX_CHARS]
     if "description" in body:
         updates["description"] = str(body["description"]).strip()[:1024]
     if "schedule_type" in body:
@@ -6889,7 +6894,9 @@ async def admin_update_schedule(request: Request) -> JSONResponse:
     if "model" in body:
         updates["model"] = str(body["model"]).strip()[:128]
     if "initial_message" in body:
-        updates["initial_message"] = str(body["initial_message"]).strip()[:4096]
+        updates["initial_message"] = str(body["initial_message"]).strip()[
+            :SCHEDULE_MESSAGE_MAX_CHARS
+        ]
     if "auto_approve" in body:
         updates["auto_approve"] = bool(body["auto_approve"])
     if "auto_approve_tools" in body:

--- a/turnstone/console/static/admin.js
+++ b/turnstone/console/static/admin.js
@@ -1171,13 +1171,9 @@ function _renderSchedules(schedules) {
     const typeCls =
       s.schedule_type === "cron" ? "scope-write" : "scope-approve";
     const schedule =
-      s.schedule_type === "cron"
-        ? s.cron_expr
-        : _utcToLocalDatetime(s.at_time).replace("T", " ");
+      s.schedule_type === "cron" ? s.cron_expr : _schLocal(s.at_time);
     const target = s.target_mode;
-    const nextRun = s.next_run
-      ? _utcToLocalDatetime(s.next_run).replace("T", " ")
-      : "\u2014";
+    const nextRun = s.next_run ? _schLocal(s.next_run) : "\u2014";
     const enabled = s.enabled;
     let statusCls = enabled ? "sched-active" : "sched-disabled";
     let statusLabel = enabled ? "active" : "disabled";
@@ -1204,7 +1200,7 @@ function _renderSchedules(schedules) {
       escapeHtml(target) +
       "</span>" +
       '<span class="admin-col admin-col-snext">' +
-      nextRun +
+      escapeHtml(nextRun) +
       "</span>" +
       '<span class="admin-col admin-col-sstatus"><span class="' +
       statusCls +
@@ -1527,300 +1523,24 @@ function _populateNotifyRows(prefix, targets) {
   });
 }
 
-function _localToUtcIso(localDatetimeStr) {
-  // datetime-local gives "YYYY-MM-DDTHH:MM" in browser local time
-  // Convert to UTC ISO string for the server
-  const d = new Date(localDatetimeStr);
-  if (isNaN(d.getTime())) return "";
-  return d.toISOString().replace(/\.\d{3}Z$/, "+00:00");
-}
-
-function _utcToLocalDatetime(utcStr) {
-  // Convert UTC ISO string to datetime-local format in browser local time
-  if (!utcStr) return "";
-  const d = new Date(utcStr);
-  if (isNaN(d.getTime())) return utcStr.slice(0, 16);
-  const pad = function (n) {
-    return n < 10 ? "0" + n : "" + n;
-  };
-  return (
-    d.getFullYear() +
-    "-" +
-    pad(d.getMonth() + 1) +
-    "-" +
-    pad(d.getDate()) +
-    "T" +
-    pad(d.getHours()) +
-    ":" +
-    pad(d.getMinutes())
+// Browser-local "YYYY-MM-DD HH:MM" for a server UTC timestamp (list cells).
+function _schLocal(utcStr) {
+  return window.TurnstoneScheduleBuilder.utcToLocalDatetime(utcStr).replace(
+    "T",
+    " ",
   );
 }
 
 // --- Schedule shelf (create + edit) ---
-// The cron DSL is compiled, not typed: the segmented Runs control builds
-// schedule_type/cron_expr/at_time, and the NEXT RUNS read-out previews the
-// result through the server's croniter (POST /v1/api/admin/schedules/preview)
-// as the user edits.  Cron mode is the raw escape hatch with the same live
-// read-out.  Storage is unchanged: on edit the saved expression is
-// reverse-parsed back into the friendly mode when its shape matches
-// (_cronToScheduleMode), else the editor opens in Cron mode.
+// Timing comes from the shared Runs builder (schedule_builder.js): the
+// segmented control compiles to schedule_type / cron_expr / at_time and the
+// NEXT RUNS read-out previews the result through the server's croniter as
+// the user edits.  The shelf owns the rest of the form plus the footer
+// "compiles to" read-out.
 
 let _schWired = false;
-let _schPreviewTimer = null;
-let _schPreviewSeq = 0;
 let _schShelfHandle = null;
-
-function _schMode() {
-  const seg = document.getElementById("sch-seg");
-  const on = seg.querySelector('[aria-pressed="true"]');
-  return on ? on.getAttribute("data-mode") : "daily";
-}
-
-function _schSetMode(mode) {
-  const seg = document.getElementById("sch-seg");
-  seg.querySelectorAll("button[data-mode]").forEach(function (b) {
-    b.setAttribute(
-      "aria-pressed",
-      b.getAttribute("data-mode") === mode ? "true" : "false",
-    );
-  });
-  document
-    .querySelectorAll("#schedule-shelf [data-sch-pane]")
-    .forEach(function (pane) {
-      pane.hidden = pane.getAttribute("data-sch-pane") !== mode;
-    });
-}
-
-function _schSelectedDays() {
-  const out = [];
-  document
-    .querySelectorAll('#sch-days button[aria-pressed="true"]')
-    .forEach(function (b) {
-      out.push(parseInt(b.getAttribute("data-day"), 10));
-    });
-  return out.sort();
-}
-
-function _schSetDays(days) {
-  document.querySelectorAll("#sch-days button").forEach(function (b) {
-    const d = parseInt(b.getAttribute("data-day"), 10);
-    b.setAttribute("aria-pressed", days.indexOf(d) >= 0 ? "true" : "false");
-  });
-}
-
-function _schTimeParts(id) {
-  const v = document.getElementById(id).value || "06:00";
-  const parts = v.split(":");
-  return [parseInt(parts[0], 10) || 0, parseInt(parts[1], 10) || 0];
-}
-
-// Compile the builder state down to the wire fields.  Returns
-// {schedule_type, cron_expr, at_time} or {error}.
-function _schCompile() {
-  const mode = _schMode();
-  if (mode === "once") {
-    const local = document.getElementById("sch-at").value || "";
-    if (!local) return { error: "Pick a date and time" };
-    return {
-      schedule_type: "at",
-      cron_expr: "",
-      at_time: _localToUtcIso(local),
-    };
-  }
-  if (mode === "cron") {
-    const expr = (document.getElementById("sch-cron").value || "").trim();
-    if (!expr) return { error: "Cron expression is required" };
-    return { schedule_type: "cron", cron_expr: expr, at_time: "" };
-  }
-  let h, m;
-  if (mode === "daily") {
-    [h, m] = _schTimeParts("sch-time-daily");
-    return {
-      schedule_type: "cron",
-      cron_expr: m + " " + h + " * * *",
-      at_time: "",
-    };
-  }
-  if (mode === "weekly") {
-    const days = _schSelectedDays();
-    if (!days.length) return { error: "Select at least one day" };
-    [h, m] = _schTimeParts("sch-time-weekly");
-    return {
-      schedule_type: "cron",
-      cron_expr: m + " " + h + " * * " + days.join(","),
-      at_time: "",
-    };
-  }
-  if (mode === "monthly") {
-    const dom = parseInt(document.getElementById("sch-dom").value, 10);
-    if (!dom || dom < 1 || dom > 31)
-      return { error: "Day of month must be 1-31" };
-    [h, m] = _schTimeParts("sch-time-monthly");
-    return {
-      schedule_type: "cron",
-      cron_expr: m + " " + h + " " + dom + " * *",
-      at_time: "",
-    };
-  }
-  // interval
-  const n = parseInt(document.getElementById("sch-every").value, 10);
-  if (!n || n < 1) return { error: "Interval must be at least 1" };
-  const unit = document.getElementById("sch-unit").value;
-  const expr = unit === "hours" ? "0 */" + n + " * * *" : "*/" + n + " * * * *";
-  return { schedule_type: "cron", cron_expr: expr, at_time: "" };
-}
-
-const _SCH_DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
-function _schDescribe() {
-  const mode = _schMode();
-  const t = function (id) {
-    const parts = _schTimeParts(id);
-    const pad = function (n) {
-      return n < 10 ? "0" + n : "" + n;
-    };
-    return pad(parts[0]) + ":" + pad(parts[1]);
-  };
-  if (mode === "daily") return "every day at " + t("sch-time-daily") + " UTC";
-  if (mode === "weekly") {
-    const names = _schSelectedDays().map(function (d) {
-      return _SCH_DAY_NAMES[d];
-    });
-    return names.length
-      ? "every " + names.join(", ") + " at " + t("sch-time-weekly") + " UTC"
-      : "no days selected";
-  }
-  if (mode === "monthly")
-    return (
-      "monthly on day " +
-      (document.getElementById("sch-dom").value || "?") +
-      " at " +
-      t("sch-time-monthly") +
-      " UTC"
-    );
-  if (mode === "interval")
-    return (
-      "every " +
-      (document.getElementById("sch-every").value || "?") +
-      " " +
-      document.getElementById("sch-unit").value
-    );
-  if (mode === "once") return "one time";
-  return "custom cron";
-}
-
-// Reverse-parse a saved expression into builder state.  Only the exact
-// shapes the builder emits round-trip; anything else opens in Cron mode.
-function _cronToScheduleMode(expr) {
-  let m = /^(\d{1,2}) (\d{1,2}) \* \* \*$/.exec(expr);
-  if (m) return { mode: "daily", h: +m[2], min: +m[1] };
-  m = /^(\d{1,2}) (\d{1,2}) \* \* ([0-7](?:,[0-7])*)$/.exec(expr);
-  if (m)
-    return {
-      mode: "weekly",
-      h: +m[2],
-      min: +m[1],
-      days: m[3].split(",").map(function (d) {
-        return +d % 7; // cron allows 7 for Sunday
-      }),
-    };
-  m = /^(\d{1,2}) (\d{1,2}) (\d{1,2}) \* \*$/.exec(expr);
-  if (m) return { mode: "monthly", h: +m[2], min: +m[1], dom: +m[3] };
-  m = /^0 \*\/(\d+) \* \* \*$/.exec(expr);
-  if (m) return { mode: "interval", every: +m[1], unit: "hours" };
-  m = /^\*\/(\d+) \* \* \* \*$/.exec(expr);
-  if (m) return { mode: "interval", every: +m[1], unit: "minutes" };
-  return { mode: "cron" };
-}
-
-function _schSetTime(id, h, min) {
-  const pad = function (n) {
-    return n < 10 ? "0" + n : "" + n;
-  };
-  document.getElementById(id).value = pad(h) + ":" + pad(min);
-}
-
-// Apply a saved schedule's timing to the builder (edit mode).
-function _schApplyTiming(scheduleType, cronExpr, atTime) {
-  if (scheduleType === "at") {
-    document.getElementById("sch-at").value = _utcToLocalDatetime(atTime);
-    _schSetMode("once");
-    return;
-  }
-  const parsed = _cronToScheduleMode(cronExpr || "");
-  if (parsed.mode === "daily")
-    _schSetTime("sch-time-daily", parsed.h, parsed.min);
-  else if (parsed.mode === "weekly") {
-    _schSetTime("sch-time-weekly", parsed.h, parsed.min);
-    _schSetDays(parsed.days);
-  } else if (parsed.mode === "monthly") {
-    _schSetTime("sch-time-monthly", parsed.h, parsed.min);
-    document.getElementById("sch-dom").value = parsed.dom;
-  } else if (parsed.mode === "interval") {
-    document.getElementById("sch-every").value = parsed.every;
-    document.getElementById("sch-unit").value = parsed.unit;
-  } else {
-    document.getElementById("sch-cron").value = cronExpr || "";
-  }
-  _schSetMode(parsed.mode);
-}
-
-function _schFmtUtc(iso) {
-  // Server emits "YYYY-MM-DDTHH:MM:SS" (UTC, no suffix) or "+00:00" ISO.
-  const d = new Date(/[Z+]/.test(iso) ? iso : iso + "Z");
-  if (isNaN(d.getTime())) return iso;
-  const pad = function (n) {
-    return n < 10 ? "0" + n : "" + n;
-  };
-  return (
-    _SCH_DAY_NAMES[d.getUTCDay()] +
-    " " +
-    d.getUTCFullYear() +
-    "-" +
-    pad(d.getUTCMonth() + 1) +
-    "-" +
-    pad(d.getUTCDate()) +
-    " " +
-    pad(d.getUTCHours()) +
-    ":" +
-    pad(d.getUTCMinutes()) +
-    " UTC"
-  );
-}
-
-function _schRel(iso) {
-  const d = new Date(/[Z+]/.test(iso) ? iso : iso + "Z");
-  if (isNaN(d.getTime())) return "";
-  const mins = Math.round((d.getTime() - Date.now()) / 60000);
-  if (mins < 1) return "now";
-  if (mins < 60) return "in " + mins + "m";
-  if (mins < 48 * 60) return "in " + Math.round(mins / 60) + "h";
-  return "in " + Math.round(mins / (24 * 60)) + "d";
-}
-
-function _schRenderRuns(runs, errText) {
-  const rows = document.getElementById("sch-runs-out");
-  while (rows.firstChild) rows.removeChild(rows.firstChild);
-  if (errText) {
-    const err = document.createElement("div");
-    err.className = "err";
-    err.textContent = errText;
-    rows.appendChild(err);
-    return;
-  }
-  runs.forEach(function (iso) {
-    const row = document.createElement("div");
-    row.className = "readout-row";
-    const when = document.createElement("span");
-    when.textContent = _schFmtUtc(iso);
-    const rel = document.createElement("span");
-    rel.className = "rel";
-    rel.textContent = _schRel(iso);
-    row.appendChild(when);
-    row.appendChild(rel);
-    rows.appendChild(row);
-  });
-}
+let _schWhen = null; // ScheduleBuilder mounted in #sch-when-mount
 
 function _schRenderCompiled(compiled) {
   const meta = document.getElementById("sch-compiled-out");
@@ -1841,70 +1561,12 @@ function _schRenderCompiled(compiled) {
   }
 }
 
-// Debounced read-out refresh: description + compiled text render instantly,
-// the next-runs list arrives from the croniter preview endpoint.
-function _schPreview() {
-  document.getElementById("sch-desc-out").textContent = _schDescribe();
-  const compiled = _schCompile();
-  _schRenderCompiled(compiled);
-  if (compiled.error) {
-    _schRenderRuns([], compiled.error);
-    return;
-  }
-  if (_schPreviewTimer) clearTimeout(_schPreviewTimer);
-  const seq = ++_schPreviewSeq;
-  _schPreviewTimer = setTimeout(function () {
-    authFetch("/v1/api/admin/schedules/preview", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(compiled),
-    })
-      .then(function (r) {
-        return r.json();
-      })
-      .then(function (data) {
-        if (seq !== _schPreviewSeq) return; // a newer edit superseded us
-        if (!data.valid) _schRenderRuns([], data.error || "Invalid schedule");
-        else _schRenderRuns(data.next || []);
-      })
-      .catch(function () {
-        if (seq === _schPreviewSeq) _schRenderRuns([], "Preview unavailable");
-      });
-  }, 250);
-}
-
 function _schWire() {
   if (_schWired) return;
-  _schWired = true;
-  document.getElementById("sch-seg").addEventListener("click", function (e) {
-    const b = e.target.closest("button[data-mode]");
-    if (!b) return;
-    _schSetMode(b.getAttribute("data-mode"));
-    _schPreview();
-  });
-  document.getElementById("sch-days").addEventListener("click", function (e) {
-    const b = e.target.closest("button[data-day]");
-    if (!b) return;
-    b.setAttribute(
-      "aria-pressed",
-      b.getAttribute("aria-pressed") === "true" ? "false" : "true",
-    );
-    _schPreview();
-  });
-  [
-    "sch-time-daily",
-    "sch-time-weekly",
-    "sch-time-monthly",
-    "sch-dom",
-    "sch-every",
-    "sch-unit",
-    "sch-at",
-    "sch-cron",
-  ].forEach(function (id) {
-    const el = document.getElementById(id);
-    el.addEventListener("input", _schPreview);
-    el.addEventListener("change", _schPreview);
-  });
+  _schWhen = new window.TurnstoneScheduleBuilder.ScheduleBuilder(
+    document.getElementById("sch-when-mount"),
+    { onChange: _schRenderCompiled },
+  );
   document.getElementById("sch-target").addEventListener("change", function () {
     const isNode = this.value === "node";
     document.getElementById("sch-node-group").hidden = !isNode;
@@ -1918,6 +1580,9 @@ function _schWire() {
   document
     .getElementById("sch-submit")
     .addEventListener("click", _submitScheduleShelf);
+  // Latched only once everything above succeeded: a failed mount is retried
+  // on the next open instead of dying on a null builder.
+  _schWired = true;
 }
 
 // Shared open path: reset to a clean create state, then edit overwrites.
@@ -1928,15 +1593,7 @@ function _schResetForm() {
   document.getElementById("sch-id").value = "";
   document.getElementById("sch-name").value = "";
   document.getElementById("sch-desc").value = "";
-  document.getElementById("sch-time-daily").value = "06:00";
-  document.getElementById("sch-time-weekly").value = "06:00";
-  document.getElementById("sch-time-monthly").value = "06:00";
-  _schSetDays([]);
-  document.getElementById("sch-dom").value = "1";
-  document.getElementById("sch-every").value = "4";
-  document.getElementById("sch-unit").value = "hours";
-  document.getElementById("sch-at").value = "";
-  document.getElementById("sch-cron").value = "";
+  _schWhen.reset();
   document.getElementById("sch-target").value = "auto";
   document.getElementById("sch-node").value = "";
   document.getElementById("sch-node-group").hidden = true;
@@ -1944,7 +1601,6 @@ function _schResetForm() {
   document.getElementById("sch-autoapprove").checked = false;
   document.getElementById("sch-enabled").checked = true;
   _populateNotifyRows("sch", []);
-  _schSetMode("daily");
 }
 
 function _schPopulateSelects(
@@ -2010,7 +1666,7 @@ function _schOpen(title, tag, kind, submitLabel) {
   document.getElementById("sch-submit").textContent = submitLabel;
   _schShelfHandle = window.TurnstoneHatch.openShelf(shelf);
   document.getElementById("sch-name").focus();
-  _schPreview();
+  _schWhen.preview();
 }
 
 function showCreateScheduleModal() {
@@ -2033,7 +1689,7 @@ function showEditScheduleModal(taskId) {
       document.getElementById("sch-id").value = s.task_id;
       document.getElementById("sch-name").value = s.name || "";
       document.getElementById("sch-desc").value = s.description || "";
-      _schApplyTiming(s.schedule_type, s.cron_expr, s.at_time);
+      _schWhen.apply(s.schedule_type, s.cron_expr, s.at_time);
       const isSpecificNode =
         s.target_mode &&
         s.target_mode !== "auto" &&
@@ -2078,8 +1734,11 @@ function _submitScheduleShelf() {
 
   if (!name) return _showModalError(errEl, "Name is required");
   if (!message) return _showModalError(errEl, "Initial message is required");
-  const compiled = _schCompile();
-  if (compiled.error) return _showModalError(errEl, compiled.error);
+  const compiled = _schWhen.compile();
+  if (compiled.error) {
+    _schWhen.showErrors();
+    return _showModalError(errEl, compiled.error);
+  }
 
   let targetMode = document.getElementById("sch-target").value;
   if (targetMode === "node") {
@@ -8848,7 +8507,8 @@ function _modelCapsRefreshBaseline() {
     return;
   }
   // Two type-then-pause cycles can have both fetches in flight; a reordered
-  // older response must not clobber the tiles (the _schPreviewSeq pattern).
+  // older response must not clobber the tiles (the same sequence guard the
+  // schedule builder's preview uses).
   authFetch(
     "/v1/api/admin/model-capabilities?provider=" +
       encodeURIComponent(provider) +

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1038,7 +1038,7 @@ window.addEventListener("popstate", function (e) {
 function _hasCoordPermission() {
   // Deny-on-absent parse lives in the shared hasPermission (auth.js, the
   // module that populates the storage) — one contract for every surface.
-  return _consoleHasPermission("admin.coordinator");
+  return _consoleHasPermission(_launcherPerm("coordinator"));
 }
 
 // POST /v1/api/workstreams/new.  Accepts the three request fields
@@ -1131,14 +1131,76 @@ function _createCoordinator(opts) {
     });
 }
 
-function _hasInteractivePermission() {
-  return _consoleHasPermission("workstreams.create");
+// Which workstream KIND the launcher creates: "coordinator" (console-local),
+// "interactive" (proxied to a compute node), or "scheduled" (an interactive
+// session the console's scheduler starts later, on a timer).  The composer
+// is shared; only the field set, the submit endpoint and what follows differ.
+let _launcherKind = "coordinator";
+
+// The kinds in toggle order, each with its radio id and the ONE place its
+// permission is named: the gate (`can`) reads `perm` (as does
+// _hasCoordPermission, for its other caller), so the refusal toast can never
+// name a permission the gate stopped checking.  The click wiring, the
+// arrow-key cycle, the availability fallback and the submit gate all walk
+// this list.
+const _LAUNCHER_KINDS = [
+  { kind: "coordinator", id: "kind-coordinator", perm: "admin.coordinator" },
+  { kind: "interactive", id: "kind-interactive", perm: "workstreams.create" },
+  { kind: "scheduled", id: "kind-scheduled", perm: "admin.schedules" },
+].map(function (k) {
+  k.can = function () {
+    return _consoleHasPermission(k.perm);
+  };
+  return k;
+});
+
+function _launcherPerm(kind) {
+  const entry = _LAUNCHER_KINDS.find(function (k) {
+    return k.kind === kind;
+  });
+  return entry ? entry.perm : "";
 }
 
-// Which workstream KIND the launcher creates: "coordinator" (console-local)
-// or "interactive" (proxied to a compute node).  The composer is shared; only
-// the submit endpoint + redirect differ.
-let _launcherKind = "coordinator";
+// The kind an arrow key lands on: the neighbour of `current` in `avail`
+// (wrapping at either end), or an end of the list when `current` is no
+// longer offered (a permission refresh mid-session).
+function _nextLauncherKind(current, avail, back) {
+  if (!avail.length) return current;
+  const at = avail.indexOf(current);
+  if (at === -1) return back ? avail[avail.length - 1] : avail[0];
+  return avail[(at + (back ? -1 : 1) + avail.length) % avail.length];
+}
+
+// A schedule dispatches an interactive workstream, so the Scheduled kind
+// draws its personas from the interactive shelf.
+function _launcherPersonaKind() {
+  return _launcherKind === "scheduled" ? "interactive" : _launcherKind;
+}
+
+// The When builder under the composer (Scheduled kind).  Mounted once with
+// the composer from the shared template; hidden with its section otherwise.
+let _launcherWhen = null;
+
+// Shown when files are staged in the Scheduled kind — at the switch (the
+// paperclip that staged them has just disappeared) and again at submit —
+// and, without the "remove them" clause, when a file is dropped on the
+// composer in that kind (nothing is staged then).
+const _SCHEDULE_NO_FILES_MSG =
+  "A schedule can't carry attachments; remove them first.";
+const _SCHEDULE_NO_DROP_MSG = "A schedule can't carry attachments.";
+
+// No try/catch around the constructor on purpose: the template, this mount
+// and the builder script ship in the one index.html, served no-cache with
+// content ETags, so a page can never load a newer app.js than its own
+// markup — a missing template is a build error, not a runtime state.  The
+// null checks below (and the "failed to load" message in _createSchedule)
+// only keep the rest of the launcher usable if that ever regresses.
+function _mountLauncherWhen() {
+  const mount = document.getElementById("launcher-when-mount");
+  const SB = window.TurnstoneScheduleBuilder;
+  if (!mount || !SB || _launcherWhen) return;
+  _launcherWhen = new SB.ScheduleBuilder(mount);
+}
 
 // Sentinel value for the project picker's "+ New project…" row — selecting it
 // prompts for a name, creates, then re-selects the new project (see
@@ -1147,14 +1209,11 @@ const _PROJECT_NEW = "__new__";
 
 function _setLauncherKind(kind, focus) {
   _launcherKind = kind;
-  const map = {
-    "kind-coordinator": "coordinator",
-    "kind-interactive": "interactive",
-  };
-  Object.keys(map).forEach(function (id) {
-    const btn = document.getElementById(id);
+  _homeShowError(""); // a message about the previous kind no longer applies
+  _LAUNCHER_KINDS.forEach(function (k) {
+    const btn = document.getElementById(k.id);
     if (!btn) return;
-    const on = map[id] === kind;
+    const on = k.kind === kind;
     btn.classList.toggle("active", on);
     btn.setAttribute("aria-checked", on ? "true" : "false");
     btn.tabIndex = on ? 0 : -1; // roving tabindex — the radiogroup is one tab stop
@@ -1167,23 +1226,57 @@ function _setLauncherKind(kind, focus) {
 }
 
 // Reflect the active kind in the shared launcher composer: the task-prompt
-// hint, and which option fields are relevant.  The node picker is
-// interactive-only (coordinators run in the console, not on a compute node);
-// its node list appears only under the "Specific node" strategy.
+// hint, the send label, and which option fields are relevant.  Node
+// placement applies to every kind that runs on a compute node (interactive
+// and scheduled; coordinators run in the console); its node list appears
+// only under the "Specific node" strategy.  The Scheduled kind drops the
+// judge model and attachments (a schedule carries neither) and reveals the
+// When builder beneath the composer.
 function _applyLauncherFields() {
   if (!_homeCoordComposer) return;
-  const interactive = _launcherKind === "interactive";
+  const scheduled = _launcherKind === "scheduled";
+  const onNode = _launcherKind !== "coordinator";
   _homeCoordComposer.setPlaceholder(
-    interactive
-      ? "What do you want to work on?"
-      : "What should this coordinator orchestrate?",
+    scheduled
+      ? "What should run on this schedule?"
+      : onNode
+        ? "What do you want to work on?"
+        : "What should this coordinator orchestrate?",
   );
-  _homeCoordComposer.setOptionFieldVisible("node_strategy", interactive);
+  _homeCoordComposer.setSendLabel(
+    scheduled ? "Schedule" : "Start",
+    scheduled ? "Scheduling…" : "Starting…",
+  );
+  _homeCoordComposer.setOptionFieldVisible("node_strategy", onNode);
   const specific =
-    interactive &&
-    _homeCoordComposer.getOptionValue("node_strategy") === "node";
+    onNode && _homeCoordComposer.getOptionValue("node_strategy") === "node";
   _homeCoordComposer.setOptionFieldVisible("node_id", specific);
   if (specific) _populateLauncherNodes();
+  _homeCoordComposer.setOptionFieldVisible("judge_model", !scheduled);
+  _homeCoordComposer.setAttachVisible(!scheduled);
+  // A schedule's name is derived client-side (the Name option stays
+  // optional); the other kinds get a server-generated name.
+  _homeCoordComposer.setOptionPlaceholder(
+    "name",
+    scheduled ? "Named from the task's first line" : "Auto-generated if empty",
+  );
+  const when = document.getElementById("launcher-when");
+  if (when && _launcherWhen) {
+    // This runs on every option change too, so act on the transitions
+    // only: preview on reveal, drop a pending preview on hide.  The block's
+    // own `hidden` is the edge on purpose — nothing else toggles it, and a
+    // tracked previous kind would be parallel state that can drift.  Files
+    // staged before the switch are refused at submit; say so now, where the
+    // paperclip that staged them has just disappeared.
+    const revealed = scheduled && when.hidden;
+    const hidden = !scheduled && !when.hidden;
+    when.hidden = !scheduled;
+    if (revealed) {
+      _launcherWhen.preview();
+      if (_homeStagedFiles.length) _homeShowError(_SCHEDULE_NO_FILES_MSG);
+    }
+    if (hidden) _launcherWhen.cancelPreview();
+  }
 
   // "+ New project…" — reset the field FIRST so the sentinel can't stick (or
   // loop on re-entry), then reveal the inline creator beneath the picker.
@@ -1226,20 +1319,16 @@ function _populateLauncherNodes() {
 
 function _wireLauncherToggle() {
   const group = document.getElementById("launcher-kinds");
-  const coordBtn = document.getElementById("kind-coordinator");
-  const intBtn = document.getElementById("kind-interactive");
-  if (coordBtn) {
-    coordBtn.addEventListener("click", function () {
-      _setLauncherKind("coordinator");
+  _LAUNCHER_KINDS.forEach(function (k) {
+    const btn = document.getElementById(k.id);
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      _setLauncherKind(k.kind);
     });
-  }
-  if (intBtn) {
-    intBtn.addEventListener("click", function () {
-      _setLauncherKind("interactive");
-    });
-  }
+  });
   if (group) {
-    // WAI-ARIA radiogroup contract: arrow keys move the selection (+ focus).
+    // WAI-ARIA radiogroup contract: arrow keys move the selection (+ focus)
+    // among the kinds this user can create, wrapping at either end.
     group.addEventListener("keydown", function (e) {
       if (
         ["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"].indexOf(e.key) ===
@@ -1248,18 +1337,32 @@ function _wireLauncherToggle() {
         return;
       }
       e.preventDefault();
+      const avail = _LAUNCHER_KINDS
+        .filter(function (k) {
+          return k.can();
+        })
+        .map(function (k) {
+          return k.kind;
+        });
+      if (!avail.length) return;
       const back = e.key === "ArrowLeft" || e.key === "ArrowUp";
-      const next = back
-        ? _launcherKind === "interactive"
-          ? "coordinator"
-          : "interactive"
-        : _launcherKind === "coordinator"
-          ? "interactive"
-          : "coordinator";
-      _setLauncherKind(next, true);
+      _setLauncherKind(_nextLauncherKind(_launcherKind, avail, back), true);
     });
   }
   _setLauncherKind(_launcherKind); // seed the initial roving-tabindex state
+}
+
+// Node placement from the launcher's node-strategy picker, shared by every
+// kind that runs on a compute node: "node" pins to the chosen node, anything
+// else is "auto" (the console or the scheduler picks the least-loaded node).
+// Pure — returns { placement } or { error } and never touches the DOM or the
+// busy flag, so callers validate BEFORE flipping busy and a missing pick
+// surfaces inline without a stuck spinner.
+function _resolveNodePlacement(opts) {
+  if (opts.node_strategy !== "node") return { placement: "auto" };
+  const placement = (opts.node_id || "").trim();
+  if (!placement) return { error: "Choose a node, or switch to Least loaded." };
+  return { placement: placement };
 }
 
 // POST /v1/api/cluster/workstreams/new — the console picks a node and PROXIES
@@ -1277,18 +1380,12 @@ function _createInteractive(opts) {
   const setBusy = opts.setBusy || function () {};
   const onSuccess = opts.onSuccess || function () {};
 
-  // Node placement (launcher node-strategy picker): "node" pins to the chosen
-  // node; anything else lets the console pick the least-loaded node ("auto").
-  // Validate the specific-node choice BEFORE flipping busy so a missing pick
-  // surfaces inline without a stuck spinner.
-  let placement = "auto";
-  if (opts.node_strategy === "node") {
-    placement = (opts.node_id || "").trim();
-    if (!placement) {
-      errEl.textContent = "Choose a node, or switch to Least loaded.";
-      return;
-    }
+  const placed = _resolveNodePlacement(opts);
+  if (placed.error) {
+    errEl.textContent = placed.error;
+    return;
   }
+  const placement = placed.placement;
 
   errEl.textContent = "";
   setBusy(true);
@@ -1353,7 +1450,8 @@ function _createInteractive(opts) {
 }
 
 // ---------------------------------------------------------------------------
-// Home-landing session launcher (coordinator or interactive) + saved sessions.
+// Home-landing session launcher (coordinator, interactive or scheduled) +
+// saved sessions.
 // The composer renders as a persistent panel on the home view.  The
 // active list and
 // cluster summary render from clusterState, so every SSE-driven patch
@@ -1436,12 +1534,22 @@ function _homeIsAttachmentAllowed(file) {
   return false;
 }
 
-function _homeShowError(msg) {
-  const errEl = document.getElementById("home-coord-error");
-  if (!errEl) return;
+// One owner for the launcher's message row (#home-coord-error): validation
+// and request errors, and the Scheduled kind's post-submit confirmation
+// (`ok`).  The create paths write their errEl directly, but only after
+// submitHomeCoord has cleared the row through here, and a kind switch
+// clears it too — so an error never lands in a confirmation-styled row.
+function _homeShowMessage(text, ok) {
+  const el = document.getElementById("home-coord-error");
+  if (!el) return;
   // Element is always rendered (min-height reserves the row); just
   // toggle the message text so layout doesn't shift on validation.
-  errEl.textContent = msg || "";
+  el.textContent = text || "";
+  el.classList.toggle("is-ok", !!(ok && text));
+}
+
+function _homeShowError(msg) {
+  _homeShowMessage(msg, false);
 }
 
 function _homeRenderChips() {
@@ -1483,6 +1591,8 @@ function _homeRenderChips() {
       rm.onclick = function () {
         _homeStagedFiles.splice(idx, 1);
         _homeRenderChips();
+        // Whatever the row said about the files no longer applies.
+        if (!_homeStagedFiles.length) _homeShowError("");
       };
       chip.appendChild(rm);
       chipsEl.appendChild(chip);
@@ -1493,6 +1603,15 @@ function _homeRenderChips() {
 function _homeStageFile(file) {
   if (!file) return false;
   const paste = window.TurnstonePasteText;
+  if (_launcherKind === "scheduled") {
+    // No paperclip in this kind; this catches drops and pasted files.  A
+    // false return keeps a large pasted text inline — that is the right
+    // outcome for a schedule's task, so the paste case says nothing; only
+    // a real drop gets the refusal.
+    if (!(paste && paste.isPastedTextFile && paste.isPastedTextFile(file)))
+      _homeShowError(_SCHEDULE_NO_DROP_MSG);
+    return false;
+  }
   if (
     paste &&
     paste.isDuplicatePastedTextFile &&
@@ -1541,6 +1660,7 @@ function _ensureHomeComposerInit() {
   if (_homeComposerInit) return;
   _homeComposerInit = true;
   _mountHomeCoordComposer();
+  _mountLauncherWhen();
   _wireLauncherToggle();
   _refreshAndPopulateSkills();
   _refreshAndPopulateModels();
@@ -1606,10 +1726,10 @@ function _populateHomePersonaDropdown() {
   const TP = window.TurnstonePersonas;
   if (!TP) return;
   const previous = _homeCoordComposer.getOptionValue("persona");
-  const choices = TP.personaChoices(_launcherKind);
+  const choices = TP.personaChoices(_launcherPersonaKind());
   _homeCoordComposer.setOptionChoices("persona", choices);
   if (!_restorePick("persona", previous, choices)) {
-    const dflt = TP.defaultPersona(_launcherKind);
+    const dflt = TP.defaultPersona(_launcherPersonaKind());
     if (dflt) _homeCoordComposer.setOptionValue("persona", dflt.name);
   }
 }
@@ -1711,24 +1831,29 @@ function _mountHomeCoordComposer() {
         // Persona surfaces only when it's a non-default pick — the kind
         // default is the zero-touch state and needs no summary line.
         if (v.persona && window.TurnstonePersonas) {
-          const dflt = window.TurnstonePersonas.defaultPersona(_launcherKind);
+          const dflt = window.TurnstonePersonas.defaultPersona(
+            _launcherPersonaKind(),
+          );
           if (!dflt || dflt.name !== v.persona)
             bits.push(window.TurnstonePersonas.personaLabel(v.persona));
         }
         if (v.name) bits.push(v.name);
         if (v.skill) bits.push(v.skill);
         if (v.model) bits.push(v.model);
-        if (v.judge_model) bits.push("judge: " + v.judge_model);
+        // The judge model is hidden (and not sent) in the Scheduled kind.
+        if (v.judge_model && _launcherKind !== "scheduled")
+          bits.push("judge: " + v.judge_model);
         if (v.project && v.project !== _PROJECT_NEW) {
           const pn = window.TurnstoneProjects
             ? window.TurnstoneProjects.projectName(v.project)
             : "";
           bits.push("project: " + (pn || v.project));
         }
-        // Node placement is interactive-only; surface it only when a specific
-        // node is pinned (the "Least loaded" default needs no summary line).
+        // Node placement applies off the console only (interactive and
+        // scheduled); surface it only when a specific node is pinned (the
+        // "Least loaded" default needs no summary line).
         if (
-          _launcherKind === "interactive" &&
+          _launcherKind !== "coordinator" &&
           v.node_strategy === "node" &&
           v.node_id
         )
@@ -1926,35 +2051,35 @@ function _populateHomeModelDropdowns() {
 function _refreshHomeComposerVisibility() {
   const panel = document.getElementById("coord-composer-panel");
   if (!panel) return;
-  const canCoord = _hasCoordPermission();
-  const canInt = _hasInteractivePermission();
-  panel.style.display = canCoord || canInt ? "" : "none";
-  const coordBtn = document.getElementById("kind-coordinator");
-  const intBtn = document.getElementById("kind-interactive");
-  if (coordBtn) coordBtn.style.display = canCoord ? "" : "none";
-  if (intBtn) intBtn.style.display = canInt ? "" : "none";
+  const avail = _LAUNCHER_KINDS.filter(function (k) {
+    return k.can();
+  });
+  panel.style.display = avail.length ? "" : "none";
+  _LAUNCHER_KINDS.forEach(function (k) {
+    const btn = document.getElementById(k.id);
+    if (btn) btn.style.display = k.can() ? "" : "none";
+  });
   // Hide the toggle when only one kind is available.
   const kinds = document.getElementById("launcher-kinds");
-  if (kinds) kinds.style.display = canCoord && canInt ? "" : "none";
+  if (kinds) kinds.style.display = avail.length > 1 ? "" : "none";
   // Default to a kind the user can actually create.
-  if (_launcherKind === "coordinator" && !canCoord && canInt) {
-    _setLauncherKind("interactive");
-  } else if (_launcherKind === "interactive" && !canInt && canCoord) {
-    _setLauncherKind("coordinator");
-  }
+  const allowed = avail.some(function (k) {
+    return k.kind === _launcherKind;
+  });
+  if (!allowed && avail.length) _setLauncherKind(avail[0].kind);
 }
 
 function submitHomeCoord(textFromComposer) {
   const kind = _launcherKind;
-  if (kind === "coordinator" && !_hasCoordPermission()) {
-    showToast("admin.coordinator permission required");
-    return;
-  }
-  if (kind === "interactive" && !_hasInteractivePermission()) {
-    showToast("workstreams.create permission required");
+  const entry = _LAUNCHER_KINDS.find(function (k) {
+    return k.kind === kind;
+  });
+  if (!entry || !entry.can()) {
+    showToast((entry ? entry.perm : kind) + " permission required");
     return;
   }
   if (!_homeCoordComposer) return;
+  _homeShowError(""); // a stale confirmation must not frame a new error
   // text arg is passed when the Composer's Enter-key handler fires;
   // direct callers (Ctrl/Cmd+Enter) invoke with no argument and we
   // read from the composer.
@@ -1965,6 +2090,12 @@ function submitHomeCoord(textFromComposer) {
   // the multipart payload (the actual reset only fires on the success
   // branch, after the response lands).
   const files = _homeStagedFiles.slice();
+  // A schedule carries no attachments: refuse before the files-need-a-task
+  // guard below, whose "add a message" advice could never resolve this.
+  if (kind === "scheduled" && files.length > 0) {
+    _homeShowError(_SCHEDULE_NO_FILES_MSG);
+    return;
+  }
   // Files-without-text would upload pending attachment rows but the
   // server's _coord_create_post_install only reserves+dispatches when
   // initial_message is non-empty — uploaded files would orphan as
@@ -2004,22 +2135,175 @@ function submitHomeCoord(textFromComposer) {
     shared.node_strategy = opts.node_strategy || "auto";
     shared.node_id = (opts.node_id || "").trim();
     _createInteractive(shared);
+  } else if (kind === "scheduled") {
+    // Same placement picker as interactive; no files (refused above).
+    shared.node_strategy = opts.node_strategy || "auto";
+    shared.node_id = (opts.node_id || "").trim();
+    _createSchedule(shared);
   } else {
     shared.files = files;
     _createCoordinator(shared);
   }
 }
 
-// Ctrl/Cmd+Enter anywhere on the home page submits the coordinator
-// composer — consistent with the modal's keyboard-shortcut convention.
-// The Composer's own Enter handler already fires submitHomeCoord when
-// focus is in the textarea; this covers the case when focus sits on
-// the attach / options buttons.
+// The schedule API keeps this many characters of the initial message and of
+// the name (SCHEDULE_MESSAGE_MAX_CHARS / SCHEDULE_NAME_MAX_CHARS in
+// console/server.py; a test keeps them in step).  Counted in code points,
+// as the server counts.
+const _SCHEDULE_TASK_MAX_CHARS = 4096;
+const _SCHEDULE_NAME_MAX_CHARS = 256;
+// A derived name is cut to this many code points (ellipsis included).
+const _SCHEDULE_NAME_CUT_CHARS = 60;
+
+// Code points, as the server counts — with the cheap UTF-16 length as a
+// short-circuit so a huge pasted task is not boxed into an array just to be
+// refused (a UTF-16 length under the cap can never exceed it in code points).
+function _overCap(text, cap) {
+  return text.length > cap && Array.from(text).length > cap;
+}
+
+// A schedule needs a name (the admin list is keyed on it).  When the Name
+// option is empty, take the (trimmed, non-empty) task's first line, cut to
+// _SCHEDULE_NAME_CUT_CHARS — code points, so the cut can't split a
+// surrogate pair.
+function _scheduleNameFromTask(task) {
+  const first = task.split("\n")[0].replace(/\s+/g, " ").trim();
+  const cp = Array.from(first);
+  if (cp.length <= _SCHEDULE_NAME_CUT_CHARS) return first;
+  return (
+    cp
+      .slice(0, _SCHEDULE_NAME_CUT_CHARS - 1)
+      .join("")
+      .trimEnd() + "…"
+  );
+}
+
+// POST /v1/api/admin/schedules — store a schedule the console's scheduler
+// dispatches later as an interactive workstream on a compute node (the same
+// create the admin shelf performs, fed from the launcher's fields).  Nothing
+// opens on success, so the confirmation is inline and persistent (a toast
+// would be gone before the first-run time is read): it names the first run
+// and where the schedule is managed from here on.  The When builder keeps
+// its state on purpose — the next schedule often shares the timing.
+function _createSchedule(opts) {
+  const errEl = opts.errEl;
+  const setBusy = opts.setBusy || function () {};
+  const onSuccess = opts.onSuccess || function () {};
+  const submittedKind = _launcherKind; // busy disables send, not the toggle
+  const task = (opts.task || "").trim();
+  if (!task) {
+    errEl.textContent = "Describe what should run on this schedule.";
+    return;
+  }
+  if (_overCap(task, _SCHEDULE_TASK_MAX_CHARS)) {
+    // The server would silently keep only the first _SCHEDULE_TASK_MAX_CHARS.
+    errEl.textContent =
+      "A schedule's task is limited to " +
+      _SCHEDULE_TASK_MAX_CHARS.toLocaleString() +
+      " characters; shorten it.";
+    return;
+  }
+  const when = _launcherWhen
+    ? _launcherWhen.compile()
+    : { error: "The schedule builder failed to load." };
+  if (when.error) {
+    // Flag the builder too: an untouched mode shows its gap as a hint until
+    // a submit is refused on it (the admin shelf does the same).
+    if (_launcherWhen) _launcherWhen.showErrors();
+    errEl.textContent = when.error;
+    return;
+  }
+  // The same picker as interactive; for a schedule "auto" means the
+  // scheduler picks the node with the most headroom at dispatch time.
+  const placed = _resolveNodePlacement(opts);
+  if (placed.error) {
+    errEl.textContent = placed.error;
+    return;
+  }
+  const target = placed.placement;
+  const name = (opts.name || "").trim() || _scheduleNameFromTask(task);
+  if (_overCap(name, _SCHEDULE_NAME_MAX_CHARS)) {
+    errEl.textContent =
+      "A schedule's name is limited to " +
+      _SCHEDULE_NAME_MAX_CHARS +
+      " characters; shorten it.";
+    return;
+  }
+
+  errEl.textContent = "";
+  setBusy(true);
+
+  const body = {
+    name: name,
+    schedule_type: when.schedule_type,
+    cron_expr: when.cron_expr,
+    at_time: when.at_time,
+    target_mode: target,
+    initial_message: task,
+    model: (opts.model || "").trim(),
+    skill: opts.skill || "",
+    persona: (opts.persona || "").trim(),
+    project_id: (opts.project_id || "").trim(),
+  };
+  authFetch("/v1/api/admin/schedules", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+    .then(function (r) {
+      return r.json().then(function (data) {
+        return { ok: r.ok, status: r.status, data: data };
+      });
+    })
+    .then(function (res) {
+      setBusy(false);
+      const data = res.data || {};
+      if (!res.ok) {
+        errEl.textContent = data.error || "HTTP " + res.status;
+        return;
+      }
+      const SB = window.TurnstoneScheduleBuilder;
+      let msg = "Scheduled '" + (data.name || name) + "'";
+      if (data.next_run && SB) {
+        const rel = SB.relativeToNow(data.next_run);
+        msg +=
+          " — first run " +
+          (rel
+            ? rel + " (" + SB.formatLocal(data.next_run) + ")"
+            : SB.formatLocal(data.next_run));
+      }
+      if (_launcherKind !== submittedKind) {
+        // The user moved on to another kind while the create was in
+        // flight: leave their composer (and anything they staged since)
+        // alone and confirm in passing.
+        showToast(msg);
+        return;
+      }
+      onSuccess(res); // a schedule stages no files of its own; this clears any left over
+      if (_homeCoordComposer) {
+        _homeCoordComposer.clear();
+        // A typed name belongs to the schedule just made, not the next one
+        // (the When builder's state is kept on purpose; a name is not timing).
+        _homeCoordComposer.setOptionValue("name", "");
+      }
+      _homeShowMessage(msg + ". Manage it under Admin › Schedules.", true);
+    })
+    .catch(function () {
+      setBusy(false);
+      errEl.textContent = "Request failed";
+    });
+}
+
+// Ctrl/Cmd+Enter anywhere in the launcher panel submits it — consistent
+// with the modal's keyboard-shortcut convention.  The Composer's own Enter
+// handler already fires submitHomeCoord when focus is in the textarea; this
+// covers focus on the attach / options buttons, the kind toggle, and the
+// When block's fields.
 document.addEventListener("keydown", function (e) {
   if (e.key !== "Enter" || !(e.ctrlKey || e.metaKey)) return;
   if (!_homeCoordComposer) return;
-  const mount = document.getElementById("home-coord-composer-mount");
-  if (!mount || !mount.contains(e.target)) return;
+  const panel = document.getElementById("coord-composer-panel");
+  if (!panel || !panel.contains(e.target)) return;
   e.preventDefault();
   if (!_homeCoordComposer.sendBtn.disabled) submitHomeCoord();
 });

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -109,9 +109,11 @@
           style="display: none"
           aria-label="Start a new session"
         >
-          <!-- Persona toggle — start a coordinator (console-local) or an
-           interactive session (proxied to a node).  app.js gates each option
-           by scope and hides the toggle when only one is available. -->
+          <!-- Kind toggle — start a coordinator (console-local), an
+           interactive session (proxied to a node), or a scheduled task (an
+           interactive session the scheduler starts later, on a timer).
+           app.js gates each option by scope and hides the toggle when only
+           one is available. -->
           <div
             id="launcher-kinds"
             class="launcher-kinds"
@@ -140,11 +142,37 @@
               <span class="kind-led" aria-hidden="true"></span>
               Interactive
             </button>
+            <button
+              type="button"
+              id="kind-scheduled"
+              class="kind-btn kind-btn--sched"
+              role="radio"
+              aria-checked="false"
+              aria-controls="launcher-when"
+              tabindex="-1"
+            >
+              <span class="kind-led" aria-hidden="true"></span>
+              Scheduled
+            </button>
           </div>
           <!-- Composer DOM is built by shared_static/composer.js into this
            mount — stacked layout (textarea above, options toggle +
            Start button below) with Name + Skill in an Options
            dropdown to match the webui dashboard composer's shape. -->
+          <!-- Scheduled kind only: the Runs builder (same template as the
+           admin shelf) sits between the kind toggle and the composer — it is
+           required input for this kind, so it precedes the task text and the
+           Schedule button rather than trailing them or hiding among the
+           options.  app.js reveals it per kind. -->
+          <section
+            id="launcher-when"
+            class="launcher-when"
+            aria-label="When to run"
+            hidden
+          >
+            <h3 class="launcher-when-title">When</h3>
+            <div id="launcher-when-mount"></div>
+          </section>
           <div id="home-coord-composer-mount"></div>
           <div
             id="home-coord-error"
@@ -240,6 +268,148 @@
           </div>
         </section>
       </div>
+
+      <!-- Schedule "When" builder — the timing control shared by the admin
+           schedule shelf and the dashboard launcher's Scheduled kind.  One
+           markup source: schedule_builder.js clones this template per
+           instance and prefixes every id, so both consumers can coexist
+           on the page.  Never rendered directly.  Carries no defaults: the
+           builder's reset() on mount writes defaultState() into every
+           control, so a value here would never be seen. -->
+      <template id="schedule-when-template">
+        <label id="when-runs-label">Runs</label>
+        <div
+          class="seg"
+          role="group"
+          aria-labelledby="when-runs-label"
+          id="when-seg"
+        >
+          <button type="button" data-mode="daily" aria-pressed="false">
+            Daily
+          </button>
+          <button type="button" data-mode="weekly" aria-pressed="false">
+            Weekly
+          </button>
+          <button type="button" data-mode="monthly" aria-pressed="false">
+            Monthly
+          </button>
+          <button type="button" data-mode="interval" aria-pressed="false">
+            Interval
+          </button>
+          <button type="button" data-mode="once" aria-pressed="false">
+            Once
+          </button>
+          <button type="button" data-mode="cron" aria-pressed="false">
+            Cron
+          </button>
+        </div>
+        <div data-when-pane="daily">
+          <label for="when-time-daily"
+            >At time <span class="label-hint">— UTC</span></label
+          >
+          <input id="when-time-daily" type="time" />
+        </div>
+        <div data-when-pane="weekly" hidden>
+          <label id="when-days-label">On days</label>
+          <div
+            class="chips"
+            id="when-days"
+            role="group"
+            aria-labelledby="when-days-label"
+          >
+            <button type="button" data-day="1" aria-pressed="false">
+              Mon
+            </button>
+            <button type="button" data-day="2" aria-pressed="false">
+              Tue
+            </button>
+            <button type="button" data-day="3" aria-pressed="false">
+              Wed
+            </button>
+            <button type="button" data-day="4" aria-pressed="false">
+              Thu
+            </button>
+            <button type="button" data-day="5" aria-pressed="false">
+              Fri
+            </button>
+            <button type="button" data-day="6" aria-pressed="false">
+              Sat
+            </button>
+            <button type="button" data-day="0" aria-pressed="false">
+              Sun
+            </button>
+          </div>
+          <label for="when-time-weekly"
+            >At time <span class="label-hint">— UTC</span></label
+          >
+          <input id="when-time-weekly" type="time" />
+        </div>
+        <div data-when-pane="monthly" hidden>
+          <div class="field-pair">
+            <div>
+              <label for="when-dom">On day</label>
+              <input id="when-dom" type="number" min="1" max="31" step="1" />
+            </div>
+            <div>
+              <label for="when-time-monthly"
+                >At time <span class="label-hint">— UTC</span></label
+              >
+              <input id="when-time-monthly" type="time" />
+            </div>
+          </div>
+        </div>
+        <div data-when-pane="interval" hidden>
+          <div class="field-pair">
+            <div>
+              <label for="when-every">Every</label>
+              <input id="when-every" type="number" min="1" step="1" />
+            </div>
+            <div>
+              <label for="when-unit">Unit</label>
+              <select id="when-unit">
+                <option value="hours">hours</option>
+                <option value="minutes">minutes</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div data-when-pane="once" hidden>
+          <label for="when-at"
+            >Run at
+            <span class="label-hint">— your local time</span></label
+          >
+          <input id="when-at" type="datetime-local" />
+        </div>
+        <div data-when-pane="cron" hidden>
+          <label for="when-cron"
+            >Cron expression
+            <span class="label-hint"
+              >min hour day month weekday</span
+            ></label
+          >
+          <input
+            id="when-cron"
+            type="text"
+            class="sh-mono"
+            placeholder="0 9 * * MON-FRI"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </div>
+        <div class="readout">
+          <div class="readout-head">
+            <span class="readout-label">Next runs</span>
+            <span class="readout-desc" id="when-desc-out"></span>
+          </div>
+          <div
+            class="readout-rows"
+            id="when-runs-out"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          ></div>
+        </div>
+      </template>
 
       <!-- FILTERED WORKSTREAMS -->
       <div id="view-filtered" style="display: none">
@@ -1367,6 +1537,7 @@
               <input
                 id="sch-name"
                 type="text"
+                maxlength="256"
                 placeholder="Daily health check"
                 autocomplete="off"
               />
@@ -1376,138 +1547,9 @@
               <input id="sch-desc" type="text" autocomplete="off" />
 
               <div class="sh-section">When</div>
-              <label id="sch-runs-label">Runs</label>
-              <div
-                class="seg"
-                role="group"
-                aria-labelledby="sch-runs-label"
-                id="sch-seg"
-              >
-                <button type="button" data-mode="daily" aria-pressed="true">
-                  Daily
-                </button>
-                <button type="button" data-mode="weekly" aria-pressed="false">
-                  Weekly
-                </button>
-                <button type="button" data-mode="monthly" aria-pressed="false">
-                  Monthly
-                </button>
-                <button type="button" data-mode="interval" aria-pressed="false">
-                  Interval
-                </button>
-                <button type="button" data-mode="once" aria-pressed="false">
-                  Once
-                </button>
-                <button type="button" data-mode="cron" aria-pressed="false">
-                  Cron
-                </button>
-              </div>
-              <div data-sch-pane="daily">
-                <label for="sch-time-daily"
-                  >At time <span class="label-hint">— UTC</span></label
-                >
-                <input id="sch-time-daily" type="time" value="06:00" />
-              </div>
-              <div data-sch-pane="weekly" hidden>
-                <label id="sch-days-label">On days</label>
-                <div
-                  class="chips"
-                  id="sch-days"
-                  role="group"
-                  aria-labelledby="sch-days-label"
-                >
-                  <button type="button" data-day="1" aria-pressed="false">
-                    Mon
-                  </button>
-                  <button type="button" data-day="2" aria-pressed="false">
-                    Tue
-                  </button>
-                  <button type="button" data-day="3" aria-pressed="false">
-                    Wed
-                  </button>
-                  <button type="button" data-day="4" aria-pressed="false">
-                    Thu
-                  </button>
-                  <button type="button" data-day="5" aria-pressed="false">
-                    Fri
-                  </button>
-                  <button type="button" data-day="6" aria-pressed="false">
-                    Sat
-                  </button>
-                  <button type="button" data-day="0" aria-pressed="false">
-                    Sun
-                  </button>
-                </div>
-                <label for="sch-time-weekly"
-                  >At time <span class="label-hint">— UTC</span></label
-                >
-                <input id="sch-time-weekly" type="time" value="06:00" />
-              </div>
-              <div data-sch-pane="monthly" hidden>
-                <div class="field-pair">
-                  <div>
-                    <label for="sch-dom">On day</label>
-                    <input
-                      id="sch-dom"
-                      type="number"
-                      min="1"
-                      max="31"
-                      value="1"
-                    />
-                  </div>
-                  <div>
-                    <label for="sch-time-monthly"
-                      >At time <span class="label-hint">— UTC</span></label
-                    >
-                    <input id="sch-time-monthly" type="time" value="06:00" />
-                  </div>
-                </div>
-              </div>
-              <div data-sch-pane="interval" hidden>
-                <div class="field-pair">
-                  <div>
-                    <label for="sch-every">Every</label>
-                    <input id="sch-every" type="number" min="1" value="4" />
-                  </div>
-                  <div>
-                    <label for="sch-unit">Unit</label>
-                    <select id="sch-unit">
-                      <option value="hours">hours</option>
-                      <option value="minutes">minutes</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-              <div data-sch-pane="once" hidden>
-                <label for="sch-at"
-                  >Run at
-                  <span class="label-hint">— your local time</span></label
-                >
-                <input id="sch-at" type="datetime-local" />
-              </div>
-              <div data-sch-pane="cron" hidden>
-                <label for="sch-cron"
-                  >Cron expression
-                  <span class="label-hint"
-                    >min hour day month weekday</span
-                  ></label
-                >
-                <input
-                  id="sch-cron"
-                  type="text"
-                  class="sh-mono"
-                  placeholder="0 9 * * MON-FRI"
-                  autocomplete="off"
-                  spellcheck="false"
-                />
-              </div>
-              <div class="readout" role="status" aria-live="polite">
-                <div class="readout-head">
-                  <span class="readout-label">Next runs</span>
-                  <span class="readout-desc" id="sch-desc-out"></span>
-                </div>
-                <div class="readout-rows" id="sch-runs-out"></div>
-              </div>
+              <!-- Runs builder: mounted by admin.js from
+                   #schedule-when-template (schedule_builder.js). -->
+              <div id="sch-when-mount"></div>
 
               <div class="sh-section">Target</div>
               <label for="sch-target">Target</label>
@@ -1557,6 +1599,7 @@
               <textarea
                 id="sch-message"
                 rows="3"
+                maxlength="4096"
                 placeholder="What should the workstream do?"
               ></textarea>
               <div class="toggle-stack">
@@ -4269,6 +4312,7 @@
       </footer>
     </dialog>
 
+    <script src="/static/schedule_builder.js"></script>
     <script src="/static/admin.js"></script>
     <script src="/static/governance.js"></script>
     <script src="/static/app.js"></script>

--- a/turnstone/console/static/schedule_builder.js
+++ b/turnstone/console/static/schedule_builder.js
@@ -1,0 +1,661 @@
+/* Schedule "When" builder — the timing control shared by the admin schedule
+   shelf and the dashboard launcher's Scheduled kind.
+
+   The cron DSL is compiled, not typed: the segmented Runs control (Daily /
+   Weekly / Monthly / Interval / Once / Cron) builds schedule_type /
+   cron_expr / at_time, and the NEXT RUNS read-out previews the result
+   through the server's croniter (POST /v1/api/admin/schedules/preview) as
+   the user edits.  Cron mode is the raw escape hatch with the same live
+   read-out.  Storage is unchanged: a saved expression is reverse-parsed
+   back into the friendly mode when its shape matches (cronToScheduleMode),
+   else the editor opens in Cron mode.
+
+   Markup comes from <template id="schedule-when-template"> — one source for
+   every consumer.  Each instance clones it and prefixes every id (plus the
+   label / aria references to them, via scopedId) so two builders can share
+   a page.  The pure helpers (compileSchedule, describeSchedule,
+   cronToScheduleMode, stateFromSaved, scopedId, the time formatters) take
+   and return plain values so they run under node without a DOM.
+
+   Classic script: exposes window.TurnstoneScheduleBuilder. */
+(function () {
+  "use strict";
+
+  const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const MODES = ["daily", "weekly", "monthly", "interval", "once", "cron"];
+  const TEMPLATE_ID = "schedule-when-template";
+  const PREVIEW_URL = "/v1/api/admin/schedules/preview";
+  const PREVIEW_DEBOUNCE_MS = 250;
+
+  function pad2(n) {
+    return n < 10 ? "0" + n : "" + n;
+  }
+
+  function byNumber(a, b) {
+    return a - b;
+  }
+
+  // "HH:MM" -> [h, m].  A blank or malformed value reads as 06:00 (the
+  // builder's default) so a cleared <input type=time> never compiles to
+  // NaN fields.
+  function timeParts(value) {
+    const parts = (value || "06:00").split(":");
+    return [parseInt(parts[0], 10) || 0, parseInt(parts[1], 10) || 0];
+  }
+
+  function hhmm(value) {
+    const p = timeParts(value);
+    return pad2(p[0]) + ":" + pad2(p[1]);
+  }
+
+  // datetime-local gives "YYYY-MM-DDTHH:MM" in browser local time; the
+  // server wants an offset-bearing ISO timestamp.  "" when unparseable.
+  function localToUtcIso(localDatetimeStr) {
+    const d = new Date(localDatetimeStr);
+    if (isNaN(d.getTime())) return "";
+    return d.toISOString().replace(/\.\d{3}Z$/, "+00:00");
+  }
+
+  // The server emits "YYYY-MM-DDTHH:MM:SS" (UTC, no suffix) for next_run and
+  // "+00:00" ISO for preview rows and at_time.  A suffix-less value is UTC,
+  // never browser-local, so pin it before parsing.
+  function parseServerTime(iso) {
+    const hasOffset = /(?:Z|[+-]\d{2}:?\d{2})$/.test(iso);
+    return new Date(hasOffset ? iso : iso + "Z");
+  }
+
+  // Server time -> datetime-local ("YYYY-MM-DDTHH:MM", browser local).
+  function utcToLocalDatetime(utcStr) {
+    if (!utcStr) return "";
+    const d = parseServerTime(utcStr);
+    if (isNaN(d.getTime())) return utcStr.slice(0, 16);
+    return (
+      d.getFullYear() +
+      "-" +
+      pad2(d.getMonth() + 1) +
+      "-" +
+      pad2(d.getDate()) +
+      "T" +
+      pad2(d.getHours()) +
+      ":" +
+      pad2(d.getMinutes())
+    );
+  }
+
+  // The browser zone's short name ("EDT", "UTC", "GMT+2"); "" when the
+  // platform cannot say.
+  function localZoneName(d) {
+    try {
+      const parts = new Intl.DateTimeFormat(undefined, {
+        timeZoneName: "short",
+      }).formatToParts(d);
+      const part = parts.find(function (p) {
+        return p.type === "timeZoneName";
+      });
+      return part ? part.value : "";
+    } catch (_e) {
+      return "";
+    }
+  }
+
+  // A server instant in the operator's local time: "Tue 2026-09-08 02:00
+  // EDT".  The raw input when it does not parse.  The cron itself stays in
+  // UTC (the scheduler has no zone), so the read-out is where an operator
+  // sees when a run actually lands for them.
+  function formatLocal(iso) {
+    const d = parseServerTime(iso);
+    if (isNaN(d.getTime())) return iso;
+    const zone = localZoneName(d);
+    return (
+      DAY_NAMES[d.getDay()] +
+      " " +
+      d.getFullYear() +
+      "-" +
+      pad2(d.getMonth() + 1) +
+      "-" +
+      pad2(d.getDate()) +
+      " " +
+      pad2(d.getHours()) +
+      ":" +
+      pad2(d.getMinutes()) +
+      (zone ? " " + zone : "")
+    );
+  }
+
+  // "in 3d" / "in 2h" / "in 15m" / "now"; "" when it does not parse.
+  // `nowMs` overrides the clock (tests); Date.now() otherwise.
+  function relativeToNow(iso, nowMs) {
+    const d = parseServerTime(iso);
+    if (isNaN(d.getTime())) return "";
+    const now = nowMs == null ? Date.now() : nowMs;
+    const mins = Math.round((d.getTime() - now) / 60000);
+    if (mins < 1) return "now";
+    if (mins < 60) return "in " + mins + "m";
+    if (mins < 48 * 60) return "in " + Math.round(mins / 60) + "h";
+    return "in " + Math.round(mins / (24 * 60)) + "d";
+  }
+
+  // A cron step field cannot exceed its range: "*/90" in the minute field
+  // matches minute 0 only (hourly), "0 */30" in the hour field matches hour
+  // 0 only (daily) — croniter accepts both.  Every place that decides
+  // whether a step is a builder-representable interval goes through
+  // intervalStepOk: compileSchedule refuses to CREATE one out of range,
+  // cronToScheduleMode refuses to READ one back as Interval (it opens in
+  // Cron mode instead, so a saved expression stays editable), and
+  // describeSchedule only claims a restart cadence for a step inside it.
+  // Saved out-of-range expressions are preserved verbatim, never rewritten
+  // or refused — refusing them stranded them.  Uneven steps ("*/7") are
+  // cron's own semantics and stay accepted; the read-out says how they
+  // restart.  Out-of-range LITERAL fields ("70 99 * * *") need no gate:
+  // croniter rejects them, so they can never be stored.
+  const INTERVAL_MAX = { minutes: 59, hours: 23 };
+  const INTERVAL_FIELD = { minutes: 60, hours: 24 };
+
+  function intervalStepOk(n, unit) {
+    return Number.isInteger(n) && n >= 1 && n <= INTERVAL_MAX[unit];
+  }
+
+  // A whole number from a numeric input's raw value, else NaN: compile and
+  // the read-out parse through here, so a "4.5" or "1e1" the input reports
+  // is refused rather than truncated to a cadence the header never named.
+  function wholeNumber(value) {
+    const n = Number(value);
+    return Number.isInteger(n) ? n : NaN;
+  }
+
+  // Builder state — plain values mirroring the template's controls.  Every
+  // mode keeps its own fields so switching modes never loses an edit.
+  // monthlyDom and intervalEvery are numbers from defaultState() /
+  // stateFromSaved() and the raw input strings from state(); consumers
+  // parse them (compileSchedule does).
+  function defaultState() {
+    return {
+      mode: "daily",
+      dailyTime: "06:00",
+      weeklyTime: "06:00",
+      weeklyDays: [],
+      monthlyTime: "06:00",
+      monthlyDom: 1,
+      intervalEvery: 4,
+      intervalUnit: "hours",
+      atLocal: "",
+      cron: "",
+    };
+  }
+
+  function cronResult(expr) {
+    return { schedule_type: "cron", cron_expr: expr, at_time: "" };
+  }
+
+  // Compile builder state down to the wire fields.  Returns
+  // {schedule_type, cron_expr, at_time} or {error}.
+  function compileSchedule(state) {
+    const mode = state.mode;
+    let h, m;
+    if (mode === "once") {
+      if (!state.atLocal) return { error: "Pick a date and time" };
+      const at = localToUtcIso(state.atLocal);
+      if (!at) return { error: "Pick a date and time" };
+      return { schedule_type: "at", cron_expr: "", at_time: at };
+    }
+    if (mode === "cron") {
+      const expr = (state.cron || "").trim();
+      if (!expr) return { error: "Cron expression is required" };
+      return cronResult(expr);
+    }
+    if (mode === "daily") {
+      [h, m] = timeParts(state.dailyTime);
+      return cronResult(m + " " + h + " * * *");
+    }
+    if (mode === "weekly") {
+      const days = (state.weeklyDays || []).slice().sort(byNumber);
+      if (!days.length) return { error: "Select at least one day" };
+      [h, m] = timeParts(state.weeklyTime);
+      return cronResult(m + " " + h + " * * " + days.join(","));
+    }
+    if (mode === "monthly") {
+      const dom = wholeNumber(state.monthlyDom);
+      if (!dom || dom < 1 || dom > 31)
+        return { error: "Day of month must be 1-31" };
+      [h, m] = timeParts(state.monthlyTime);
+      return cronResult(m + " " + h + " " + dom + " * *");
+    }
+    if (mode === "interval") {
+      const n = wholeNumber(state.intervalEvery);
+      if (!n || n < 1)
+        return { error: "Interval must be a whole number, at least 1" };
+      const unit = state.intervalUnit === "hours" ? "hours" : "minutes";
+      if (!intervalStepOk(n, unit))
+        return {
+          error:
+            (unit === "hours" ? "Hours" : "Minutes") +
+            " interval must be 1-" +
+            INTERVAL_MAX[unit] +
+            (unit === "hours" ? " (Daily runs once a day)" : ""),
+        };
+      return cronResult(
+        unit === "hours" ? "0 */" + n + " * * *" : "*/" + n + " * * * *",
+      );
+    }
+    return { error: "Unknown schedule mode" };
+  }
+
+  // Plain-words summary of the state for the read-out header.
+  function describeSchedule(state) {
+    switch (state.mode) {
+      case "daily":
+        return "every day at " + hhmm(state.dailyTime) + " UTC";
+      case "weekly": {
+        const names = (state.weeklyDays || [])
+          .slice()
+          .sort(byNumber)
+          .map(function (d) {
+            return DAY_NAMES[d];
+          });
+        return names.length
+          ? "every " +
+              names.join(", ") +
+              " at " +
+              hhmm(state.weeklyTime) +
+              " UTC"
+          : "no days selected";
+      }
+      case "monthly":
+        return (
+          "monthly on day " +
+          (wholeNumber(state.monthlyDom) >= 1
+            ? wholeNumber(state.monthlyDom)
+            : "?") +
+          " at " +
+          hhmm(state.monthlyTime) +
+          " UTC"
+        );
+      case "interval": {
+        const n = wholeNumber(state.intervalEvery);
+        const unit = state.intervalUnit === "hours" ? "hours" : "minutes";
+        // The phrase names the step compile will use — never the raw text.
+        const base = "every " + (n >= 1 ? n : "?") + " " + unit;
+        // A step that does not divide its field restarts at the field
+        // boundary ("*/7" hours fires 00, 07, 14, 21, then 00): say so.
+        if (!intervalStepOk(n, unit) || INTERVAL_FIELD[unit] % n === 0)
+          return base;
+        return (
+          base +
+          (unit === "hours"
+            ? ", restarting at midnight"
+            : ", restarting each hour")
+        );
+      }
+      case "once": {
+        const at = state.atLocal ? localToUtcIso(state.atLocal) : "";
+        return at ? "once at " + formatLocal(at) : "one time";
+      }
+      default:
+        return "custom cron";
+    }
+  }
+
+  // Reverse-parse a saved expression into builder state.  Only the exact
+  // shapes the builder emits round-trip; anything else opens in Cron mode.
+  function cronToScheduleMode(expr) {
+    let m = /^(\d{1,2}) (\d{1,2}) \* \* \*$/.exec(expr);
+    if (m) return { mode: "daily", h: +m[2], min: +m[1] };
+    m = /^(\d{1,2}) (\d{1,2}) \* \* ([0-7](?:,[0-7])*)$/.exec(expr);
+    if (m)
+      return {
+        mode: "weekly",
+        h: +m[2],
+        min: +m[1],
+        days: m[3].split(",").map(function (d) {
+          return +d % 7; // cron allows 7 for Sunday
+        }),
+      };
+    m = /^(\d{1,2}) (\d{1,2}) (\d{1,2}) \* \*$/.exec(expr);
+    if (m) return { mode: "monthly", h: +m[2], min: +m[1], dom: +m[3] };
+    m = /^0 \*\/(\d+) \* \* \*$/.exec(expr);
+    if (m && intervalStepOk(+m[1], "hours"))
+      return { mode: "interval", every: +m[1], unit: "hours" };
+    m = /^\*\/(\d+) \* \* \* \*$/.exec(expr);
+    if (m && intervalStepOk(+m[1], "minutes"))
+      return { mode: "interval", every: +m[1], unit: "minutes" };
+    return { mode: "cron" };
+  }
+
+  // Saved timing -> the state a builder shows for it (edit mode).
+  function stateFromSaved(scheduleType, cronExpr, atTime) {
+    const s = defaultState();
+    if (scheduleType === "at") {
+      s.mode = "once";
+      s.atLocal = utcToLocalDatetime(atTime);
+      return s;
+    }
+    // The raw expression is always carried, whatever mode opens: switching
+    // to Cron never shows an empty box for a saved schedule.
+    s.cron = cronExpr || "";
+    const parsed = cronToScheduleMode(cronExpr || "");
+    s.mode = parsed.mode;
+    if (parsed.mode === "daily") {
+      s.dailyTime = pad2(parsed.h) + ":" + pad2(parsed.min);
+    } else if (parsed.mode === "weekly") {
+      s.weeklyTime = pad2(parsed.h) + ":" + pad2(parsed.min);
+      s.weeklyDays = parsed.days;
+    } else if (parsed.mode === "monthly") {
+      s.monthlyTime = pad2(parsed.h) + ":" + pad2(parsed.min);
+      s.monthlyDom = parsed.dom;
+    } else if (parsed.mode === "interval") {
+      s.intervalEvery = parsed.every;
+      s.intervalUnit = parsed.unit;
+    }
+    return s;
+  }
+
+  // How an unmet compile shows in the read-out: a neutral hint while the
+  // mode is untouched (it still needs input), an error once it has been
+  // edited or a submit was refused on it; null when it compiles.
+  function runsMessageKind(compiled, dirty) {
+    if (!compiled.error) return null;
+    return dirty ? "err" : "hint";
+  }
+
+  // Instance-scope a template id: "when-seg" -> "when1-seg" for the prefix
+  // "when1-".  Ids outside the template's vocabulary pass through.
+  function scopedId(id, prefix) {
+    return id.replace(/^when-/, prefix);
+  }
+
+  // ---------------------------------------------------------------------
+  // DOM instance
+  // ---------------------------------------------------------------------
+
+  let _instances = 0;
+
+  /**
+   * Mount a builder into `mount`.  `opts.onChange(compiled)` fires with the
+   * compiled wire fields ({schedule_type, cron_expr, at_time} or {error})
+   * on every edit and on preview().
+   */
+  function ScheduleBuilder(mount, opts) {
+    if (!(this instanceof ScheduleBuilder))
+      return new ScheduleBuilder(mount, opts);
+    if (!mount) throw new Error("ScheduleBuilder: mount element required");
+    const tpl = document.getElementById(TEMPLATE_ID);
+    if (!tpl || !tpl.content)
+      throw new Error("ScheduleBuilder: #" + TEMPLATE_ID + " missing");
+    this._opts = opts || {};
+    this._els = {};
+    this._previewTimer = null;
+    this._previewSeq = 0;
+    this._previewAbort = null; // AbortController of the in-flight request
+    // False until the current mode is edited: an untouched mode that does
+    // not compile yet (Weekly with no days, Once with no date, an empty
+    // Cron) reads as a hint, not an error.  setMode() clears it.
+    this._dirty = false;
+
+    // Instance-scope every id (and the label / aria references to them):
+    // the template's "when-seg" becomes "when1-seg", "when2-seg", …  The
+    // lookups below keep using the template's own names.
+    const prefix = "when" + ++_instances + "-";
+    const root = document.createElement("div");
+    root.className = "when-builder";
+    root.appendChild(tpl.content.cloneNode(true));
+    const els = this._els;
+    root.querySelectorAll("[id]").forEach(function (el) {
+      els[el.id] = el;
+      el.id = scopedId(el.id, prefix);
+    });
+    root.querySelectorAll("[for]").forEach(function (el) {
+      el.setAttribute("for", scopedId(el.getAttribute("for"), prefix));
+    });
+    root.querySelectorAll("[aria-labelledby]").forEach(function (el) {
+      el.setAttribute(
+        "aria-labelledby",
+        scopedId(el.getAttribute("aria-labelledby"), prefix),
+      );
+    });
+    mount.appendChild(root);
+    this.root = root;
+    this._wire();
+    this.reset();
+  }
+
+  ScheduleBuilder.prototype._wire = function () {
+    const self = this;
+    const els = this._els;
+    els["when-seg"].addEventListener("click", function (e) {
+      const b = e.target.closest("button[data-mode]");
+      if (!b) return;
+      self.setMode(b.getAttribute("data-mode"));
+      self.preview();
+    });
+    els["when-days"].addEventListener("click", function (e) {
+      const b = e.target.closest("button[data-day]");
+      if (!b) return;
+      b.setAttribute(
+        "aria-pressed",
+        b.getAttribute("aria-pressed") === "true" ? "false" : "true",
+      );
+      self._edited();
+    });
+    // Every field the template carries — wired from the clone, not from a
+    // list that a new control could be left off.
+    this.root.querySelectorAll("input, select").forEach(function (el) {
+      el.addEventListener("input", function () {
+        self._edited();
+      });
+      el.addEventListener("change", function () {
+        self._edited();
+      });
+    });
+    els["when-unit"].addEventListener("change", function () {
+      self._syncIntervalMax();
+    });
+  };
+
+  // The step input's max follows the unit (the same bound compileSchedule
+  // enforces), so the browser's own validation hints before the read-out.
+  ScheduleBuilder.prototype._syncIntervalMax = function () {
+    const unit = this._els["when-unit"].value === "hours" ? "hours" : "minutes";
+    this._els["when-every"].max = INTERVAL_MAX[unit];
+  };
+
+  ScheduleBuilder.prototype._edited = function () {
+    this._dirty = true;
+    this.preview();
+  };
+
+  /** Read the controls into a plain state object. */
+  ScheduleBuilder.prototype.state = function () {
+    const els = this._els;
+    const on = els["when-seg"].querySelector('[aria-pressed="true"]');
+    const days = [];
+    els["when-days"]
+      .querySelectorAll('button[aria-pressed="true"]')
+      .forEach(function (b) {
+        days.push(parseInt(b.getAttribute("data-day"), 10));
+      });
+    return {
+      mode: on ? on.getAttribute("data-mode") : "daily",
+      dailyTime: els["when-time-daily"].value,
+      weeklyTime: els["when-time-weekly"].value,
+      weeklyDays: days,
+      monthlyTime: els["when-time-monthly"].value,
+      monthlyDom: els["when-dom"].value,
+      intervalEvery: els["when-every"].value,
+      intervalUnit: els["when-unit"].value,
+      atLocal: els["when-at"].value,
+      cron: els["when-cron"].value,
+    };
+  };
+
+  /** Write a plain state object into the controls (no preview). */
+  ScheduleBuilder.prototype.setState = function (state) {
+    const els = this._els;
+    els["when-time-daily"].value = state.dailyTime;
+    els["when-time-weekly"].value = state.weeklyTime;
+    const days = state.weeklyDays || [];
+    els["when-days"].querySelectorAll("button[data-day]").forEach(function (b) {
+      const d = parseInt(b.getAttribute("data-day"), 10);
+      b.setAttribute("aria-pressed", days.indexOf(d) >= 0 ? "true" : "false");
+    });
+    els["when-time-monthly"].value = state.monthlyTime;
+    els["when-dom"].value = state.monthlyDom;
+    els["when-every"].value = state.intervalEvery;
+    els["when-unit"].value = state.intervalUnit;
+    this._syncIntervalMax();
+    els["when-at"].value = state.atLocal;
+    els["when-cron"].value = state.cron;
+    this.setMode(state.mode);
+  };
+
+  ScheduleBuilder.prototype.setMode = function (mode) {
+    if (MODES.indexOf(mode) === -1) mode = "cron";
+    this._els["when-seg"]
+      .querySelectorAll("button[data-mode]")
+      .forEach(function (b) {
+        b.setAttribute(
+          "aria-pressed",
+          b.getAttribute("data-mode") === mode ? "true" : "false",
+        );
+      });
+    this.root.querySelectorAll("[data-when-pane]").forEach(function (pane) {
+      pane.hidden = pane.getAttribute("data-when-pane") !== mode;
+    });
+    this._dirty = false;
+  };
+
+  /** Back to the defaults (Daily 06:00) with an empty read-out. */
+  ScheduleBuilder.prototype.reset = function () {
+    this.setState(defaultState());
+    this.cancelPreview();
+    this._els["when-desc-out"].textContent = "";
+    this._renderRuns([]);
+  };
+
+  /** Show a saved schedule's timing (edit mode). */
+  ScheduleBuilder.prototype.apply = function (scheduleType, cronExpr, atTime) {
+    this.setState(stateFromSaved(scheduleType, cronExpr, atTime));
+  };
+
+  ScheduleBuilder.prototype.compile = function () {
+    return compileSchedule(this.state());
+  };
+
+  /**
+   * A submit was refused on this builder's state: show the compile error
+   * as an error even if the mode was never touched.
+   */
+  ScheduleBuilder.prototype.showErrors = function () {
+    this._dirty = true;
+    this.preview();
+  };
+
+  /**
+   * Void any pending or in-flight preview (the host is hiding the builder,
+   * or its state moved on): the sequence bump makes a late response a
+   * no-op.
+   */
+  ScheduleBuilder.prototype.cancelPreview = function () {
+    if (this._previewTimer) clearTimeout(this._previewTimer);
+    this._previewTimer = null;
+    if (this._previewAbort) this._previewAbort.abort();
+    this._previewAbort = null;
+    this._previewSeq++;
+  };
+
+  /**
+   * Refresh the read-out: the description and the compiled fields render
+   * at once (and reach onChange); the next-runs list arrives from the
+   * server preview after a debounce.
+   */
+  ScheduleBuilder.prototype.preview = function () {
+    const self = this;
+    const state = this.state();
+    const descEl = this._els["when-desc-out"];
+    const desc = describeSchedule(state);
+    if (descEl.textContent !== desc) descEl.textContent = desc;
+    const compiled = compileSchedule(state);
+    if (typeof this._opts.onChange === "function")
+      this._opts.onChange(compiled);
+    this.cancelPreview();
+    const seq = this._previewSeq;
+    const kind = runsMessageKind(compiled, this._dirty);
+    if (kind) {
+      this._renderRuns([], compiled.error, kind === "hint");
+      return;
+    }
+    this._previewTimer = setTimeout(function () {
+      self._previewTimer = null;
+      const fetchFn = window.authFetch;
+      if (typeof fetchFn !== "function") {
+        self._renderRuns([], "Preview unavailable");
+        return;
+      }
+      const abort =
+        typeof AbortController === "function" ? new AbortController() : null;
+      self._previewAbort = abort;
+      fetchFn(PREVIEW_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(compiled),
+        signal: abort ? abort.signal : undefined,
+      })
+        .then(function (r) {
+          return r.json();
+        })
+        .then(function (data) {
+          if (seq !== self._previewSeq) return; // a newer edit superseded us
+          self._previewAbort = null;
+          if (!data.valid)
+            self._renderRuns([], data.error || "Invalid schedule");
+          else self._renderRuns(data.next || []);
+        })
+        .catch(function () {
+          // An aborted request was superseded (seq moved on) — silent.
+          if (seq === self._previewSeq) {
+            self._previewAbort = null;
+            self._renderRuns([], "Preview unavailable");
+          }
+        });
+    }, PREVIEW_DEBOUNCE_MS);
+  };
+
+  // `asHint` renders the message in the neutral hint style (an untouched
+  // mode that still needs input) rather than as an error.
+  ScheduleBuilder.prototype._renderRuns = function (runs, errText, asHint) {
+    const rows = this._els["when-runs-out"];
+    while (rows.firstChild) rows.removeChild(rows.firstChild);
+    if (errText) {
+      const err = document.createElement("div");
+      err.className = asHint ? "hint" : "err";
+      err.textContent = errText;
+      rows.appendChild(err);
+      return;
+    }
+    runs.forEach(function (iso) {
+      const row = document.createElement("div");
+      row.className = "readout-row";
+      const when = document.createElement("span");
+      when.textContent = formatLocal(iso);
+      const rel = document.createElement("span");
+      rel.className = "rel";
+      rel.textContent = relativeToNow(iso);
+      row.appendChild(when);
+      row.appendChild(rel);
+      rows.appendChild(row);
+    });
+  };
+
+  window.TurnstoneScheduleBuilder = {
+    ScheduleBuilder: ScheduleBuilder,
+    compileSchedule: compileSchedule,
+    describeSchedule: describeSchedule,
+    cronToScheduleMode: cronToScheduleMode,
+    stateFromSaved: stateFromSaved,
+    defaultState: defaultState,
+    scopedId: scopedId,
+    runsMessageKind: runsMessageKind,
+    utcToLocalDatetime: utcToLocalDatetime,
+    formatLocal: formatLocal,
+    relativeToNow: relativeToNow,
+  };
+})();

--- a/turnstone/console/static/style.css
+++ b/turnstone/console/static/style.css
@@ -99,6 +99,41 @@
   padding: 4px 2px 0;
 }
 
+/* Scheduled kind: the When builder between the kind toggle and the
+   composer.  Required input for this kind, so it is NOT the options tier
+   (--bg-highlight): it sits on the surface tier and wears the kind's blue
+   (the system-operation hue; magenta is the MCP surface's) — border and left
+   rule here, and the pressed segments / chips / read-out inside follow
+   through --hatch-accent (hatch.css).  The builder's
+   labels and fields take the shelf cadence from hatch.css (.when-builder);
+   only the panel and its heading live here. */
+.launcher-when {
+  --hatch-accent: var(--blue);
+  padding: 10px 12px 12px;
+  background: var(--bg-surface);
+  border: 1px solid color-mix(in srgb, var(--blue) 35%, var(--border-strong));
+  border-left: 2px solid var(--blue);
+  border-radius: var(--r-sm);
+}
+/* A heading, not another field label: the shelf's .sh-section treatment
+   (hairline rule) at the panel's own ink. */
+.launcher-when-title {
+  margin: 0 0 4px;
+  padding-bottom: 7px;
+  border-bottom: 1px solid var(--hair);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg);
+}
+/* The message row doubles as the Scheduled kind's post-submit confirmation
+   (app.js _homeShowMessage toggles the class). */
+.home-composer-error.is-ok {
+  color: var(--green);
+}
+
 /* Drag-over feedback for the home coord composer — wired by Composer's
    dragDrop option (dropClass: home-coord-drop) on the composer mount.
    Mirrors the dashed-outline affordance on coord-main so users see the

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -993,7 +993,9 @@
    cyan tool surface, the yellow operator bubbles, and the amber user turns.
    NOT magenta: that accent is reserved for the MCP surface (.scope-mcp and
    the admin scope chips); blue's other uses are admin-surface only (model
-   status dots, provider chips) and never co-render with transcript cards. */
+   status dots, provider chips) plus the dashboard launcher's Scheduled kind
+   (a scheduler-started session), and never co-render with transcript
+   cards. */
 .msg.compaction-card {
   border-left-color: var(--blue);
   background: var(--panel);

--- a/turnstone/shared_static/composer.js
+++ b/turnstone/shared_static/composer.js
@@ -19,6 +19,8 @@
  *   value           — current textarea value (getter / setter)
  *   focus()         — focus the textarea
  *   clear()         — empty the textarea + reset auto-resize
+ *   setSendLabel(label, busyLabel?) — swap the send button's labels
+ *   setAttachVisible(visible) — show / hide the attach button
  *   setBusy(b)      — toggle send/queue label, show/hide stop button,
  *                     swap placeholder if `busyPlaceholder` was set
  *   destroy()       — detach event listeners and remove DOM
@@ -306,20 +308,49 @@ Composer.prototype._buildInput = function (row, opts) {
   row.appendChild(this.inputEl);
 };
 
+// Swap the send button's idle / busy labels after construction (a launcher
+// whose kind changes what "send" means).  Mirrors the constructor's
+// busyLabel fallback and setBusy's rotation, so the label shown matches the
+// current busy state and the aria-label tracks it; a glyph send button keeps
+// its glyph (only the aria-label follows).
+// The busy label's fallback rule, shared by construction and setSendLabel:
+// "Queue" only makes sense when queueWhileBusy=true (the send button stays
+// clickable during busy to accept queued messages); non-queue consumers that
+// omit busyLabel get no label rotation, so the disabled button doesn't
+// misleadingly read "Queue" when queueing isn't supported by the caller.
+function resolveBusyLabel(idle, busyLabel, queueWhileBusy) {
+  if (busyLabel != null) return busyLabel;
+  return queueWhileBusy ? "Queue" : idle;
+}
+
+Composer.prototype.setSendLabel = function (label, busyLabel) {
+  var idle = label || "Send";
+  var busy = resolveBusyLabel(idle, busyLabel, this._opts.queueWhileBusy);
+  // Callers repeat this on every option change; skip the DOM writes when
+  // nothing moved (compare the resolved labels, not the raw arguments).
+  if (idle === this._sendLabel && busy === this._busyLabel) return;
+  this._sendLabel = idle;
+  this._busyLabel = busy;
+  var shown = this._busy ? this._busyLabel : this._sendLabel;
+  if (!this._sendGlyph) this.sendBtn.textContent = shown;
+  if (!this._opts.queueWhileBusy)
+    this.sendBtn.setAttribute("aria-label", shown + " message");
+};
+
+// Show / hide the attach button (a launcher kind that cannot carry files).
+// The button keeps its busy-managed disabled / title state while hidden;
+// no-op when attachments are disabled.
+Composer.prototype.setAttachVisible = function (visible) {
+  if (this.attachBtn) this.attachBtn.hidden = !visible;
+};
+
 Composer.prototype._buildSendButton = function (row, opts) {
   this._sendLabel = opts.sendLabel || "Send";
-  // busyLabel default is context-sensitive: "Queue" only makes sense
-  // when queueWhileBusy=true (the send button stays clickable during
-  // busy to accept queued messages).  Non-queue consumers that omit
-  // busyLabel fall back to sendLabel — no label rotation on busy —
-  // so the disabled button doesn't misleadingly read "Queue" when
-  // queueing isn't actually supported by the caller.
-  this._busyLabel =
-    opts.busyLabel != null
-      ? opts.busyLabel
-      : opts.queueWhileBusy
-        ? "Queue"
-        : this._sendLabel;
+  this._busyLabel = resolveBusyLabel(
+    this._sendLabel,
+    opts.busyLabel,
+    opts.queueWhileBusy,
+  );
   // Glyph mode (chat composers): show a send GLYPH instead of a word.  The
   // textual sendLabel stays the aria-label and drives setBusy's a11y
   // rotation, but the visible glyph is constant (setBusy never overwrites it).
@@ -822,15 +853,24 @@ Composer.prototype.setOptionChoices = function (id, choices) {
   this._refreshOptionsSummary();
 };
 
-// Update just the placeholder (first) option's text without disturbing
-// the rest of the choice list.  Callers that resolve the effective
-// default asynchronously use this to annotate the empty option with the
-// concrete alias — e.g. "Default model" → "Default model (gpt-5)".
+// Update a field's placeholder: for a select, just the placeholder (first)
+// option's text without disturbing the rest of the choice list — callers
+// that resolve the effective default asynchronously use this to annotate
+// the empty option with the concrete alias, e.g. "Default model" → "Default
+// model (gpt-5)"; for a text input, its placeholder attribute (a launcher
+// whose kind changes what an empty field means).
 Composer.prototype.setOptionPlaceholder = function (id, text) {
   var ctrl = this._optionFields && this._optionFields[id];
-  if (!ctrl || ctrl.tagName !== "SELECT") return;
-  if (ctrl.options.length === 0) return;
-  ctrl.options[0].textContent = text == null ? "" : String(text);
+  if (!ctrl) return;
+  var isSelect = ctrl.tagName === "SELECT";
+  if (isSelect && ctrl.options.length === 0) return;
+  var value = text == null ? "" : String(text);
+  // Callers repeat this on every repaint / option change; skip the write
+  // and the summary refresh when the text is already in place.
+  var current = isSelect ? ctrl.options[0].textContent : ctrl.placeholder;
+  if (current === value) return;
+  if (isSelect) ctrl.options[0].textContent = value;
+  else ctrl.placeholder = value;
   this._refreshOptionsSummary();
 };
 

--- a/turnstone/shared_static/composer_paste_text.js
+++ b/turnstone/shared_static/composer_paste_text.js
@@ -41,6 +41,13 @@ export function pasteTextToFile(text) {
   return file;
 }
 
+// True for a File this module synthesized from a paste (a consumer that
+// cannot take files returns false for it silently, keeping the text inline;
+// a real drop or picked file still deserves its refusal message).
+export function isPastedTextFile(file) {
+  return pastedTextSources.has(file);
+}
+
 export function isDuplicatePastedTextFile(file, existingFiles) {
   const source = pastedTextSources.get(file);
   if (source === undefined) return false;
@@ -54,6 +61,7 @@ export function isDuplicatePastedTextFile(file, existingFiles) {
 if (typeof window !== "undefined") {
   window.TurnstonePasteText = {
     isDuplicatePastedTextFile,
+    isPastedTextFile,
     pasteTextToFile,
   };
 }

--- a/turnstone/shared_static/hatch.css
+++ b/turnstone/shared_static/hatch.css
@@ -395,8 +395,11 @@
   border-radius: 3px;
 }
 
-/* form cadence — the .admin-modal label/input language, carried verbatim */
-.sh-body label {
+/* form cadence — the .admin-modal label/input language, carried verbatim.
+   .when-builder (the schedule "When" template) carries the same cadence
+   wherever it is mounted, so the launcher host renders it like a shelf. */
+.sh-body label,
+.when-builder label {
   display: block;
   font-family: var(--font-ui);
   font-size: 10px;
@@ -406,7 +409,8 @@
   color: var(--fg-dim);
   margin: 14px 0 5px;
 }
-.sh-body label:first-child {
+.sh-body label:first-child,
+.when-builder label:first-child {
   margin-top: 0;
 }
 /* The console's label.toggle-switch (style.css) ties with .sh-body label at
@@ -423,7 +427,10 @@
   font-weight: 500;
   color: var(--fg);
 }
+/* Monospace field: the input cadence below sets font from --field-font so
+   the class wins without a specificity contest against `font: inherit`. */
 .sh-mono {
+  --field-font: var(--font-mono);
   font-family: var(--font-mono);
 }
 .label-hint {
@@ -438,7 +445,9 @@
 }
 .sh-body input:not([type="checkbox"]):not([type="radio"]),
 .sh-body select,
-.sh-body textarea {
+.sh-body textarea,
+.when-builder input:not([type="checkbox"]):not([type="radio"]),
+.when-builder select {
   width: 100%;
   padding: 9px 12px;
   background: var(--bg);
@@ -446,21 +455,29 @@
   border-radius: var(--r-sm);
   color: var(--fg);
   font: inherit;
+  font-family: var(--field-font, inherit);
   font-size: 13px;
   transition:
     border-color 0.15s,
     box-shadow 0.15s;
 }
+/* Focus rings stay on the system --accent in every host on purpose: a focus
+   ring is a system-wide affordance, not host chrome (the launcher's builder
+   retints its pressed states through --hatch-accent, not its rings). */
 .sh-body input:focus-visible,
 .sh-body select:focus-visible,
-.sh-body textarea:focus-visible {
+.sh-body textarea:focus-visible,
+.when-builder input:focus-visible,
+.when-builder select:focus-visible {
   border-color: var(--accent);
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
 .sh-body input:disabled,
 .sh-body select:disabled,
-.sh-body textarea:disabled {
+.sh-body textarea:disabled,
+.when-builder input:disabled,
+.when-builder select:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   background: var(--bg-highlight);
@@ -468,7 +485,8 @@
   color: var(--fg-dim);
 }
 .sh-body input::placeholder,
-.sh-body textarea::placeholder {
+.sh-body textarea::placeholder,
+.when-builder input::placeholder {
   color: var(--fg-dim);
   opacity: 0.6;
 }
@@ -476,7 +494,8 @@
   resize: vertical;
   min-height: 64px;
 }
-.sh-body select {
+.sh-body select,
+.when-builder select {
   appearance: none;
   -webkit-appearance: none;
   cursor: pointer;
@@ -704,9 +723,13 @@
    Smart-input primitives — "the system already knows"
    ========================================================================== */
 
-/* segmented mode picker (compiles to the raw field) */
+/* segmented mode picker (compiles to the raw field).  Wraps rather than
+   overflowing its track in a narrow pane.  Pressed / selected states below
+   follow the host's --hatch-accent (a shelf's kind colour, the launcher's
+   blue) and tint at 15% with a same-hue ring so they read in light too. */
 .seg {
   display: flex;
+  flex-wrap: wrap;
   background: var(--bg);
   border: 1px solid var(--border-strong);
   border-radius: var(--r-sm);
@@ -734,8 +757,14 @@
   color: var(--fg);
 }
 .seg button[aria-pressed="true"] {
-  background: var(--accent-dim);
-  color: var(--accent);
+  background: color-mix(
+    in srgb,
+    var(--hatch-accent, var(--accent)) 15%,
+    transparent
+  );
+  color: var(--hatch-accent, var(--accent));
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--hatch-accent, var(--accent)) 45%, transparent);
   font-weight: 600;
 }
 .seg button:focus-visible {
@@ -767,9 +796,13 @@
     color 0.12s;
 }
 .chips button[aria-pressed="true"] {
-  background: var(--accent-dim);
-  border-color: var(--accent);
-  color: var(--accent);
+  background: color-mix(
+    in srgb,
+    var(--hatch-accent, var(--accent)) 15%,
+    transparent
+  );
+  border-color: var(--hatch-accent, var(--accent));
+  color: var(--hatch-accent, var(--accent));
 }
 .chips button:focus-visible {
   outline: 2px solid var(--accent);
@@ -814,7 +847,7 @@
   flex: 1;
   text-align: right;
   font-size: 11.5px;
-  color: var(--accent);
+  color: var(--hatch-accent, var(--accent));
   font-weight: 600;
 }
 .readout-rows {
@@ -832,11 +865,16 @@
 .readout-row .rel {
   color: var(--ink-4);
 }
-.readout-rows .err {
+.readout-rows .err,
+.readout-rows .hint {
   color: var(--red);
   font-family: var(--font-ui);
   font-size: 11.5px;
   padding: 4px 0;
+}
+/* an untouched mode that still needs input — a prompt, not a failure */
+.readout-rows .hint {
+  color: var(--fg-dim);
 }
 [data-theme="light"] .readout-label,
 [data-theme="light"] .readout-row .rel {

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -1052,16 +1052,20 @@
   outline-offset: -2px;
 }
 
-/* ===== Dashboard session launcher — kind toggle (coordinator | interactive).
-   A console-dashboard control; lives here because the L-shell loads shell.css.
+/* ===== Dashboard session launcher — kind toggle
+   (coordinator | interactive | scheduled).  A console-dashboard control;
+   lives here because the L-shell loads shell.css.
 
    The active option wears its KIND, not a neutral highlight: amber for
    coordinator, cyan for interactive — the same vocabulary as the pane-head
-   .ptag chips and the rail's session rows, so "which kind am I starting"
-   reads at a glance.  Tints are 15% (sub-0.10 washes out at chip size) and
-   colour is never alone: the kind LED + label weight carry the state too. */
+   .ptag chips and the rail's session rows — and blue for scheduled (the
+   system-operation hue: the scheduler starts it; magenta is reserved for
+   the MCP surface), so "which kind am I starting" reads at a glance.  Tints
+   are 15% (sub-0.10 washes out at chip size) and colour is never alone: the
+   kind LED + label weight carry the state too. */
 .launcher-kinds {
   display: inline-flex;
+  flex-wrap: wrap; /* three kinds outgrow a narrow split pane — wrap, not clip */
   gap: 2px;
   margin-bottom: 10px;
   padding: 3px;
@@ -1072,6 +1076,7 @@
 .kind-btn {
   display: inline-flex;
   align-items: center;
+  min-width: 0;
   gap: 7px;
   padding: 5px 14px;
   border: 0;
@@ -1123,6 +1128,15 @@
   background: var(--cyan);
   opacity: 1;
   box-shadow: 0 0 6px var(--cyan-glow);
+}
+.kind-btn--sched.active {
+  background: color-mix(in srgb, var(--blue) 15%, transparent);
+  color: var(--blue);
+}
+.kind-btn--sched.active .kind-led {
+  background: var(--blue);
+  opacity: 1;
+  box-shadow: 0 0 6px var(--blue-glow);
 }
 /* kind tag in the saved-sessions table — shares the rail chip base
    (.row .tag above); only no-wrap + the INT colour differ. */


### PR DESCRIPTION
The launcher's kind toggle gains Scheduled next to Coordinator and
Interactive, shown to callers with admin.schedules. It takes the
interactive field set (persona from the interactive shelf, name, skill,
model, project, node placement) and a When block between the toggle and
the composer with Daily / Weekly / Monthly / Interval / Once / Cron modes
and a live next-runs read-out. Submitting stores the schedule through the
existing create endpoint; nothing opens, so a persistent confirmation in
the launcher's message row names the first run and where the schedule is
managed. A typed Name is optional and derives from the task's first line.
Judge model and attachments do not apply to a schedule and are hidden.

The admin shelf's Runs builder is extracted into schedule_builder.js and
its markup into one template that each instance clones with scoped ids,
so the shelf and the launcher share one timing builder. Along the way the
builder gained: the interval bound as one predicate shared by compile,
reverse-parse and the read-out (a saved out-of-range cron opens in Cron
mode unchanged instead of being refused); whole-number steps; an untouched
mode shows its gap as a hint until edited or refused; next runs and the
confirmation render in the browser's local zone; a superseded preview is
aborted, not just ignored. The shelf's NEXT RUN column now converts the
server's UTC time to local time instead of relabelling it, and its name
and message inputs carry the server's caps, which the server now names.

The shared composer gains setSendLabel and setAttachVisible, and its
setOptionPlaceholder handles text inputs; the paste helper exports
isPastedTextFile so a large paste stays inline in a kind that carries no
files. Blue is the Scheduled colour: magenta is the MCP surface's.

Tests: node-driven cases for the builder's pure helpers and the launcher's
derived-name, cap and arrow-cycle helpers; structural pins for the kind
registry, the template's id contract, and the shelf's use of the shared
builder; server cap cross-checks.

Closes #1090.

## Follow-ups

- #1091 evaluates recurring crons in the operator's zone (needs a migration); recurring inputs stay UTC here, with the read-out and confirmation in local time.
- #1092 lifts the light-theme contrast of the launcher's kind labels (token-level, affects all three kinds).
