### PR TITLE
fix(channels): preserve conversations across restarts and idle timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
-      - run: pip install -e ".[test]"
+      - run: pip install -e ".[test,discord]"
       # -v lists each test id as it starts (pytest prints the nodeid at
       # logstart), so a hang names the culprit on the last line instead of
       # riding the job timeout with only a trail of "..." dots.
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
-      - run: pip install -e ".[test]"
+      - run: pip install -e ".[test,discord]"
       - run: pytest tests/ -m "not live and not e2e_recovery" --storage-backend=postgresql -v
         env:
           TURNSTONE_TEST_PG_URL: postgresql+psycopg://postgres:postgres@localhost:5432/turnstone_test

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1332,6 +1332,7 @@ An absent or malformed JSON body returns `400`.
 | `auto_approve_tools` | string/array | `""` | Tool names to auto-approve even when `auto_approve` is false; accepts comma-separated text or an array |
 | `user_id`         | string        | `""`  | Owner override honored only for a trusted `console` service identity carrying the `service` scope; ordinary callers remain bound to their authenticated identity |
 | `resume_ws`       | string        | `""`    | Source workstream ID or alias to fork atomically into this new ID |
+| `resume_ws_exact` | bool          | false   | Require `resume_ws` to match an exact source ID; never resolve an alias or prefix |
 | `skill`           | string        | `""`    | Skill name. Applies its system prompt and session configuration. Returns 400 if missing/disabled; ignored for a fork because the source configuration is cloned. |
 | `persona`         | string        | `""`    | Persona slug; empty selects the kind's default. A fork keeps the source persona. |
 | `judge_model`     | string        | `""`    | Optional judge model alias                                     |
@@ -1341,6 +1342,10 @@ An absent or malformed JSON body returns `400`.
 | `notify_targets`  | string/array  | `[]`    | Completion-notification targets                                |
 | `client_type`     | string        | `web`   | Client surface label (`web`, `cli`, `chat`, or `scheduled`)    |
 | `parent_ws_id`    | string/null   | none    | Owning coordinator ID for a coordinator-spawned child          |
+
+A deleted workstream ID remains reserved while a channel route references it.
+Creating a new workstream with that ID returns `409`; channel recovery forks or
+starts a conversation under a new ID before updating the association.
 
 > **Skill behavior:** When `skill` is specified, the skill's content is injected as a system message and its session config fields (model, temperature, auto-approve, token budget, etc.) override system defaults for the new workstream.
 
@@ -1352,6 +1357,11 @@ the source's checkpoint-bounded conversation, saved session configuration,
 persona, effective project, and attachment references. The source remains
 unchanged. Use `POST .../{ws_id}/open` when you want to rehydrate the original
 ID instead.
+
+Set `resume_ws_exact: true` when recovering a stored canonical ID. A missing
+exact source returns `404` even if another workstream has that ID as its alias.
+The console preserves this requirement after resolving an ordinary alias, so
+the node cannot substitute another source if the original disappears in transit.
 
 The clone transaction rechecks source visibility, private-project membership
 and attachability, persona/project construction context, destination ownership
@@ -2821,6 +2831,7 @@ the ordinary create fields plus `target_node`:
 |-------|------------------|
 | `ws_id` | Optional 32-hex destination. When present, it is preserved and used as the rendezvous key, including on a fork. A 503 never replaces a caller-selected ID. |
 | `resume_ws` | Optional source ID or saved alias for an atomic fork. The console resolves aliases to the canonical source ID before routing and forwards that canonical value. When no destination `ws_id` is supplied, the source is the placement key. |
+| `resume_ws_exact` | Optional boolean, default false. Requires an exact source ID in `resume_ws`; disables alias and prefix resolution. |
 | `target_node` | Optional node ID hint. When neither `ws_id` nor `resume_ws` selects placement, the console generates a destination whose rendezvous owner is this live node. |
 
 Without any placement field, the console generates a destination ID and routes

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -41,9 +41,9 @@ Key components:
   creation via HTTP, stale route detection, and user identity resolution.
 - **channel_users table** — maps `(channel_type, channel_user_id)` to a
   turnstone `user_id`. Messages from unlinked users are silently dropped.
-- **channel_routes table** — persistent channel-to-workstream mappings.
-  Survives bot restarts. Stale routes (evicted workstreams) are detected
-  and refreshed on the next message.
+- **channel_routes table** — persistent channel-to-workstream mappings, including the Discord user
+  who started the conversation. The association and owner survive node and bot restarts. Recovery
+  runs on the next authorized message.
 
 ---
 
@@ -195,17 +195,37 @@ both and the gateway hosts both adapters in one process.
 - All subsequent messages in the thread are routed to the same workstream.
 - The bot streams responses via message edits, updated approximately every
   1.5 seconds.
-- If a persisted channel route is no longer active on its owning node, the
-  router asks the create endpoint to fork the old workstream into a new ID via
-  `resume_ws`. The saved source can still resolve normally; its
-  checkpoint-bounded history, configuration, persona, effective project, and
-  attachment references are cloned before the channel route is repointed. The
-  old route remains durable until the replacement (and any initial message)
-  succeeds. If the create endpoint returns the ordinary
-  source-not-found response *and* a fresh authoritative storage lookup confirms
-  that the source is gone, the router retries once without `resume_ws` and
-  starts a fresh conversation. Other access, conflict, routing, and storage
-  failures remain visible rather than silently discarding history.
+- If a persisted channel route is no longer active on its owning node, the router asks the create
+  endpoint to fork the old workstream into a new ID via `resume_ws`. The saved source can still
+  resolve normally; its checkpoint-bounded history, configuration, persona, effective project, and
+  attachment references are cloned before the channel route is repointed. The old route remains
+  durable until the replacement succeeds. The router swaps the mapping atomically, preserving its
+  owner; concurrent recovery cannot overwrite another replacement. Initial messages are sent only
+  after the route is claimed. If the create endpoint returns the ordinary source-not-found response
+  *and* a fresh authoritative storage lookup confirms that the source is gone, the router retries
+  once without `resume_ws` and starts a fresh conversation. Other access, conflict, routing, and
+  storage failures remain visible rather than silently discarding history.
+- Recovery uses the exact saved workstream ID; another conversation's alias cannot replace it.
+  A deleted ID also remains reserved while a channel route references it, preventing a new
+  workstream from receiving that channel's messages under the old identity.
+- A missing SSE session stops that subscription without deleting the conversation's route. Discord
+  thread replies, Slack thread replies, and Slack DMs all check the saved association before sending
+  the next message and restore their subscription. With a console, each SSE connection resolves the
+  current node address; console errors trigger retries rather than a fallback to the configured node.
+- Routes do not expire merely because a node is unavailable. An explicit close removes a route only
+  after the node confirms closure (or reports no loaded session), and only if the route still names
+  that workstream. A refused close or concurrent replacement retains the association and reports a
+  retryable failure.
+- Discord recovers uncached threads through the platform API. Missing or inaccessible threads retain
+  their saved routes. Only the original linked invoker may send follow-ups or close the workstream;
+  approval prompts also identify that invoker, including for bot-owned `/ask` threads.
+- Startup recovery subscribes only to already-live workstreams. Direct mode reads the active list
+  once; console mode limits both concurrent liveness probes and the total discovery time. Inactive
+  and temporarily unreachable conversations keep their associations for lazy recovery on a message.
+- `/close` acknowledges privately and archives the thread after confirmed closure.
+- Older Discord routes lack a saved invoker. The bot creates these threads, so Discord's platform
+  owner cannot identify the human who started them. Start a new conversation with `/ask` in the
+  parent channel. Linking an account does not grant ownership of an older thread.
 
 ### Slash Commands
 
@@ -288,8 +308,9 @@ See [Security: Database Schema](security.md#database-schema) for the
    `channel_routes` table.
 2. **Active** — messages are routed bidirectionally. The bot streams
    responses via message edits (updated every ~1.5 seconds).
-3. **Eviction** — the server evicts an idle workstream for capacity. Its saved
-   source row and channel route remain durable, and the thread stays open.
+3. **Unavailability** — a node restart or capacity eviction can unload a workstream. Its saved source
+   and channel association remain durable. An SSE 404 clears only the listener's transient state;
+   a connection error reconnects with backoff.
 4. **Reactivation** — the next message resolves the saved route and probes
    whether that workstream is live on its owning node. If it is not, the router
    creates a distinct workstream with the old `ws_id` as `resume_ws`. The

--- a/docs/diagrams/16-channel-architecture.puml
+++ b/docs/diagrams/16-channel-architecture.puml
@@ -86,13 +86,13 @@ class "ChannelRouter" as Router <<service>> {
     +_is_ws_live(ws_id)
     +send_message(ws_id, message)
     +send_approval(ws_id, ...)
-    +lookup_ws_id(channel_type, channel_id)
     +resolve_user(channel_type, channel_user_id)
         -> user_id | None
     --
     Maps channels -> workstreams
     Maps platform users -> turnstone users
-    Caches routes in memory
+    Conditionally replaces durable routes
+    Resolves SSE destination on reconnect
 }
 
 class "turnstone-console router" as ConsoleRouter <<server>> {
@@ -136,6 +136,7 @@ class "channel_routes" as CR <<storage>> {
     channel_id (PK)
     ws_id
     node_id
+    channel_user_id: external owner
     created
     --
     Maps platform channels

--- a/docs/diagrams/png/16-channel-architecture.png
+++ b/docs/diagrams/png/16-channel-architecture.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:edf02b97e1e1287ebba9e74b9858474dcda42e5542656e505ea133a5b2416f47
-size 402992
+oid sha256:a0ac60dc804e980943de34d0707bbe75f5d0e3ca28e7c701ea0d5b84b525103f
+size 436673

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -15099,6 +15099,12 @@
             "title": "Resume Ws",
             "type": "string"
           },
+          "resume_ws_exact": {
+            "default": false,
+            "description": "Require an exact source ID in resume_ws; disable alias and prefix resolution",
+            "title": "Resume Ws Exact",
+            "type": "boolean"
+          },
           "skill": {
             "default": "",
             "description": "Skill name (replaces default skills)",

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "turnstone Server API",
-    "version": "1.8.0a7",
+    "version": "1.8.2",
     "description": "Single-node workstream management, chat interaction, and real-time streaming."
   },
   "paths": {
@@ -2967,6 +2967,12 @@
             "description": "Source workstream ID or alias to fork atomically into the new workstream (empty = fresh start)",
             "title": "Resume Ws",
             "type": "string"
+          },
+          "resume_ws_exact": {
+            "default": false,
+            "description": "Require an exact source ID in resume_ws; disable alias and prefix resolution",
+            "title": "Resume Ws Exact",
+            "type": "boolean"
           },
           "skill": {
             "default": "",

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -169,6 +169,8 @@ export interface CreateWorkstreamRequest {
    */
   user_id?: string;
   resume_ws?: string;
+  /** Require an exact source ID; disable alias and prefix resolution. */
+  resume_ws_exact?: boolean;
   /** Completion-notification targets as JSON text or structured target objects. */
   notify_targets?: string | Array<Record<string, string>>;
   /** Client surface label such as web, cli, chat, or scheduled. */

--- a/tests/test_channel_discord.py
+++ b/tests/test_channel_discord.py
@@ -76,6 +76,8 @@ def _make_interaction(*, footer_text=None, has_embeds=True):
     interaction.user.id = 67890
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
 
     if has_embeds and footer_text is not None:
         embed = MagicMock()
@@ -400,6 +402,14 @@ class TestAskModelSelection:
 
         _, kwargs = ts.router.get_or_create_workstream.call_args
         assert kwargs["model"] == "explicit-model"
+        assert kwargs["channel_user_id"] == "67890"
+
+    def test_disallowed_channel_cannot_start_conversation(self):
+        cog, ts, interaction = self._make_cog_and_interaction()
+        ts._is_allowed_channel.return_value = False
+        _run(cog._cmd_ask(interaction, "hello"))
+        interaction.channel.create_thread.assert_not_awaited()
+        ts.router.get_or_create_workstream.assert_not_awaited()
 
     def test_channel_default_used_when_no_explicit_model(self):
         cog, ts, interaction = self._make_cog_and_interaction()
@@ -574,7 +584,8 @@ class TestApprovalVerdictDisplay:
         bot.config.streaming_edit_interval = 1.5
         bot.config.auto_approve = False
         bot.config.auto_approve_tools = []
-        bot.storage = None
+        bot.storage = MagicMock()
+        bot.storage.get_channel_route_by_ws.return_value = None
         bot._streaming = {}
         bot._thinking_msgs = {}
         bot._tool_info_msgs = {}
@@ -644,6 +655,21 @@ class TestApprovalVerdictDisplay:
         embed = call_kwargs["embed"]
         # No verdict field added
         assert len(embed.fields) == 0
+
+    def test_approval_uses_persisted_invoker_for_bot_owned_thread(self):
+        from turnstone.sdk.events import ApproveRequestEvent
+
+        bot = self._make_bot()
+        bot.storage.get_channel_route_by_ws.return_value = {"channel_user_id": "111"}
+        thread = AsyncMock()
+        thread.owner_id = 99999
+        event = ApproveRequestEvent(
+            ws_id="ws-1",
+            cycle_id="cycle",
+            items=[{"func_name": "bash", "needs_approval": True, "preview": "pwd"}],
+        )
+        _run(bot._on_ws_event("ws-1", thread, event))
+        assert thread.send.call_args.kwargs["embed"].footer.text == "ws-1|cycle|111"
 
     def test_intent_verdict_event_updates_embed(self):
         """IntentVerdictEvent should update the pending approval embed."""
@@ -1368,7 +1394,8 @@ class TestThinkingIndicator:
         bot.config.streaming_edit_interval = 1.5
         bot.config.auto_approve = False
         bot.config.auto_approve_tools = []
-        bot.storage = None
+        bot.storage = MagicMock()
+        bot.storage.get_channel_route_by_ws.return_value = None
         bot._streaming = {}
         bot._thinking_msgs = {}
         bot._tool_info_msgs = {}
@@ -1468,7 +1495,8 @@ class TestToolInfoEvent:
         bot.config.streaming_edit_interval = 1.5
         bot.config.auto_approve = False
         bot.config.auto_approve_tools = []
-        bot.storage = None
+        bot.storage = MagicMock()
+        bot.storage.get_channel_route_by_ws.return_value = None
         bot._streaming = {}
         bot._thinking_msgs = {}
         bot._tool_info_msgs = {}
@@ -1562,7 +1590,8 @@ class TestToolResultEvent:
         bot.config.streaming_edit_interval = 1.5
         bot.config.auto_approve = False
         bot.config.auto_approve_tools = []
-        bot.storage = None
+        bot.storage = MagicMock()
+        bot.storage.get_channel_route_by_ws.return_value = None
         bot._streaming = {}
         bot._thinking_msgs = {}
         bot._tool_info_msgs = {}
@@ -1718,7 +1747,8 @@ class TestApprovalResolved:
         bot.config.streaming_edit_interval = 1.5
         bot.config.auto_approve = False
         bot.config.auto_approve_tools = []
-        bot.storage = None
+        bot.storage = MagicMock()
+        bot.storage.get_channel_route_by_ws.return_value = None
         bot._streaming = {}
         bot._thinking_msgs = {}
         bot._tool_info_msgs = {}
@@ -1915,7 +1945,6 @@ class TestDiscordThreadOwnerCheck:
         ts._is_allowed_channel = MagicMock(return_value=True)
         ts.storage = MagicMock()
         ts.router = MagicMock()
-        ts.router.lookup_ws_id = AsyncMock(return_value="ws-1")
         ts.router.resolve_user = AsyncMock(return_value="turnstone-user-1")
         ts.router.send_message = AsyncMock()
         ts.router.get_or_create_workstream = AsyncMock(return_value=("ws-1", False))
@@ -1924,7 +1953,7 @@ class TestDiscordThreadOwnerCheck:
         ts._subscribed_ws = {"ws-1"}
         ts._notify_ws_map = {}
         ts._notify_reply_channels = {}
-        ts.get_thread_invoker = MagicMock(return_value=None)
+        ts.storage.get_channel_route.return_value = {"ws_id": "ws-1", "channel_user_id": "111"}
         ts.subscribe_ws = AsyncMock()
         bot.turnstone = ts
 
@@ -1950,12 +1979,71 @@ class TestDiscordThreadOwnerCheck:
         ts.router.send_message.assert_not_awaited()
         ts.router.get_or_create_workstream.assert_not_awaited()
 
+    @pytest.mark.parametrize("owner_id", [111, 99999, None])
+    def test_legacy_route_requires_starting_a_new_conversation(self, owner_id):
+        cog, ts = self._make_cog_and_ts()
+        ts.storage.get_channel_route.return_value["channel_user_id"] = ""
+        thread = MagicMock(spec=discord.Thread)
+        thread.id, thread.parent_id, thread.name = 555, 222, "legacy"
+        thread.owner_id = owner_id
+        thread.send = AsyncMock()
+        msg = _make_message(guild=True, channel=thread)
+        msg.author.id = 111
+        _run(cog._on_message(msg))
+        ts.router.get_or_create_workstream.assert_not_awaited()
+        ts.router.send_message.assert_not_awaited()
+        assert "`/ask` in the parent channel" in thread.send.call_args.args[0]
+
+    @pytest.mark.parametrize(
+        ("actor", "linked", "allowed"),
+        [
+            (111, True, True),
+            (222, True, False),
+            (111, False, False),
+        ],
+    )
+    def test_close_uses_saved_owner_and_current_link(self, actor, linked, allowed):
+        cog, ts = self._make_cog_and_ts()
+        ts.storage.get_channel_route.return_value = {"ws_id": "ws-1", "channel_user_id": "111"}
+        ts.router.resolve_user.return_value = "user" if linked else None
+        ts.router.close_workstream = AsyncMock()
+        ts.router.delete_route = AsyncMock()
+        ts.unsubscribe_ws = AsyncMock()
+        interaction = _make_interaction()
+        interaction.user.id = actor
+        thread = MagicMock(spec=discord.Thread)
+        thread.id, thread.owner_id = 555, 99999
+        thread.edit = AsyncMock()
+        interaction.channel = thread
+        _run(cog._cmd_close(interaction))
+        if allowed:
+            ts.router.close_workstream.assert_awaited_once_with("ws-1")
+            ts.router.delete_route.assert_awaited_once_with("discord", "555", expected_ws_id="ws-1")
+        else:
+            ts.router.close_workstream.assert_not_awaited()
+            ts.router.delete_route.assert_not_awaited()
+
+    def test_unavailable_recovery_keeps_route_and_reports_failure(self):
+        from turnstone.sdk._types import TurnstoneAPIError
+
+        cog, ts = self._make_cog_and_ts()
+        thread = MagicMock(spec=discord.Thread)
+        thread.id, thread.parent_id, thread.owner_id = 555, 222, 111
+        thread.send = AsyncMock()
+        ts.router.get_or_create_workstream.side_effect = TurnstoneAPIError(503, "offline")
+        msg = _make_message(guild=True, channel=thread)
+        msg.author.id = 111
+        _run(cog._on_message(msg))
+        ts.storage.delete_channel_route.assert_not_called()
+        ts.router.send_message.assert_not_awaited()
+        assert "try your message again" in thread.send.call_args.args[0]
+
     def test_ask_thread_followup_allowed_when_invoker_registered(self):
         """/ask creates threads with owner_id=bot; follow-ups from the
         registered invoker must still reach the workstream."""
         cog, ts = self._make_cog_and_ts()
         # Simulate what _cmd_ask does after channel.create_thread().
-        ts.get_thread_invoker = MagicMock(return_value=111)
+        ts.storage.get_channel_route.return_value = {"ws_id": "ws-1", "channel_user_id": "111"}
 
         thread = MagicMock(spec=discord.Thread)
         thread.id = 555
@@ -1973,7 +2061,7 @@ class TestDiscordThreadOwnerCheck:
     def test_ask_thread_rejects_other_user_even_when_invoker_registered(self):
         """Registered invoker lock: only that user's follow-ups pass."""
         cog, ts = self._make_cog_and_ts()
-        ts.get_thread_invoker = MagicMock(return_value=111)
+        ts.storage.get_channel_route.return_value = {"ws_id": "ws-1", "channel_user_id": "111"}
 
         thread = MagicMock(spec=discord.Thread)
         thread.id = 555

--- a/tests/test_channel_recovery.py
+++ b/tests/test_channel_recovery.py
@@ -1,0 +1,666 @@
+"""Restart recovery across platform adapters, HTTP handlers and durable storage.
+
+Platform delivery and model sessions are fake; routing, authorization, history
+cloning and the SSE 404 response use the real implementations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from tests._helpers import wait_until
+from tests.test_server_authz import _auth
+from tests.test_server_authz import app_client as app_client
+from turnstone.channels._routing import ChannelRouter
+from turnstone.core.storage import get_storage
+from turnstone.sdk.server import AsyncTurnstoneServer
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning"
+)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["discord", "slack-thread", "slack-dm"])
+@pytest.mark.parametrize("restart", ["node", "bot", "both"])
+async def test_restart_retains_association_and_recovers_history(app_client, platform, restart):
+    client, manager = app_client
+    storage = get_storage()
+    assert storage is not None
+    source = client.post(
+        "/v1/api/workstreams/new", json={"name": "channel"}, headers=_auth("owner")
+    ).json()["ws_id"]
+    storage.save_message(source, "user", "Remember the original conversation")
+    if restart != "bot":
+        manager.close(source)
+        assert manager.get(source) is None
+
+    if platform == "discord":
+        discord = pytest.importorskip("discord")
+        from tests.test_channel_discord import _make_message
+        from turnstone.channels.discord.bot import TurnstoneBot
+        from turnstone.channels.discord.cog import MessageCog
+        from turnstone.channels.discord.config import DiscordConfig
+
+        storage.create_channel_user("discord", "111", "owner")
+        storage.create_channel_route("discord", "555", source, channel_user_id="111")
+        bot = TurnstoneBot(DiscordConfig(allowed_channels=[222]), "http://server.example", storage)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id, thread.parent_id, thread.owner_id, thread.name = 555, 222, 99999, "conversation"
+        thread.send = AsyncMock()
+        cog = MessageCog(bot._bot)
+        message = _make_message(guild=True, channel=thread)
+        message.author.id = 111
+        message.content = "Continue please"
+        channel_type, route_id = "discord", "555"
+
+        async def inbound(author):
+            message.author.id = author
+            await cog._on_message(message)
+
+        async def receive_unavailable():
+            await bot._sse_listener(source, thread)
+
+    else:
+        pytest.importorskip("slack_bolt")
+        from turnstone.channels.slack.bot import TurnstoneSlackBot
+        from turnstone.channels.slack.config import SlackConfig
+
+        channel = "D1" if platform == "slack-dm" else "C1"
+        stamp = "" if platform == "slack-dm" else "1000.000001"
+        route_id = f"{channel}:111" + (f":{stamp}" if stamp else "")
+        storage.create_channel_user("slack", "111", "owner")
+        storage.create_channel_route("slack", route_id, source)
+        with (
+            patch("turnstone.channels.slack.bot.AsyncApp"),
+            patch("turnstone.channels.slack.bot.AsyncWebClient", return_value=AsyncMock()),
+        ):
+            bot = TurnstoneSlackBot(
+                SlackConfig(bot_token="test", allowed_channels=[channel]),
+                "http://server.example",
+                storage,
+            )
+        channel_type = "slack"
+        if stamp:
+            bot._channel_sessions[(channel, "111")] = (source, stamp)
+
+        async def inbound(author):
+            await bot._on_message(
+                {
+                    "channel": channel,
+                    "user": str(author),
+                    "thread_ts": stamp,
+                    "text": "Continue please",
+                },
+                AsyncMock(),
+            )
+
+        async def receive_unavailable():
+            await bot._sse_listener(source, route_id)
+
+    await bot.router.aclose()
+    await bot._http_client.aclose()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client.app),
+        base_url="http://server.example",
+        headers=_auth("owner"),
+    ) as http:
+        bot._http_client = http
+        bot.router._server = AsyncTurnstoneServer(httpx_client=http)
+        # Test startup and inbound subscription requests without opening an
+        # infinite ASGI stream. The unavailable response below uses real SSE.
+        bot.subscribe_ws = AsyncMock()
+        try:
+            if restart in {"bot", "both"}:
+                if platform == "discord":
+                    with (
+                        patch.object(bot._bot, "get_channel", return_value=None),
+                        patch.object(
+                            bot._bot, "fetch_channel", new=AsyncMock(return_value=thread)
+                        ) as fetch,
+                    ):
+                        await bot._recover_routes()
+                        if restart == "bot":
+                            fetch.assert_awaited_once_with(555)
+                        else:
+                            fetch.assert_not_awaited()
+                else:
+                    bot._channel_sessions.clear()
+                    await bot._recover_routes()
+            bot.subscribe_ws.reset_mock()
+
+            if restart != "bot":
+                bot._subscribed_ws.add(source)
+                await asyncio.wait_for(receive_unavailable(), timeout=2)
+                assert source not in bot._subscribed_ws
+                assert storage.get_channel_route(channel_type, route_id)["ws_id"] == source
+
+            # Another linked user must not acquire this existing thread.
+            # A Slack DM is a separate user route, so exercise isolation on
+            # the thread variants, which share a platform conversation.
+            if platform != "slack-dm":
+                storage.create_channel_user(channel_type, "222", "other-user")
+                await inbound(222)
+                assert storage.get_channel_route(channel_type, route_id)["ws_id"] == source
+                bot.subscribe_ws.assert_not_awaited()
+
+            await inbound(111)
+            route = storage.get_channel_route(channel_type, route_id)
+            destination = route["ws_id"]
+            assert (destination == source) is (restart == "bot")
+            assert storage.get_workstream(source) is not None
+            assert (
+                storage.load_messages(destination)[0]["content"]
+                == "Remember the original conversation"
+            )
+            if platform == "discord":
+                assert route["channel_user_id"] == "111"
+                bot.subscribe_ws.assert_awaited_once_with(destination, thread)
+            else:
+                bot.subscribe_ws.assert_awaited_once_with(destination, route_id)
+                if platform == "slack-thread":
+                    assert bot._channel_sessions[("C1", "111")] == (destination, stamp)
+            session = manager.get(destination).session
+            await asyncio.to_thread(wait_until, lambda: len(session.sends) == 1)
+            assert session.sends[0][0] == "Continue please"
+        finally:
+            await bot.router.aclose()
+            if platform == "discord":
+                await bot._bot.close()
+            for ws in manager.list_all():
+                manager.close(ws.id)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("existing", [False, True])
+async def test_competing_gateways_only_dispatch_after_claiming_route(db, existing):
+    if existing:
+        db.create_channel_route("discord", "555", "source", channel_user_id="111")
+    routers = [ChannelRouter("http://server.example", db) for _ in range(2)]
+    barrier = asyncio.Barrier(2)
+
+    async def create(ws_id, **kwargs):
+        await barrier.wait()
+        return MagicMock(ws_id=ws_id)
+
+    for index, router in enumerate(routers):
+
+        async def create_candidate(_index=index, **kwargs):
+            return await create(f"candidate-{_index}", **kwargs)
+
+        router._server.create_workstream = create_candidate
+        router._server.send = AsyncMock()
+        router.close_workstream = AsyncMock()
+    try:
+        results = await asyncio.gather(
+            *[
+                router.get_or_create_workstream(
+                    "discord", "555", channel_user_id="111", initial_message="hello"
+                )
+                for router in routers
+            ],
+            return_exceptions=True,
+        )
+        winner = db.get_channel_route("discord", "555")
+        assert winner["channel_user_id"] == "111"
+        assert sum(isinstance(result, RuntimeError) for result in results) == 1
+        for index, (router, result) in enumerate(zip(routers, results, strict=True)):
+            if isinstance(result, RuntimeError):
+                router.close_workstream.assert_awaited_once_with(f"candidate-{index}")
+                router._server.send.assert_not_awaited()
+            else:
+                assert result == (winner["ws_id"], True)
+                router.close_workstream.assert_not_awaited()
+                if not existing:
+                    router._server.send.assert_awaited_once_with("hello", winner["ws_id"])
+    finally:
+        for router in routers:
+            await router.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["discord", "slack"])
+async def test_old_listener_cannot_clear_a_new_subscription(platform):
+    if platform == "discord":
+        pytest.importorskip("discord")
+        from tests.test_channel_discord import _make_real_bot
+
+        bot = _make_real_bot()
+    else:
+        pytest.importorskip("slack_bolt")
+        from tests.test_channel_slack import _make_bot
+
+        bot, _, _ = _make_bot()
+        bot._channel_sessions[("C1", "111")] = ("new-ws", "1000")
+
+    release = asyncio.Event()
+
+    async def old_listener():
+        await release.wait()
+        await bot._stop_unavailable_stream("ws")
+
+    old = asyncio.create_task(old_listener())
+    replacement = asyncio.create_task(asyncio.Event().wait())
+    bot._sse_tasks["ws"] = replacement
+    bot._subscribed_ws.add("ws")
+    try:
+        release.set()
+        await old
+        assert bot._sse_tasks["ws"] is replacement
+        assert "ws" in bot._subscribed_ws
+        # Cleanup for a different, old workstream cannot delete a newly
+        # recovered thread association either.
+        await bot._stop_unavailable_stream("old-ws")
+        bot.storage.delete_channel_route.assert_not_called()
+        if platform == "slack":
+            assert bot._channel_sessions[("C1", "111")] == ("new-ws", "1000")
+    finally:
+        await bot.unsubscribe_ws("ws")
+        await bot.router.aclose()
+        await bot._http_client.aclose()
+        if platform == "discord":
+            await bot._bot.close()
+
+
+@pytest.mark.anyio
+async def test_close_during_fork_cannot_resurrect_route(db):
+    db.create_channel_route("discord", "555", "source", channel_user_id="111")
+    router = ChannelRouter("http://server.example", db)
+
+    async def create(**kwargs):
+        db.delete_channel_route("discord", "555")
+        return MagicMock(ws_id="candidate")
+
+    router._server.create_workstream = create
+    router._server.send = AsyncMock()
+    router.close_workstream = AsyncMock()
+    try:
+        with pytest.raises(RuntimeError, match="route changed"):
+            await router.get_or_create_workstream(
+                "discord", "555", channel_user_id="111", require_existing=True
+            )
+        assert db.get_channel_route("discord", "555") is None
+        router.close_workstream.assert_awaited_once_with("candidate")
+        router._server.send.assert_not_awaited()
+        with pytest.raises(RuntimeError, match="was closed"):
+            await router.get_or_create_workstream(
+                "discord", "555", channel_user_id="111", require_existing=True
+            )
+    finally:
+        await router.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("status", [403, 404, 503])
+async def test_uncached_discord_thread_fetch_failure_preserves_route(db, status):
+    discord = pytest.importorskip("discord")
+    from tests.test_channel_discord import _make_real_bot
+
+    bot = _make_real_bot()
+    bot.router.get_live_workstream_ids = AsyncMock(return_value={"ws"})
+    bot.storage = db
+    db.create_channel_route("discord", "555", "ws", channel_user_id="111")
+    bot.subscribe_ws = AsyncMock()
+    try:
+        with (
+            patch.object(bot._bot, "get_channel", return_value=None),
+            patch.object(
+                bot._bot,
+                "fetch_channel",
+                new=AsyncMock(
+                    side_effect=discord.HTTPException(
+                        MagicMock(status=status, reason="unavailable"),
+                        "unavailable",
+                    )
+                ),
+            ),
+        ):
+            await bot._recover_routes()
+        bot.subscribe_ws.assert_not_awaited()
+        assert db.get_channel_route("discord", "555")["channel_user_id"] == "111"
+    finally:
+        await bot.router.aclose()
+        await bot._http_client.aclose()
+        await bot._bot.close()
+
+
+@pytest.mark.anyio
+async def test_discord_close_serializes_with_pending_reply(db):
+    discord = pytest.importorskip("discord")
+    from tests.test_channel_discord import (
+        TestDiscordThreadOwnerCheck,
+        _make_interaction,
+        _make_message,
+    )
+
+    db.create_channel_route("discord", "555", "source", channel_user_id="111")
+    db.create_channel_user("discord", "111", "owner")
+    router = ChannelRouter("http://server.example", db)
+    cog, ts = TestDiscordThreadOwnerCheck._make_cog_and_ts()
+    ts.storage, ts.router = db, router
+    ts.unsubscribe_ws = AsyncMock()
+    router._server.send = AsyncMock()
+    router._server.create_workstream = AsyncMock()
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def close(ws_id):
+        assert ws_id == "source"
+        entered.set()
+        await release.wait()
+
+    router._server.close_workstream = close
+    thread = MagicMock(spec=discord.Thread)
+    thread.id, thread.parent_id, thread.owner_id = 555, 222, 99999
+    thread.edit = AsyncMock()
+    interaction = _make_interaction()
+    interaction.user.id, interaction.channel = 111, thread
+    message = _make_message(channel=thread)
+    message.author.id = 111
+    tasks = []
+    try:
+        tasks.append(asyncio.create_task(cog._cmd_close(interaction)))
+        await asyncio.wait_for(entered.wait(), 1)
+        tasks.append(asyncio.create_task(cog._on_message(message)))
+        await asyncio.sleep(0)
+        router._server.create_workstream.assert_not_awaited()
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*tasks), 2)
+        assert db.get_channel_route("discord", "555") is None
+        router._server.send.assert_not_awaited()
+        ts.subscribe_ws.assert_not_awaited()
+        interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+        interaction.followup.send.assert_awaited_once_with("Workstream closed.")
+    finally:
+        release.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await router.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["discord", "slack"])
+@pytest.mark.parametrize("outcome", ["refused", "replaced"])
+async def test_close_failure_preserves_current_route(db, platform, outcome):
+    from turnstone.sdk._types import TurnstoneAPIError
+
+    route_id = "555" if platform == "discord" else "C1:111:1000"
+    db.create_channel_route(platform, route_id, "source", channel_user_id="111")
+    db.create_channel_user(platform, "111", "owner")
+    router = ChannelRouter("http://server.example", db)
+
+    async def close(ws_id):
+        if outcome == "refused":
+            raise TurnstoneAPIError(409, "close refused")
+        assert db.replace_channel_route(platform, route_id, "source", "replacement")
+
+    router._server.close_workstream = close
+    try:
+        if platform == "discord":
+            discord = pytest.importorskip("discord")
+            from tests.test_channel_discord import TestDiscordThreadOwnerCheck, _make_interaction
+
+            cog, ts = TestDiscordThreadOwnerCheck._make_cog_and_ts()
+            ts.storage, ts.router = db, router
+            ts.unsubscribe_ws = AsyncMock()
+            interaction = _make_interaction()
+            interaction.user.id = 111
+            interaction.channel = MagicMock(spec=discord.Thread)
+            interaction.channel.id = 555
+            await cog._cmd_close(interaction)
+            ts.unsubscribe_ws.assert_not_awaited()
+            assert "Workstream closed." not in interaction.followup.send.call_args.args
+        else:
+            from tests.test_channel_slack import _make_bot
+
+            bot, _, _ = _make_bot()
+            bot.router, bot.storage = router, db
+            bot._channel_sessions[("C1", "111")] = ("source", "1000")
+            with pytest.raises((TurnstoneAPIError, RuntimeError)):
+                await bot._archive_session("C1", "111", "source", "1000")
+            cached_ws = "source" if outcome == "refused" else "replacement"
+            assert bot._channel_sessions[("C1", "111")] == (cached_ws, "1000")
+        expected = "source" if outcome == "refused" else "replacement"
+        assert db.get_channel_route(platform, route_id)["ws_id"] == expected
+    finally:
+        await router.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("fetch_fails", [False, True])
+async def test_discord_restores_cached_threads_before_fetching_and_skips_live_streams(fetch_fails):
+    discord = pytest.importorskip("discord")
+    from tests.test_channel_discord import _make_real_bot
+
+    bot = _make_real_bot()
+    bot.router.get_live_workstream_ids = AsyncMock(side_effect=lambda ws_ids: set(ws_ids))
+    bot.storage.list_channel_routes_by_type.return_value = [
+        {"ws_id": "uncached", "channel_id": "111"},
+        {"ws_id": "cached", "channel_id": "222"},
+    ]
+    cached = MagicMock(spec=discord.Thread)
+    cached.id, cached.parent_id = 222, 333
+    uncached = MagicMock(spec=discord.Thread)
+    uncached.id, uncached.parent_id = 111, 333
+
+    async def fetch(channel_id):
+        assert "cached" in bot._subscribed_ws
+        if fetch_fails:
+            raise TimeoutError("platform unavailable")
+        return uncached
+
+    async def listen(*args):
+        await asyncio.Event().wait()
+
+    bot._sse_listener = listen
+    try:
+        with (
+            patch.object(
+                bot._bot,
+                "get_channel",
+                side_effect=lambda channel_id: cached if channel_id == 222 else None,
+            ),
+            patch.object(bot._bot, "fetch_channel", new=AsyncMock(side_effect=fetch)) as fetch_mock,
+        ):
+            await bot._recover_routes()
+            assert "cached" in bot._subscribed_ws
+            if not fetch_fails:
+                await bot._recover_routes()
+                fetch_mock.assert_awaited_once_with(111)
+        bot.storage.delete_channel_route.assert_not_called()
+    finally:
+        await bot.stop()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("cancel_scan", [False, True])
+async def test_discord_coalesces_recovery_and_allows_later_retry(cancel_scan):
+    pytest.importorskip("discord")
+    from tests.test_channel_discord import _make_real_bot
+
+    bot = _make_real_bot()
+    bot.router.get_live_workstream_ids = AsyncMock(side_effect=lambda ws_ids: set(ws_ids))
+    bot.storage.list_channel_routes_by_type.return_value = [
+        {"ws_id": "source", "channel_id": "111"}
+    ]
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def fetch(channel_id):
+        entered.set()
+        await release.wait()
+        raise TimeoutError("platform unavailable")
+
+    task = None
+    try:
+        with (
+            patch.object(bot._bot, "get_channel", return_value=None),
+            patch.object(bot._bot, "fetch_channel", new=AsyncMock(side_effect=fetch)) as fetch_mock,
+        ):
+            task = asyncio.create_task(bot._recover_routes())
+            await asyncio.wait_for(entered.wait(), 1)
+            await asyncio.wait_for(asyncio.gather(*(bot._recover_routes() for _ in range(3))), 1)
+            fetch_mock.assert_awaited_once_with(111)
+            if cancel_scan:
+                task.cancel()
+            release.set()
+            await asyncio.gather(task, return_exceptions=True)
+            await bot._recover_routes()
+            assert fetch_mock.await_count == 2
+    finally:
+        release.set()
+        if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
+        await bot.stop()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("replacement_exists", [False, True])
+async def test_slack_close_conflict_refreshes_cache_so_next_restart_converges(
+    db, replacement_exists
+):
+    from tests.test_channel_slack import _make_bot
+
+    channel, user, stamp = "C01SAPU5414", "U12345", "1000.000001"
+    route_id = f"{channel}:{user}:{stamp}"
+    db.create_channel_user("slack", user, "owner")
+    db.create_channel_route("slack", route_id, "source")
+    bot, _, _ = _make_bot()
+    router = ChannelRouter("http://server.example", db)
+    bot.router, bot.storage = router, db
+    bot._channel_sessions[(channel, user)] = ("source", stamp)
+    closed = []
+
+    async def close(ws_id):
+        closed.append(ws_id)
+        if len(closed) == 1:
+            if replacement_exists:
+                assert db.replace_channel_route("slack", route_id, "source", "replacement")
+            else:
+                assert db.delete_channel_route("slack", route_id)
+
+    router._server.close_workstream = close
+    router._server.create_workstream = AsyncMock(return_value=MagicMock(ws_id="new-session"))
+    try:
+        for _ in range(2):
+            await bot._on_slash_command(
+                AsyncMock(), {"channel_id": channel, "user_id": user, "text": ""}
+            )
+        assert closed == (["source", "replacement"] if replacement_exists else ["source"])
+        router._server.create_workstream.assert_awaited_once()
+        assert bot._channel_sessions[(channel, user)][0] == "new-session"
+    finally:
+        await bot.stop()
+
+
+@pytest.mark.anyio
+async def test_slack_restart_wins_over_pending_recovery():
+    from tests.test_channel_slack import _make_bot
+
+    bot, router, client = _make_bot()
+    key = ("C01SAPU5414", "U12345")
+    old_thread = "1000.000001"
+    new_thread = "2000.000001"
+    bot._channel_sessions[key] = ("source", old_thread)
+    entered_cleanup, finish_cleanup = (asyncio.Event(), asyncio.Event())
+
+    async def old_listener():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            entered_cleanup.set()
+            await finish_cleanup.wait()
+
+    old = asyncio.create_task(old_listener())
+    bot._sse_tasks["source"] = old
+    bot._subscribed_ws.add("source")
+    await asyncio.sleep(0)
+    router.get_or_create_workstream.side_effect = [("recovered", True), ("new-session", True)]
+    client.chat_postMessage.return_value = {"ok": True, "ts": new_thread}
+    inbound = asyncio.create_task(
+        bot._on_message(
+            {
+                "channel": key[0],
+                "user": key[1],
+                "thread_ts": old_thread,
+                "text": "continue old conversation",
+            },
+            AsyncMock(),
+        )
+    )
+    try:
+        await asyncio.wait_for(entered_cleanup.wait(), 1)
+        await bot._on_slash_command(
+            AsyncMock(), {"channel_id": key[0], "user_id": key[1], "text": ""}
+        )
+        finish_cleanup.set()
+        await asyncio.wait_for(inbound, 1)
+        assert bot._channel_sessions[key] == ("new-session", new_thread)
+        router.send_message.assert_not_awaited()
+    finally:
+        finish_cleanup.set()
+        await bot.stop()
+
+
+@pytest.mark.anyio
+async def test_slack_concurrent_replies_share_recovery():
+    from tests.test_channel_slack import _make_bot
+
+    bot, _, _ = _make_bot()
+    storage = MagicMock()
+    route = {"ws_id": "source", "channel_user_id": ""}
+    storage.get_channel_route.side_effect = lambda *args: dict(route)
+    storage.get_workstream.side_effect = lambda ws_id: {"ws_id": ws_id}
+
+    def replace(channel_type, channel_id, expected, ws_id):
+        if route["ws_id"] != expected:
+            return False
+        route["ws_id"] = ws_id
+        return True
+
+    storage.replace_channel_route.side_effect = replace
+    live = set()
+    router = ChannelRouter("http://server.example", storage)
+
+    async def create(**kwargs):
+        live.add("recovered")
+        return MagicMock(ws_id="recovered")
+
+    router._server.create_workstream = create
+    router._server.list_workstreams = AsyncMock(
+        side_effect=lambda: MagicMock(
+            workstreams=[MagicMock(ws_id=ws_id, state="idle") for ws_id in live]
+        )
+    )
+    router._server.send = AsyncMock()
+    bot.router = router
+    bot.subscribe_ws = AsyncMock()
+    bot._channel_sessions["C01SAPU5414", "U12345"] = ("source", "1000.000001")
+    barrier = asyncio.Barrier(2)
+
+    async def linked(*args):
+        await barrier.wait()
+        return True
+
+    bot._require_linked = linked
+    notices = [AsyncMock(), AsyncMock()]
+    try:
+        await asyncio.gather(
+            *[
+                bot._on_message(
+                    {
+                        "channel": "C01SAPU5414",
+                        "user": "U12345",
+                        "thread_ts": "1000.000001",
+                        "text": f"message {index}",
+                    },
+                    notices[index],
+                )
+                for index in range(2)
+            ]
+        )
+        assert router._server.send.await_count == 2
+        assert all(notice.await_count == 0 for notice in notices)
+    finally:
+        await bot.stop()

--- a/tests/test_channel_recovery_identity.py
+++ b/tests/test_channel_recovery_identity.py
@@ -1,0 +1,154 @@
+"""Channel recovery cannot substitute another conversation's identity."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from tests._helpers import wait_until
+from tests.test_server_authz import _auth
+from tests.test_server_authz import app_client as app_client
+from turnstone.core.storage import get_storage
+from turnstone.sdk.server import AsyncTurnstoneServer
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning"
+)
+
+
+@pytest.mark.parametrize("exact", [False, True])
+def test_exact_resume_is_opt_in_for_public_alias_api(app_client, exact):
+    client, manager = app_client
+    alias = "f" * 32
+    source = client.post("/v1/api/workstreams/new", json={}, headers=_auth("owner")).json()["ws_id"]
+    manager.close(source)
+    response = client.post(
+        f"/v1/api/workstreams/{source}/title", json={"title": alias}, headers=_auth("owner")
+    )
+    assert response.status_code == 200
+    response = client.post(
+        "/v1/api/workstreams/new",
+        json={"resume_ws": alias, "resume_ws_exact": exact},
+        headers=_auth("owner"),
+    )
+    assert response.status_code == (404 if exact else 200), response.text
+    if not exact:
+        assert response.json()["resumed"] is True
+
+
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [("true", "resume_ws_exact must be a boolean"), (True, "resume_ws_exact requires resume_ws")],
+)
+def test_exact_resume_validates_input(app_client, value, error):
+    client, _ = app_client
+    response = client.post(
+        "/v1/api/workstreams/new", json={"resume_ws_exact": value}, headers=_auth("owner")
+    )
+    assert response.status_code == 400
+    assert response.json() == {"error": error}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("substitution", ["alias-before-message", "alias-before-create", "same-id"])
+async def test_retained_channel_cannot_adopt_another_users_workstream(app_client, substitution):
+    discord = pytest.importorskip("discord")
+    from tests.test_channel_discord import _make_message
+    from turnstone.channels.discord.bot import TurnstoneBot
+    from turnstone.channels.discord.cog import MessageCog
+    from turnstone.channels.discord.config import DiscordConfig
+
+    client, manager = app_client
+    storage = get_storage()
+    assert storage is not None
+    service = _auth("channel-gateway", scopes=frozenset({"read", "write", "approve", "service"}))
+    source = client.post("/v1/api/workstreams/new", json={}, headers=service).json()["ws_id"]
+    attacker = client.post("/v1/api/workstreams/new", json={}, headers=_auth("attacker")).json()[
+        "ws_id"
+    ]
+    storage.save_message(attacker, "user", "ATTACKER-CONTROLLED SAVED HISTORY")
+    storage.create_channel_user("discord", "111", "victim")
+    storage.create_channel_route("discord", "555", source, channel_user_id="111")
+    manager.close(source)
+    manager.close(attacker)
+
+    def delete_source():
+        response = client.post(f"/v1/api/workstreams/{source}/delete", headers=service)
+        assert response.status_code == 200, response.text
+
+    def install_alias():
+        delete_source()
+        response = client.post(
+            f"/v1/api/workstreams/{attacker}/title",
+            json={"title": source},
+            headers=_auth("attacker"),
+        )
+        assert response.status_code == 200, response.text
+
+    bot = TurnstoneBot(DiscordConfig(allowed_channels=[222]), "http://server.example", storage)
+    await bot.router.aclose()
+    await bot._http_client.aclose()
+    bot.subscribe_ws, bot.unsubscribe_ws = AsyncMock(), AsyncMock()
+    thread = MagicMock(spec=discord.Thread)
+    thread.id, thread.parent_id, thread.owner_id, thread.name = 555, 222, 99999, "conversation"
+    thread.send = AsyncMock()
+    message = _make_message(guild=True, channel=thread)
+    message.author.id, message.content = 111, "Victim next message"
+    cog = MessageCog(bot._bot)
+    create_bodies = []
+
+    async def before_request(request):
+        if request.url.path.endswith("/workstreams/new"):
+            body = json.loads(request.content)
+            create_bodies.append(body)
+            if substitution == "alias-before-create" and body.get("resume_ws") == source:
+                assert storage.get_workstream(source) is not None
+                install_alias()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client.app),
+        base_url="http://server.example",
+        headers=service,
+        event_hooks={"request": [before_request]},
+    ) as http:
+        bot._http_client, bot.router._server = http, AsyncTurnstoneServer(httpx_client=http)
+        try:
+            await asyncio.wait_for(bot._sse_listener(source, thread), 2)
+            assert storage.get_channel_route("discord", "555")["ws_id"] == source
+            if substitution == "alias-before-message":
+                install_alias()
+            elif substitution == "same-id":
+                delete_source()
+                response = client.post(
+                    "/v1/api/workstreams/new",
+                    json={"ws_id": source},
+                    headers=_auth("attacker"),
+                )
+                assert response.status_code == 409, response.text
+                assert storage.get_workstream(source) is None
+
+            await cog._on_message(message)
+            route = storage.get_channel_route("discord", "555")
+            destination = route["ws_id"]
+            assert destination not in {source, attacker}
+            assert route["channel_user_id"] == "111"
+            assert create_bodies[0]["resume_ws"] == source
+            assert create_bodies[0]["resume_ws_exact"] is True
+            assert "resume_ws" not in create_bodies[1]
+            session = manager.get(destination).session
+            await asyncio.to_thread(wait_until, lambda: bool(session.sends))
+            assert session.sends[0][0] == "Victim next message"
+            assert not session.fork_calls
+            assert all(
+                item["content"] != "ATTACKER-CONTROLLED SAVED HISTORY"
+                for item in storage.load_messages(destination)
+            )
+        finally:
+            await bot.router.aclose()
+            await bot._bot.close()
+            for ws in manager.list_all():
+                manager.close(ws.id)

--- a/tests/test_channel_routing.py
+++ b/tests/test_channel_routing.py
@@ -18,8 +18,9 @@ def mock_storage() -> MagicMock:
     storage.get_channel_user = MagicMock(return_value=None)
     storage.get_channel_route = MagicMock(return_value=None)
     storage.get_channel_route_by_ws = MagicMock(return_value=None)
-    storage.resolve_workstream = MagicMock(side_effect=lambda ws_id: ws_id)
-    storage.create_channel_route = MagicMock()
+    storage.get_workstream = MagicMock(side_effect=lambda ws_id: {"ws_id": ws_id})
+    storage.create_channel_route = MagicMock(return_value=True)
+    storage.replace_channel_route = MagicMock(return_value=True)
     storage.delete_channel_route = MagicMock(return_value=True)
     return storage
 
@@ -123,7 +124,9 @@ class TestDeleteRoute:
         self, router: ChannelRouter, mock_storage: MagicMock
     ) -> None:
         await router.delete_route("discord", "ch-123")
-        mock_storage.delete_channel_route.assert_called_once_with("discord", "ch-123")
+        mock_storage.delete_channel_route.assert_called_once_with(
+            "discord", "ch-123", expected_ws_id=None
+        )
 
 
 class TestWorkstreamLiveness:
@@ -180,7 +183,9 @@ class TestGetOrCreateWorkstream:
         ws_id, is_new = await router.get_or_create_workstream("discord", "ch-1", name="test")
         assert ws_id == "ws-new"
         assert is_new is True
-        mock_storage.create_channel_route.assert_called_once_with("discord", "ch-1", "ws-new")
+        mock_storage.create_channel_route.assert_called_once_with(
+            "discord", "ch-1", "ws-new", channel_user_id=""
+        )
         mock_create.assert_awaited_once()
 
     @pytest.mark.anyio
@@ -206,9 +211,9 @@ class TestGetOrCreateWorkstream:
         )
         assert ws_id == "ws-new"
         assert is_new is True
-        mock_storage.create_channel_route.assert_called_once_with("discord", "ch-1", "ws-new")
-        # Node URL should be cached.
-        assert console_router._node_urls["ws-new"] == "http://node1:8080/v1"
+        mock_storage.create_channel_route.assert_called_once_with(
+            "discord", "ch-1", "ws-new", channel_user_id=""
+        )
 
     @pytest.mark.anyio
     async def test_returns_existing_alive_workstream(
@@ -250,9 +255,10 @@ class TestGetOrCreateWorkstream:
         ws_id, is_new = await router.get_or_create_workstream("discord", "ch-1", name="test")
         assert ws_id == "ws-resumed"
         assert is_new is True
-        # Should have deleted the stale route and created a new one.
-        mock_storage.delete_channel_route.assert_called_once_with("discord", "ch-1")
-        mock_storage.create_channel_route.assert_called_once_with("discord", "ch-1", "ws-resumed")
+        mock_storage.delete_channel_route.assert_not_called()
+        mock_storage.replace_channel_route.assert_called_once_with(
+            "discord", "ch-1", "ws-stale", "ws-resumed"
+        )
         # The create call should include resume_ws pointing at the old ws.
         mock_create.assert_awaited_once()
         call_kwargs = mock_create.call_args[1]
@@ -270,8 +276,8 @@ class TestGetOrCreateWorkstream:
             "channel_type": "discord",
             "channel_id": "ch-1",
         }
-        mock_storage.resolve_workstream.side_effect = None
-        mock_storage.resolve_workstream.return_value = None
+        mock_storage.get_workstream.side_effect = None
+        mock_storage.get_workstream.return_value = None
         assert router._server is not None
         mock_create = AsyncMock(
             side_effect=[
@@ -296,7 +302,9 @@ class TestGetOrCreateWorkstream:
             "",
         ]
         mock_send.assert_awaited_once_with("hello", "ws-fresh")
-        mock_storage.create_channel_route.assert_called_once_with("discord", "ch-1", "ws-fresh")
+        mock_storage.replace_channel_route.assert_called_once_with(
+            "discord", "ch-1", "ws-pruned", "ws-fresh"
+        )
 
     @pytest.mark.anyio
     async def test_missing_stale_source_retries_fresh_via_console(
@@ -310,8 +318,8 @@ class TestGetOrCreateWorkstream:
             "channel_type": "slack",
             "channel_id": "ch-1",
         }
-        mock_storage.resolve_workstream.side_effect = None
-        mock_storage.resolve_workstream.return_value = None
+        mock_storage.get_workstream.side_effect = None
+        mock_storage.get_workstream.return_value = None
         assert console_router._console is not None
         mock_create = AsyncMock(
             side_effect=[
@@ -342,8 +350,9 @@ class TestGetOrCreateWorkstream:
             "",
         ]
         mock_send.assert_awaited_once_with("hello", "ws-fresh")
-        assert console_router._node_urls["ws-fresh"] == "http://node2:8080/v1"
-        mock_storage.create_channel_route.assert_called_once_with("slack", "ch-1", "ws-fresh")
+        mock_storage.replace_channel_route.assert_called_once_with(
+            "slack", "ch-1", "ws-pruned", "ws-fresh"
+        )
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(
@@ -403,8 +412,8 @@ class TestGetOrCreateWorkstream:
             "channel_type": "discord",
             "channel_id": "ch-1",
         }
-        mock_storage.resolve_workstream.side_effect = None
-        mock_storage.resolve_workstream.return_value = None
+        mock_storage.get_workstream.side_effect = None
+        mock_storage.get_workstream.return_value = None
         assert router._server is not None
         error = TurnstoneAPIError(404, "Workstream not found")
         mock_create = AsyncMock(side_effect=[error, error])
@@ -431,7 +440,7 @@ class TestGetOrCreateWorkstream:
             "channel_type": "discord",
             "channel_id": "ch-1",
         }
-        mock_storage.resolve_workstream.side_effect = RuntimeError("storage offline")
+        mock_storage.get_workstream.side_effect = RuntimeError("storage offline")
         assert router._server is not None
         mock_create = AsyncMock()
         monkeypatch.setattr(router._server, "create_workstream", mock_create)
@@ -493,6 +502,17 @@ class TestGetOrCreateWorkstream:
 
 class TestCloseWorkstream:
     @pytest.mark.anyio
+    @pytest.mark.parametrize("status", [403, 409, 503])
+    async def test_close_refusal_propagates(self, router, monkeypatch, status):
+        monkeypatch.setattr(
+            router._server,
+            "close_workstream",
+            AsyncMock(side_effect=TurnstoneAPIError(status, "not closed")),
+        )
+        with pytest.raises(TurnstoneAPIError, match="not closed"):
+            await router.close_workstream("ws-1")
+
+    @pytest.mark.anyio
     async def test_calls_server_close(
         self, router: ChannelRouter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -547,10 +567,24 @@ class TestAclose:
 
 class TestGetNodeUrl:
     @pytest.mark.anyio
-    async def test_returns_cached_url(self, router: ChannelRouter) -> None:
-        router._node_urls["ws-1"] = "http://node1:8080/v1"
-        url = await router.get_node_url("ws-1")
-        assert url == "http://node1:8080/v1"
+    async def test_reconnect_refreshes_address_and_propagates_failures(
+        self, console_router, monkeypatch
+    ):
+        lookup = AsyncMock(
+            side_effect=[
+                {"node_url": "http://old.example/"},
+                {"node_url": "http://new.example/"},
+                TurnstoneAPIError(503, "unavailable"),
+                {},
+            ]
+        )
+        monkeypatch.setattr(console_router._console, "route_lookup", lookup)
+        assert await console_router.get_node_url("ws-1") == "http://old.example"
+        assert await console_router.get_node_url("ws-1") == "http://new.example"
+        with pytest.raises(TurnstoneAPIError, match="unavailable"):
+            await console_router.get_node_url("ws-1")
+        with pytest.raises(RuntimeError, match="no node URL"):
+            await console_router.get_node_url("ws-1")
 
     @pytest.mark.anyio
     async def test_falls_back_to_server_url(self, router: ChannelRouter) -> None:
@@ -567,5 +601,3 @@ class TestGetNodeUrl:
         url = await console_router.get_node_url("ws-1")
         assert url == "http://node2:8080/v1"
         mock_lookup.assert_awaited_once_with("ws-1")
-        # Should be cached now.
-        assert console_router._node_urls["ws-1"] == "http://node2:8080/v1"

--- a/tests/test_channel_slack.py
+++ b/tests/test_channel_slack.py
@@ -66,6 +66,7 @@ def _make_bot() -> tuple[object, MagicMock, MagicMock]:
 
     router = MagicMock()
     router.get_or_create_workstream = AsyncMock(return_value=("ws-1", True))
+    router.get_live_workstream_ids = AsyncMock(side_effect=lambda ws_ids: set(ws_ids))
     router.send_message = AsyncMock()
     router.send_approval = AsyncMock()
     router.get_node_url = AsyncMock(return_value="http://localhost:8080")
@@ -99,6 +100,7 @@ def _make_bot() -> tuple[object, MagicMock, MagicMock]:
             storage=storage,
         )
 
+    bot._sse_listener = AsyncMock()  # Subscription behavior is tested separately.
     bot.router = router  # type: ignore[attr-defined]
     bot._client = client  # type: ignore[attr-defined]
 
@@ -277,7 +279,7 @@ class TestArchiveSession:
         _run(bot._archive_session("C1", "U1", "ws-old", "1000000.000001"))  # type: ignore[attr-defined]
 
         router.delete_route.assert_awaited_once_with(  # type: ignore[attr-defined]
-            "slack", "C1:U1:1000000.000001"
+            "slack", "C1:U1:1000000.000001", expected_ws_id="ws-old"
         )
         router.close_workstream.assert_awaited_once_with("ws-old")  # type: ignore[attr-defined]
         assert ("C1", "U1") not in bot._channel_sessions  # type: ignore[attr-defined]
@@ -836,6 +838,7 @@ class TestWsEventDispatch:
                 server_url="http://localhost:8080",
                 storage=storage,
             )
+        bot._sse_listener = AsyncMock()  # Subscription behavior is tested separately.
         bot.router = router  # type: ignore[attr-defined]
         bot._client = client  # type: ignore[attr-defined]
         bot.storage = None  # type: ignore[attr-defined]
@@ -914,6 +917,7 @@ class TestWsEventDispatch:
             ),
         ):
             bot = TurnstoneSlackBot(config, server_url="http://localhost:8080", storage=storage)
+        bot._sse_listener = AsyncMock()  # Subscription behavior is tested separately.
         bot.router = router  # type: ignore[attr-defined]
         bot._client = client  # type: ignore[attr-defined]
         bot.storage = None  # type: ignore[attr-defined]

--- a/tests/test_channel_sse.py
+++ b/tests/test_channel_sse.py
@@ -96,19 +96,19 @@ def _valid_event_data(ws_id: str = "ws-1") -> str:
 
 
 # ---------------------------------------------------------------------------
-# 404 → on_stale + exit
+# 404 → on_unavailable + exit
 # ---------------------------------------------------------------------------
 
 
-class TestStaleRoute:
-    def test_404_calls_on_stale_and_returns(self, monkeypatch, _fast_sleep):
+class TestUnavailableStream:
+    def test_404_calls_on_unavailable_and_returns(self, monkeypatch, _fast_sleep):
         from turnstone.channels import _sse
 
         queue = [_FakeEventSource(status_code=404, events=[])]
         fake_connect = _FakeConnect(queue)
         monkeypatch.setattr(_sse.httpx_sse, "aconnect_sse", fake_connect)
 
-        on_stale = AsyncMock()
+        on_unavailable = AsyncMock()
         on_event = AsyncMock()
 
         async def node_url_fn(ws_id: str) -> str:
@@ -122,26 +122,26 @@ class TestStaleRoute:
                 node_url_fn=node_url_fn,
                 token_factory=None,
                 on_event=on_event,
-                on_stale=on_stale,
+                on_unavailable=on_unavailable,
             )
         )
 
-        on_stale.assert_awaited_once()
+        on_unavailable.assert_awaited_once()
         on_event.assert_not_awaited()
         # No reconnect after 404.
         assert fake_connect.call_count == 1
         assert fake_connect.calls[0][1]["params"] == {"user_turn": 1}
         assert _fast_sleep == []
 
-    def test_on_stale_exception_still_exits(self, monkeypatch, _fast_sleep):
-        """If on_stale raises, the loop must not reconnect."""
+    def test_on_unavailable_exception_still_exits(self, monkeypatch, _fast_sleep):
+        """If on_unavailable raises, the loop must not reconnect."""
         from turnstone.channels import _sse
 
         queue = [_FakeEventSource(status_code=404, events=[])]
         fake_connect = _FakeConnect(queue)
         monkeypatch.setattr(_sse.httpx_sse, "aconnect_sse", fake_connect)
 
-        on_stale = AsyncMock(side_effect=RuntimeError("storage down"))
+        on_unavailable = AsyncMock(side_effect=RuntimeError("storage down"))
 
         async def node_url_fn(ws_id: str) -> str:
             return "http://node"
@@ -154,11 +154,11 @@ class TestStaleRoute:
                 node_url_fn=node_url_fn,
                 token_factory=None,
                 on_event=AsyncMock(),
-                on_stale=on_stale,
+                on_unavailable=on_unavailable,
             )
         )
 
-        on_stale.assert_awaited_once()
+        on_unavailable.assert_awaited_once()
         # Still a single connect — no livelock.
         assert fake_connect.call_count == 1
 
@@ -192,7 +192,7 @@ class TestBackoff:
                     node_url_fn=node_url_fn,
                     token_factory=None,
                     on_event=AsyncMock(),
-                    on_stale=AsyncMock(),
+                    on_unavailable=AsyncMock(),
                 )
             )
 
@@ -232,7 +232,7 @@ class TestBackoff:
                     node_url_fn=node_url_fn,
                     token_factory=None,
                     on_event=on_event,
-                    on_stale=AsyncMock(),
+                    on_unavailable=AsyncMock(),
                 )
             )
 
@@ -274,7 +274,7 @@ class TestEventDispatch:
                     node_url_fn=node_url_fn,
                     token_factory=None,
                     on_event=on_event,
-                    on_stale=AsyncMock(),
+                    on_unavailable=AsyncMock(),
                 )
             )
 
@@ -304,7 +304,7 @@ class TestEventDispatch:
                     node_url_fn=node_url_fn,
                     token_factory=None,
                     on_event=on_event,
-                    on_stale=AsyncMock(),
+                    on_unavailable=AsyncMock(),
                 )
             )
 
@@ -318,6 +318,40 @@ class TestEventDispatch:
 
 
 class TestTokenFactory:
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("rotating", [False, True])
+    async def test_real_sdk_preserves_auth_headers(self, rotating):
+        from turnstone.channels._sse import run_sse_stream
+
+        requests = []
+
+        def respond(request):
+            requests.append(request)
+            return httpx.Response(404)
+
+        on_unavailable = AsyncMock()
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(respond),
+            headers={"Authorization": "Bearer static-token"},
+        ) as client:
+            await asyncio.wait_for(
+                run_sse_stream(
+                    http_client=client,
+                    log_prefix="test",
+                    ws_id="ws-1",
+                    node_url_fn=AsyncMock(return_value="http://node.example"),
+                    token_factory=(lambda: "rotating-token") if rotating else None,
+                    on_event=AsyncMock(),
+                    on_unavailable=on_unavailable,
+                ),
+                timeout=2,
+            )
+        assert len(requests) == 1
+        expected = "rotating-token" if rotating else "static-token"
+        assert requests[0].headers["Authorization"] == f"Bearer {expected}"
+        assert requests[0].headers["Accept"] == "text/event-stream"
+        on_unavailable.assert_awaited_once()
+
     def test_header_refreshed_per_connection(self, monkeypatch, _fast_sleep):
         """token_factory is called once per reconnect so rotating service
         JWTs stay fresh."""
@@ -350,7 +384,7 @@ class TestTokenFactory:
                     node_url_fn=node_url_fn,
                     token_factory=factory,
                     on_event=AsyncMock(),
-                    on_stale=AsyncMock(),
+                    on_unavailable=AsyncMock(),
                 )
             )
 
@@ -391,7 +425,7 @@ class TestTransportErrors:
                     node_url_fn=node_url_fn,
                     token_factory=None,
                     on_event=AsyncMock(),
-                    on_stale=AsyncMock(),
+                    on_unavailable=AsyncMock(),
                 )
             )
 

--- a/tests/test_channel_startup_recovery.py
+++ b/tests/test_channel_startup_recovery.py
@@ -1,0 +1,126 @@
+"""Eager channel recovery spends platform requests only on live sessions."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from turnstone.channels._routing import ChannelRouter
+from turnstone.sdk.server import AsyncTurnstoneServer
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning"
+)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["discord", "slack"])
+@pytest.mark.parametrize("initial_state", ["empty", "live", "unavailable"])
+async def test_startup_only_subscribes_live_routes_and_retains_inactive_associations(
+    db, platform, initial_state
+):
+    if platform == "discord":
+        discord = pytest.importorskip("discord")
+        from tests.test_channel_discord import _make_real_bot
+
+        bot = _make_real_bot()
+        thread = MagicMock(spec=discord.Thread)
+        thread.parent_id = 222
+        fetch = AsyncMock(return_value=thread)
+        platform_patch = patch.object(bot._bot, "fetch_channel", new=fetch)
+        cache_patch = patch.object(bot._bot, "get_channel", return_value=None)
+    else:
+        from contextlib import nullcontext
+
+        from tests.test_channel_slack import _make_bot
+
+        bot, _, _ = _make_bot()
+        platform_patch = cache_patch = nullcontext()
+
+    await bot.router.aclose()
+    bot.storage = db
+    bot.subscribe_ws = AsyncMock()
+    for index in range(20):
+        channel_id = str(1000 + index) if platform == "discord" else f"C1:U{index}:1000.000001"
+        db.create_channel_route(platform, channel_id, f"ws-{index}", channel_user_id="111")
+
+    state = initial_state
+    list_calls = 0
+
+    def handler(request):
+        nonlocal list_calls
+        assert request.method == "GET" and request.url.path == "/v1/api/workstreams"
+        list_calls += 1
+        if state == "unavailable":
+            return httpx.Response(503, json={"error": "node unavailable"})
+        workstreams = []
+        if state == "live":
+            workstreams = [
+                {"ws_id": "ws-0", "name": "live", "state": "idle"},
+                {"ws_id": "ws-1", "name": "pending", "state": "creating"},
+            ]
+        return httpx.Response(200, json={"workstreams": workstreams})
+
+    router = ChannelRouter("http://server.example", db)
+    await router.aclose()
+    bot.router = router
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server.example"
+    ) as http:
+        router._server = AsyncTurnstoneServer(httpx_client=http)
+        try:
+            with platform_patch, cache_patch:
+                expected = 0
+                for _ in range(2):
+                    await bot._recover_routes()
+                    expected += int(state == "live")
+                    assert bot.subscribe_ws.await_count == expected
+                    if platform == "discord":
+                        assert fetch.await_count == expected
+                    else:
+                        assert len(bot._channel_sessions) == 20
+                    assert len(db.list_channel_routes_by_type(platform)) == 20
+                    if state == "unavailable":
+                        state = "live"
+                assert list_calls == 2
+        finally:
+            await bot.stop()
+
+
+@pytest.mark.anyio
+async def test_console_startup_discovery_bounds_time_and_concurrency(db, monkeypatch):
+    monkeypatch.setattr("turnstone.channels._routing._STARTUP_PROBE_CONCURRENCY", 2)
+    monkeypatch.setattr("turnstone.channels._routing._STARTUP_PROBE_TIMEOUT", 0.05)
+    router = ChannelRouter("http://server.example", db, console_url="http://console.example")
+    active = maximum = 0
+    calls = Counter()
+
+    async def probe(ws_id):
+        nonlocal active, maximum
+        calls[ws_id] += 1
+        active += 1
+        maximum = max(maximum, active)
+        try:
+            if ws_id == "blocked":
+                await asyncio.Event().wait()
+            if ws_id == "error":
+                raise RuntimeError("node unavailable")
+            return MagicMock(live=ws_id == "live")
+        finally:
+            active -= 1
+
+    router._console.route_workstream_live = probe
+    try:
+        found = await asyncio.wait_for(
+            router.get_live_workstream_ids(["blocked", "live", "error", "idle", "live"]), 1
+        )
+        assert found == {"live"}
+        assert maximum == 2
+        assert active == 0
+        assert calls == {"blocked": 1, "live": 1, "error": 1, "idle": 1}
+    finally:
+        await router.aclose()

--- a/tests/test_channel_storage.py
+++ b/tests/test_channel_storage.py
@@ -64,6 +64,17 @@ class TestChannelUserCRUD:
 class TestChannelRouteCRUD:
     """Tests for channel_routes table operations."""
 
+    def test_retained_route_reserves_deleted_workstream_id(self, db):
+        assert db.register_workstream("source", user_id="gateway")
+        db.create_channel_route("discord", "thread", "source", channel_user_id="owner")
+        assert db.delete_workstream("source")
+        assert not db.register_workstream("source", user_id="attacker")
+        assert db.get_workstream("source") is None
+        assert db.get_channel_route("discord", "thread")["ws_id"] == "source"
+        assert db.register_workstream("replacement", user_id="gateway")
+        assert db.replace_channel_route("discord", "thread", "source", "replacement")
+        assert db.register_workstream("source", user_id="attacker")
+
     def test_create_and_get(self, db):
         db.create_channel_route("discord", "thread_123", "ws_abc", "node_1")
         result = db.get_channel_route("discord", "thread_123")
@@ -78,11 +89,31 @@ class TestChannelRouteCRUD:
         assert db.get_channel_route("discord", "thread_999") is None
 
     def test_create_duplicate_noop(self, db):
-        db.create_channel_route("discord", "thread_123", "ws_abc")
-        db.create_channel_route("discord", "thread_123", "ws_different")
+        assert db.create_channel_route("discord", "thread_123", "ws_abc", channel_user_id="123")
+        assert not db.create_channel_route(
+            "discord", "thread_123", "ws_different", channel_user_id="456"
+        )
         result = db.get_channel_route("discord", "thread_123")
         assert result is not None
         assert result["ws_id"] == "ws_abc"  # first write wins
+        assert result["channel_user_id"] == "123"
+
+    def test_replace_is_conditional_and_preserves_owner(self, db):
+        db.create_channel_route(
+            "discord", "thread_123", "ws_old", "node_old", channel_user_id="123"
+        )
+        original = db.get_channel_route("discord", "thread_123")
+        assert db.replace_channel_route("discord", "thread_123", "ws_old", "ws_new")
+        assert not db.replace_channel_route("discord", "thread_123", "ws_old", "ws_loser")
+        expected = {**original, "ws_id": "ws_new", "node_id": ""}
+        assert db.get_channel_route("discord", "thread_123") == expected
+        assert db.get_channel_route_by_ws("ws_new") == expected
+        assert db.list_channel_routes_by_type("discord") == [expected]
+        assert not db.delete_channel_route("discord", "thread_123", expected_ws_id="ws_old")
+        assert db.get_channel_route("discord", "thread_123") == expected
+        assert db.delete_channel_route("discord", "thread_123", expected_ws_id="ws_new")
+        assert not db.replace_channel_route("discord", "thread_123", "ws_new", "ws_late")
+        assert db.get_channel_route("discord", "thread_123") is None
 
     def test_default_empty_node_id(self, db):
         db.create_channel_route("discord", "thread_123", "ws_abc")

--- a/tests/test_console_routing_proxy.py
+++ b/tests/test_console_routing_proxy.py
@@ -200,6 +200,7 @@ class TestRouteCreate:
             NodeRef("node-b", "http://b:8080"),
         )
         assert app.state.proxy_client.post.call_args.kwargs["json"]["resume_ws"] == "d" * 32
+        assert app.state.proxy_client.post.call_args.kwargs["json"]["resume_ws_exact"] is True
         client.close()
 
     def test_route_create_target_node(self):
@@ -318,6 +319,8 @@ class TestRouteCreate:
         ("field", "value", "error"),
         [
             ("resume_ws", 3, "resume_ws must be a string"),
+            ("resume_ws_exact", "true", "resume_ws_exact must be a boolean"),
+            ("resume_ws_exact", True, "resume_ws_exact requires resume_ws"),
             ("resume_ws", "x" * 257, "resume_ws must be at most 256 characters"),
             ("target_node", ["node-a"], "target_node must be a string"),
             ("target_node", "bad/node", "invalid target_node format"),
@@ -404,6 +407,29 @@ class TestRouteCreate:
         storage.resolve_workstream.assert_not_called()
         router.route.assert_called_once_with(source_id)
         assert post.call_args.kwargs["json"]["resume_ws"] == source_id
+
+    @pytest.mark.anyio
+    async def test_sdk_exact_resume_does_not_resolve_a_missing_id_as_an_alias(self):
+        from turnstone.sdk._types import TurnstoneAPIError
+        from turnstone.sdk.console import AsyncTurnstoneConsole
+
+        storage = MagicMock()
+        storage.get_workstream.return_value = None
+        storage.resolve_workstream.return_value = "e" * 32
+        app = _make_app(router=_make_mock_router(), auth_storage=storage)
+        post = _make_proxy_post(json_data={"ws_id": _FORK_DEST_WS_ID})
+        _wire_proxy(app, post)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            headers=_TEST_AUTH_HEADERS,
+        ) as http_client:
+            sdk = AsyncTurnstoneConsole(httpx_client=http_client)
+            with pytest.raises(TurnstoneAPIError) as error:
+                await sdk.route_create_workstream(resume_ws="d" * 32, resume_ws_exact=True)
+        assert error.value.status_code == 404
+        storage.resolve_workstream.assert_not_called()
+        post.assert_not_called()
 
     @pytest.mark.parametrize(
         "upstream",

--- a/tests/test_migration_075.py
+++ b/tests/test_migration_075.py
@@ -1,0 +1,46 @@
+"""Channel ownership survives migration without claiming legacy conversations."""
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+
+def test_channel_route_owner_upgrade_and_downgrade(tmp_path):
+    path = tmp_path / "channels.db"
+    cfg = Config()
+    cfg.set_main_option(
+        "script_location",
+        str(Path(__file__).resolve().parents[1] / "turnstone/core/storage/migrations"),
+    )
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{path}")
+    command.upgrade(cfg, "074")
+    engine = sa.create_engine(f"sqlite:///{path}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO channel_routes (channel_type, channel_id, ws_id, created) "
+                    "VALUES ('discord', '123', 'ws-old', '2026-01-01')"
+                )
+            )
+        command.upgrade(cfg, "075")
+        with engine.begin() as conn:
+            assert conn.execute(
+                sa.text("SELECT ws_id, channel_user_id FROM channel_routes")
+            ).one() == ("ws-old", "")
+            conn.execute(sa.text("UPDATE channel_routes SET channel_user_id = '456'"))
+        command.downgrade(cfg, "074")
+        with engine.connect() as conn:
+            assert (
+                conn.execute(sa.text("SELECT ws_id FROM channel_routes")).scalar_one() == "ws-old"
+            )
+        command.upgrade(cfg, "075")
+        with engine.connect() as conn:
+            assert (
+                conn.execute(sa.text("SELECT channel_user_id FROM channel_routes")).scalar_one()
+                == ""
+            )
+    finally:
+        engine.dispose()

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -245,6 +245,10 @@ class CreateWorkstreamRequest(BaseModel):
             "workstream (empty = fresh start)"
         ),
     )
+    resume_ws_exact: bool = Field(
+        default=False,
+        description="Require an exact source ID in resume_ws; disable alias and prefix resolution",
+    )
     skill: str = Field(default="", description="Skill name (replaces default skills)")
     persona: str = Field(
         default="",

--- a/turnstone/channels/_routing.py
+++ b/turnstone/channels/_routing.py
@@ -45,7 +45,7 @@ class PolicyVerdict:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, MutableMapping
+    from collections.abc import Callable, Iterable, Mapping, MutableMapping
 
     from turnstone.core.storage import StorageBackend
 
@@ -54,9 +54,9 @@ log = get_logger(__name__)
 _WS_CREATE_TIMEOUT = 30.0  # seconds
 _CHANNEL_DEFAULT_TTL = 300.0  # cache channel default alias for 5 minutes
 _MODELS_CACHE_TTL = 30.0  # cache model list for autocomplete
-_ROUTE_CACHE_TTL = 30.0  # cache (channel_type, channel_id) → ws_id lookups
-_ROUTE_CACHE_CAP = 4096  # LRU bound on the lookup cache
 _FORK_SOURCE_NOT_FOUND = "Workstream not found"
+_STARTUP_PROBE_CONCURRENCY = 8
+_STARTUP_PROBE_TIMEOUT = 10.0
 
 
 # ---------------------------------------------------------------------------
@@ -145,11 +145,6 @@ class ChannelRouter:
         self._auto_approve_tools: list[str] = auto_approve_tools or []
         self._skill = skill
         self._create_locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
-        # Per-workstream node URLs from console routing responses.
-        # Populated when console_url is set and the create response
-        # includes node_url.
-        self._node_urls: dict[str, str] = {}
-
         # SDK clients: use console for multi-node, server for single-node.
         self._console: AsyncTurnstoneConsole | None = None
         self._server: AsyncTurnstoneServer | None = None
@@ -174,9 +169,6 @@ class ChannelRouter:
         # Cached model list for autocomplete (shorter TTL).
         self._models_cache: dict[str, Any] = {}
         self._models_cache_ts: float = 0.0
-        # TTL cache for (channel_type, channel_id) → ws_id so hot inbound
-        # paths don't hit storage on every message. Bounded LRU.
-        self._route_cache: OrderedDict[tuple[str, str], tuple[str, float]] = OrderedDict()
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -253,9 +245,45 @@ class ChannelRouter:
             result = await self._console.route_workstream_live(ws_id)
             return result.live
 
+        return ws_id in await self._direct_live_workstream_ids()
+
+    async def _direct_live_workstream_ids(self) -> set[str]:
         assert self._server is not None
         response = await self._server.list_workstreams()
-        return any(ws.ws_id == ws_id and ws.state != "creating" for ws in response.workstreams)
+        return {ws.ws_id for ws in response.workstreams if ws.state != "creating"}
+
+    async def get_live_workstream_ids(self, ws_ids: Iterable[str]) -> set[str]:
+        """Best-effort, bounded discovery for eager startup subscriptions only.
+
+        Direct mode needs one manager list for all routes. Console mode uses
+        the authoritative routed probes with a fixed worker pool and a total
+        time budget. Errors skip eager subscription; inbound messages retain
+        their strict liveness checks and can recover the saved routes later.
+        """
+        candidates = dict.fromkeys(ws_ids)
+        live: set[str] = set()
+        if not candidates:
+            return live
+        pending = iter(candidates)
+
+        async def probe() -> None:
+            for ws_id in pending:
+                try:
+                    if await self._is_ws_live(ws_id):
+                        live.add(ws_id)
+                except Exception:
+                    log.warning("channel_router.startup_probe_failed", ws_id=ws_id, exc_info=True)
+
+        try:
+            async with asyncio.timeout(_STARTUP_PROBE_TIMEOUT):
+                if self._console is None:
+                    return (await self._direct_live_workstream_ids()).intersection(candidates)
+                async with asyncio.TaskGroup() as tasks:
+                    for _ in range(min(len(candidates), _STARTUP_PROBE_CONCURRENCY)):
+                        tasks.create_task(probe())
+        except Exception:
+            log.warning("channel_router.startup_discovery_incomplete", exc_info=True)
+        return live
 
     # -- workstream management -----------------------------------------------
 
@@ -267,6 +295,8 @@ class ChannelRouter:
         model: str = "",
         initial_message: str = "",
         client_type: str = "",
+        channel_user_id: str = "",
+        require_existing: bool = False,
     ) -> tuple[str, bool]:
         """Look up or create a workstream for a channel.
 
@@ -308,13 +338,16 @@ class ChannelRouter:
             route = await asyncio.to_thread(
                 self._storage.get_channel_route, channel_type, channel_id
             )
+            if require_existing and route is None:
+                raise RuntimeError("Channel conversation was closed; start a new conversation")
             if route:
-                # Resolve storage first so failures are fail-closed and aliases
-                # are compared to the canonical ids returned by the live seam.
-                source_ws_id = await asyncio.to_thread(
-                    self._storage.resolve_workstream, route["ws_id"]
-                )
-                if source_ws_id is not None and await self._is_ws_live(source_ws_id):
+                owner = route.get("channel_user_id", "")
+                if owner and owner != channel_user_id:
+                    raise RuntimeError("Channel conversation belongs to another user")
+                # Persisted routes contain exact IDs. An alias matching a
+                # deleted ID must never substitute another conversation.
+                source = await asyncio.to_thread(self._storage.get_workstream, route["ws_id"])
+                if source is not None and await self._is_ws_live(route["ws_id"]):
                     return route["ws_id"], False
                 # The route is not currently usable. Keep it persisted until
                 # its replacement has been created successfully so ACL,
@@ -337,33 +370,35 @@ class ChannelRouter:
                 resume_ws=resume_ws or None,
             )
 
-            async def _create(resume_from: str) -> tuple[dict[str, Any], str]:
+            async def _create(resume_from: str) -> str:
                 if self._console:
                     result = await self._console.route_create_workstream(
                         name=name,
                         model=model,
                         resume_ws=resume_from,
+                        resume_ws_exact=bool(resume_from),
                         skill=self._skill,
                         auto_approve=self._auto_approve,
                         auto_approve_tools=_tools_csv,
                         client_type=client_type,
                     )
-                    return result.model_dump(), result.ws_id
+                    return result.ws_id
 
                 assert self._server is not None
                 response = await self._server.create_workstream(
                     name=name,
                     model=model,
                     resume_ws=resume_from,
+                    resume_ws_exact=bool(resume_from),
                     skill=self._skill,
                     auto_approve=self._auto_approve,
                     auto_approve_tools=_tools_csv,
                     client_type=client_type,
                 )
-                return {"ws_id": response.ws_id, "name": response.name}, response.ws_id
+                return response.ws_id
 
             try:
-                data, ws_id = await _create(resume_ws)
+                ws_id = await _create(resume_ws)
             except TurnstoneAPIError as exc:
                 # Retry fresh only when BOTH the API response and a new
                 # authoritative storage lookup confirm the fork source is gone.
@@ -372,8 +407,8 @@ class ChannelRouter:
                 # authorization failure into an empty replacement conversation.
                 if not resume_ws or exc.status_code != 404 or exc.message != _FORK_SOURCE_NOT_FOUND:
                     raise
-                source_ws_id = await asyncio.to_thread(self._storage.resolve_workstream, resume_ws)
-                if source_ws_id is not None:
+                source = await asyncio.to_thread(self._storage.get_workstream, resume_ws)
+                if source is not None:
                     raise
                 log.info(
                     "channel_router.fork_source_missing",
@@ -382,43 +417,40 @@ class ChannelRouter:
                     channel_id=channel_id,
                 )
                 resume_ws = ""
-                data, ws_id = await _create(resume_ws)
+                ws_id = await _create(resume_ws)
 
             if not ws_id:
                 msg_err = "workstream creation returned empty ws_id"
                 raise RuntimeError(msg_err)
 
-            # 3. Send the initial message if this is a brand-new workstream.
-            if initial_message and not resume_ws:
-                if self._console:
-                    await self._console.route_send(initial_message, ws_id)
-                else:
-                    assert self._server is not None
-                    await self._server.send(initial_message, ws_id)
-
-            # 4. Replace the stale route only after the destination (and any
-            # initial message) succeeded. ``create_channel_route`` is
-            # first-write-wins, so the old mapping must be removed first.
+            # Claim the route before dispatching anything. Other gateway
+            # processes and explicit closes can race this local lock; a
+            # conditional write must not resurrect or overwrite their route.
             if old_ws_id:
-                await asyncio.to_thread(
-                    self._storage.delete_channel_route, channel_type, channel_id
+                claimed = await asyncio.to_thread(
+                    self._storage.replace_channel_route,
+                    channel_type,
+                    channel_id,
+                    old_ws_id,
+                    ws_id,
                 )
-                self._route_cache.pop((channel_type, channel_id), None)
-                log.info(
-                    "channel_router.stale_route_cleared",
-                    ws_id=old_ws_id,
-                    channel_type=channel_type,
-                    channel_id=channel_id,
+            else:
+                claimed = await asyncio.to_thread(
+                    self._storage.create_channel_route,
+                    channel_type,
+                    channel_id,
+                    ws_id,
+                    channel_user_id=channel_user_id,
                 )
-            await asyncio.to_thread(
-                self._storage.create_channel_route, channel_type, channel_id, ws_id
-            )
+            if not claimed:
+                try:
+                    await self.close_workstream(ws_id)
+                except Exception:
+                    log.warning("channel_router.unclaimed_close_failed", ws_id=ws_id, exc_info=True)
+                raise RuntimeError("Channel route changed; retry your message")
 
-            # When routed through the console, capture the node URL for
-            # direct SSE connections after route persistence succeeds.
-            node_url = data.get("node_url", "")
-            if node_url:
-                self._node_urls[ws_id] = node_url.rstrip("/")
+            if initial_message and not resume_ws:
+                await self.send_message(ws_id, initial_message)
 
             log.info(
                 "channel_router.route_created",
@@ -432,23 +464,16 @@ class ChannelRouter:
     async def get_node_url(self, ws_id: str) -> str:
         """Return the direct server URL for SSE connections to *ws_id*.
 
-        When routing through a console, this is the ``node_url`` from the
-        create response.  If the ws_id is not cached (e.g. after a bot
-        restart), queries the console's route lookup endpoint before
-        falling back to the configured server_url.
+        Resolve through the console on every connection attempt so a node's
+        changed address is picked up after restart. Lookup failures propagate
+        to the SSE retry loop; they do not authorize a different destination.
         """
-        url = self._node_urls.get(ws_id)
-        if url:
-            return url
         if self._console:
-            try:
-                data = await self._console.route_lookup(ws_id)
-                node_url = data.get("node_url", "")
-                if node_url:
-                    self._node_urls[ws_id] = node_url.rstrip("/")
-                    return self._node_urls[ws_id]
-            except Exception:
-                log.debug("Console route lookup failed for ws %s", ws_id, exc_info=True)
+            data = await self._console.route_lookup(ws_id)
+            node_url = data.get("node_url", "")
+            if not node_url:
+                raise RuntimeError("Console route lookup returned no node URL")
+            return str(node_url).rstrip("/")
         return self._server_url
 
     # -- user resolution -----------------------------------------------------
@@ -562,38 +587,15 @@ class ChannelRouter:
 
     # -- route management ----------------------------------------------------
 
-    async def lookup_ws_id(self, channel_type: str, channel_id: str) -> str | None:
-        """Return the ws_id bound to (channel_type, channel_id), or None.
-
-        TTL-cached so the hot inbound-message path (thread replies,
-        DM replies) doesn't hit storage on every token.
-        """
-        key = (channel_type, channel_id)
-        now = time.monotonic()
-        cached = self._route_cache.get(key)
-        if cached is not None:
-            ws_id, expires_at = cached
-            if now < expires_at:
-                self._route_cache.move_to_end(key)
-                return ws_id
-            # Expired — fall through to a fresh lookup.
-            del self._route_cache[key]
-
-        route = await asyncio.to_thread(self._storage.get_channel_route, channel_type, channel_id)
-        if route is None:
-            return None
-
-        ws_id = route["ws_id"]
-        self._route_cache[key] = (ws_id, now + _ROUTE_CACHE_TTL)
-        if len(self._route_cache) > _ROUTE_CACHE_CAP:
-            self._route_cache.popitem(last=False)
-        return ws_id
-
-    async def delete_route(self, channel_type: str, channel_id: str) -> None:
+    async def delete_route(
+        self, channel_type: str, channel_id: str, *, expected_ws_id: str | None = None
+    ) -> bool:
         """Remove a channel-to-workstream mapping."""
-        self._route_cache.pop((channel_type, channel_id), None)
         deleted = await asyncio.to_thread(
-            self._storage.delete_channel_route, channel_type, channel_id
+            self._storage.delete_channel_route,
+            channel_type,
+            channel_id,
+            expected_ws_id=expected_ws_id,
         )
         log.info(
             "channel_router.delete_route",
@@ -601,10 +603,10 @@ class ChannelRouter:
             channel_id=channel_id,
             deleted=deleted,
         )
+        return deleted
 
     async def close_workstream(self, ws_id: str) -> None:
         """Close a workstream via the server API."""
-        self._node_urls.pop(ws_id, None)
         try:
             if self._console:
                 await self._console.route_close(ws_id)
@@ -613,6 +615,8 @@ class ChannelRouter:
                 await self._server.close_workstream(ws_id)
             log.info("channel_router.close_workstream", ws_id=ws_id)
         except TurnstoneAPIError as exc:
+            if exc.status_code != 404:
+                raise
             log.warning(
                 "channel_router.close_workstream_failed",
                 ws_id=ws_id,

--- a/turnstone/channels/_sse.py
+++ b/turnstone/channels/_sse.py
@@ -1,9 +1,9 @@
 """Shared SSE listener loop for channel adapters.
 
 Both the Discord and Slack adapters subscribe to per-workstream SSE event
-streams with identical reconnect / 404-stale-route / backoff behaviour.
+streams with identical reconnect / unavailable-session / backoff behaviour.
 :func:`run_sse_stream` extracts that loop so each adapter supplies only
-its platform-specific ``on_event`` and ``on_stale`` callbacks.
+its platform-specific ``on_event`` and ``on_unavailable`` callbacks.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ async def run_sse_stream(
     node_url_fn: Callable[[str], Awaitable[str]],
     token_factory: Callable[[], str] | None,
     on_event: Callable[[ServerEvent], Awaitable[None]],
-    on_stale: Callable[[], Awaitable[None]],
+    on_unavailable: Callable[[], Awaitable[None]],
 ) -> None:
     """Run an SSE subscription loop with reconnect/backoff for one workstream.
 
@@ -54,10 +54,11 @@ async def run_sse_stream(
     on_event:
         Async callback invoked once per parsed :class:`ServerEvent`.
         Exceptions are logged and do not kill the stream.
-    on_stale:
+    on_unavailable:
         Async callback invoked when the server returns 404 for *ws_id*,
-        indicating the workstream was evicted/closed. After ``on_stale``
-        returns, the loop exits (does not reconnect).
+        indicating no usable session on that node. Only transient subscription
+        state should be cleared: saved history and the channel route may still
+        exist. The loop then exits; an inbound message can recover the session.
     """
     delay = SSE_RECONNECT_DELAY
     url = ""
@@ -67,7 +68,7 @@ async def run_sse_stream(
             node_base = await node_url_fn(ws_id)
             url = f"{node_base}/v1/api/workstreams/{ws_id}/events"
 
-            sse_headers: dict[str, str] | None = None
+            sse_headers: dict[str, str] = {}
             if token_factory is not None:
                 sse_headers = {"Authorization": f"Bearer {token_factory()}"}
 
@@ -80,14 +81,14 @@ async def run_sse_stream(
             ) as event_source:
                 status = event_source.response.status_code
                 if status == 404:
-                    log.info(f"{log_prefix}.sse_ws_gone", ws_id=ws_id)
+                    log.info(f"{log_prefix}.sse_ws_unavailable", ws_id=ws_id)
                     # The 404-stops-reconnect invariant belongs to this loop,
-                    # not to the caller — if on_stale raises we still exit.
+                    # not to the caller — if cleanup raises we still exit.
                     try:
-                        await on_stale()
+                        await on_unavailable()
                     except Exception:
                         log.warning(
-                            f"{log_prefix}.sse_on_stale_failed",
+                            f"{log_prefix}.sse_on_unavailable_failed",
                             ws_id=ws_id,
                             exc_info=True,
                         )

--- a/turnstone/channels/cli.py
+++ b/turnstone/channels/cli.py
@@ -53,7 +53,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("TURNSTONE_CONSOLE_URL", ""),
         help="Console URL for multi-node routing (default: $TURNSTONE_CONSOLE_URL). "
         "When set, control-plane POSTs route through the console; "
-        "SSE connects to node_url from the create response.",
+        "SSE resolves the node through the console on each connection.",
     )
 
     # -- Discord -------------------------------------------------------------

--- a/turnstone/channels/discord/bot.py
+++ b/turnstone/channels/discord/bot.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -50,9 +49,6 @@ if TYPE_CHECKING:
     from turnstone.core.storage._protocol import StorageBackend
 
 log = get_logger(__name__)
-
-
-_THREAD_INVOKER_CAP: int = 4096
 
 
 def _thread_owner_id(thread: discord.abc.Messageable) -> str:
@@ -226,6 +222,7 @@ class TurnstoneBot:
         )
 
         self._commands_synced: bool = False
+        self._recovering_routes = False
         self._subscribed_ws: set[str] = set()
         self._sse_tasks: dict[str, asyncio.Task[None]] = {}
         self._streaming: dict[str, StreamingMessage] = {}
@@ -254,14 +251,6 @@ class TurnstoneBot:
         # notification reply DM.  The target_user_id is carried so the
         # response message can be re-tracked for multi-turn DM conversations.
         self._notify_reply_channels: dict[str, tuple[discord.abc.Messageable, str]] = {}
-        # Explicit thread-invoker map so the sec-3 owner check can admit
-        # `/ask` follow-ups (Discord sets `thread.owner_id = bot` when the
-        # thread is created via `channel.create_thread(...)` without a
-        # starter message, so `channel.owner_id` alone would reject every
-        # legitimate follow-up from the human who ran the slash command).
-        # Bounded LRU to prevent unbounded growth across long bot uptime.
-        self._thread_invokers: OrderedDict[int, int] = OrderedDict()
-
         # Shared HTTP client for SSE connections.
         # Read timeout detects half-open connections (server sends ping=5s
         # keepalives, so 90s is very conservative).
@@ -371,18 +360,55 @@ class TurnstoneBot:
             log.info("discord.purged_dead_tasks", trigger=trigger, count=len(dead), ws_ids=dead)
 
     async def _recover_routes(self) -> None:
+        """Coalesce overlapping gateway lifecycle events into one recovery pass."""
+        if self._recovering_routes:
+            return
+        self._recovering_routes = True
+        try:
+            await self._restore_saved_routes()
+        finally:
+            self._recovering_routes = False
+
+    async def _restore_saved_routes(self) -> None:
         """Re-subscribe to event channels for existing discord routes.
 
         Queries the storage backend for all channel routes of type ``discord``
-        and opens SSE connections for each workstream.
+        and opens SSE connections only for workstreams that are already live.
         """
+        import aiohttp
+        import discord
+
         routes = await asyncio.to_thread(self.storage.list_channel_routes_by_type, "discord")
+        # Restore cached threads before any platform lookup can block on I/O.
+        routes.sort(key=lambda route: self._bot.get_channel(int(route["channel_id"])) is None)
+        live_ids = await self.router.get_live_workstream_ids(
+            route["ws_id"]
+            for route in routes
+            if route["ws_id"] not in self._sse_tasks or self._sse_tasks[route["ws_id"]].done()
+        )
         for route in routes:
             ws_id = route["ws_id"]
+            if ws_id not in live_ids:
+                continue
+            task = self._sse_tasks.get(ws_id)
+            if task is not None and not task.done():
+                continue
             channel_id = int(route["channel_id"])
             channel = self._bot.get_channel(channel_id)
-            if channel is not None:
-                await self.subscribe_ws(ws_id, channel)  # type: ignore[arg-type]
+            if channel is None:
+                try:
+                    channel = await self._bot.fetch_channel(channel_id)
+                except (discord.HTTPException, aiohttp.ClientError, TimeoutError):
+                    # Missing/inaccessible threads and platform outages do not
+                    # revoke the durable association or its owner metadata.
+                    log.warning(
+                        "discord.route_recovery_fetch_failed", channel_id=channel_id, exc_info=True
+                    )
+                    continue
+            if isinstance(channel, discord.Thread) and self._is_allowed_channel(
+                channel.parent_id or 0
+            ):
+                await self.subscribe_ws(ws_id, channel)
                 log.info("discord.route_recovered", ws_id=ws_id, channel_id=channel_id)
             else:
                 log.warning(
@@ -399,6 +425,9 @@ class TurnstoneBot:
         thread: discord.abc.Messageable,
     ) -> None:
         """Subscribe to workstream events via SSE and dispatch them to *thread*."""
+        prior = self._sse_tasks.get(ws_id)
+        if prior is not None and prior.done():
+            self._purge_dead_sse_tasks("subscribe")
         if ws_id in self._subscribed_ws:
             return
 
@@ -415,14 +444,11 @@ class TurnstoneBot:
 
         Does not cancel or await the SSE task — callers handle task
         lifecycle differently (``unsubscribe_ws`` cancels and awaits;
-        ``_cleanup_stale_route`` is itself invoked from inside the task).
+        ``_stop_unavailable_stream`` is itself invoked from inside the task).
         """
         self._subscribed_ws.discard(ws_id)
         self._streaming.pop(ws_id, None)
         thinking_msg = self._thinking_msgs.pop(ws_id, None)
-        if thinking_msg is not None:
-            with contextlib.suppress(Exception):
-                await thinking_msg.delete()
         self._tool_info_msgs.pop(ws_id, None)
         self._pop_ws_approvals(ws_id)
         self._notify_reply_channels.pop(ws_id, None)
@@ -430,6 +456,9 @@ class TurnstoneBot:
         stale = [mid for mid, entry in self._notify_ws_map.items() if entry[0] == ws_id]
         for mid in stale:
             del self._notify_ws_map[mid]
+        if thinking_msg is not None:
+            with contextlib.suppress(Exception):
+                await thinking_msg.delete()
 
     def _pop_ws_approvals(self, ws_id: str) -> None:
         """Drop every tracked approval embed for *ws_id* (all cycles)."""
@@ -449,15 +478,11 @@ class TurnstoneBot:
         await self._clear_ws_state(ws_id)
         log.info("discord.unsubscribed", ws_id=ws_id)
 
-    async def _cleanup_stale_route(self, ws_id: str) -> None:
-        """Remove a channel route whose workstream no longer exists."""
-        route = await asyncio.to_thread(self.storage.get_channel_route_by_ws, ws_id)
-        if route:
-            # Route deletion must go through the router so the TTL cache
-            # of (channel_type, channel_id) → ws_id is also invalidated.
-            await self.router.delete_route(route["channel_type"], route["channel_id"])
-            log.info("discord.stale_route_removed", ws_id=ws_id)
-        # Called from inside the SSE task itself — don't await the task here.
+    async def _stop_unavailable_stream(self, ws_id: str) -> None:
+        """Retire this listener while retaining the route for inbound recovery."""
+        task = self._sse_tasks.get(ws_id)
+        if task is not None and task is not asyncio.current_task():
+            return
         self._sse_tasks.pop(ws_id, None)
         await self._clear_ws_state(ws_id)
 
@@ -468,14 +493,14 @@ class TurnstoneBot:
 
         Delegates the reconnect/backoff loop to :func:`run_sse_stream`;
         this wrapper just translates events to ``_on_ws_event`` calls and
-        handles the 404 stale-route case.
+        stops an unavailable subscription without deleting its route.
         """
 
         async def _on_event(event: ServerEvent) -> None:
             await self._on_ws_event(ws_id, thread, event)
 
-        async def _on_stale() -> None:
-            await self._cleanup_stale_route(ws_id)
+        async def _on_unavailable() -> None:
+            await self._stop_unavailable_stream(ws_id)
 
         await run_sse_stream(
             http_client=self._http_client,
@@ -484,7 +509,7 @@ class TurnstoneBot:
             node_url_fn=self.router.get_node_url,
             token_factory=self._token_factory,
             on_event=_on_event,
-            on_stale=_on_stale,
+            on_unavailable=_on_unavailable,
         )
 
     # -- event dispatch ------------------------------------------------------
@@ -740,7 +765,11 @@ class TurnstoneBot:
             # Footer format ws_id|cycle_id|owner — the persistent view
             # parses it back on click and routes the decision to exactly
             # this cycle.
-            embed.set_footer(text=f"{ws_id}|{cycle_id}|{_thread_owner_id(thread)}")
+            route = await asyncio.to_thread(self.storage.get_channel_route_by_ws, ws_id)
+            owner_id = (
+                route.get("channel_user_id", "") if route is not None else _thread_owner_id(thread)
+            )
+            embed.set_footer(text=f"{ws_id}|{cycle_id}|{owner_id}")
             msg = await thread.send(embed=embed, view=ApprovalView(self)._view)
             call_ids = frozenset(
                 str(it.get("call_id", "")) for it in event.items if it.get("call_id")
@@ -916,27 +945,6 @@ class TurnstoneBot:
             msg = await target.send(chunk)  # type: ignore[union-attr]
 
         return str(msg.id) if msg else ""
-
-    def register_thread_invoker(self, thread_id: int, discord_user_id: int) -> None:
-        """Record the Discord user who caused *thread_id* to be created.
-
-        Sec-3 gates inbound messages on thread ownership.  When the bot
-        itself creates the thread via ``channel.create_thread(...)``
-        Discord sets ``thread.owner_id`` to the bot, so ``channel.owner_id``
-        alone would silently drop every legitimate follow-up from the
-        human who triggered the session.
-        """
-        self._thread_invokers[thread_id] = discord_user_id
-        self._thread_invokers.move_to_end(thread_id)
-        while len(self._thread_invokers) > _THREAD_INVOKER_CAP:
-            self._thread_invokers.popitem(last=False)
-
-    def get_thread_invoker(self, thread_id: int) -> int | None:
-        """Return the recorded invoker for *thread_id*, or ``None``."""
-        invoker = self._thread_invokers.get(thread_id)
-        if invoker is not None:
-            self._thread_invokers.move_to_end(thread_id)
-        return invoker
 
     async def send_notification(self, channel_id: str, content: str, ws_id: str) -> str:
         """Send a notification and track the message for reply routing (DMs only).

--- a/turnstone/channels/discord/cog.py
+++ b/turnstone/channels/discord/cog.py
@@ -10,6 +10,7 @@ import asyncio
 import time
 from collections import OrderedDict, deque
 from typing import TYPE_CHECKING
+from weakref import WeakValueDictionary
 
 from turnstone.core.log import get_logger
 
@@ -24,6 +25,10 @@ log = get_logger(__name__)
 
 _THREAD_NAME_MAX = 100
 _DM_REPLY_MAX_LENGTH = 4096  # Discord's own message limit
+_LEGACY_THREAD_MESSAGE = (
+    "I can't verify who started this older thread. Use `/ask` in the parent channel "
+    "to start a new conversation."
+)
 
 # /link is the only flow that reads Turnstone API tokens out of user
 # input; throttle aggressively so an attacker with throw-away Discord
@@ -50,6 +55,7 @@ class MessageCog:
         # Per-Discord-user sliding-window rate limit on /link, to block
         # online enumeration of Turnstone API tokens.
         self._link_buckets: OrderedDict[str, deque[float]] = OrderedDict()
+        self._thread_locks: WeakValueDictionary[int, asyncio.Lock] = WeakValueDictionary()
 
         # -- Cog wiring (manual since we can't use decorators with guarded imports) --
 
@@ -141,73 +147,9 @@ class MessageCog:
 
         # --- Message in a Discord Thread ---
         if isinstance(channel, discord.Thread):
-            parent_id = channel.parent_id or 0
-            if not self.ts._is_allowed_channel(parent_id):
-                return
-
-            # Check if this thread has an existing route (TTL-cached).
-            existing_ws_id = await self.ts.router.lookup_ws_id("discord", str(channel.id))
-            if existing_ws_id is None:
-                # Not our thread — ignore.
-                return
-
-            # Owner check: only the thread creator (who initiated the
-            # workstream) can inject messages. Without this gate, any
-            # linked user in a public / multi-member thread could
-            # redirect someone else's assistant and bill their quota,
-            # because the gateway forwards with its service-scoped JWT
-            # and the server bypasses ownership on service scope.
-            #
-            # We prefer the explicitly-recorded invoker over
-            # `thread.owner_id`: `/ask` creates threads via
-            # `channel.create_thread(...)` which reports the bot as
-            # owner, so the Discord-reported value alone would reject
-            # every legitimate follow-up.
-            effective_owner_id = self.ts.get_thread_invoker(channel.id)
-            if effective_owner_id is None:
-                effective_owner_id = channel.owner_id
-            if effective_owner_id is None or message.author.id != effective_owner_id:
-                log.debug(
-                    "discord.thread_message_rejected_non_owner",
-                    thread_id=channel.id,
-                    author_id=message.author.id,
-                    owner_id=effective_owner_id,
-                )
-                return
-
-            # Resolve user.
-            user_id = await self.ts.router.resolve_user("discord", str(message.author.id))
-            if user_id is None:
-                return
-
-            # Use get_or_create_workstream so stale routes (evicted ws) are
-            # auto-refreshed with a new workstream.
-            try:
-                ws_id, is_new = await self.ts.router.get_or_create_workstream(
-                    "discord",
-                    str(channel.id),
-                    name=channel.name or "",
-                    initial_message="",
-                    client_type="chat",
-                )
-            except (TimeoutError, RuntimeError):
-                log.warning("discord.ws_reactivation_failed", thread_id=channel.id)
-                return
-
-            if is_new:
-                await channel.send("*Workstream reactivated.*")
-
-            # Ensure subscription is active (handles bot restart recovery).
-            if ws_id not in self.ts._subscribed_ws:
-                await self.ts.subscribe_ws(ws_id, channel)
-
-            await self.ts.router.send_message(ws_id, message.content)
-            log.debug(
-                "discord.message_routed",
-                ws_id=ws_id,
-                thread_id=channel.id,
-                author=str(message.author),
-            )
+            lock = self._thread_lock(channel.id)
+            async with lock:
+                await self._handle_thread_message(message, channel)
             return
 
         # --- @mention in a non-thread channel ---
@@ -234,10 +176,6 @@ class MessageCog:
                 name=thread_name,
                 auto_archive_duration=self.ts.config.thread_auto_archive,  # type: ignore[arg-type]
             )
-            # Record invoker so the sec-3 gate admits follow-ups even if
-            # Discord's reported thread.owner_id diverges.
-            self.ts.register_thread_invoker(thread.id, message.author.id)
-
             # Create workstream WITHOUT initial_message — subscribe to events
             # first, then send the message.  With SSE the event stream is
             # reliable once connected, but we still subscribe first for
@@ -252,6 +190,7 @@ class MessageCog:
                 model=mention_model,
                 initial_message="",
                 client_type="chat",
+                channel_user_id=str(message.author.id),
             )
 
             await self.ts.subscribe_ws(ws_id, thread)
@@ -262,6 +201,92 @@ class MessageCog:
                 thread_id=thread.id,
                 author=str(message.author),
             )
+
+    def _thread_lock(self, thread_id: int) -> asyncio.Lock:
+        """Serialize local reply/close operations; idle locks are not retained."""
+        lock = self._thread_locks.get(thread_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._thread_locks[thread_id] = lock
+        return lock
+
+    async def _handle_thread_message(
+        self, message: discord.Message, channel: discord.Thread
+    ) -> None:
+        parent_id = channel.parent_id or 0
+        if not self.ts._is_allowed_channel(parent_id):
+            return
+
+        # Read the association and its durable owner together. A bot-owned
+        # /ask thread cannot prove the human invoker through owner_id alone.
+        route = await asyncio.to_thread(
+            self.ts.storage.get_channel_route, "discord", str(channel.id)
+        )
+        if route is None:
+            # Not our thread — ignore.
+            return
+
+        # Owner check: only the thread creator (who initiated the
+        # workstream) can inject messages. Without this gate, any
+        # linked user in a public / multi-member thread could
+        # redirect someone else's assistant and bill their quota,
+        # because the gateway forwards with its service-scoped JWT
+        # and the server bypasses ownership on service scope.
+        #
+        effective_owner_id = route.get("channel_user_id", "")
+        if not effective_owner_id:
+            if await self.ts.router.resolve_user("discord", str(message.author.id)):
+                await channel.send(_LEGACY_THREAD_MESSAGE)
+            return
+        if str(message.author.id) != effective_owner_id:
+            log.debug(
+                "discord.thread_message_rejected_non_owner",
+                thread_id=channel.id,
+                author_id=message.author.id,
+                owner_id=effective_owner_id,
+            )
+            return
+
+        # Resolve user.
+        user_id = await self.ts.router.resolve_user("discord", str(message.author.id))
+        if user_id is None:
+            return
+
+        # Use get_or_create_workstream so stale routes (evicted ws) are
+        # auto-refreshed with a new workstream.
+        try:
+            ws_id, is_new = await self.ts.router.get_or_create_workstream(
+                "discord",
+                str(channel.id),
+                name=channel.name or "",
+                initial_message="",
+                client_type="chat",
+                channel_user_id=str(message.author.id),
+                require_existing=True,
+            )
+        except Exception:
+            log.warning("discord.ws_reactivation_failed", thread_id=channel.id, exc_info=True)
+            await channel.send(
+                "I couldn't recover this conversation. Please try your message again."
+            )
+            return
+
+        if is_new:
+            await channel.send("*Workstream reactivated.*")
+
+        # Ensure subscription is active (handles bot restart recovery).
+        if ws_id != route["ws_id"]:
+            await self.ts.unsubscribe_ws(route["ws_id"])
+        await self.ts.subscribe_ws(ws_id, channel)
+
+        await self.ts.router.send_message(ws_id, message.content)
+        log.debug(
+            "discord.message_routed",
+            ws_id=ws_id,
+            thread_id=channel.id,
+            author=str(message.author),
+        )
+        return
 
     # -- DM reply handling ---------------------------------------------------
 
@@ -447,6 +472,11 @@ class MessageCog:
         if channel is None:
             await interaction.followup.send("Cannot determine channel.", ephemeral=True)
             return
+        if not self.ts._is_allowed_channel(channel.id):
+            await interaction.followup.send(
+                "This channel is not enabled for Turnstone.", ephemeral=True
+            )
+            return
 
         thread_name = message[:_THREAD_NAME_MAX] if len(message) > _THREAD_NAME_MAX else message
 
@@ -457,10 +487,6 @@ class MessageCog:
                 auto_archive_duration=self.ts.config.thread_auto_archive,  # type: ignore[arg-type]
                 type=discord.ChannelType.public_thread,
             )
-            # `channel.create_thread` without a starter message makes the
-            # bot the thread owner, so the sec-3 gate needs to see the
-            # real invoker here — otherwise `/ask` follow-ups get dropped.
-            self.ts.register_thread_invoker(thread.id, interaction.user.id)
         else:
             await interaction.followup.send(
                 "Cannot create a thread in this channel type.",
@@ -482,6 +508,7 @@ class MessageCog:
             model=effective_model,
             initial_message="",
             client_type="chat",
+            channel_user_id=str(interaction.user.id),
         )
 
         await self.ts.subscribe_ws(ws_id, thread)
@@ -570,13 +597,41 @@ class MessageCog:
             )
             return
 
+        await interaction.response.defer(ephemeral=True)
+        lock = self._thread_lock(channel.id)
+        async with lock:
+            try:
+                await self._close_thread(interaction, channel)
+            except Exception:
+                log.warning("discord.workstream_close_failed", thread_id=channel.id, exc_info=True)
+                await interaction.followup.send(
+                    "I couldn't close this conversation. Please try again.", ephemeral=True
+                )
+
+    async def _close_thread(
+        self, interaction: discord.Interaction, channel: discord.Thread
+    ) -> None:
+        import discord
+
         route = await asyncio.to_thread(
             self.ts.storage.get_channel_route, "discord", str(channel.id)
         )
         if route is None:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "No workstream is associated with this thread.",
                 ephemeral=True,
+            )
+            return
+
+        owner_id = route.get("channel_user_id", "")
+        if not owner_id:
+            await interaction.followup.send(_LEGACY_THREAD_MESSAGE, ephemeral=True)
+            return
+        if str(interaction.user.id) != owner_id or not await self.ts.router.resolve_user(
+            "discord", str(interaction.user.id)
+        ):
+            await interaction.followup.send(
+                "Only the linked conversation owner can close this workstream.", ephemeral=True
             )
             return
 
@@ -586,10 +641,14 @@ class MessageCog:
         await self.ts.router.close_workstream(ws_id)
 
         # Delete route and unsubscribe.
-        await self.ts.router.delete_route("discord", str(channel.id))
+        if not await self.ts.router.delete_route("discord", str(channel.id), expected_ws_id=ws_id):
+            await interaction.followup.send(
+                "The conversation changed while closing. Please try `/close` again.", ephemeral=True
+            )
+            return
         await self.ts.unsubscribe_ws(ws_id)
 
-        await interaction.response.send_message("Workstream closed.")
+        await interaction.followup.send("Workstream closed.")
         log.info("discord.workstream_closed", ws_id=ws_id, thread_id=channel.id)
 
         # Archive the thread.

--- a/turnstone/channels/slack/bot.py
+++ b/turnstone/channels/slack/bot.py
@@ -365,7 +365,7 @@ class TurnstoneSlackBot:
         log.info("slack.stopped")
 
     async def _recover_routes(self) -> None:
-        """Re-subscribe to SSE streams for existing slack routes."""
+        """Restore all associations, then subscribe only to already-live sessions."""
         routes = await asyncio.to_thread(
             self.storage.list_channel_routes_by_type,
             "slack",
@@ -377,8 +377,6 @@ class TurnstoneSlackBot:
             ws_id = route["ws_id"]
             channel_id = route["channel_id"]
 
-            await self.subscribe_ws(ws_id, channel_id)
-
             slack_route = SlackRoute.parse(channel_id)
             if slack_route.channel and slack_route.user_id and slack_route.thread_ts:
                 key = (slack_route.channel, slack_route.user_id)
@@ -387,9 +385,15 @@ class TurnstoneSlackBot:
                 if existing is None or _parse_ts(slack_route.thread_ts) > _parse_ts(existing[1]):
                     latest_sessions[key] = (ws_id, slack_route.thread_ts)
 
-            log.info("slack.route_recovered", ws_id=ws_id, channel_id=channel_id)
-
         self._channel_sessions = latest_sessions
+
+        live_ids = await self.router.get_live_workstream_ids(route["ws_id"] for route in routes)
+        for route in routes:
+            if route["ws_id"] in live_ids:
+                await self.subscribe_ws(route["ws_id"], route["channel_id"])
+                log.info(
+                    "slack.route_recovered", ws_id=route["ws_id"], channel_id=route["channel_id"]
+                )
 
         for (slack_channel, user_id), (ws_id, thread_ts) in self._channel_sessions.items():
             log.info(
@@ -448,12 +452,16 @@ class TurnstoneSlackBot:
         existing = self._channel_sessions.get((slack_channel, user_id))
         if existing is not None:
             old_ws_id, old_thread_ts = existing
-            await self._archive_session(
-                slack_channel,
-                user_id,
-                old_ws_id,
-                old_thread_ts,
-            )
+            try:
+                await self._archive_session(slack_channel, user_id, old_ws_id, old_thread_ts)
+            except Exception:
+                log.warning("slack.session_archive_failed", exc_info=True)
+                await self._client.chat_postEphemeral(
+                    channel=slack_channel,
+                    user=user_id,
+                    text="I couldn't close the previous session. Please try again.",
+                )
+                return
 
         opener = await self._client.chat_postMessage(
             channel=slack_channel,
@@ -690,48 +698,32 @@ class TurnstoneSlackBot:
         ws_id: str,
         thread_ts: str,
     ) -> None:
-        """Mark the old session as archived and unsubscribe."""
+        """Close the selected session without removing a concurrent replacement."""
+        route = SlackRoute(channel=slack_channel, user_id=user_id, thread_ts=thread_ts)
+        await self.router.close_workstream(ws_id)
+        if not await self.router.delete_route("slack", route.to_channel_id(), expected_ws_id=ws_id):
+            current = await asyncio.to_thread(
+                self.storage.get_channel_route, "slack", route.to_channel_id()
+            )
+            key = (slack_channel, user_id)
+            if self._channel_sessions.get(key) == (ws_id, thread_ts):
+                if current is None:
+                    self._channel_sessions.pop(key, None)
+                else:
+                    self._channel_sessions[key] = (current["ws_id"], thread_ts)
+            raise RuntimeError("Slack session changed; retry closing it")
+        if self._channel_sessions.get((slack_channel, user_id)) == (ws_id, thread_ts):
+            self._channel_sessions.pop((slack_channel, user_id), None)
+        await self.unsubscribe_ws(ws_id)
         try:
             await self._client.chat_postMessage(
                 channel=slack_channel,
                 thread_ts=thread_ts,
-                text="_This session has been archived. A new one has started._",
+                text="_This session has been archived._",
             )
         except Exception:
             log.debug("slack.archive_session.notify_failed", ws_id=ws_id, exc_info=True)
-
-        route = SlackRoute(
-            channel=slack_channel,
-            user_id=user_id,
-            thread_ts=thread_ts,
-        )
-
-        try:
-            await self.router.delete_route("slack", route.to_channel_id())
-            log.info(
-                "slack.archived_route_deleted",
-                ws_id=ws_id,
-                channel_id=route.to_channel_id(),
-            )
-        except Exception:
-            log.exception(
-                "slack.archived_route_delete_failed",
-                ws_id=ws_id,
-                channel_id=route.to_channel_id(),
-            )
-
-        await self.unsubscribe_ws(ws_id)
-        # close_workstream is the only path that drops the ws_id from
-        # ChannelRouter._node_urls; skipping it leaks one cache entry per
-        # archived session over long bot uptime.
-        await self.router.close_workstream(ws_id)
-        self._channel_sessions.pop((slack_channel, user_id), None)
-        log.info(
-            "slack.session_archived",
-            ws_id=ws_id,
-            channel=slack_channel,
-            user=user_id,
-        )
+        log.info("slack.session_archived", ws_id=ws_id, channel=slack_channel, user=user_id)
 
     async def _on_message(self, event: dict[str, Any], say: Any) -> None:
         """Route messages — thread-only in channels, free in DMs."""
@@ -831,6 +823,22 @@ class TurnstoneSlackBot:
             return
 
         try:
+            route = SlackRoute(channel=channel_id, user_id=user_id, thread_ts=thread_ts)
+            recovered_ws_id, _is_new = await self.router.get_or_create_workstream(
+                channel_type="slack",
+                channel_id=route.to_channel_id(),
+                name=f"slack-{user_id[:8]}",
+                client_type="chat",
+                require_existing=True,
+            )
+            if recovered_ws_id != ws_id:
+                await self.unsubscribe_ws(ws_id)
+            current = self._channel_sessions.get((channel_id, user_id))
+            if current is None or current[1] != thread_ts:
+                raise RuntimeError("Slack session changed; retry your message")
+            ws_id = recovered_ws_id
+            self._channel_sessions[(channel_id, user_id)] = (ws_id, thread_ts)
+            await self.subscribe_ws(ws_id, route.to_channel_id())
             await self.router.send_message(ws_id, text)
             log.info("slack.message_dispatched", ws_id=ws_id, channel=channel_id)
         except Exception:
@@ -866,14 +874,13 @@ class TurnstoneSlackBot:
         )
 
         try:
-            ws_id, is_new = await self.router.get_or_create_workstream(
+            ws_id, _is_new = await self.router.get_or_create_workstream(
                 channel_type="slack",
                 channel_id=route.to_channel_id(),
                 name=f"slack-dm-{user_id[:8]}",
                 client_type="chat",
             )
-            if is_new:
-                await self.subscribe_ws(ws_id, route.to_channel_id())
+            await self.subscribe_ws(ws_id, route.to_channel_id())
 
             await self.router.send_message(ws_id, text)
             log.info("slack.dm_dispatched", ws_id=ws_id, user=user_id)
@@ -985,7 +992,7 @@ class TurnstoneSlackBot:
 
         Does not cancel or await the SSE task — callers handle task
         lifecycle differently (``unsubscribe_ws`` cancels and awaits;
-        ``_cleanup_stale_route`` is itself invoked from inside the task).
+        ``_stop_unavailable_stream`` is itself invoked from inside the task).
         """
         self._subscribed_ws.discard(ws_id)
         self._streaming.pop(ws_id, None)
@@ -1020,8 +1027,8 @@ class TurnstoneSlackBot:
             )
             await self._on_ws_event(ws_id, effective_route, event)
 
-        async def _on_stale() -> None:
-            await self._cleanup_stale_route(ws_id, channel_id)
+        async def _on_unavailable() -> None:
+            await self._stop_unavailable_stream(ws_id)
 
         await run_sse_stream(
             http_client=self._http_client,
@@ -1030,21 +1037,16 @@ class TurnstoneSlackBot:
             node_url_fn=self.router.get_node_url,
             token_factory=self._token_factory,
             on_event=_on_event,
-            on_stale=_on_stale,
+            on_unavailable=_on_unavailable,
         )
 
-    async def _cleanup_stale_route(self, ws_id: str, channel_id: str) -> None:
-        """Remove a channel route whose workstream no longer exists."""
-        route = SlackRoute.parse(channel_id)
-        if route.channel and route.user_id and route.thread_ts:
-            self._channel_sessions.pop((route.channel, route.user_id), None)
-
-        await self.router.delete_route("slack", channel_id)
-        # Called from inside the SSE task itself — don't await the task here.
+    async def _stop_unavailable_stream(self, ws_id: str) -> None:
+        """Retire this listener while retaining the route and session association."""
+        task = self._sse_tasks.get(ws_id)
+        if task is not None and task is not asyncio.current_task():
+            return
         self._sse_tasks.pop(ws_id, None)
         self._clear_ws_state(ws_id)
-
-        log.info("slack.stale_route_removed", ws_id=ws_id)
 
     async def _on_ws_event(
         self,

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -2143,6 +2143,16 @@ async def route_create(request: Request) -> Response:
                 )
 
         resume_ws = body.get("resume_ws", "")
+        resume_ws_exact = body.get("resume_ws_exact", False)
+        if not isinstance(resume_ws_exact, bool) or (resume_ws_exact and not resume_ws):
+            message = (
+                "resume_ws_exact must be a boolean"
+                if not isinstance(resume_ws_exact, bool)
+                else "resume_ws_exact requires resume_ws"
+            )
+            return _record_route(
+                request, "create", 400, t0, JSONResponse({"error": message}, status_code=400)
+            )
         target_node = body.get("target_node", "")
         requested_ws_id = body.get("ws_id", "")
         if resume_ws and len(resume_ws) > _MAX_ROUTE_RESUME_LEN:
@@ -2196,14 +2206,14 @@ async def route_create(request: Request) -> Response:
                 # id can redirect the routed fork before it reaches the node.
                 exact_row = (
                     await asyncio.to_thread(storage.get_workstream, resume_ws)
-                    if _VALID_CREATE_WS_ID_RE.fullmatch(resume_ws)
+                    if resume_ws_exact or _VALID_CREATE_WS_ID_RE.fullmatch(resume_ws)
                     else None
                 )
-                canonical_resume = (
-                    resume_ws
-                    if exact_row is not None
-                    else await asyncio.to_thread(storage.resolve_workstream, resume_ws)
-                )
+                canonical_resume = resume_ws if exact_row is not None else None
+                if canonical_resume is None and not resume_ws_exact:
+                    canonical_resume = await asyncio.to_thread(
+                        storage.resolve_workstream, resume_ws
+                    )
             except Exception:
                 log.warning(
                     "route_create.resume_lookup_failed source=%s",
@@ -2226,6 +2236,9 @@ async def route_create(request: Request) -> Response:
                     JSONResponse({"error": "Workstream not found"}, status_code=404),
                 )
             body["resume_ws"] = canonical_resume
+            # Preserve the resolved identity even if it disappears before the
+            # node's preflight; another row's alias cannot replace this source.
+            body["resume_ws_exact"] = True
             resume_ws = canonical_resume
 
         fixed_ws_id = bool(requested_ws_id)

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -1428,23 +1428,29 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         # Use ON CONFLICT DO NOTHING to match SQLite's OR IGNORE semantics
         # and close the SELECT-then-INSERT TOCTOU window under concurrent
         # register_workstream calls for the same ws_id.
-        stmt = pg_insert(workstreams).values(
-            ws_id=ws_id,
-            node_id=node_id,
-            user_id=user_id,
-            name=name,
-            state=state,
-            alias=alias,
-            title=title,
-            skill_id=skill_id,
-            skill_version=skill_version,
-            kind=norm_kind,
-            parent_ws_id=norm_parent,
-            project_id=norm_project,
-            persona=norm_persona,
-            created=now,
-            updated=now,
+        values = {
+            "ws_id": ws_id,
+            "node_id": node_id,
+            "user_id": user_id,
+            "name": name,
+            "state": state,
+            "alias": alias,
+            "title": title,
+            "skill_id": skill_id,
+            "skill_version": skill_version,
+            "kind": norm_kind,
+            "parent_ws_id": norm_parent,
+            "project_id": norm_project,
+            "persona": norm_persona,
+            "created": now,
+            "updated": now,
+        }
+        # Keep the reference check in the INSERT statement, matching SQLite:
+        # a channel's deleted source ID cannot be claimed by a new incarnation.
+        source = sa.select(*(sa.literal(value) for value in values.values())).where(
+            ~sa.exists().where(channel_routes.c.ws_id == ws_id)
         )
+        stmt = pg_insert(workstreams).from_select(list(values), source)
         insert_stmt = stmt.on_conflict_do_nothing(index_elements=["ws_id"]).returning(
             workstreams.c.ws_id
         )
@@ -2379,24 +2385,50 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
     # -- Channel routing -------------------------------------------------------
 
     def create_channel_route(
-        self, channel_type: str, channel_id: str, ws_id: str, node_id: str = ""
-    ) -> None:
+        self,
+        channel_type: str,
+        channel_id: str,
+        ws_id: str,
+        node_id: str = "",
+        *,
+        channel_user_id: str = "",
+    ) -> bool:
         from sqlalchemy.dialects import postgresql
 
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
-            conn.execute(
+            result = conn.execute(
                 postgresql.insert(channel_routes)
                 .values(
                     channel_type=channel_type,
                     channel_id=channel_id,
                     ws_id=ws_id,
                     node_id=node_id,
+                    channel_user_id=channel_user_id,
                     created=now,
                 )
                 .on_conflict_do_nothing()
+                .returning(channel_routes.c.ws_id)
+            )
+            inserted = result.scalar_one_or_none() is not None
+            conn.commit()
+            return inserted
+
+    def replace_channel_route(
+        self, channel_type: str, channel_id: str, expected_ws_id: str, ws_id: str
+    ) -> bool:
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.update(channel_routes)
+                .where(
+                    (channel_routes.c.channel_type == channel_type)
+                    & (channel_routes.c.channel_id == channel_id)
+                    & (channel_routes.c.ws_id == expected_ws_id)
+                )
+                .values(ws_id=ws_id, node_id="")
             )
             conn.commit()
+            return result.rowcount > 0
 
     def get_channel_route(self, channel_type: str, channel_id: str) -> dict[str, str] | None:
 
@@ -2408,6 +2440,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     channel_routes.c.ws_id,
                     channel_routes.c.node_id,
                     channel_routes.c.created,
+                    channel_routes.c.channel_user_id,
                 ).where(
                     (channel_routes.c.channel_type == channel_type)
                     & (channel_routes.c.channel_id == channel_id)
@@ -2420,6 +2453,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     "ws_id": row[2],
                     "node_id": row[3],
                     "created": row[4],
+                    "channel_user_id": row[5],
                 }
             return None
 
@@ -2433,6 +2467,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     channel_routes.c.ws_id,
                     channel_routes.c.node_id,
                     channel_routes.c.created,
+                    channel_routes.c.channel_user_id,
                 ).where(channel_routes.c.ws_id == ws_id)
             ).fetchone()
             if row:
@@ -2442,6 +2477,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     "ws_id": row[2],
                     "node_id": row[3],
                     "created": row[4],
+                    "channel_user_id": row[5],
                 }
             return None
 
@@ -2455,6 +2491,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     channel_routes.c.ws_id,
                     channel_routes.c.node_id,
                     channel_routes.c.created,
+                    channel_routes.c.channel_user_id,
                 )
                 .where(channel_routes.c.channel_type == channel_type)
                 .order_by(channel_routes.c.created.desc())
@@ -2466,19 +2503,22 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     "ws_id": r[2],
                     "node_id": r[3],
                     "created": r[4],
+                    "channel_user_id": r[5],
                 }
                 for r in rows
             ]
 
-    def delete_channel_route(self, channel_type: str, channel_id: str) -> bool:
-
+    def delete_channel_route(
+        self, channel_type: str, channel_id: str, *, expected_ws_id: str | None = None
+    ) -> bool:
+        statement = sa.delete(channel_routes).where(
+            (channel_routes.c.channel_type == channel_type)
+            & (channel_routes.c.channel_id == channel_id)
+        )
+        if expected_ws_id is not None:
+            statement = statement.where(channel_routes.c.ws_id == expected_ws_id)
         with self._conn() as conn:
-            result = conn.execute(
-                sa.delete(channel_routes).where(
-                    (channel_routes.c.channel_type == channel_type)
-                    & (channel_routes.c.channel_id == channel_id)
-                )
-            )
+            result = conn.execute(statement)
             conn.commit()
             return result.rowcount > 0
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -1080,7 +1080,9 @@ class StorageBackend(Protocol):
         reservation. An existing row returns ``False``; generated-ID callers
         may draw another ID while caller-selected IDs surface the collision.
         Hard deletion releases the ID for later reuse after removing the
-        workstream and its owned state in the same transaction.
+        workstream and its owned state in the same transaction, unless a
+        retained channel route still references it. Such references also
+        return ``False`` to prevent redirecting a channel into a new incarnation.
 
         ``kind`` accepts a ``WorkstreamKind`` member or its raw string value
         (``"interactive"`` / ``"coordinator"``); the storage edge validates
@@ -1554,9 +1556,21 @@ class StorageBackend(Protocol):
     # -- Channel routing -------------------------------------------------------
 
     def create_channel_route(
-        self, channel_type: str, channel_id: str, ws_id: str, node_id: str = ""
-    ) -> None:
-        """Map a channel/thread to a workstream. No-op if exists."""
+        self,
+        channel_type: str,
+        channel_id: str,
+        ws_id: str,
+        node_id: str = "",
+        *,
+        channel_user_id: str = "",
+    ) -> bool:
+        """Map a channel/thread and its external owner. Return whether inserted."""
+        ...
+
+    def replace_channel_route(
+        self, channel_type: str, channel_id: str, expected_ws_id: str, ws_id: str
+    ) -> bool:
+        """Atomically replace the expected workstream, preserving owner and creation time."""
         ...
 
     def get_channel_route(self, channel_type: str, channel_id: str) -> dict[str, str] | None:
@@ -1571,8 +1585,10 @@ class StorageBackend(Protocol):
         """List all routes for a channel type, ordered by created DESC."""
         ...
 
-    def delete_channel_route(self, channel_type: str, channel_id: str) -> bool:
-        """Remove a channel route. Returns True if existed."""
+    def delete_channel_route(
+        self, channel_type: str, channel_id: str, *, expected_ws_id: str | None = None
+    ) -> bool:
+        """Remove a route, optionally only if its workstream still matches. Return whether removed."""
         ...
 
     # -- Scheduled tasks -------------------------------------------------------

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -288,6 +288,7 @@ channel_routes = sa.Table(
     sa.Column("channel_id", sa.Text, nullable=False),
     sa.Column("ws_id", sa.Text, nullable=False),
     sa.Column("node_id", sa.Text, nullable=False, server_default=""),
+    sa.Column("channel_user_id", sa.Text, nullable=False, server_default=""),
     sa.Column("created", sa.Text, nullable=False),
     sa.PrimaryKeyConstraint("channel_type", "channel_id"),
 )

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -1454,26 +1454,31 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         norm_parent = parent_ws_id if parent_ws_id else None
         norm_project = project_id if project_id else None
         norm_persona = persona if persona else None
+        values = {
+            "ws_id": ws_id,
+            "node_id": node_id,
+            "user_id": user_id,
+            "alias": alias,
+            "title": title,
+            "name": name,
+            "state": state,
+            "skill_id": skill_id,
+            "skill_version": skill_version,
+            "kind": norm_kind,
+            "parent_ws_id": norm_parent,
+            "project_id": norm_project,
+            "persona": norm_persona,
+            "created": now,
+            "updated": now,
+        }
+        # A retained channel route reserves its deleted source's ID. Reusing
+        # that ID would redirect the conversation into another incarnation.
+        source = sa.select(*(sa.literal(value) for value in values.values())).where(
+            ~sa.exists().where(channel_routes.c.ws_id == ws_id)
+        )
         with self._conn() as conn:
             result = conn.execute(
-                sa.insert(workstreams).prefix_with("OR IGNORE"),
-                {
-                    "ws_id": ws_id,
-                    "node_id": node_id,
-                    "user_id": user_id,
-                    "alias": alias,
-                    "title": title,
-                    "name": name,
-                    "state": state,
-                    "skill_id": skill_id,
-                    "skill_version": skill_version,
-                    "kind": norm_kind,
-                    "parent_ws_id": norm_parent,
-                    "project_id": norm_project,
-                    "persona": norm_persona,
-                    "created": now,
-                    "updated": now,
-                },
+                sa.insert(workstreams).prefix_with("OR IGNORE").from_select(list(values), source)
             )
             inserted = result.rowcount == 1
             if inserted:
@@ -2412,22 +2417,46 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
     # -- Channel routing -------------------------------------------------------
 
     def create_channel_route(
-        self, channel_type: str, channel_id: str, ws_id: str, node_id: str = ""
-    ) -> None:
+        self,
+        channel_type: str,
+        channel_id: str,
+        ws_id: str,
+        node_id: str = "",
+        *,
+        channel_user_id: str = "",
+    ) -> bool:
 
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
-            conn.execute(
+            result = conn.execute(
                 sa.insert(channel_routes).prefix_with("OR IGNORE"),
                 {
                     "channel_type": channel_type,
                     "channel_id": channel_id,
                     "ws_id": ws_id,
                     "node_id": node_id,
+                    "channel_user_id": channel_user_id,
                     "created": now,
                 },
             )
             conn.commit()
+            return result.rowcount > 0
+
+    def replace_channel_route(
+        self, channel_type: str, channel_id: str, expected_ws_id: str, ws_id: str
+    ) -> bool:
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.update(channel_routes)
+                .where(
+                    (channel_routes.c.channel_type == channel_type)
+                    & (channel_routes.c.channel_id == channel_id)
+                    & (channel_routes.c.ws_id == expected_ws_id)
+                )
+                .values(ws_id=ws_id, node_id="")
+            )
+            conn.commit()
+            return result.rowcount > 0
 
     def get_channel_route(self, channel_type: str, channel_id: str) -> dict[str, str] | None:
 
@@ -2439,6 +2468,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     channel_routes.c.ws_id,
                     channel_routes.c.node_id,
                     channel_routes.c.created,
+                    channel_routes.c.channel_user_id,
                 ).where(
                     (channel_routes.c.channel_type == channel_type)
                     & (channel_routes.c.channel_id == channel_id)
@@ -2451,6 +2481,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     "ws_id": row[2],
                     "node_id": row[3],
                     "created": row[4],
+                    "channel_user_id": row[5],
                 }
             return None
 
@@ -2464,6 +2495,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     channel_routes.c.ws_id,
                     channel_routes.c.node_id,
                     channel_routes.c.created,
+                    channel_routes.c.channel_user_id,
                 ).where(channel_routes.c.ws_id == ws_id)
             ).fetchone()
             if row:
@@ -2473,6 +2505,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     "ws_id": row[2],
                     "node_id": row[3],
                     "created": row[4],
+                    "channel_user_id": row[5],
                 }
             return None
 
@@ -2486,6 +2519,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     channel_routes.c.ws_id,
                     channel_routes.c.node_id,
                     channel_routes.c.created,
+                    channel_routes.c.channel_user_id,
                 )
                 .where(channel_routes.c.channel_type == channel_type)
                 .order_by(channel_routes.c.created.desc())
@@ -2497,19 +2531,22 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     "ws_id": r[2],
                     "node_id": r[3],
                     "created": r[4],
+                    "channel_user_id": r[5],
                 }
                 for r in rows
             ]
 
-    def delete_channel_route(self, channel_type: str, channel_id: str) -> bool:
-
+    def delete_channel_route(
+        self, channel_type: str, channel_id: str, *, expected_ws_id: str | None = None
+    ) -> bool:
+        statement = sa.delete(channel_routes).where(
+            (channel_routes.c.channel_type == channel_type)
+            & (channel_routes.c.channel_id == channel_id)
+        )
+        if expected_ws_id is not None:
+            statement = statement.where(channel_routes.c.ws_id == expected_ws_id)
         with self._conn() as conn:
-            result = conn.execute(
-                sa.delete(channel_routes).where(
-                    (channel_routes.c.channel_type == channel_type)
-                    & (channel_routes.c.channel_id == channel_id)
-                )
-            )
+            result = conn.execute(statement)
             conn.commit()
             return result.rowcount > 0
 

--- a/turnstone/core/storage/migrations/versions/075_channel_route_owner.py
+++ b/turnstone/core/storage/migrations/versions/075_channel_route_owner.py
@@ -1,0 +1,29 @@
+"""Persist the external user who initiated a channel conversation.
+
+Legacy routes retain an empty owner; platform-proven ownership is still usable,
+but a bot-owned Discord thread must not be claimed by an arbitrary linked user.
+
+Revision ID: 075
+Revises: 074
+Create Date: 2026-09-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "075"
+down_revision = "074"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("channel_routes") as batch_op:
+        batch_op.add_column(
+            sa.Column("channel_user_id", sa.Text, nullable=False, server_default="")
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("channel_routes") as batch_op:
+        batch_op.drop_column("channel_user_id")

--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -220,6 +220,7 @@ class AsyncTurnstoneConsole(_BaseClient):
         persona: str = "",
         project_id: str = "",
         resume_ws: str = "",
+        resume_ws_exact: bool = False,
         judge_model: str = "",
         target_node: str = "",
         user_id: str = "",
@@ -229,6 +230,9 @@ class AsyncTurnstoneConsole(_BaseClient):
         attachments: list[AttachmentUpload] | None = None,
     ) -> RouteCreateResponse:
         """Create a workstream via the console's routing proxy.
+
+        *resume_ws_exact* requires the exact source ID, preventing alias or
+        prefix substitution when recovering a persisted association.
 
         Posts to /v1/api/route/workstreams/new.  When *attachments* is
         non-empty, the request is sent as multipart and the console
@@ -255,6 +259,8 @@ class AsyncTurnstoneConsole(_BaseClient):
             body["project_id"] = project_id
         if resume_ws:
             body["resume_ws"] = resume_ws
+        if resume_ws_exact:
+            body["resume_ws_exact"] = True
         if judge_model:
             body["judge_model"] = judge_model
         if target_node:
@@ -1337,6 +1343,7 @@ class TurnstoneConsole:
         persona: str = "",
         project_id: str = "",
         resume_ws: str = "",
+        resume_ws_exact: bool = False,
         judge_model: str = "",
         target_node: str = "",
         user_id: str = "",
@@ -1356,6 +1363,7 @@ class TurnstoneConsole:
                 persona=persona,
                 project_id=project_id,
                 resume_ws=resume_ws,
+                resume_ws_exact=resume_ws_exact,
                 judge_model=judge_model,
                 target_node=target_node,
                 user_id=user_id,

--- a/turnstone/sdk/server.py
+++ b/turnstone/sdk/server.py
@@ -110,6 +110,7 @@ class AsyncTurnstoneServer(_BaseClient):
         judge_model: str = "",
         auto_approve: bool = False,
         resume_ws: str = "",
+        resume_ws_exact: bool = False,
         skill: str = "",
         persona: str = "",
         initial_message: str = "",
@@ -122,6 +123,9 @@ class AsyncTurnstoneServer(_BaseClient):
         attachments: list[AttachmentUpload] | None = None,
     ) -> CreateWorkstreamResponse:
         """Create a new workstream.
+
+        *resume_ws_exact* requires the exact source ID, preventing alias or
+        prefix substitution when recovering a persisted association.
 
         When *attachments* is non-empty the request is sent as
         ``multipart/form-data`` with the metadata in a ``meta`` JSON
@@ -148,6 +152,8 @@ class AsyncTurnstoneServer(_BaseClient):
             body["auto_approve"] = True
         if resume_ws:
             body["resume_ws"] = resume_ws
+        if resume_ws_exact:
+            body["resume_ws_exact"] = True
         if skill:
             body["skill"] = skill
         if persona:
@@ -711,6 +717,7 @@ class TurnstoneServer:
         judge_model: str = "",
         auto_approve: bool = False,
         resume_ws: str = "",
+        resume_ws_exact: bool = False,
         skill: str = "",
         persona: str = "",
         initial_message: str = "",
@@ -729,6 +736,7 @@ class TurnstoneServer:
                 judge_model=judge_model,
                 auto_approve=auto_approve,
                 resume_ws=resume_ws,
+                resume_ws_exact=resume_ws_exact,
                 skill=skill,
                 persona=persona,
                 initial_message=initial_message,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2552,6 +2552,11 @@ async def _interactive_create_validate_request(
     if requested_ws_id and not _VALID_WS_ID.match(requested_ws_id):
         return JSONResponse({"error": "invalid ws_id format"}, status_code=400)
     resume_ws_id = body.get("resume_ws", "") or ""
+    resume_ws_exact = body.get("resume_ws_exact", False)
+    if not isinstance(resume_ws_exact, bool):
+        return JSONResponse({"error": "resume_ws_exact must be a boolean"}, status_code=400)
+    if resume_ws_exact and (not isinstance(resume_ws_id, str) or not resume_ws_id):
+        return JSONResponse({"error": "resume_ws_exact requires resume_ws"}, status_code=400)
     if uploaded_files and resume_ws_id:
         return JSONResponse(
             {"error": "attachments cannot be combined with resume_ws"},
@@ -2629,15 +2634,16 @@ async def _interactive_create_validate_request(
         # through alias-first resolution: an unrelated row may legally carry
         # that 32-hex string as its alias, and a routing proxy has already
         # canonicalized saved aliases before forwarding the request.  Retain
-        # support for 32-hex aliases only when no exact row exists.
+        # support for 32-hex aliases only when no exact row exists and the
+        # caller has not required an exact identity (as channel recovery does).
         _exact_source = (
-            _rstorage.get_workstream(resume_ws_id) if _VALID_WS_ID.fullmatch(resume_ws_id) else None
+            _rstorage.get_workstream(resume_ws_id)
+            if resume_ws_exact or _VALID_WS_ID.fullmatch(resume_ws_id)
+            else None
         )
-        _canonical = (
-            resume_ws_id
-            if _exact_source is not None
-            else _rstorage.resolve_workstream(resume_ws_id)
-        )
+        _canonical = resume_ws_id if _exact_source is not None else None
+        if _canonical is None and not resume_ws_exact:
+            _canonical = _rstorage.resolve_workstream(resume_ws_id)
         _src_row = (
             _rstorage.ensure_workstream_incarnation_snapshot(_canonical) if _canonical else None
         )


### PR DESCRIPTION
Server restarts and idle closure currently detach Discord and Slack conversations when SSE returns 404. Preserve the channel association and recover saved history into a new workstream on the owner's next message, continuing in the same Discord thread, Slack thread, or Slack DM.

Persist the Discord invoker with migration 075, claim replacement routes conditionally before dispatch, and remove routes only after confirmed closure and a matching conditional delete. Exact source lookup prevents alias substitution; IDs still referenced by channel routes remain reserved against recreation. Console SSE destinations are resolved on every reconnect.

Startup restores only live subscriptions: direct mode uses one manager list, and console discovery has bounded concurrency and a total time budget. Inactive routes remain available for lazy recovery. Existing Discord threads without saved invokers require a new `/ask` conversation. Discord `/close` now acknowledges privately and archives the thread.

DM identity checks remain in place. Discord notification replies still require a matching tracked recipient and a currently linked account; that notification tracking expires on bot restart. Slack DMs retain per-user routing, account-link checks, and rate and size limits.

Fixes #1067. Follow-up work for #1089 covers durable execution affinity.

Validation:

- Python suite excluding live and end-to-end recovery markers: 13,326 passed, 27 skipped, 17 deselected in 471.90 seconds.
- PostgreSQL-focused storage, recovery, startup, fork, schema, and prune checks: 117 passed, 1 skipped.
- TypeScript SDK: 84 tests passed. Ruff, formatting, package-wide mypy, TypeScript typecheck, and OpenAPI artifact checks passed.
- Real HTTP/history recovery covers node, bot, and combined restarts across Discord threads, Slack threads, and Slack DMs. A separate idle-reaper probe confirms continuation in the same Discord thread after autoclose.
- Independent performance, quality, security, and correctness reviews completed; reproduced race and identity-substitution cases pass. Twenty inactive routes now cause zero platform fetches or SSE connections across two startup passes.

Platform delivery and model sessions were simulated; no live provider calls or host reboot were performed. CI now installs the Discord extra so its regression coverage runs.
