### PR TITLE
fix(theme): darker light-theme indicator hues for AA text on tints (#1092, #1094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,15 @@ frozen.
 
 ### Changed
 
-- **Darker amber, cyan and blue in the light theme (#1092).** The launcher's
-  active kind label is drawn in its kind's hue over a tint of the same hue,
-  and in the light theme that sat just under the 4.5:1 text-contrast
-  threshold; the skill shelf's origin badge had the same pairing in cyan.
-  The light-theme amber, cyan and blue tokens now run one step darker,
-  which clears the threshold with room to spare and deepens every other
-  light-theme chip, badge and button that uses those hues by the same
-  step. The dark theme is unchanged.
+- **Darker indicator hues in the light theme (#1092, #1094).** The
+  launcher's active kind label is drawn in its kind's hue over a tint of
+  the same hue, and in the light theme that sat just under the 4.5:1
+  text-contrast threshold; the skill shelf's origin badge had the same
+  pairing in cyan. The light theme's amber, cyan, blue, green, red,
+  yellow, magenta and two channel accents now run one step darker, which
+  clears the threshold with room to spare, keeps that family at one tier,
+  and deepens every light-theme chip, badge and button that uses those
+  hues by the same step. The dark theme is unchanged.
 
 ## [1.8.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ frozen.
   run in the browser's local zone, and the shelf's NEXT RUN column now
   converts the server's UTC time to local time instead of relabelling it.
 
+### Changed
+
+- **Darker amber, cyan and blue in the light theme (#1092).** The launcher's
+  active kind label is drawn in its kind's hue over a tint of the same hue,
+  and in the light theme that sat just under the 4.5:1 text-contrast
+  threshold; the skill shelf's origin badge had the same pairing in cyan.
+  The light-theme amber, cyan and blue tokens now run one step darker,
+  which clears the threshold with room to spare and deepens every other
+  light-theme chip, badge and button that uses those hues by the same
+  step. The dark theme is unchanged.
+
 ## [1.8.2]
 
 Turnstone 1.8.2 moves model endpoints entirely into model definitions and

--- a/turnstone/shared_static/base.css
+++ b/turnstone/shared_static/base.css
@@ -29,6 +29,10 @@
   --accent: #e5a042;
   --accent-dim: rgba(229, 160, 66, 0.15);
   --accent-glow: rgba(229, 160, 66, 0.08);
+  /* Far stop of the rail's brand-mark gradient: a step below the accent
+     here, a step above it in the light theme, so the mark keeps the same
+     shading depth on both. */
+  --brand-mark-end: #b9762a;
 
   /* Semantic indicators */
   --green: #34d399;
@@ -134,25 +138,34 @@
   --fg: #1e293b;
   --fg-dim: #576275;
   --fg-bright: #0f172a;
-  --accent: #8c5e1b;
-  --accent-dim: rgba(140, 94, 27, 0.1);
-  --accent-glow: rgba(140, 94, 27, 0.05);
+  /* The amber, cyan and blue run one step darker than the first light cut
+     (#8c5e1b / #0e7490 / #0369a1): text in the hue over a 15% tint of the
+     same hue — the launcher's active kind at 12px, the skill shelf's
+     origin badge at 9px — has to clear the 4.5:1 text ratio on --bg and
+     --panel, and the lighter cut landed at 4.07–4.45.  The amber keeps the
+     brand's saturation at the lower lightness but sits at hue 40 rather
+     than 35 so it still reads gold at that depth instead of brown.  Each
+     of the three carries its triplet into its rgba siblings below. */
+  --accent: #745415;
+  --accent-dim: rgba(116, 84, 21, 0.1);
+  --accent-glow: rgba(116, 84, 21, 0.05);
+  --brand-mark-end: #9f731d;
   --green: #047857;
   --red: #b91c1c;
   --yellow: #b45309;
-  --cyan: #0e7490;
+  --cyan: #155e75;
   --magenta: #7c3aed;
-  --blue: #0369a1;
+  --blue: #075985;
   --discord: #4f46e5; /* darker indigo on white surface — passes WCAG AA */
   --slack: #be185d; /* darker rose */
   --on-color: #ffffff;
   --green-glow: rgba(4, 120, 87, 0.25);
   --red-glow: rgba(220, 38, 38, 0.25);
   --yellow-glow: rgba(180, 83, 9, 0.25);
-  --accent-glow-strong: rgba(140, 94, 27, 0.15);
-  --cyan-glow: rgba(14, 116, 144, 0.2);
+  --accent-glow-strong: rgba(116, 84, 21, 0.15);
+  --cyan-glow: rgba(21, 94, 117, 0.2);
   --magenta-glow: rgba(124, 58, 237, 0.2);
-  --blue-glow: rgba(3, 105, 161, 0.2);
+  --blue-glow: rgba(7, 89, 133, 0.2);
   --discord-glow: rgba(79, 70, 229, 0.2);
   --slack-glow: rgba(190, 24, 93, 0.2);
   --border: rgba(0, 0, 0, 0.08);

--- a/turnstone/shared_static/base.css
+++ b/turnstone/shared_static/base.css
@@ -138,36 +138,40 @@
   --fg: #1e293b;
   --fg-dim: #576275;
   --fg-bright: #0f172a;
-  /* The amber, cyan and blue run one step darker than the first light cut
-     (#8c5e1b / #0e7490 / #0369a1): text in the hue over a 15% tint of the
-     same hue — the launcher's active kind at 12px, the skill shelf's
-     origin badge at 9px — has to clear the 4.5:1 text ratio on --bg and
-     --panel, and the lighter cut landed at 4.07–4.45.  The amber keeps the
-     brand's saturation at the lower lightness but sits at hue 40 rather
-     than 35 so it still reads gold at that depth instead of brown.  Each
-     of the three carries its triplet into its rgba siblings below. */
+  /* The indicator hues run one step darker than the first light cut: text
+     in a hue over a 15% tint of the same hue — the launcher's active kind
+     at 12px, the skill shelf's origin badge at 9px — has to clear the
+     4.5:1 text ratio on --bg and --panel, and the first cut landed
+     between 3.8 and 4.7 with seven of the nine under 4.5.  Amber, cyan
+     and blue moved first; the rest followed so the family stays one tier.  The amber keeps the brand's saturation at the
+     lower lightness but sits at hue 40 rather than 35 so it still reads
+     gold at that depth instead of brown.  Each hue carries its triplet
+     into its rgba glow sibling below. */
   --accent: #745415;
   --accent-dim: rgba(116, 84, 21, 0.1);
   --accent-glow: rgba(116, 84, 21, 0.05);
   --brand-mark-end: #9f731d;
-  --green: #047857;
-  --red: #b91c1c;
-  --yellow: #b45309;
+  --green: #065f46;
+  --red: #991b1b;
+  --yellow: #92400e;
   --cyan: #155e75;
-  --magenta: #7c3aed;
+  --magenta: #6d28d9;
   --blue: #075985;
-  --discord: #4f46e5; /* darker indigo on white surface — passes WCAG AA */
-  --slack: #be185d; /* darker rose */
+  --discord: #4338ca; /* darker indigo on white surface — passes WCAG AA */
+  --slack: #9d174d; /* darker rose */
   --on-color: #ffffff;
-  --green-glow: rgba(4, 120, 87, 0.25);
-  --red-glow: rgba(220, 38, 38, 0.25);
-  --yellow-glow: rgba(180, 83, 9, 0.25);
+  --green-glow: rgba(6, 95, 70, 0.25);
+  --red-glow: rgba(153, 27, 27, 0.25);
+  /* 0.2, not the 0.25 of its siblings: --yellow text sits on this glow
+     (.dash-persistence-badge, .policy-ask) and clears 4.5:1 only below
+     0.25. */
+  --yellow-glow: rgba(146, 64, 14, 0.2);
   --accent-glow-strong: rgba(116, 84, 21, 0.15);
   --cyan-glow: rgba(21, 94, 117, 0.2);
-  --magenta-glow: rgba(124, 58, 237, 0.2);
+  --magenta-glow: rgba(109, 40, 217, 0.2);
   --blue-glow: rgba(7, 89, 133, 0.2);
-  --discord-glow: rgba(79, 70, 229, 0.2);
-  --slack-glow: rgba(190, 24, 93, 0.2);
+  --discord-glow: rgba(67, 56, 202, 0.2);
+  --slack-glow: rgba(157, 23, 77, 0.2);
   --border: rgba(0, 0, 0, 0.08);
   --border-strong: rgba(0, 0, 0, 0.12);
   --code-bg: #f0f1f5;

--- a/turnstone/shared_static/cards.css
+++ b/turnstone/shared_static/cards.css
@@ -112,8 +112,8 @@
   /* Dark-theme --red (#f87171) on #fff is only 3.0:1 — below WCAG AA
      for normal text on a destructive button.  Use the deeper red
      (#dc2626 → 4.85:1) on the filled state so the button label clears
-     AA in the default theme. Light theme already uses --red (#b91c1c,
-     5.9:1) and stays put — the override below pins it. */
+     AA in the default theme. Light theme uses --red (#991b1b,
+     8.3:1) and stays put — the override below pins it. */
   background: #dc2626;
   color: #fff;
   border: none;
@@ -438,5 +438,5 @@
   background: rgba(248, 113, 113, 0.08);
 }
 [data-theme="light"] .dash-row.ws-selected {
-  background: rgba(220, 38, 38, 0.08);
+  background: color-mix(in srgb, var(--red) 8%, transparent);
 }

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -1527,10 +1527,10 @@
   border-left: 2px solid var(--green);
 }
 [data-theme="light"] .hljs-addition {
-  background: rgba(4, 120, 87, 0.06);
+  background: color-mix(in srgb, var(--green) 6%, transparent);
 }
 [data-theme="light"] .hljs-deletion {
-  background: rgba(220, 38, 38, 0.06);
+  background: color-mix(in srgb, var(--red) 6%, transparent);
 }
 
 /* KaTeX math wrappers — shared for the same reason as the hljs theme above:

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -47,7 +47,7 @@
   width: 18px;
   height: 18px;
   border-radius: 5px;
-  background: linear-gradient(135deg, var(--accent), #b9762a);
+  background: linear-gradient(135deg, var(--accent), var(--brand-mark-end));
   box-shadow: 0 0 10px var(--accent-glow-strong);
   flex: none;
 }
@@ -962,8 +962,8 @@
   bottom: 2px;
   height: 2px;
   border-radius: 2px;
-  /* 80%: 55% composited to 2.34:1 on the light --panel (sub-3:1 for a
-     load-bearing state mark); 80% = ~3.7:1 light / ~5:1 dark */
+  /* 80%: 55% composited to ~2.5:1 on the light --panel (sub-3:1 for a
+     load-bearing state mark); 80% = ~4.3:1 light / ~5.5:1 dark */
   background: color-mix(in srgb, var(--accent) 80%, transparent);
 }
 .pane-head {
@@ -1062,7 +1062,9 @@
    system-operation hue: the scheduler starts it; magenta is reserved for
    the MCP surface), so "which kind am I starting" reads at a glance.  Tints
    are 15% (sub-0.10 washes out at chip size) and colour is never alone: the
-   kind LED + label weight carry the state too. */
+   kind LED + label weight carry the state too.  The light-theme --accent /
+   --cyan / --blue (base.css) are cut dark enough that the label clears
+   4.5:1 on its tint; measure again before lightening them. */
 .launcher-kinds {
   display: inline-flex;
   flex-wrap: wrap; /* three kinds outgrow a narrow split pane — wrap, not clip */


### PR DESCRIPTION
Closes #1092. Closes #1094.

## Darken the light-theme amber, cyan and blue for AA text on tints (#1092)

The console launcher's active kind label is drawn in its kind's hue over a 15% tint of the same hue. In the light theme that landed at 4.29:1 (amber), 4.07:1 (cyan) and 4.45:1 (blue) for 12px semibold text, under the 4.5:1 text threshold; the skill shelf's origin badge had the same cyan pairing at 9px. Thinning the tint to 8% still leaves cyan at 4.49 and breaks the chip-tint floor, so the fix is in the tokens.

The light-theme `--accent`, `--cyan` and `--blue` run one step darker (`#745415` / `#155e75` / `#075985`), which puts the launcher labels at 5.2 to 5.6:1 on the tint over `--bg` and 5.6 to 6.0:1 over `--panel`. The amber keeps the brand's saturation at the lower lightness but sits at hue 40 rather than 35 so it still reads gold at that depth instead of brown. Each rgba sibling carries its hue's new triplet.

The rail's brand mark blended `var(--accent)` into a literal `#b9762a`, which sat below the dark accent and above the old light one; with the deeper light accent the mark read two-tone. The far stop is now the per-theme `--brand-mark-end` token, so the mark keeps the same shading depth on both themes and the dark theme renders exactly as before. The pane-head state bar's measured-contrast comment is refreshed for the new accent.

## Bring the remaining light-theme indicator hues to the same tier (#1094)

After the amber, cyan and blue moved one step darker, the light palette sat in two tiers: those three around 6.5 to 7:1 on `--bg`, the untouched green, red, yellow, magenta and the two channel accents a visible step lighter (4.7 to 6.0), so a coordinator chip beside a green status chip no longer read as one family. Every hue in that family now takes the same one-step move (`#065f46` / `#991b1b` / `#92400e` / `#6d28d9` / `#4338ca` / `#9d174d`), which lands plain text at 6.6 to 7.7:1 on `--bg` and text over a 15% tint of its own hue at 5.2 to 6.0:1.

Each rgba glow sibling carries its hue's triplet; `--red-glow` had been carrying a brighter red than `--red` and is aligned. The light yellow glow drops to 0.2 alpha because `--yellow` text sits directly on it in the persistence badge and the policy-ask chip, and at 0.25 the pairing stays under 4.5:1 on `--bg`.

Three light-scoped rules that hardcoded rgba copies of the old red and green at 6 to 8% alpha (the selected dashboard row, hljs addition and deletion lines) now mix the token at the same alpha, so they follow the palette instead of drifting from it.

## Verification

- WCAG ratios measured from the committed token values for every hue: plain on `--bg`, over its own 15% tint on `--bg` and `--panel`, white on the fill, and the 25% glow pairings.
- Light and dark headless renders of the launcher toggle, the brand mark, and all nine hues as tinted chips, filled pills and plain text; dark theme byte-identical.
- `scripts/css_specificity_audit.py` reports the same findings as `main`, differing only in line numbers.
- Two designer-review rounds; every verified finding is folded in.
- CSS-reading test modules pass (367 tests).
