### PR TITLE
fix: preserve explicit node affinity across restarts and timeouts

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1333,6 +1333,7 @@ An absent or malformed JSON body returns `400`.
 | `user_id`         | string        | `""`  | Owner override honored only for a trusted `console` service identity carrying the `service` scope; ordinary callers remain bound to their authenticated identity |
 | `resume_ws`       | string        | `""`    | Source workstream ID or alias to fork atomically into this new ID |
 | `resume_ws_exact` | bool          | false   | Require `resume_ws` to match an exact source ID; never resolve an alias or prefix |
+| `required_node_id` | string/null | none | Require execution on this node. Omission inherits the fork source's requirement; a fresh direct create without it stays flexible. |
 | `skill`           | string        | `""`    | Skill name. Applies its system prompt and session configuration. Returns 400 if missing/disabled; ignored for a fork because the source configuration is cloned. |
 | `persona`         | string        | `""`    | Persona slug; empty selects the kind's default. A fork keeps the source persona. |
 | `judge_model`     | string        | `""`    | Optional judge model alias                                     |
@@ -1357,6 +1358,14 @@ the source's checkpoint-bounded conversation, saved session configuration,
 persona, effective project, and attachment references. The source remains
 unchanged. Use `POST .../{ws_id}/open` when you want to rehydrate the original
 ID instead.
+
+An explicit `required_node_id` applies to the new destination and can differ
+from the source requirement. Omission (including `null`) inherits it. A
+same-ID reopen never changes the requirement. The receiving node returns
+`409` with `code: "wrong_execution_node"` and `required_node_id` before
+constructing executable state if it is not the required node. Node IDs accept
+1–256 letters, digits, dots, underscores, and hyphens; empty requirements are
+invalid. Requirements survive restart, soft close, idle timeout, and eviction.
 
 Set `resume_ws_exact: true` when recovering a stored canonical ID. A missing
 exact source returns `404` even if another workstream has that ID as its alias.
@@ -2818,8 +2827,8 @@ turnstone_tool_calls_total{tool="read_file"} 3
 ## Console Routing Proxy Endpoints
 
 These endpoints are served by the console (`turnstone-console`) and proxy
-requests to the correct server node via rendezvous (HRW) hashing over the
-live service registry. In multi-node deployments, clients (SDK, channel
+requests to the required execution node, or use placement overrides and
+rendezvous (HRW) hashing for flexible workstreams. In multi-node deployments, clients (SDK, channel
 gateway) talk to the console instead of individual server nodes.
 
 ### `POST /v1/api/route/workstreams/new`
@@ -2829,25 +2838,27 @@ the ordinary create fields plus `target_node`:
 
 | Field | Routing behavior |
 |-------|------------------|
-| `ws_id` | Optional 32-hex destination. When present, it is preserved and used as the rendezvous key, including on a fork. A 503 never replaces a caller-selected ID. |
-| `resume_ws` | Optional source ID or saved alias for an atomic fork. The console resolves aliases to the canonical source ID before routing and forwards that canonical value. When no destination `ws_id` is supplied, the source is the placement key. |
+| `ws_id` | Optional 32-hex destination. It is preserved; without an explicit or inherited requirement it is the rendezvous key. A 503 never replaces a caller-selected ID. |
+| `resume_ws` | Optional source ID or saved alias for an atomic fork. The console authorizes and canonicalizes the source before routing. Its node requirement is inherited unless explicitly replaced on the new ID. For flexible forks without a destination ID, the source is the placement key. |
 | `resume_ws_exact` | Optional boolean, default false. Requires an exact source ID in `resume_ws`; disables alias and prefix resolution. |
-| `target_node` | Optional node ID hint. When neither `ws_id` nor `resume_ws` selects placement, the console generates a destination whose rendezvous owner is this live node. |
+| `target_node` | Optional required execution node, including when `ws_id` or `resume_ws` is supplied. |
+| `required_node_id` | Same durable requirement as direct create. Must match `target_node` when both are supplied. |
 
 Without any placement field, the console generates a destination ID and routes
 it by rendezvous. Multipart callers must pre-allocate the destination and put
 the **same** 32-hex value in both `?ws_id=<32-hex>` and the multipart
-`meta.ws_id` field. The query value selects the target node; the console
+`meta.ws_id` field. An explicit requirement takes precedence over hashing; the console
 buffers the body, parses only `meta` to require the same destination ID, then
 forwards the original bytes and boundary unchanged. The node uses `meta.ws_id`
-as the destination identity.
+as the destination identity. Metadata-only multipart forks use the common JSON
+fork path after parsing, including canonicalization and inherited requirements.
+Uploads cannot be combined with a fork; fork first, then upload.
 
 The response extends the node create response with three required fields:
 `node_url`, authoritative `node_id`, and `routing_strategy`.
-`routing_strategy` is `rendezvous` for generated, explicit JSON, and multipart
-destination IDs; `target_node` when the console generated an ID for a requested
-node; or `resume` only when an atomic fork was placed by its canonical source
-ID. The node-returned destination `ws_id` is authoritative for the response,
+`routing_strategy` is `target_node` for an explicit requirement, `resume` for
+inherited affinity or source placement, and `rendezvous` for destination-ID
+placement. The node-returned destination `ws_id` is authoritative for the response,
 storage binding lookup, and audit record; the fork source is never reported as
 the created destination.
 
@@ -2858,9 +2869,16 @@ returns `200` without an object containing a valid destination `ws_id`, the
 console returns a bounded `502` instead of exposing or trusting the malformed
 payload.
 
+A required node missing from live membership returns `503` with
+`code: "required_node_unavailable"` and `required_node_id`. An unreachable
+registered node can return an upstream `502`. Neither condition permits a
+fallback to another node. Ordinary route resolution reads the durable
+requirement before cached placement, including after the node disappears.
+Private-project requirements follow the same visibility rules as history.
+
 ### `GET /v1/api/route/workstreams/{ws_id}/live`
 
-Probe the rendezvous-selected owner without opening or rehydrating the
+Probe the routed node without opening or rehydrating the
 workstream. The console asks that node's manager-authoritative active list and
 returns only:
 
@@ -2871,6 +2889,8 @@ returns only:
 Missing, unloaded, still-`creating`, and caller-invisible workstreams all
 produce `live: false`. Routing, upstream, and authorization uncertainty returns
 an error instead of a false miss, so callers can preserve an existing route.
+This includes an unavailable required node: channel recovery retains its
+saved association and retries when that node returns.
 
 ### `POST /v1/api/route/workstreams/{ws_id}/send`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1656,8 +1656,21 @@ and size its server pool for expected concurrent fork traffic.
 `ws_id` is the persistent conversation/lifecycle identity. There is no
 separate `session_id`: `workstreams` holds lifecycle, owner, kind, hierarchy,
 project, and display metadata, while `conversations` stores the append-only
-trajectory. `node_id` is an owning-service hint; rendezvous/service liveness,
-not that historical field alone, determines cluster routing and orphan safety.
+trajectory. `node_id` records creation origin and remains a maintenance hint.
+The nullable `required_node_id` column independently records execution
+eligibility. Console routing checks that requirement before cached placement
+overrides or rendezvous; manager create/open and core resume enforce it at the
+executor. The requirement survives residency changes and close. Ordinary
+operations cannot alter it in place; an explicitly targeted fork creates a new
+identity with its own requirement. Legacy rows remain unbound.
+
+Affinity does not establish exclusive live ownership. A future same-ID
+migration still needs a fenced ownership handoff; neither a registry heartbeat
+nor an affinity check supplies that lease. The router reads requirements from
+storage on every resolution, so future authorized changes need no permanent
+policy-cache invalidation. A handoff must report temporary unavailability to
+channel recovery, rather than a clean absent-workstream result that starts a
+new fork.
 
 `ChatSession.messages` is `list[Turn]`. Persistence serializes the neutral
 fields, opaque provider-native lane, attachment references, SSE cursor, and

--- a/docs/console.md
+++ b/docs/console.md
@@ -184,7 +184,7 @@ All fields are optional:
 - `node_id` — targeting mode:
   - **omitted or `"auto"`** — console picks the reachable node with the most available capacity (max_ws - ws_total) and proxies the request to it.
   - **`"pool"`** — compatibility alias for automatic placement on the reachable node with the most headroom.
-  - **specific node ID** — proxies the request to that node directly.
+  - **specific node ID** — requires execution on that node, including after restart or close.
 - `name` — workstream display name. Auto-generated if omitted.
 - `model` — model alias from the target node's registry. Uses the node's default model if omitted.
 - `judge_model` — optional judge-model alias for this workstream.
@@ -195,6 +195,11 @@ All fields are optional:
 - `resume_ws` — source ID to **fork** atomically into a new workstream. The
   source remains unchanged; its checkpoint-bounded history, configuration,
   persona, project, and attachment references are copied transactionally.
+  Omission of a destination node inherits the source's execution requirement;
+  an explicit destination pins the new conversation there.
+- `resume_ws_exact` — require the exact source ID without alias resolution.
+- `required_node_id` — optional explicit execution requirement; must agree with
+  a specific `node_id` when both are supplied.
 
 The endpoint also accepts the same multipart create shape as a node: one
 JSON-encoded `meta` field plus up to ten `file` parts. Files require an
@@ -220,9 +225,9 @@ rather than treating them as two creates.
 
 For safety, the console masks most target-node failures as the opaque `502`
 shape `{"error":"Dispatch to node <node_id> failed"}` instead of reflecting
-arbitrary node text or retry-triggering 401/429 responses. The coded
-`server.require_project` refusal is the exception and remains a `400` with
-actionable wording. Consult the target node's logs for the underlying create
+arbitrary node text or retry-triggering 401/429 responses. Coded
+`server.require_project` (`400`) and wrong-execution-node (`409`) refusals retain
+their actionable wording. Consult the target node's logs for the underlying create
 correlation when a reachable node returns a masked 502.
 
 ### `GET /v1/api/cluster/events`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -95,6 +95,23 @@ TURNSTONE_NODE_ID=host-1 \
   turnstone-server --host 0.0.0.0 --port 8080
 ```
 
+Keep `TURNSTONE_NODE_ID` stable across restarts when conversations require this
+host. Without it, the server generates a new identity on each start. Give each
+execution environment a unique ID: a host server and a container with different
+files or devices should not share one. A returning identity may advertise a
+new URL; the console resolves that URL from service registration.
+
+Selecting **Specific node** in the launcher persists an execution requirement.
+If that node is unavailable, the conversation waits for it. **Continue
+elsewhere** creates a separate conversation from saved history on the chosen
+node; local files and running tools are not transferred. Automatic placement
+remains flexible. Existing conversations are left unbound during migration
+because historical placement does not establish explicit intent; fork one to
+a specific node to create a bound continuation.
+
+Deploy the updated console and server code with migration 076 before relying
+on node requirements. Older server versions do not enforce the new field.
+
 The host server registers itself in PostgreSQL; the console reaches it back via
 `host.docker.internal`. `TURNSTONE_CONSOLE_URL` points the node at the console's
 published ACME endpoint so it can enroll its mTLS certificate (needed only when

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -94,6 +94,23 @@ Both `TurnstoneServer` (sync) and `AsyncTurnstoneServer` (async) expose:
 
 ### Console Client API
 
+Use `required_node_id="host-1"` with direct or routed creation to preserve an
+execution requirement across close/reopen and restart. Console `node_id` and
+routed `target_node` selections express the same requirement; automatic
+placement leaves fresh conversations flexible. A fork (`resume_ws`) inherits
+the source requirement unless an explicit destination is supplied. For example:
+
+```python
+copy = console.route_create_workstream(
+    resume_ws=saved_ws_id,
+    resume_ws_exact=True,
+    target_node="node-1",
+)
+```
+
+This creates a new conversation and leaves the original saved. It does not
+move a running session or transfer node-local files.
+
 Both `TurnstoneConsole` (sync) and `AsyncTurnstoneConsole` (async) expose:
 
 | Category | Method | Returns |

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -8783,7 +8783,7 @@
         "properties": {
           "node_id": {
             "default": "",
-            "description": "Target node: specific ID, 'auto', 'pool', or empty for auto",
+            "description": "Required node: a specific ID pins execution; 'auto', 'pool', or empty select initial placement only",
             "title": "Node Id",
             "type": "string"
           },
@@ -8828,6 +8828,28 @@
             "description": "Source workstream ID or alias to fork atomically into the new workstream",
             "title": "Resume Ws",
             "type": "string"
+          },
+          "resume_ws_exact": {
+            "default": false,
+            "description": "Require an exact fork source ID",
+            "title": "Resume Ws Exact",
+            "type": "boolean"
+          },
+          "required_node_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9_.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Durable execution requirement; omission inherits the fork source requirement",
+            "title": "Required Node Id"
           },
           "judge_model": {
             "default": "",
@@ -15047,6 +15069,22 @@
       "RouteCreateRequest": {
         "description": "JSON workstream creation through the routing proxy.",
         "properties": {
+          "required_node_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9_.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Required execution node. Omission permits automatic placement for a fresh workstream and inherits the source requirement for a fork. An explicit destination applies only to the new workstream ID.",
+            "title": "Required Node Id"
+          },
           "name": {
             "default": "",
             "description": "Workstream display name (auto-generated if empty)",
@@ -15187,7 +15225,7 @@
           },
           "target_node": {
             "default": "",
-            "description": "Optional node id to pin placement to. The console generates a workstream id whose rendezvous owner is that node.",
+            "description": "Optional required execution node. Applies even with a supplied destination ID or fork source. Must match required_node_id when both are supplied.",
             "title": "Target Node",
             "type": "string"
           }
@@ -15255,7 +15293,7 @@
             "type": "string"
           },
           "routing_strategy": {
-            "description": "Placement reason: rendezvous for a destination id, target_node for a generated pinned id, or resume when an atomic fork is routed by its canonical source id",
+            "description": "Placement reason: rendezvous for a destination id, target_node for an explicit execution requirement, or resume when an atomic fork inherits its source requirement or placement",
             "enum": [
               "rendezvous",
               "target_node",

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -4932,12 +4932,12 @@
     },
     "/v1/api/route/workstreams/new": {
       "post": {
-        "summary": "Create workstream via rendezvous routing proxy",
+        "summary": "Create workstream via console routing proxy",
         "operationId": "v1_api_route_workstreams_new_post",
         "tags": [
           "Routing"
         ],
-        "description": "The documented JSON form accepts RouteCreateRequest. The endpoint also accepts multipart/form-data with a JSON `meta` field and file parts; multipart callers must supply `ws_id` as a query parameter; the console requires the cached `meta.ws_id` to match before forwarding the original body. A JSON body may instead carry an explicit `ws_id`; the console preserves it and uses it as the rendezvous placement key. `resume_ws` accepts an id or saved alias and is resolved to the canonical source id before an atomic fork is routed.",
+        "description": "The documented JSON form accepts RouteCreateRequest. The endpoint also accepts multipart/form-data with a JSON `meta` field and file parts; multipart callers must supply `ws_id` as a query parameter; the console requires `meta.ws_id` to match before forwarding the original upload body. A JSON body may instead carry an explicit destination `ws_id`. Explicit or inherited node requirements take precedence over rendezvous placement while preserving the destination ID. `resume_ws` accepts an id or saved alias and is authorized and resolved to its canonical source before routing an atomic fork. A fork inherits the source requirement unless an explicit destination node is selected for the new ID. Metadata-only multipart forks use the same JSON fork path; uploads cannot be combined with a fork.",
         "parameters": [
           {
             "name": "ws_id",
@@ -4946,7 +4946,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "32-hex rendezvous key required for multipart creates. JSON callers put an optional destination ws_id in the request body."
+            "description": "32-hex destination ID required for multipart creates. JSON callers put an optional destination ws_id in the request body."
           }
         ],
         "requestBody": {
@@ -5070,7 +5070,7 @@
         "tags": [
           "Routing"
         ],
-        "description": "Routes to the workstream's rendezvous owner and checks its manager-authoritative active list. The response does not expose workstream metadata; missing, unloaded, creating, and caller-invisible rows all report ``live=false``. Routing and upstream uncertainty fail with an error rather than reporting a false miss.",
+        "description": "Resolves the workstream's required node or flexible placement and checks its manager-authoritative active list. The response does not expose workstream metadata; missing, unloaded, creating, and caller-invisible rows all report ``live=false``. Routing and upstream uncertainty, including an unavailable required node, fail with an error rather than reporting a false miss.",
         "parameters": [
           {
             "name": "ws_id",

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -2916,6 +2916,22 @@
       },
       "CreateWorkstreamRequest": {
         "properties": {
+          "required_node_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9_.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Required execution node. Omission permits automatic placement for a fresh workstream and inherits the source requirement for a fork. An explicit destination applies only to the new workstream ID.",
+            "title": "Required Node Id"
+          },
           "name": {
             "default": "",
             "description": "Workstream display name (auto-generated if empty)",

--- a/sdk/typescript/src/console.ts
+++ b/sdk/typescript/src/console.ts
@@ -150,28 +150,18 @@ export class TurnstoneConsole extends BaseClient {
   // -- Routing proxy --------------------------------------------------------
 
   /**
-   * Create a workstream via the console rendezvous router.
+   * Create a workstream through console routing.
    *
    * When `attachments` is non-empty the request is sent as
-   * multipart/form-data and the console routes via `?ws_id=<hex>`
-   * (auto-generated when not supplied) so the body lands on the
-   * owning node directly.
+   * multipart/form-data with the same destination ID in `?ws_id=<hex>`
+   * and the metadata (auto-generated when not supplied). An explicit
+   * node requirement takes precedence over rendezvous placement.
    */
   async routeCreateWorkstream(
     opts?: RouteCreateRequest,
   ): Promise<RouteCreateResponse> {
     const attachments = opts?.attachments;
     if (attachments && attachments.length > 0) {
-      // The console's multipart route_create routes by `?ws_id=` only —
-      // it does not parse the body to honor `target_node`. Refuse the
-      // combination at the SDK boundary so callers don't silently get
-      // routed to the wrong node.
-      if (opts?.target_node) {
-        throw new Error(
-          "target_node is not supported with attachments; " +
-            "use ws_id (caller-generated to hash to the desired node) instead",
-        );
-      }
       const meta: Record<string, unknown> = { ...opts };
       delete (meta as { attachments?: unknown }).attachments;
       let wsId = (meta.ws_id as string | undefined) ?? "";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -171,6 +171,8 @@ export interface CreateWorkstreamRequest {
   resume_ws?: string;
   /** Require an exact source ID; disable alias and prefix resolution. */
   resume_ws_exact?: boolean;
+  /** Durable execution requirement. Omission inherits the fork source requirement. */
+  required_node_id?: string | null;
   /** Completion-notification targets as JSON text or structured target objects. */
   notify_targets?: string | Array<Record<string, string>>;
   /** Client surface label such as web, cli, chat, or scheduled. */
@@ -605,6 +607,7 @@ export interface ClusterSnapshotResponse {
 }
 
 export interface ConsoleCreateWsRequest {
+  /** Specific IDs require that node; auto/pool choose initial placement only. */
   node_id?: string;
   name?: string;
   model?: string;
@@ -615,6 +618,8 @@ export interface ConsoleCreateWsRequest {
   /** Project to attach the workstream to. */
   project_id?: string;
   resume_ws?: string;
+  resume_ws_exact?: boolean;
+  required_node_id?: string | null;
   /** Override judge model alias for this workstream. */
   judge_model?: string;
 }
@@ -626,7 +631,7 @@ export interface ConsoleCreateWsResponse {
 }
 
 export interface RouteCreateRequest extends CreateWorkstreamRequest {
-  /** Pin placement to this node by generating a matching rendezvous key. */
+  /** Require execution on this node, including when forking saved history. */
   target_node?: string;
 }
 

--- a/sdk/typescript/tests/console.test.ts
+++ b/sdk/typescript/tests/console.test.ts
@@ -169,27 +169,39 @@ describe("TurnstoneConsole", () => {
     });
   });
 
-  it("routeCreateWorkstream rejects attachments + target_node", async () => {
-    const fetchFn = vi.fn().mockResolvedValue(
-      new Response("{}", {
-        status: 500,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-    const client = new TurnstoneConsole({
-      baseUrl: "http://test",
-      fetch: fetchFn,
-    });
-    const data = new TextEncoder().encode("hi");
-    await expect(
-      client.routeCreateWorkstream({
+  it.each([undefined, "1".repeat(32)])(
+    "routeCreateWorkstream preserves targeted multipart metadata (ws_id: %s)",
+    async (wsId) => {
+      const fetchFn = mockFetch({ ws_id: "new-id", node_id: "n1" });
+      const client = new TurnstoneConsole({
+        baseUrl: "http://test",
+        fetch: fetchFn,
+      });
+      const data = new TextEncoder().encode("hi");
+      await client.routeCreateWorkstream({
         name: "x",
+        ws_id: wsId,
         target_node: "n1",
+        required_node_id: "n1",
         attachments: [{ filename: "a.txt", data }],
-      }),
-    ).rejects.toThrow(/target_node/);
-    expect(fetchFn).not.toHaveBeenCalled();
-  });
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      const [url, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
+      const queryId = new URL(url).searchParams.get("ws_id");
+      expect(queryId).toMatch(/^[a-f0-9]{32}$/);
+      if (wsId) expect(queryId).toBe(wsId);
+      const form = init.body as FormData;
+      expect(JSON.parse(form.get("meta") as string)).toEqual({
+        name: "x",
+        ws_id: queryId,
+        target_node: "n1",
+        required_node_id: "n1",
+      });
+      const file = form.get("file") as File;
+      expect(file.name).toBe("a.txt");
+      expect(await file.text()).toBe("hi");
+    },
+  );
 
   it("routeWorkstreamLive returns the non-mutating liveness probe", async () => {
     const fetchFn = mockFetch({ ws_id: "saved/ws", live: true });

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -3011,7 +3011,8 @@ class TestSendGenerationInitializationPublication:
     ) -> None:
         """A resume during the user save cannot retarget deferred title work."""
         session = _make_session(ws_id="opening-ws", user_id="opening-principal")
-        _bind_storage_mock()
+        storage = _bind_storage_mock()
+        storage.ensure_workstream_incarnation_snapshot.return_value = None
         generation = session._claim_generation()
         successor_turn = turn_from_dict(
             {"role": "user", "content": "successor workstream history"},

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -3012,6 +3012,7 @@ class TestSendGenerationInitializationPublication:
         """A resume during the user save cannot retarget deferred title work."""
         session = _make_session(ws_id="opening-ws", user_id="opening-principal")
         storage = _bind_storage_mock()
+        storage.get_workstream.return_value = None
         storage.ensure_workstream_incarnation_snapshot.return_value = None
         generation = session._claim_generation()
         successor_turn = turn_from_dict(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1469,7 +1469,9 @@ class TestConsoleWorkstreamCreation:
             "/v1/api/cluster/workstreams/new",
             json={"node_id": "nonexistent"},
         )
-        assert resp.status_code == 404
+        assert resp.status_code == 503
+        assert resp.json()["code"] == "required_node_unavailable"
+        mock_post.assert_not_called()
 
     def test_create_invalid_json(self, client_and_mock):
         client, mock_post = client_and_mock
@@ -1516,6 +1518,10 @@ class TestConsoleWorkstreamCreation:
     def test_create_with_resume_ws_directed(self, client_and_mock, mock_collector):
         """resume_ws is forwarded in directed dispatch."""
         client, mock_post = client_and_mock
+        storage = MagicMock()
+        storage.resolve_workstream.return_value = "old-ws-id-123"
+        storage.get_workstream.return_value = {"ws_id": "old-ws-id-123", "state": "idle"}
+        client.app.state.auth_storage = storage
         resp = client.post(
             "/v1/api/cluster/workstreams/new",
             json={"node_id": "node-a", "resume_ws": "old-ws-id-123"},
@@ -1527,6 +1533,10 @@ class TestConsoleWorkstreamCreation:
     def test_create_with_resume_ws_auto(self, client_and_mock, mock_collector):
         """resume_ws is forwarded in auto-select dispatch."""
         client, mock_post = client_and_mock
+        storage = MagicMock()
+        storage.resolve_workstream.return_value = "old-ws-id-789"
+        storage.get_workstream.return_value = {"ws_id": "old-ws-id-789", "state": "idle"}
+        client.app.state.auth_storage = storage
         resp = client.post(
             "/v1/api/cluster/workstreams/new",
             json={"resume_ws": "old-ws-id-789"},

--- a/tests/test_console_route_attachments.py
+++ b/tests/test_console_route_attachments.py
@@ -15,6 +15,7 @@ from starlette.testclient import TestClient
 
 from turnstone.console.collector import ClusterCollector
 from turnstone.console.router import ConsoleRouter, NodeRef
+from turnstone.core.rendezvous import NoAvailableNodeError
 
 _TEST_JWT_SECRET = "test-jwt-secret-minimum-32-chars!"
 
@@ -112,7 +113,7 @@ class TestRouteCreateMultipart:
             # Body bytes were forwarded raw
             assert isinstance(captured["content"], (bytes, bytearray))
             assert b"hello" in bytes(captured["content"])
-            router.route.assert_called_with(ws_id)
+            assert router.route.call_args.args == (ws_id,)
         finally:
             client.close()
 
@@ -362,6 +363,7 @@ class TestRoutingFailures:
     def test_router_not_ready_returns_503(self):
         router = MagicMock(spec=ConsoleRouter)
         router.is_ready.return_value = False
+        router.route.side_effect = NoAvailableNodeError("no live nodes")
         router.refresh_cache.return_value = None
         app = _make_app(router=router)
         app.state.proxy_client = MagicMock(spec=httpx.AsyncClient)

--- a/tests/test_console_router.py
+++ b/tests/test_console_router.py
@@ -308,24 +308,6 @@ class TestRefreshLifecycle:
         assert router.version > v2
 
 
-class TestGenerateWsId:
-    def test_generates_routable_id(self) -> None:
-        router, storage = _make_router()
-        storage.services = [NODE_A, NODE_B, NODE_C]
-        router.refresh_cache()
-
-        ws_id = router.generate_ws_id_for_node("node-b")
-        assert len(ws_id) == 32
-        assert router.route(ws_id).node_id == "node-b"
-
-    def test_unknown_node_raises(self) -> None:
-        router, storage = _make_router()
-        storage.services = [NODE_A]
-        router.refresh_cache()
-        with pytest.raises(NoAvailableNodeError, match="node-z"):
-            router.generate_ws_id_for_node("node-z")
-
-
 class TestIsReady:
     def test_false_when_empty(self) -> None:
         router, _ = _make_router()

--- a/tests/test_console_router.py
+++ b/tests/test_console_router.py
@@ -8,6 +8,7 @@ import threading
 import pytest
 
 from turnstone.console.router import ConsoleRouter, NodeRef
+from turnstone.core.node_affinity import NodeAffinityError
 from turnstone.core.rendezvous import NoAvailableNodeError
 
 
@@ -17,6 +18,10 @@ class FakeStorage:
     def __init__(self) -> None:
         self.services: list[dict[str, str]] = []
         self.overrides: list[dict[str, str]] = []
+        self.workstreams: dict[str, dict[str, str]] = {}
+
+    def get_workstream(self, ws_id: str) -> dict[str, str] | None:
+        return self.workstreams.get(ws_id)
 
     def list_services(self, service_type: str, max_age_seconds: int = 120) -> list[dict[str, str]]:
         return list(self.services)
@@ -339,3 +344,56 @@ class TestNodeCount:
         storage.services = [NODE_A, NODE_B, NODE_C]
         router.refresh_cache()
         assert router.node_count() == 3
+
+
+class TestDurableRequirement:
+    def test_requirement_precedes_overrides_and_survives_membership_loss(self):
+        router, storage = _make_router()
+        storage.services = [NODE_A, NODE_B]
+        storage.workstreams["pinned"] = {"required_node_id": "node-a"}
+        storage.overrides = [{"ws_id": "pinned", "node_id": "node-b"}]
+        router.refresh_cache()
+        assert router.route("pinned").node_id == "node-a"
+        for services in ([NODE_B], []):
+            storage.services = services
+            router.refresh_cache()
+            with pytest.raises(NodeAffinityError) as error:
+                router.route("pinned")
+            assert error.value.status_code == 503
+            assert error.value.required_node_id == "node-a"
+        storage.services = [{**NODE_A, "url": "http://returned:8080"}, NODE_B]
+        router.refresh_cache()
+        assert router.route("pinned") == NodeRef("node-a", "http://returned:8080")
+
+    def test_policy_is_read_after_creation_and_after_authorized_policy_change(self):
+        router, storage = _make_router()
+        storage.services = [NODE_A, NODE_B]
+        router.refresh_cache()
+        router.route("new-id")  # A cached miss must not release a later requirement.
+        storage.workstreams["new-id"] = {"required_node_id": "node-a"}
+        assert router.route("new-id").node_id == "node-a"
+        # Future fenced migration can change the row without invalidating a
+        # separate, indefinitely cached affinity map.
+        storage.workstreams["new-id"]["required_node_id"] = "node-b"
+        assert router.route("new-id").node_id == "node-b"
+
+    def test_private_requirement_does_not_disclose_missing_node(self):
+        router, storage = _make_router()
+        storage.services = [NODE_B]
+        storage.workstreams["private"] = {"required_node_id": "secret-node"}
+        router.refresh_cache()
+        assert router.route("private", can_read=lambda row: False) == router.route("unknown")
+        with pytest.raises(NodeAffinityError):
+            router.route("private", can_read=lambda row: True)
+
+    def test_storage_failure_never_means_flexible_placement(self, monkeypatch):
+        router, storage = _make_router()
+        storage.services = [NODE_A, NODE_B]
+        router.refresh_cache()
+
+        def broken(ws_id):
+            raise RuntimeError("storage unavailable")
+
+        monkeypatch.setattr(storage, "get_workstream", broken)
+        with pytest.raises(NoAvailableNodeError):
+            router.route("pinned")

--- a/tests/test_console_routing_proxy.py
+++ b/tests/test_console_routing_proxy.py
@@ -57,10 +57,11 @@ def _make_mock_router(ready: bool = True) -> MagicMock:
     if not ready:
         router.route.side_effect = NoAvailableNodeError("no live nodes")
     router.route.return_value = NodeRef("node-a", "http://a:8080")
+    router.node_count.return_value = 2
+    router.rendezvous_node.return_value = NodeRef("node-b", "http://b:8080")
     router.required_node.side_effect = lambda node_id: NodeRef(
         node_id, f"http://{node_id.removeprefix('node-')}:8080"
     )
-    router.generate_ws_id_for_node.return_value = "00ff" + "0" * 28
     return router
 
 
@@ -212,7 +213,6 @@ class TestRouteCreate:
     def test_route_create_target_node(self):
         """An explicit target is persisted without constraining the ID hash."""
         router = _make_mock_router()
-        router.generate_ws_id_for_node.return_value = "00ff" + "0" * 28
         router.route.return_value = NodeRef("node-c", "http://c:8080")
         app = _make_app(router=router)
         _wire_proxy(
@@ -247,7 +247,6 @@ class TestRouteCreate:
 
     def test_route_create_routing_strategy_target_node(self):
         router = _make_mock_router()
-        router.generate_ws_id_for_node.return_value = "00ff" + "0" * 28
         router.route.return_value = NodeRef("node-c", "http://c:8080")
         app = _make_app(router=router)
         _wire_proxy(app, _make_proxy_post(json_data={"ws_id": "00ff" + "0" * 28, "name": "pinned"}))
@@ -363,7 +362,6 @@ class TestRouteCreate:
         assert resp.json()["routing_strategy"] == "target_node"
         router.required_node.assert_called_once_with("node-a")
         router.route.assert_not_called()
-        router.generate_ws_id_for_node.assert_not_called()
         assert post.call_args.kwargs["json"]["ws_id"] == _DEST_WS_ID
 
     def test_resume_alias_missing_and_storage_uncertainty_are_bounded(self):

--- a/tests/test_console_routing_proxy.py
+++ b/tests/test_console_routing_proxy.py
@@ -54,7 +54,12 @@ def _make_mock_collector() -> MagicMock:
 def _make_mock_router(ready: bool = True) -> MagicMock:
     router = MagicMock(spec=ConsoleRouter)
     router.is_ready.return_value = ready
+    if not ready:
+        router.route.side_effect = NoAvailableNodeError("no live nodes")
     router.route.return_value = NodeRef("node-a", "http://a:8080")
+    router.required_node.side_effect = lambda node_id: NodeRef(
+        node_id, f"http://{node_id.removeprefix('node-')}:8080"
+    )
     router.generate_ws_id_for_node.return_value = "00ff" + "0" * 28
     return router
 
@@ -177,6 +182,7 @@ class TestRouteCreate:
         router.route.return_value = NodeRef("node-b", "http://b:8080")
         storage = MagicMock()
         storage.resolve_workstream.return_value = "d" * 32
+        storage.get_workstream.return_value = {"ws_id": "d" * 32, "state": "idle"}
         app = _make_app(router=router, auth_storage=storage)
         _wire_proxy(
             app,
@@ -194,7 +200,7 @@ class TestRouteCreate:
         assert data["node_url"] == "http://b:8080"
         assert data["node_id"] == "node-b"
         storage.resolve_workstream.assert_called_once_with("saved-alias")
-        router.route.assert_called_with("d" * 32)
+        assert router.route.call_args.args == ("d" * 32,)
         router.remember_override.assert_called_once_with(
             _FORK_DEST_WS_ID,
             NodeRef("node-b", "http://b:8080"),
@@ -204,7 +210,7 @@ class TestRouteCreate:
         client.close()
 
     def test_route_create_target_node(self):
-        """target_node should generate a ws_id that hashes to that node."""
+        """An explicit target is persisted without constraining the ID hash."""
         router = _make_mock_router()
         router.generate_ws_id_for_node.return_value = "00ff" + "0" * 28
         router.route.return_value = NodeRef("node-c", "http://c:8080")
@@ -223,7 +229,8 @@ class TestRouteCreate:
         assert resp.status_code == 200
         data = resp.json()
         assert data["node_id"] == "node-c"
-        router.generate_ws_id_for_node.assert_called_with("node-c")
+        router.required_node.assert_called_with("node-c")
+        assert app.state.proxy_client.post.call_args.kwargs["json"]["required_node_id"] == "node-c"
         client.close()
 
     def test_route_create_routing_strategy_rendezvous(self, client):
@@ -259,6 +266,7 @@ class TestRouteCreate:
         router.route.return_value = NodeRef("node-b", "http://b:8080")
         storage = MagicMock()
         storage.resolve_workstream.return_value = "d" * 32
+        storage.get_workstream.return_value = {"ws_id": "d" * 32, "state": "idle"}
         app = _make_app(router=router, auth_storage=storage)
         _wire_proxy(
             app,
@@ -337,7 +345,7 @@ class TestRouteCreate:
         assert resp.status_code == 400
         assert resp.json() == {"error": error}
 
-    def test_explicit_json_ws_id_is_preserved_and_routed_by_rendezvous(self):
+    def test_explicit_json_ws_id_is_preserved_with_required_node(self):
         router = _make_mock_router()
         app = _make_app(router=router)
         post = _make_proxy_post(json_data={"ws_id": _DEST_WS_ID, "name": "fixed"})
@@ -352,8 +360,9 @@ class TestRouteCreate:
         client.close()
 
         assert resp.status_code == 200
-        assert resp.json()["routing_strategy"] == "rendezvous"
-        router.route.assert_called_once_with(_DEST_WS_ID)
+        assert resp.json()["routing_strategy"] == "target_node"
+        router.required_node.assert_called_once_with("node-a")
+        router.route.assert_not_called()
         router.generate_ws_id_for_node.assert_not_called()
         assert post.call_args.kwargs["json"]["ws_id"] == _DEST_WS_ID
 
@@ -405,7 +414,8 @@ class TestRouteCreate:
         assert resp.status_code == 200, resp.text
         storage.get_workstream.assert_any_call(source_id)
         storage.resolve_workstream.assert_not_called()
-        router.route.assert_called_once_with(source_id)
+        assert router.route.call_count == 1
+        assert router.route.call_args.args == (source_id,)
         assert post.call_args.kwargs["json"]["resume_ws"] == source_id
 
     @pytest.mark.anyio
@@ -468,7 +478,12 @@ class TestRouteCreate:
         router = _make_mock_router()
         storage = MagicMock()
         storage.resolve_workstream.return_value = "d" * 32
-        storage.get_workstream.return_value = {"node_id": "stored-node"}
+        storage.get_workstream.return_value = {"ws_id": "d" * 32, "state": "idle"}
+        storage.get_workstream.side_effect = lambda ws_id: {
+            "ws_id": ws_id,
+            "state": "idle",
+            "node_id": "stored-node",
+        }
         app = _make_app(router=router, auth_storage=storage)
         _wire_proxy(
             app,
@@ -486,7 +501,7 @@ class TestRouteCreate:
 
         assert resp.status_code == 200
         assert resp.json()["node_id"] == "stored-node"
-        storage.get_workstream.assert_called_once_with(_FORK_DEST_WS_ID)
+        storage.get_workstream.assert_any_call(_FORK_DEST_WS_ID)
         audit.assert_called_once()
         assert audit.call_args.args[2] == _FORK_DEST_WS_ID
 
@@ -505,7 +520,8 @@ class TestRouteCreate:
 
         assert resp.status_code == 200
         assert resp.json()["routing_strategy"] == "rendezvous"
-        router.route.assert_called_once_with(_DEST_WS_ID)
+        assert router.route.call_count == 1
+        assert router.route.call_args.args == (_DEST_WS_ID,)
 
 
 class TestRouteCreate503Retry:
@@ -516,7 +532,7 @@ class TestRouteCreate503Retry:
         router = _make_mock_router()
         call_count = 0
 
-        def side_effect_route(ws_id: str) -> NodeRef:
+        def side_effect_route(ws_id: str, **kwargs: Any) -> NodeRef:
             nonlocal call_count
             call_count += 1
             if call_count <= 1:
@@ -579,11 +595,35 @@ class TestRouteCreate503Retry:
         assert resp.status_code == 503
         assert post.call_count == 1
         assert post.call_args.kwargs["json"]["ws_id"] == _DEST_WS_ID
-        router.route.assert_called_once_with(_DEST_WS_ID)
+        assert router.route.call_count == 1
+        assert router.route.call_args.args == (_DEST_WS_ID,)
 
 
 class TestRouteCreate409Retry:
     """Generated destination ids retry live collisions at the router."""
+
+    def test_wrong_executor_conflict_is_not_an_id_collision(self):
+        router = _make_mock_router()
+        app = _make_app(router=router)
+        post = _make_proxy_post(
+            status_code=409,
+            json_data={
+                "error": "This workstream must run on node 'host-1'.",
+                "code": "wrong_execution_node",
+                "required_node_id": "host-1",
+            },
+        )
+        _wire_proxy(app, post)
+        client = TestClient(app, raise_server_exceptions=False)
+        try:
+            response = client.post(
+                "/v1/api/route/workstreams/new", json={}, headers=_TEST_AUTH_HEADERS
+            )
+        finally:
+            client.close()
+        assert response.status_code == 409
+        assert response.json()["code"] == "wrong_execution_node"
+        assert post.call_count == 1
 
     def test_generated_ws_id_collision_draws_another_id(self, monkeypatch):
         first_id = "1" * 32
@@ -622,11 +662,12 @@ class TestRouteCreate409Retry:
         assert posted_ids == [first_id, second_id]
         assert generated.call_count == 2
 
-    def test_target_node_collision_retries_with_targeted_generator(self):
+    def test_target_node_collision_keeps_required_node(self, monkeypatch):
         first_id = "1" * 32
         second_id = "2" * 32
         router = _make_mock_router()
-        router.generate_ws_id_for_node.side_effect = [first_id, second_id]
+        generated = MagicMock(side_effect=[first_id, second_id])
+        monkeypatch.setattr("turnstone.console.server.secrets.token_hex", generated)
         router.route.return_value = NodeRef("node-c", "http://c:8080")
         app = _make_app(router=router)
         posted_ids: list[str] = []
@@ -657,9 +698,9 @@ class TestRouteCreate409Retry:
         assert resp.status_code == 200
         assert resp.json()["node_id"] == "node-c"
         assert posted_ids == [first_id, second_id]
-        assert router.generate_ws_id_for_node.call_count == 2
-        assert router.generate_ws_id_for_node.call_args_list[0].args == ("node-c",)
-        assert router.generate_ws_id_for_node.call_args_list[1].args == ("node-c",)
+        assert generated.call_count == 2
+        assert router.required_node.call_count == 2
+        assert all(call.args == ("node-c",) for call in router.required_node.call_args_list)
 
     def test_explicit_ws_id_collision_is_not_retried(self):
         router = _make_mock_router()
@@ -1068,7 +1109,8 @@ class TestRouteWorkstreamLive:
 
         assert resp.status_code == 200
         assert resp.json() == {"ws_id": "ws-live", "live": True}
-        router.route.assert_called_once_with("ws-live")
+        assert router.route.call_count == 1
+        assert router.route.call_args.args == ("ws-live",)
         assert mock_get.call_args.args[0] == "http://a:8080/v1/api/workstreams"
 
     def test_false_miss_refreshes_stale_override_and_reprobes_new_owner(self):
@@ -1282,3 +1324,40 @@ class TestRouteNoNode:
             headers=_TEST_AUTH_HEADERS,
         )
         assert resp.status_code == 503
+
+
+def test_route_proxy_refresh_retries_new_url_for_same_node_identity():
+    router = _make_mock_router()
+    router.route.side_effect = [
+        NodeRef("host-1", "http://old:8080"),
+        NodeRef("host-1", "http://new:8080"),
+    ]
+    app = _make_app(router=router)
+    requests = []
+
+    async def upstream(method, url, **kwargs):
+        requests.append(url)
+        return httpx.Response(
+            404 if len(requests) == 1 else 200,
+            json={"status": "ok"},
+            request=httpx.Request(method, url),
+        )
+
+    proxy = MagicMock(spec=httpx.AsyncClient)
+    proxy.request = MagicMock(side_effect=upstream)
+    app.state.proxy_client = proxy
+    client = TestClient(app, raise_server_exceptions=False)
+    try:
+        response = client.post(
+            "/v1/api/route/workstreams/saved/send",
+            json={"message": "continue"},
+            headers=_TEST_AUTH_HEADERS,
+        )
+    finally:
+        client.close()
+    assert response.status_code == 200
+    assert requests == [
+        "http://old:8080/v1/api/workstreams/saved/send",
+        "http://new:8080/v1/api/workstreams/saved/send",
+    ]
+    router.force_refresh.assert_called_once()

--- a/tests/test_migration_076.py
+++ b/tests/test_migration_076.py
@@ -1,0 +1,59 @@
+"""Affinity migration preserves saved rows and leaves legacy intent unspecified."""
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+
+def _roundtrip(url):
+    cfg = Config()
+    cfg.set_main_option(
+        "script_location",
+        str(Path(__file__).resolve().parents[1] / "turnstone/core/storage/migrations"),
+    )
+    cfg.set_main_option("sqlalchemy.url", str(url).replace("%", "%%"))
+    command.upgrade(cfg, "075")
+    engine = sa.create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO workstreams (ws_id, node_id, created, updated) VALUES ('saved', 'old-origin', '2026-01-01', '2026-01-01')"
+                )
+            )
+        command.upgrade(cfg, "076")
+        with engine.begin() as conn:
+            assert conn.execute(
+                sa.text("SELECT node_id, required_node_id FROM workstreams WHERE ws_id = 'saved'")
+            ).one() == ("old-origin", None)
+            conn.execute(
+                sa.text("UPDATE workstreams SET required_node_id = 'host-1' WHERE ws_id = 'saved'")
+            )
+        command.downgrade(cfg, "075")
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    sa.text("SELECT node_id FROM workstreams WHERE ws_id = 'saved'")
+                ).scalar_one()
+                == "old-origin"
+            )
+        command.upgrade(cfg, "076")
+        with engine.connect() as conn:
+            assert (
+                conn.execute(
+                    sa.text("SELECT required_node_id FROM workstreams WHERE ws_id = 'saved'")
+                ).scalar_one()
+                is None
+            )
+    finally:
+        engine.dispose()
+
+
+def test_affinity_migration_sqlite(tmp_path):
+    _roundtrip(f"sqlite:///{tmp_path / 'affinity.db'}")
+
+
+def test_affinity_migration_postgresql(fresh_pg_url):
+    _roundtrip(fresh_pg_url.render_as_string(hide_password=False))

--- a/tests/test_node_affinity.py
+++ b/tests/test_node_affinity.py
@@ -98,7 +98,10 @@ def test_node_create_and_fork_requirements(app_client, multipart):
     assert storage.get_workstream(source)["required_node_id"] == "host-1"
 
 
-def test_core_resume_checks_node_before_adopting_identity(app_client):
+@pytest.mark.parametrize("replace_during_load", [False, True])
+def test_core_resume_checks_node_before_adopting_identity(app_client, replace_during_load):
+    from unittest.mock import Mock
+
     from turnstone.core.session import ChatSession
 
     client, manager = app_client
@@ -107,12 +110,25 @@ def test_core_resume_checks_node_before_adopting_identity(app_client):
         "/v1/api/workstreams/new", json={"required_node_id": "host-1"}, headers=_auth("owner")
     ).json()["ws_id"]
     session = ChatSession.__new__(ChatSession)
-    session._node_id, session._ws_id = "node-1", "original"
-    session._load_message_turns = lambda _: [object()]
-    session._load_workstream_config = lambda _: {}
+    session._node_id = "host-1" if replace_during_load else "node-1"
+    session._ws_id = "original"
+    session._load_message_turns = Mock(return_value=[object()])
+    session._load_workstream_config = Mock(return_value={})
+    if replace_during_load:
+        storage = get_storage()
+
+        def replace_source(_ws_id):
+            storage.delete_workstream(source)
+            storage.register_workstream(source, required_node_id="node-1")
+            return [object()]
+
+        session._load_message_turns.side_effect = replace_source
     with pytest.raises(NodeAffinityError):
         session.resume(source)
     assert session._ws_id == "original"
+    if not replace_during_load:
+        session._load_message_turns.assert_not_called()
+        session._load_workstream_config.assert_not_called()
 
 
 def test_cli_resume_refuses_requirement_without_exiting_repl(monkeypatch):
@@ -131,6 +147,9 @@ def test_cli_resume_refuses_requirement_without_exiting_repl(monkeypatch):
         "required_node_id": "host-1",
         "fork_reservation_token": "token",
     }
+    storage.get_workstream.return_value = (
+        storage.ensure_workstream_incarnation_snapshot.return_value
+    )
     monkeypatch.setattr("turnstone.core.session.current_worker_claim", lambda _: None)
     monkeypatch.setattr("turnstone.core.session.resolve_workstream", lambda _: "target")
     monkeypatch.setattr("turnstone.core.session.get_storage", lambda: storage)

--- a/tests/test_node_affinity.py
+++ b/tests/test_node_affinity.py
@@ -1,0 +1,227 @@
+"""Execution requirements survive lifecycle changes and reject wrong-node loads."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.test_server_authz import _auth
+from tests.test_server_authz import app_client as app_client
+from tests.test_session_manager import FakeAdapter
+from turnstone.core.node_affinity import NodeAffinityError, parse_required_node_id
+from turnstone.core.session_manager import SessionManager
+from turnstone.core.storage import get_storage
+
+
+@pytest.mark.parametrize("value", ["", " a", "a/b", True, 123, [], "a" * 257])
+def test_invalid_requirement(value):
+    with pytest.raises(ValueError, match="required_node_id"):
+        parse_required_node_id(value)
+
+
+def test_requirement_survives_close_and_rejects_another_manager(db):
+    host = SessionManager(FakeAdapter(), storage=db, node_id="host-1", max_active=4)
+    other = SessionManager(FakeAdapter(), storage=db, node_id="node-1", max_active=4)
+    ws = host.create(user_id="owner", required_node_id="host-1")
+    try:
+        with pytest.raises(NodeAffinityError):
+            other.open(ws.id)
+        assert other.list_all() == []
+        host.close(ws.id)
+        assert db.get_workstream(ws.id)["required_node_id"] == "host-1"
+        with pytest.raises(NodeAffinityError):
+            other.open(ws.id)
+        assert host.open(ws.id) is not None
+        assert db.get_workstreams_batch([ws.id])[ws.id]["required_node_id"] == "host-1"
+    finally:
+        host.close(ws.id)
+
+
+def test_wrong_node_create_does_not_reserve_or_evict(db):
+    manager = SessionManager(FakeAdapter(), storage=db, node_id="node-1", max_active=1)
+    current = manager.create(user_id="owner")
+    try:
+        with pytest.raises(NodeAffinityError):
+            manager.create(user_id="owner", ws_id="wrong", required_node_id="host-1")
+        assert manager.get(current.id) is current
+        assert db.get_workstream("wrong") is None
+    finally:
+        manager.close(current.id)
+
+
+@pytest.mark.parametrize("multipart", [False, True])
+def test_node_create_and_fork_requirements(app_client, multipart):
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = "host-1"
+    body = {"required_node_id": "host-1"}
+    kwargs = (
+        {"files": {"meta": (None, json.dumps(body), "application/json")}}
+        if multipart
+        else {"json": body}
+    )
+    response = client.post("/v1/api/workstreams/new", headers=_auth("owner"), **kwargs)
+    assert response.status_code == 200, response.text
+    source = response.json()["ws_id"]
+    storage = get_storage()
+    storage.save_message(source, "user", "Saved host history")
+    manager.close(source)
+    response = client.post(
+        "/v1/api/workstreams/new", json={"resume_ws": source}, headers=_auth("owner")
+    )
+    assert response.status_code == 200, response.text
+    fork = response.json()["ws_id"]
+    assert fork != source
+    assert storage.get_workstream(fork)["required_node_id"] == "host-1"
+    manager.close(fork)
+
+    client.app.state.node_id = manager._node_id = "node-1"
+    response = client.post(
+        "/v1/api/workstreams/new", json={"resume_ws": source}, headers=_auth("owner")
+    )
+    assert response.status_code == 409, response.text
+    assert response.json()["code"] == "wrong_execution_node"
+    for verb in ("open", "detail"):
+        request = client.post if verb == "open" else client.get
+        suffix = "/open" if verb == "open" else ""
+        response = request(f"/v1/api/workstreams/{source}{suffix}", headers=_auth("owner"))
+        assert response.status_code == 409, response.text
+    response = client.post(
+        "/v1/api/workstreams/new",
+        json={"resume_ws": source, "required_node_id": "node-1"},
+        headers=_auth("owner"),
+    )
+    assert response.status_code == 200, response.text
+    moved_copy = response.json()["ws_id"]
+    assert moved_copy != source
+    assert storage.get_workstream(moved_copy)["required_node_id"] == "node-1"
+    assert storage.get_workstream(source)["required_node_id"] == "host-1"
+
+
+def test_core_resume_checks_node_before_adopting_identity(app_client):
+    from turnstone.core.session import ChatSession
+
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = "host-1"
+    source = client.post(
+        "/v1/api/workstreams/new", json={"required_node_id": "host-1"}, headers=_auth("owner")
+    ).json()["ws_id"]
+    session = ChatSession.__new__(ChatSession)
+    session._node_id, session._ws_id = "node-1", "original"
+    session._load_message_turns = lambda _: [object()]
+    session._load_workstream_config = lambda _: {}
+    with pytest.raises(NodeAffinityError):
+        session.resume(source)
+    assert session._ws_id == "original"
+
+
+def test_cli_resume_refuses_requirement_without_exiting_repl(monkeypatch):
+    from unittest.mock import Mock
+
+    from turnstone.core.session import ChatSession
+
+    session = ChatSession.__new__(ChatSession)
+    session._user_id, session._node_id, session._ws_id = "owner", None, "current"
+    session.ui = Mock()
+    session._drain_queue_for_identity_swap = lambda: None
+    session._load_message_turns = lambda _: [object()]
+    session._load_workstream_config = lambda _: {}
+    storage = Mock()
+    storage.ensure_workstream_incarnation_snapshot.return_value = {
+        "required_node_id": "host-1",
+        "fork_reservation_token": "token",
+    }
+    monkeypatch.setattr("turnstone.core.session.current_worker_claim", lambda _: None)
+    monkeypatch.setattr("turnstone.core.session.resolve_workstream", lambda _: "target")
+    monkeypatch.setattr("turnstone.core.session.get_storage", lambda: storage)
+    assert session.handle_command("/resume target", principal_id="owner") is False
+    assert session._ws_id == "current"
+    session.ui.on_error.assert_called_once()
+    assert "host-1" in session.ui.on_error.call_args.args[0]
+
+
+@pytest.mark.parametrize("lifecycle", ["autoclose", "eviction", "restart"])
+def test_requirement_survives_lifecycle_and_same_node_restart(db, lifecycle):
+    from turnstone.core.session_manager import SessionManager
+
+    manager = SessionManager(FakeAdapter(), storage=db, node_id="host-1", max_active=1)
+    ws = manager.create(user_id="owner", required_node_id="host-1")
+    try:
+        if lifecycle == "autoclose":
+            ws.last_active = 0
+            assert ws.id in manager.close_idle(max_age_seconds=1)
+        elif lifecycle == "eviction":
+            manager.create(user_id="owner")
+            assert manager.get(ws.id) is None
+        else:
+            manager.close(ws.id)
+        assert db.get_workstream(ws.id)["required_node_id"] == "host-1"
+        restarted = SessionManager(FakeAdapter(), storage=db, node_id="host-1", max_active=1)
+        wrong = SessionManager(FakeAdapter(), storage=db, node_id="node-1", max_active=1)
+        with pytest.raises(NodeAffinityError):
+            wrong.open(ws.id)
+        try:
+            assert restarted.open(ws.id) is not None
+        finally:
+            restarted.close(ws.id)
+    finally:
+        for current in manager.list_all():
+            manager.close(current.id)
+
+
+@pytest.mark.parametrize("entrypoint", ["cli.py", "server.py"])
+def test_startup_resume_refusal_closes_temporary_session(monkeypatch, entrypoint):
+    """Run the startup blocks with real resume, without starting network services."""
+    import ast
+    import sys
+    from pathlib import Path
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    from turnstone.core.session import ChatSession
+
+    session = ChatSession.__new__(ChatSession)
+    session._node_id, session._ws_id = "node-1", "temporary"
+    session._load_message_turns = lambda _: [object()]
+    session._load_workstream_config = lambda _: {}
+    storage = Mock()
+    storage.ensure_workstream_incarnation_snapshot.return_value = {
+        "required_node_id": "host-1",
+        "fork_reservation_token": "token",
+    }
+    monkeypatch.setattr("turnstone.core.session.get_storage", lambda: storage)
+    monkeypatch.setattr("turnstone.core.memory.resolve_workstream", lambda _: "saved")
+    ws = SimpleNamespace(id="temporary", session=session, ui=SimpleNamespace())
+    manager = Mock()
+    manager.create.return_value = ws
+    source = Path(__file__).resolve().parents[1] / "turnstone" / entrypoint
+    tree = ast.parse(source.read_text())
+    expected_test = "resume_target" if entrypoint == "cli.py" else "args.resume"
+    blocks = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == expected_test
+        and "ws.session.resume(" in ast.unparse(node)
+    ]
+    assert len(blocks) == 1
+    namespace = dict(
+        args=SimpleNamespace(resume="saved", skip_permissions=False),
+        resume_target="saved",
+        ws=ws,
+        manager=manager,
+        red=lambda value: value,
+        sys=sys,
+        log=Mock(),
+        _get_storage=lambda: storage,
+        _watch_restore_owner=lambda *_: "owner",
+        _resume_persona_kwargs=lambda _: {},
+        WebUI=SimpleNamespace,
+        config_store=SimpleNamespace(get=lambda _: False),
+    )
+    code = compile(ast.Module(body=blocks, type_ignores=[]), str(source), "exec")
+    with pytest.raises(SystemExit) as error:
+        exec(code, namespace)
+    assert error.value.code == 1
+    assert session._ws_id == "temporary"
+    manager.close.assert_called_once_with("temporary")

--- a/tests/test_node_affinity_js.py
+++ b/tests/test_node_affinity_js.py
@@ -109,9 +109,18 @@ submit.onclick();
 submit.onclick(); // Busy guard prevents a duplicate continuation.
 await new Promise(resolve=>setTimeout(resolve,0));
 assert.equal(posted.length,1);
-assert.deepEqual(posted[0],{url:'/v1/api/cluster/workstreams/new',body:{node_id:'node-1',resume_ws:'saved-id',resume_ws_exact:true}});
+assert.deepEqual(posted[0],{url:'/v1/api/cluster/workstreams/new',body:{node_id:'node-1',required_node_id:'node-1',resume_ws:'saved-id',resume_ws_exact:true}});
 assert.deepEqual(opened,[['interactive','new-id',{nodeId:'node-1'}]]);
 assert.equal(dlg.open,false);
+for(const nodeId of ['auto','pool']) {
+  clusterState.nodes[nodeId]={};
+  window.TS_APP.continueInteractiveElsewhere('saved-id','host-1');
+  select.value=nodeId;
+  submit.onclick();
+  await new Promise(resolve=>setTimeout(resolve,0));
+  assert.equal(posted.at(-1).body.node_id,nodeId);
+  assert.equal(posted.at(-1).body.required_node_id,nodeId);
+}
 """
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_node_affinity_js.py
+++ b/tests/test_node_affinity_js.py
@@ -1,0 +1,117 @@
+"""Execute the browser recovery and continuation flows with controlled HTTP."""
+
+from pathlib import Path
+
+from tests._js_harness_helpers import node_skip, run_node_source, slice_braced_block
+
+pytestmark = node_skip
+_APP = Path(__file__).resolve().parents[1] / "turnstone/console/static/app.js"
+
+
+def test_browser_recovery_preserves_required_node_and_refreshes_stale_hints():
+    source = _APP.read_text()
+    seam = source[
+        source.index("window.TS_APP.resolveInteractiveNode = function") : source.index(
+            "// === MCP consent badge"
+        )
+    ]
+    result = run_node_source(
+        """
+import assert from 'node:assert/strict';
+const window = {TS_APP:{}};
+let authFetch;
+"""
+        + seam
+        + """
+const response = (status, body={}) => ({status, ok:status===200, json:async()=>body});
+for (const hintStatus of [404, 502, 409]) {
+  const calls=[];
+  authFetch=async(url)=>{
+    calls.push(url);
+    if(calls.length===1) return response(hintStatus, hintStatus===409 ? {code:'wrong_execution_node',required_node_id:'host-1'} : {});
+    if(url.startsWith('/v1/api/route?')) return response(503, {code:'required_node_unavailable',required_node_id:'host-1'});
+    throw Error('An unavailable required node must not fall back to another executor');
+  };
+  const result=await window.TS_APP.resolveInteractiveNode('saved','old-hint');
+  assert.equal(result.code,'required_node_unavailable');
+  assert.equal(result.requiredNodeId,'host-1');
+  assert.equal(result.canContinue,true);
+  assert.equal(calls.length,2);
+}
+for(const hintStatus of [200,403,429]) {
+  for(const code of [undefined,'wrong_execution_node','required_node_unavailable']) {
+    let calls=0;
+    authFetch=async()=>{calls++;return response(hintStatus,{code,required_node_id:'host-1'})};
+    const result=await window.TS_APP.resolveInteractiveNode('saved','host-1');
+    assert.equal(calls,1);
+    assert.equal(Boolean(result.nodeId),hintStatus===200);
+    assert.equal(Boolean(result.canContinue),false);
+  }
+}
+for(const required of [false,true]) {
+  const calls=[];
+  authFetch=async(url)=>{
+    calls.push(url);
+    if(calls.length===1) return response(required?409:502,required?{code:'wrong_execution_node',required_node_id:'host-1'}:{});
+    if(calls.length===2) return response(200,{node_id:required?'host-1':'node-1'});
+    return response(200);
+  };
+  const result=await window.TS_APP.resolveInteractiveNode('saved','stale');
+  assert.equal(result.nodeId,required?'host-1':'node-1');
+  assert.equal(calls.length,3);
+}
+"""
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_explicit_continuation_uses_launcher_with_new_identity():
+    source = _APP.read_text()
+    functions = "\n".join(
+        source[
+            source.index("function " + name + "(") : source.index(
+                "{", source.index("function " + name + "(")
+            )
+        ]
+        + slice_braced_block(source, source.index("function " + name + "("))
+        for name in (
+            "_resolveNodePlacement",
+            "_createWorkstreamFetchOpts",
+            "_createInteractive",
+        )
+    )
+    seam_start = source.index("window.TS_APP.continueInteractiveElsewhere = function")
+    seam = source[seam_start : source.index("// === MCP consent badge", seam_start)]
+    result = run_node_source(
+        """
+import assert from 'node:assert/strict';
+let busy=false, posted=[], opened=[];
+const dlg={open:false,hasAttribute:()=>busy,close(){this.open=false}};
+const select={options:[],value:'',replaceChildren(...rows){this.options=rows;this.value=''},add(row){this.options.push(row)}};
+const error={textContent:''}, submit={};
+const elements={'continue-session-dialog':dlg,'continue-session-node':select,'continue-session-error':error,'continue-session-submit':submit};
+const document={getElementById:id=>elements[id]};
+function Option(text,value){this.text=text;this.value=value}
+const clusterState={nodes:{'host-1':{},'node-1':{},'offline':{reachable:false},console:{}}};
+const window={TS_APP:{},TurnstoneHatch:{openDialog(d){d.open=true},setBusy(d,b){busy=b}},TS_SHELL:{panes:{openPane(...args){opened.push(args)}}}};
+const authFetch=async(url,opts)=>{posted.push({url,body:JSON.parse(opts.body)});return{ok:true,status:200,json:async()=>({correlation_id:'new-id',target_node:'node-1'})}};
+"""
+        + functions
+        + seam
+        + """
+window.TS_APP.continueInteractiveElsewhere('saved-id','host-1');
+assert.deepEqual(select.options.map(x=>x.value),['','node-1']);
+submit.onclick();
+assert.equal(posted.length,0);
+assert.match(error.textContent,/Choose a node/);
+select.value='node-1';
+submit.onclick();
+submit.onclick(); // Busy guard prevents a duplicate continuation.
+await new Promise(resolve=>setTimeout(resolve,0));
+assert.equal(posted.length,1);
+assert.deepEqual(posted[0],{url:'/v1/api/cluster/workstreams/new',body:{node_id:'node-1',resume_ws:'saved-id',resume_ws_exact:true}});
+assert.deepEqual(opened,[['interactive','new-id',{nodeId:'node-1'}]]);
+assert.equal(dlg.open,false);
+"""
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_node_affinity_routing.py
+++ b/tests/test_node_affinity_routing.py
@@ -1,0 +1,315 @@
+"""Real console -> node requests preserve placement intent and channel identity."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from tests.test_console_routing_proxy import (
+    _TEST_AUTH_HEADERS,
+    _TEST_JWT_SECRET,
+    _make_app,
+    _make_mock_collector,
+)
+from tests.test_server_authz import _DEFAULT_TEST_PERMS, _auth
+from tests.test_server_authz import app_client as app_client
+from turnstone.console.router import ConsoleRouter
+from turnstone.core.storage import get_storage
+
+
+def _console(storage):
+    storage.register_service("server", "host-1", "http://host.example:8080")
+    router = ConsoleRouter(storage)
+    router.refresh_cache()
+    collector = _make_mock_collector()
+    collector.get_node_detail.side_effect = lambda node_id: (
+        {"server_url": "http://host.example:8080"} if node_id == "host-1" else None
+    )
+    collector.get_all_nodes.return_value = [
+        dict(node_id="host-1", reachable=True, max_ws=10, ws_total=0)
+    ]
+    app = _make_app(collector=collector, router=router, auth_storage=storage)
+    app.state.proxy_client = object()  # read-only/denied requests must never dispatch
+    return app, router
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "endpoint,body,multipart,required",
+    [
+        ("route", {}, False, None),
+        ("route", {"ws_id": "a" * 32}, False, None),
+        ("route", {"target_node": "host-1"}, False, "host-1"),
+        ("route", {"required_node_id": "host-1"}, False, "host-1"),
+        ("route", {"ws_id": "a" * 32, "target_node": "host-1"}, False, "host-1"),
+        ("route", {"ws_id": "a" * 32}, True, None),
+        ("route", {"ws_id": "a" * 32, "target_node": "host-1"}, True, "host-1"),
+        ("cluster", {}, False, None),
+        ("cluster", {"node_id": "pool"}, False, None),
+        ("cluster", {"node_id": "host-1"}, False, "host-1"),
+        ("cluster", {"node_id": "host-1"}, True, "host-1"),
+    ],
+)
+async def test_create_intent_crosses_console_and_node(
+    app_client, endpoint, body, multipart, required
+):
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = "host-1"
+    storage = get_storage()
+    console, router = _console(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client.app), base_url="http://host.example:8080"
+    ) as node:
+        console.state.proxy_client = node
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=console), base_url="http://console"
+        ) as proxy:
+            path = f"/v1/api/{endpoint}/workstreams/new"
+            if multipart and endpoint == "route":
+                path += "?ws_id=" + body["ws_id"]
+            kwargs = (
+                {"files": {"meta": (None, json.dumps(body), "application/json")}}
+                if multipart
+                else {"json": body}
+            )
+            response = await proxy.post(path, headers=_TEST_AUTH_HEADERS, **kwargs)
+            assert response.status_code == 200, response.text
+            ws_id = response.json().get("ws_id") or response.json()["correlation_id"]
+            assert storage.get_workstream(ws_id)["required_node_id"] == required
+            manager.close(ws_id)
+            router.refresh_cache()
+            assert storage.get_workstream(ws_id)["required_node_id"] == required
+            if required:
+                storage.deregister_service("server", "host-1")
+                storage.register_service("server", "node-1", "http://other:8080")
+                router.refresh_cache()
+                response = await proxy.get(
+                    "/v1/api/route", params={"ws_id": ws_id}, headers=_TEST_AUTH_HEADERS
+                )
+                assert response.status_code == 503, response.text
+                assert response.json()["required_node_id"] == "host-1"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "endpoint,multipart", [("route", False), ("cluster", False), ("route", True)]
+)
+async def test_explicit_continuation_is_new_identity_and_inheritance_is_enforced(
+    app_client, endpoint, multipart
+):
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = "host-1"
+    source = client.post(
+        "/v1/api/workstreams/new",
+        json={"required_node_id": "host-1"},
+        headers=_auth("test-routing"),
+    ).json()["ws_id"]
+    storage = get_storage()
+    storage.save_message(source, "user", "saved history")
+    manager.close(source)
+    console, router = _console(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client.app), base_url="http://host.example:8080"
+    ) as node:
+        console.state.proxy_client = node
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=console), base_url="http://console"
+        ) as proxy:
+            path = f"/v1/api/{endpoint}/workstreams/new"
+            if multipart:
+                storage.register_service("server", "node-1", "http://other:8080")
+                router.refresh_cache()
+                from turnstone.core.rendezvous import NodeRef, select
+
+                candidates = [
+                    NodeRef("host-1", "http://host.example:8080"),
+                    NodeRef("node-1", "http://other:8080"),
+                ]
+                destination_id = next(
+                    f"{i:032x}"
+                    for i in range(1000)
+                    if select(f"{i:032x}", candidates).node_id == "node-1"
+                )
+                observed = []
+
+                async def capture(request):
+                    observed.append(request)
+
+                node.event_hooks["request"].append(capture)
+                response = await proxy.post(
+                    path + "?ws_id=" + destination_id,
+                    files={
+                        "meta": (
+                            None,
+                            json.dumps(
+                                {
+                                    "ws_id": destination_id,
+                                    "resume_ws": source,
+                                    "resume_ws_exact": True,
+                                }
+                            ),
+                            "application/json",
+                        )
+                    },
+                    headers=_TEST_AUTH_HEADERS,
+                )
+                assert observed[-1].url.host == "host.example"
+                assert json.loads(observed[-1].content)["resume_ws_exact"] is True
+            else:
+                response = await proxy.post(
+                    path, json={"resume_ws": source}, headers=_TEST_AUTH_HEADERS
+                )
+            assert response.status_code == 200, response.text
+            inherited = response.json().get("ws_id") or response.json()["correlation_id"]
+            assert inherited != source
+            assert storage.get_workstream(inherited)["required_node_id"] == "host-1"
+            manager.close(inherited)
+            storage.deregister_service("server", "host-1")
+            storage.register_service("server", "node-1", "http://other:8080")
+            router.refresh_cache()
+            console.state.collector.get_node_detail.side_effect = lambda nid: (
+                {"server_url": "http://other:8080"} if nid == "node-1" else None
+            )
+            client.app.state.node_id = manager._node_id = "node-1"
+            response = await proxy.post(
+                path, json={"resume_ws": source}, headers=_TEST_AUTH_HEADERS
+            )
+            assert response.status_code == 503, response.text
+            assert manager.list_all() == []
+            target_field = "target_node" if endpoint == "route" else "node_id"
+            response = await proxy.post(
+                path, json={"resume_ws": source, target_field: "node-1"}, headers=_TEST_AUTH_HEADERS
+            )
+            assert response.status_code == 200, response.text
+            destination = response.json().get("ws_id") or response.json()["correlation_id"]
+            assert destination not in {source, inherited}
+            assert storage.get_workstream(destination)["required_node_id"] == "node-1"
+            assert storage.get_workstream(source)["required_node_id"] == "host-1"
+            assert [row["content"] for row in storage.load_messages(destination)] == [
+                "saved history"
+            ]
+
+
+@pytest.mark.anyio
+async def test_private_requirement_is_hidden_from_route_and_fork(app_client):
+    from turnstone.core.auth import JWT_AUD_CONSOLE, create_jwt
+
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = "host-1"
+    source = client.post(
+        "/v1/api/workstreams/new", json={"required_node_id": "host-1"}, headers=_auth("owner")
+    ).json()["ws_id"]
+    manager.close(source)
+    storage = get_storage()
+    storage.create_project("private", "Private", "owner", visibility="private")
+    import sqlalchemy as sa
+
+    from turnstone.core.storage._schema import workstreams
+
+    with storage._conn() as conn:
+        conn.execute(
+            sa.update(workstreams).where(workstreams.c.ws_id == source).values(project_id="private")
+        )
+        conn.commit()
+    console, router = _console(storage)
+    storage.deregister_service("server", "host-1")
+    storage.register_service("server", "node-1", "http://other:8080")
+    router.refresh_cache()
+    token = create_jwt(
+        user_id="stranger",
+        scopes=frozenset({"read", "write"}),
+        permissions=_DEFAULT_TEST_PERMS,
+        source="test",
+        secret=_TEST_JWT_SECRET,
+        audience=JWT_AUD_CONSOLE,
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=console), base_url="http://console"
+    ) as proxy:
+        for ws_id in (source, "b" * 32):
+            response = await proxy.get("/v1/api/route", params={"ws_id": ws_id}, headers=headers)
+            assert response.status_code == 200, response.text
+            assert response.json()["node_id"] == "node-1"
+            for endpoint in ("route", "cluster"):
+                response = await proxy.post(
+                    f"/v1/api/{endpoint}/workstreams/new",
+                    json={"resume_ws": ws_id, "resume_ws_exact": True},
+                    headers=headers,
+                )
+                assert response.status_code == 404, response.text
+                assert response.json() == {"error": "Workstream not found"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("console_mode", [False, True])
+async def test_channel_preserves_pin_when_required_node_is_absent(app_client, console_mode):
+    from turnstone.channels._routing import ChannelRouter
+    from turnstone.sdk._types import TurnstoneAPIError
+    from turnstone.sdk.console import AsyncTurnstoneConsole
+    from turnstone.sdk.server import AsyncTurnstoneServer
+
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = "host-1"
+    source = client.post(
+        "/v1/api/workstreams/new",
+        json={"required_node_id": "host-1"},
+        headers=_auth("test-routing"),
+    ).json()["ws_id"]
+    manager.close(source)
+    storage = get_storage()
+    storage.create_channel_route("discord", "123", source, channel_user_id="owner")
+    channels = ChannelRouter("http://other:8080", storage)
+    await channels.aclose()
+    if console_mode:
+        app, router = _console(storage)
+        storage.deregister_service("server", "host-1")
+        storage.register_service("server", "node-1", "http://other:8080")
+        router.refresh_cache()
+        headers = _TEST_AUTH_HEADERS
+    else:
+        app = client.app
+        headers = _auth("test-routing")
+    client.app.state.node_id = manager._node_id = "node-1"
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://other:8080", headers=headers
+    ) as http:
+        if console_mode:
+            channels._server = None
+            channels._console = AsyncTurnstoneConsole(httpx_client=http)
+        else:
+            channels._server = AsyncTurnstoneServer(httpx_client=http)
+        with pytest.raises(TurnstoneAPIError) as error:
+            await channels.get_or_create_workstream("discord", "123", channel_user_id="owner")
+        assert error.value.status_code == (503 if console_mode else 409)
+        assert storage.get_channel_route("discord", "123")["ws_id"] == source
+        assert manager.list_all() == []
+    await channels.aclose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "endpoint,body,status",
+    [
+        ("route", {"target_node": "missing"}, 503),
+        ("cluster", {"node_id": "missing"}, 503),
+        ("route", {"required_node_id": "host-1", "target_node": "node-1"}, 400),
+        ("cluster", {"required_node_id": "host-1", "node_id": "node-1"}, 400),
+        ("route", {"required_node_id": ""}, 400),
+        ("cluster", {"required_node_id": False}, 400),
+    ],
+)
+async def test_invalid_or_missing_required_node_never_dispatches(
+    app_client, endpoint, body, status
+):
+    console, _ = _console(get_storage())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=console), base_url="http://console"
+    ) as proxy:
+        response = await proxy.post(
+            f"/v1/api/{endpoint}/workstreams/new", json=body, headers=_TEST_AUTH_HEADERS
+        )
+    assert response.status_code == status, response.text
+    assert app_client[1].list_all() == []

--- a/tests/test_node_affinity_routing.py
+++ b/tests/test_node_affinity_routing.py
@@ -93,6 +93,93 @@ async def test_create_intent_crosses_console_and_node(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("reserved_node", ["auto", "pool"])
+@pytest.mark.parametrize("fork", [False, True])
+async def test_required_node_identity_is_not_an_automatic_placement_mode(
+    app_client, reserved_node, fork
+):
+    client, manager = app_client
+    client.app.state.node_id = manager._node_id = reserved_node
+    storage = get_storage()
+    body = {"required_node_id": reserved_node}
+    if fork:
+        source = client.post(
+            "/v1/api/workstreams/new", json=body, headers=_auth("test-routing")
+        ).json()["ws_id"]
+        manager.close(source)
+        body = {"resume_ws": source, "resume_ws_exact": True}
+    console, _router = _console(storage)
+    collector = console.state.collector
+    collector.get_node_detail.side_effect = lambda node_id: {
+        "server_url": f"http://{node_id}.example:8080"
+    }
+    collector.get_all_nodes.return_value = [
+        dict(node_id=reserved_node, reachable=True, max_ws=5, ws_total=4),
+        dict(node_id="node-1", reachable=True, max_ws=10, ws_total=0),
+    ]
+    dispatched = []
+
+    async def capture(request):
+        dispatched.append(request.url.host)
+        client.app.state.node_id = manager._node_id = request.url.host.split(".")[0]
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client.app),
+        event_hooks={"request": [capture]},
+    ) as node:
+        console.state.proxy_client = node
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=console), base_url="http://console"
+        ) as proxy:
+            response = await proxy.post(
+                "/v1/api/cluster/workstreams/new", json=body, headers=_TEST_AUTH_HEADERS
+            )
+    assert response.status_code == 200, response.text
+    assert dispatched == [f"{reserved_node}.example"]
+    destination = response.json()["correlation_id"]
+    assert storage.get_workstream(destination)["required_node_id"] == reserved_node
+    if fork:
+        assert destination != source
+        assert storage.get_workstream(source)["required_node_id"] == reserved_node
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("node_count", [1, 2])
+async def test_failed_create_skips_policy_reads_for_unsuitable_candidates(
+    app_client, monkeypatch, node_count
+):
+    from unittest.mock import Mock
+
+    storage = get_storage()
+    console, router = _console(storage)
+    if node_count == 2:
+        storage.register_service("server", "node-1", "http://other.example:8080")
+        router.refresh_cache()
+    # Every candidate hashes back to the failed node. A single-node cluster
+    # skips the search; a larger cluster rejects these candidates from cache.
+    monkeypatch.setattr("turnstone.console.server.secrets.token_hex", lambda _: "a" * 32)
+    lookup = Mock(wraps=storage.get_workstream)
+    monkeypatch.setattr(storage, "get_workstream", lookup)
+    dispatched = []
+
+    def fail(request):
+        dispatched.append(request)
+        return httpx.Response(503, json={"error": "Node unavailable"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(fail)) as node:
+        console.state.proxy_client = node
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=console), base_url="http://console"
+        ) as proxy:
+            response = await proxy.post(
+                "/v1/api/route/workstreams/new", json={}, headers=_TEST_AUTH_HEADERS
+            )
+    assert response.status_code == 503
+    assert len(dispatched) == 1
+    assert lookup.call_count == 1
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "endpoint,multipart", [("route", False), ("cluster", False), ("route", True)]
 )

--- a/tests/test_per_user_message_context.py
+++ b/tests/test_per_user_message_context.py
@@ -532,6 +532,7 @@ def test_resume_resets_shared_state():
     s._shared_workstream = True
     turns = [turn_from_dict({"role": "user", "content": "x", "_sender": "owner"})]
     storage = MagicMock()
+    storage.get_workstream.return_value = None
     storage.ensure_workstream_incarnation_snapshot.return_value = None
     with (
         patch("turnstone.core.session.load_message_turns", return_value=turns),

--- a/tests/test_per_user_message_context.py
+++ b/tests/test_per_user_message_context.py
@@ -554,10 +554,12 @@ def test_fork_persists_sender_meta():
         turn_from_dict({"role": "user", "content": "wake", "_source": "wake"}),
         turn_from_dict({"role": "assistant", "content": "yo"}),
     ]
+    storage = MagicMock()
+    storage.get_workstream.return_value = None
     with (
         patch("turnstone.core.session.load_message_turns", return_value=turns),
         patch("turnstone.core.session.save_messages_bulk") as bulk,
-        patch("turnstone.core.session.get_storage", return_value=None),
+        patch("turnstone.core.session.get_storage", return_value=storage),
         patch.object(s, "_save_config"),
         patch.object(s, "_init_system_messages"),
     ):

--- a/tests/test_route_proxy_audit.py
+++ b/tests/test_route_proxy_audit.py
@@ -73,7 +73,6 @@ def _make_mock_router(node_id: str = "node-a", url: str = "http://a:8080") -> Ma
     router = MagicMock(spec=ConsoleRouter)
     router.is_ready.return_value = True
     router.route.return_value = NodeRef(node_id, url)
-    router.generate_ws_id_for_node.return_value = "00ff" + "0" * 28
     return router
 
 

--- a/tests/test_route_proxy_audit.py
+++ b/tests/test_route_proxy_audit.py
@@ -200,7 +200,7 @@ class TestRouteCreateAudit:
 
         call_count = 0
 
-        def _route(_ws_id: str) -> NodeRef:
+        def _route(_ws_id: str, **kwargs: Any) -> NodeRef:
             nonlocal call_count
             call_count += 1
             if call_count <= 1:

--- a/tests/test_route_proxy_audit.py
+++ b/tests/test_route_proxy_audit.py
@@ -196,6 +196,8 @@ class TestRouteCreateAudit:
     def test_503_retry_records_final_node_id(self):
         """Audit row must reflect the node that actually served 200, not the failed first node."""
         router = _make_mock_router()
+        router.node_count.return_value = 2
+        router.rendezvous_node.return_value = NodeRef("node-b-retry", "http://b:8080")
 
         call_count = 0
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -545,6 +545,10 @@ class TestSchedulerTick:
             scheduler._tick()
 
         assert create.call_count == 2
+        expected_required = None if target_mode in {"auto", "pool"} else "node-001"
+        assert all(
+            call.kwargs["required_node_id"] == expected_required for call in create.call_args_list
+        )
         storage.update_scheduled_task.assert_not_called()
         rows = [
             (c.kwargs["status"], c.kwargs["error"]) for c in storage.record_task_run.call_args_list

--- a/tests/test_sdk_console.py
+++ b/tests/test_sdk_console.py
@@ -634,24 +634,34 @@ async def test_route_create_workstream():
 
 
 @pytest.mark.anyio
-async def test_route_create_workstream_rejects_attachments_with_target_node():
-    """Regression: target_node has no effect on multipart route_create
-    (which routes by ?ws_id=) — refuse the combination at the SDK boundary
-    instead of silently routing to the wrong node.
-    """
+async def test_route_create_workstream_attachments_with_target_node():
+    """Multipart preserves the explicit requirement alongside the chosen ID."""
     from turnstone.sdk._types import AttachmentUpload
 
-    transport = httpx.MockTransport(
-        lambda req: _json_response({"error": "should not be called"}, status=500)
-    )
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert b'"target_node": "n1"' in request.content
+        assert b'"required_node_id": "n1"' in request.content
+        assert b'filename="a.txt"' in request.content
+        return _json_response(
+            {
+                "ws_id": request.url.params["ws_id"],
+                "name": "x",
+                "node_id": "n1",
+                "node_url": "http://n1:8080",
+                "routing_strategy": "target_node",
+            }
+        )
+
+    transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as hc:
         client = AsyncTurnstoneConsole(httpx_client=hc)
-        with pytest.raises(ValueError, match="target_node"):
-            await client.route_create_workstream(
-                name="x",
-                target_node="n1",
-                attachments=[AttachmentUpload(filename="a.txt", data=b"hi")],
-            )
+        result = await client.route_create_workstream(
+            name="x",
+            target_node="n1",
+            required_node_id="n1",
+            attachments=[AttachmentUpload(filename="a.txt", data=b"hi")],
+        )
+        assert result.node_id == "n1"
 
 
 @pytest.mark.anyio

--- a/tests/test_server_authz.py
+++ b/tests/test_server_authz.py
@@ -305,6 +305,7 @@ class _FakeSession:
         *,
         principal_id: str,
         source_reservation_token: str,
+        source_required_node_id: str | None = None,
         trusted_internal: bool = False,
     ) -> Any:
         from turnstone.core.storage import get_storage
@@ -3108,6 +3109,7 @@ class TestCreateForkRollback:
             *,
             principal_id: str,
             source_reservation_token: str,
+            source_required_node_id: str | None = None,
             trusted_internal: bool = False,
         ) -> Any:
             assert fork_source_id == source_id
@@ -3117,6 +3119,7 @@ class TestCreateForkRollback:
                 fork_source_id,
                 principal_id=principal_id,
                 source_reservation_token=source_reservation_token,
+                source_required_node_id=source_required_node_id,
                 trusted_internal=trusted_internal,
             )
 
@@ -3166,6 +3169,7 @@ class TestCreateForkRollback:
             *,
             principal_id: str,
             source_reservation_token: str,
+            source_required_node_id: str | None = None,
             trusted_internal: bool = False,
         ) -> Any:
             assert fork_source_id == source_id
@@ -3246,6 +3250,7 @@ class TestCreateForkRollback:
             *,
             principal_id: str,
             source_reservation_token: str,
+            source_required_node_id: str | None = None,
             trusted_internal: bool = False,
         ) -> Any:
             fork_calls.append((fork_source_id, principal_id, trusted_internal))
@@ -3372,6 +3377,7 @@ class TestCreateForkRollback:
             *,
             principal_id: str,
             source_reservation_token: str,
+            source_required_node_id: str | None = None,
             trusted_internal: bool = False,
         ) -> Any:
             entered_clone.set()
@@ -3381,6 +3387,7 @@ class TestCreateForkRollback:
                 fork_source_id,
                 principal_id=principal_id,
                 source_reservation_token=source_reservation_token,
+                source_required_node_id=source_required_node_id,
                 trusted_internal=trusted_internal,
             )
 
@@ -3495,6 +3502,7 @@ class TestCreateForkRollback:
             *,
             principal_id: str,
             source_reservation_token: str,
+            source_required_node_id: str | None = None,
             trusted_internal: bool = False,
         ) -> Any:
             entered_clone.set()
@@ -3505,6 +3513,7 @@ class TestCreateForkRollback:
                     fork_source_id,
                     principal_id=principal_id,
                     source_reservation_token=source_reservation_token,
+                    source_required_node_id=source_required_node_id,
                     trusted_internal=trusted_internal,
                 )
             finally:
@@ -3578,6 +3587,7 @@ class TestCreateForkRollback:
             *,
             principal_id: str,
             source_reservation_token: str,
+            source_required_node_id: str | None = None,
             trusted_internal: bool = False,
         ) -> Any:
             assert storage.delete_project("fork-project") is True
@@ -3586,6 +3596,7 @@ class TestCreateForkRollback:
                 fork_source_id,
                 principal_id=principal_id,
                 source_reservation_token=source_reservation_token,
+                source_required_node_id=source_required_node_id,
                 trusted_internal=trusted_internal,
             )
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -213,6 +213,7 @@ class _Row:
     parent_ws_id: str | None = None
     updated: str = ""
     node_id: str | None = None
+    required_node_id: str | None = None
     project_id: str | None = None
     persona: str | None = None
 
@@ -262,6 +263,7 @@ class FakeStorage:
         state: str = "idle",
         updated: str | None = None,
         fork_reservation_token: str = "",
+        required_node_id: str | None = None,
     ) -> None:
         if self.register_raises:
             raise RuntimeError("register forced failure")
@@ -276,6 +278,7 @@ class FakeStorage:
                 parent_ws_id=parent_ws_id,
                 updated=updated if updated is not None else self._now_iso(),
                 node_id=node_id,
+                required_node_id=required_node_id,
                 project_id=project_id,
                 persona=persona if persona else None,
             )
@@ -386,6 +389,7 @@ class FakeStorage:
                 "state": row.state,
                 "parent_ws_id": row.parent_ws_id,
                 "persona": row.persona,
+                "required_node_id": row.required_node_id,
             }
 
     def ensure_workstream_incarnation_snapshot(self, ws_id: str) -> dict[str, Any] | None:
@@ -406,6 +410,7 @@ class FakeStorage:
                 "parent_ws_id": row.parent_ws_id,
                 "project_id": row.project_id,
                 "persona": row.persona,
+                "required_node_id": row.required_node_id,
                 "fork_reservation_token": token,
             }
 

--- a/tests/test_storage_fork_clone.py
+++ b/tests/test_storage_fork_clone.py
@@ -749,3 +749,103 @@ def test_compacted_clone_rewrites_marker_to_destination_id_space(storage_backend
     assert marker_id != source_watermark
     assert backend.get_compaction_checkpoint("destination") == marker_id
     assert backend.count_messages("destination") == 3  # marker + two live tail rows
+
+
+@pytest.mark.parametrize(
+    "destination_required,executor,changed",
+    [
+        (None, "host-1", False),
+        ("node-1", "node-1", False),
+        (None, "node-1", False),
+        ("node-1", "node-1", True),
+    ],
+)
+def test_clone_requirement_inheritance_override_and_atomic_recheck(
+    storage_backend,
+    destination_required,
+    executor,
+    changed,
+):
+    from turnstone.core.node_affinity import NodeAffinityError
+
+    backend = storage_backend
+    backend.register_workstream(
+        "source",
+        user_id="alice",
+        state="idle",
+        kind="interactive",
+        required_node_id="host-1",
+        fork_reservation_token="source-token",
+    )
+    backend.register_workstream(
+        "destination",
+        user_id="alice",
+        state="creating",
+        kind="interactive",
+        required_node_id=destination_required,
+        fork_reservation_token="destination-token",
+    )
+    backend.save_message("source", "user", "saved history")
+    if changed:
+        with backend._conn() as conn:
+            conn.execute(
+                sa.update(workstreams)
+                .where(workstreams.c.ws_id == "source")
+                .values(required_node_id="new-host")
+            )
+            conn.commit()
+    expectation = ForkCloneExpectation(
+        persona_config=(),
+        project_id="",
+        project_name="",
+        project_writable=False,
+        destination_reservation_token="destination-token",
+        source_reservation_token="source-token",
+        source_required_node_id="host-1",
+        node_id=executor,
+    )
+
+    def clone():
+        return backend.clone_workstream(
+            "source", "destination", principal_id="alice", expected_session=expectation
+        )
+
+    if changed or (destination_required is None and executor != "host-1"):
+        with pytest.raises(ForkSourceUnavailableError if changed else NodeAffinityError):
+            clone()
+        assert backend.load_message_turns("destination") == []
+        assert backend.get_workstream("destination")["required_node_id"] == destination_required
+    else:
+        result = clone()
+        assert [turn.text for turn in result.turns] == ["saved history"]
+        assert result.required_node_id == (destination_required or "host-1")
+        assert backend.get_workstream("destination")["required_node_id"] == result.required_node_id
+        assert backend.get_workstream("source")["required_node_id"] == "host-1"
+
+
+def test_foreign_destination_hides_its_execution_requirement(storage_backend):
+    backend = storage_backend
+    _register(backend, "source", "alice", fork_reservation_token="source-token", state="idle")
+    backend.register_workstream(
+        "destination",
+        user_id="bob",
+        state="creating",
+        required_node_id="private-host",
+        fork_reservation_token="destination-token",
+    )
+    with pytest.raises(ForkDestinationConflictError, match="destination is not available"):
+        backend.clone_workstream(
+            "source",
+            "destination",
+            principal_id="alice",
+            expected_session=ForkCloneExpectation(
+                persona_config=(),
+                project_id="",
+                project_name="",
+                project_writable=False,
+                source_reservation_token="source-token",
+                destination_reservation_token="destination-token",
+                node_id="node-1",
+            ),
+        )
+    assert backend.get_workstream("destination")["required_node_id"] == "private-host"

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -156,7 +156,7 @@ class ClusterSnapshotResponse(BaseModel):
 class ConsoleCreateWsRequest(BaseModel):
     node_id: str = Field(
         default="",
-        description="Target node: specific ID, 'auto', 'pool', or empty for auto",
+        description="Required node: a specific ID pins execution; 'auto', 'pool', or empty select initial placement only",
     )
     name: str = Field(default="", description="Workstream name (auto-generated if empty)")
     model: str = Field(default="", description="Model alias from node registry")
@@ -175,6 +175,14 @@ class ConsoleCreateWsRequest(BaseModel):
     resume_ws: str = Field(
         default="",
         description=("Source workstream ID or alias to fork atomically into the new workstream"),
+    )
+    resume_ws_exact: bool = Field(default=False, description="Require an exact fork source ID")
+    required_node_id: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        pattern=r"^[A-Za-z0-9_.-]+$",
+        description="Durable execution requirement; omission inherits the fork source requirement",
     )
     judge_model: str = Field(
         default="", description="Override judge model alias for this workstream"
@@ -1450,8 +1458,8 @@ class RouteCreateRequest(CreateWorkstreamRequest):
     target_node: str = Field(
         default="",
         description=(
-            "Optional node id to pin placement to. The console generates a "
-            "workstream id whose rendezvous owner is that node."
+            "Optional required execution node. Applies even with a supplied destination ID "
+            "or fork source. Must match required_node_id when both are supplied."
         ),
     )
 
@@ -1464,8 +1472,8 @@ class RouteCreateResponse(CreateWorkstreamResponse):
     routing_strategy: Literal["rendezvous", "target_node", "resume"] = Field(
         description=(
             "Placement reason: rendezvous for a destination id, target_node for "
-            "a generated pinned id, or resume when an atomic fork is routed by "
-            "its canonical source id"
+            "an explicit execution requirement, or resume when an atomic fork inherits "
+            "its source requirement or placement"
         ),
     )
 

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -1213,16 +1213,20 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         "/v1/api/route/workstreams/new",
         "POST",
-        "Create workstream via rendezvous routing proxy",
+        "Create workstream via console routing proxy",
         description=(
             "The documented JSON form accepts RouteCreateRequest. The endpoint also "
             "accepts multipart/form-data with a JSON `meta` field and file parts; "
             "multipart callers must supply `ws_id` as a query parameter; the console "
-            "requires the cached `meta.ws_id` to match before forwarding the original "
-            "body. A JSON body may instead carry "
-            "an explicit `ws_id`; the console preserves it and uses it as the "
-            "rendezvous placement key. `resume_ws` accepts an id or saved alias and "
-            "is resolved to the canonical source id before an atomic fork is routed."
+            "requires `meta.ws_id` to match before forwarding the original upload "
+            "body. A JSON body may instead carry an explicit destination `ws_id`. "
+            "Explicit or inherited node requirements take precedence over rendezvous "
+            "placement while preserving the destination ID. `resume_ws` accepts an "
+            "id or saved alias and is authorized and resolved to its canonical source "
+            "before routing an atomic fork. A fork inherits the source requirement "
+            "unless an explicit destination node is selected for the new ID. "
+            "Metadata-only multipart forks use the same JSON fork path; uploads "
+            "cannot be combined with a fork."
         ),
         request_model=RouteCreateRequest,
         response_model=RouteCreateResponse,
@@ -1231,7 +1235,7 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
             QueryParam(
                 "ws_id",
                 (
-                    "32-hex rendezvous key required for multipart creates. JSON "
+                    "32-hex destination ID required for multipart creates. JSON "
                     "callers put an optional destination ws_id in the request body."
                 ),
             )
@@ -1243,12 +1247,12 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "GET",
         "Probe whether a routed workstream is loaded without rehydrating it",
         description=(
-            "Routes to the workstream's rendezvous owner and checks its "
+            "Resolves the workstream's required node or flexible placement and checks its "
             "manager-authoritative active list. The response does not expose "
             "workstream metadata; missing, unloaded, creating, and "
             "caller-invisible rows all report ``live=false``. Routing and "
-            "upstream uncertainty fail with an error rather than reporting a "
-            "false miss."
+            "upstream uncertainty, including an unavailable required node, fail "
+            "with an error rather than reporting a false miss."
         ),
         response_model=RouteLiveResponse,
         error_codes=[400, 502, 503],

--- a/turnstone/api/server_schemas.py
+++ b/turnstone/api/server_schemas.py
@@ -213,6 +213,17 @@ class RewindRequest(BaseModel):
 
 
 class CreateWorkstreamRequest(BaseModel):
+    required_node_id: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        pattern=r"^[A-Za-z0-9_.-]+$",
+        description=(
+            "Required execution node. Omission permits automatic placement for a fresh "
+            "workstream and inherits the source requirement for a fork. An explicit "
+            "destination applies only to the new workstream ID."
+        ),
+    )
     name: str = Field(default="", description="Workstream display name (auto-generated if empty)")
     model: str = Field(default="", description="Model alias from registry")
     judge_model: str = Field(

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -1485,11 +1485,21 @@ def main() -> None:
 
     # Handle --resume
     if resume_target:
+        from turnstone.core.node_affinity import NodeAffinityError
+
         if ws.session is None:
             print(red("No session available."))
+            manager.close(ws.id)
             sys.exit(1)
-        if not ws.session.resume(resume_target):
+        try:
+            resumed = ws.session.resume(resume_target)
+        except NodeAffinityError as exc:
+            manager.close(ws.id)
+            print(red(f"Cannot resume {resume_target}: {exc}"))
+            sys.exit(1)
+        if not resumed:
             print(red(f"Workstream '{args.resume}' has no messages."))
+            manager.close(ws.id)
             sys.exit(1)
         print(f"Resumed workstream {bold(resume_target)} ({len(ws.session.messages)} messages)")
 

--- a/turnstone/console/router.py
+++ b/turnstone/console/router.py
@@ -1,22 +1,20 @@
 """Console routing layer — routes workstream requests to server nodes.
 
-Uses rendezvous (HRW) hashing over the live ``services`` table.  The
-routing function is a pure function of ``(ws_id, live_nodes)``: every
-reader given the same membership list produces the same answer, and
-``services.last_heartbeat`` is the single source of truth for both
-liveness and routing.
+Uses durable execution requirements before placement overrides and rendezvous
+(HRW) hashing over the live ``services`` table. Requirements are read from the
+saved row on each resolution, so a missing cache entry never releases a pin.
 
 **Cache ownership**: the router's cache is push-driven by the
-collector's background discovery thread.  ``route()`` and ``is_ready()``
-are pure in-memory lookups — they do not touch storage on the hot path.
+collector's background discovery thread. ``route()`` also reads the saved
+workstream row; async callers must run it in a worker thread.
 The collector calls ``refresh_cache()`` on every discovery tick and
 again immediately on observed membership changes (node_joined /
 node_lost).  ``force_refresh()`` exists for the 404-retry path;
 callers must wrap it in ``asyncio.to_thread`` when invoking from an
 async handler so its DB read doesn't stall the event loop.
 
-Per-route cost is O(N) hash computes — microseconds at typical cluster
-sizes, dwarfed by every downstream HTTP round-trip.
+Each resolution costs one indexed workstream read and, for flexible placement,
+O(N) hash computes. Node membership and placement overrides remain cached.
 """
 
 from __future__ import annotations
@@ -24,11 +22,14 @@ from __future__ import annotations
 import json
 import secrets
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from turnstone.core.node_affinity import NodeAffinityError, parse_required_node_id
 from turnstone.core.rendezvous import NoAvailableNodeError, NodeRef, select
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from turnstone.core.storage._protocol import StorageBackend
 
 # Brute-force attempt cap for ``generate_ws_id_for_node``.  Expected
@@ -151,26 +152,45 @@ class ConsoleRouter:
     # Routing
     # ------------------------------------------------------------------
 
-    def route(self, ws_id: str) -> NodeRef:
+    def route(
+        self, ws_id: str, *, can_read: Callable[[dict[str, Any]], bool] | None = None
+    ) -> NodeRef:
         """Route a workstream to its assigned node.
 
         Priority:
-        1. Per-workstream override (pinned to a specific node)
-        2. Rendezvous (HRW) selection over the live-node list
-
-        Pure in-memory lookup — does not touch storage.  Cache freshness
-        is the collector's responsibility (see module docstring).
+        A durable requirement wins over location overrides and HRW. Invisible
+        rows use the same placement as unknown IDs, avoiding a private-source
+        oracle through unavailable-node responses. Callers without a filter
+        are trusted internal consumers.
         """
+        if not ws_id:
+            raise NoAvailableNodeError("invalid ws_id: empty")
+        try:
+            row = self._storage.get_workstream(ws_id)
+            visible = row is None or can_read is None or can_read(row)
+            required = (
+                parse_required_node_id(row.get("required_node_id")) if row and visible else None
+            )
+        except Exception as exc:
+            raise NoAvailableNodeError("Cannot resolve workstream execution requirement") from exc
+        if required:
+            return self.required_node(required)
         with self._lock:
-            ref = self._overrides.get(ws_id)
+            ref = self._overrides.get(ws_id) if visible else None
             if ref is not None:
                 return ref
             nodes = self._nodes  # snapshot — list is replaced wholesale on refresh
         if not nodes:
             raise NoAvailableNodeError("no live nodes")
-        if not ws_id:
-            raise NoAvailableNodeError("invalid ws_id: empty")
         return select(ws_id, nodes)
+
+    def required_node(self, node_id: str) -> NodeRef:
+        """Resolve one required identity without permitting placement fallback."""
+        with self._lock:
+            for ref in self._nodes:
+                if ref.node_id == node_id:
+                    return ref
+        raise NodeAffinityError(node_id, unavailable=True)
 
     def remember_override(self, ws_id: str, ref: NodeRef) -> None:
         """Publish one just-confirmed durable placement into this cache.

--- a/turnstone/console/router.py
+++ b/turnstone/console/router.py
@@ -20,7 +20,6 @@ O(N) hash computes. Node membership and placement overrides remain cached.
 from __future__ import annotations
 
 import json
-import secrets
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -31,14 +30,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from turnstone.core.storage._protocol import StorageBackend
-
-# Brute-force attempt cap for ``generate_ws_id_for_node``.  Expected
-# attempts for a weight-w_t target in a cluster with total weight W is
-# W/w_t (the target wins w_t/W of keys).  At typical scale (N≤50,
-# weights ∈ {1..4}) the worst case is ~200 attempts; the cap is well
-# above that to absorb pathologically-skewed configurations without
-# spurious failures.
-_GENERATE_ATTEMPT_CAP = 65_536
 
 
 def _parse_weight(metadata_json: str) -> int:
@@ -179,6 +170,17 @@ class ConsoleRouter:
             ref = self._overrides.get(ws_id) if visible else None
             if ref is not None:
                 return ref
+            nodes = self._nodes
+        if not nodes:
+            raise NoAvailableNodeError("no live nodes")
+        return select(ws_id, nodes)
+
+    def rendezvous_node(self, ws_id: str) -> NodeRef:
+        """Compute cached HRW placement before admitting a fresh candidate.
+
+        This does not resolve durable policy; existing IDs must use route().
+        """
+        with self._lock:
             nodes = self._nodes  # snapshot — list is replaced wholesale on refresh
         if not nodes:
             raise NoAvailableNodeError("no live nodes")
@@ -238,31 +240,3 @@ class ConsoleRouter:
         """
         with self._lock:
             return self._refresh_counter
-
-    # ------------------------------------------------------------------
-    # Workstream ID generation
-    # ------------------------------------------------------------------
-
-    def generate_ws_id_for_node(self, node_id: str) -> str:
-        """Generate a 32-hex-char ws_id where rendezvous selects *node_id*.
-
-        Brute-force loop: pick a random candidate, check whether HRW
-        picks the target.  Expected attempts ≈ ``W/w_t`` where ``W`` is
-        total cluster weight and ``w_t`` is the target's weight.  Cap
-        at ``_GENERATE_ATTEMPT_CAP`` to bound worst case for skewed
-        configurations.
-        """
-        with self._lock:
-            nodes = list(self._nodes)
-        if not nodes:
-            raise NoAvailableNodeError(f"no live node {node_id!r}")
-        if not any(n.node_id == node_id for n in nodes):
-            raise NoAvailableNodeError(f"no live node {node_id!r}")
-
-        for _ in range(_GENERATE_ATTEMPT_CAP):
-            candidate = secrets.token_hex(16)
-            if select(candidate, nodes).node_id == node_id:
-                return candidate
-        raise NoAvailableNodeError(
-            f"could not generate ws_id targeting {node_id!r} after {_GENERATE_ATTEMPT_CAP} attempts"
-        )

--- a/turnstone/console/scheduler.py
+++ b/turnstone/console/scheduler.py
@@ -526,6 +526,9 @@ class TaskScheduler:
         try:
             resp = client.create_workstream(
                 name=task["name"],
+                required_node_id=(
+                    node_id if task.get("target_mode", "auto") not in {"auto", "pool"} else None
+                ),
                 model=task.get("model", ""),
                 initial_message=task["initial_message"],
                 auto_approve=bool(task.get("auto_approve", 0)),

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -81,6 +81,7 @@ from turnstone.core.model_registry import (
     strip_control_characters,
 )
 from turnstone.core.model_registry import MODEL_AUTH_MODES as _MODEL_AUTH_MODES
+from turnstone.core.node_affinity import NodeAffinityError, requested_node_requirement
 from turnstone.core.project_access import fold_role_permissions
 from turnstone.core.rendezvous import NoAvailableNodeError, NodeRef
 from turnstone.core.rerank_calibrate import canonical_caps_value
@@ -1843,6 +1844,23 @@ async def create_workstream(request: Request) -> JSONResponse:
     auth = getattr(getattr(request, "state", None), "auth_result", None)
     uid: str = getattr(auth, "user_id", "") or ""
 
+    try:
+        explicit_required = requested_node_requirement(
+            body.get("required_node_id"), node_id if node_id not in {"", "auto", "pool"} else None
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    source_row = await _resolve_fork_source(request, body)
+    if isinstance(source_row, JSONResponse):
+        return source_row
+    if source_row is not None:
+        resume_ws = body["resume_ws"]
+    effective_required = explicit_required or (
+        source_row.get("required_node_id") if source_row else None
+    )
+    if effective_required:
+        node_id = effective_required
+
     # Pool — pick any available node
     if node_id == "pool":
         node_id = _pick_best_node(collector)
@@ -1858,6 +1876,9 @@ async def create_workstream(request: Request) -> JSONResponse:
     # Validate node exists and get its URL
     detail = collector.get_node_detail(node_id)
     if not detail:
+        if effective_required:
+            error = NodeAffinityError(effective_required, unavailable=True)
+            return JSONResponse(error.as_dict(), status_code=error.status_code)
         return JSONResponse({"error": "Node not found"}, status_code=404)
 
     server_url = detail.get("server_url", "")
@@ -1872,6 +1893,8 @@ async def create_workstream(request: Request) -> JSONResponse:
         "skill": skill,
         "persona": persona,
         "resume_ws": resume_ws,
+        "resume_ws_exact": bool(resume_ws),
+        "required_node_id": explicit_required,
         "user_id": uid,
         "project_id": project_id,
     }
@@ -1899,9 +1922,8 @@ async def create_workstream(request: Request) -> JSONResponse:
         log.warning("Workstream dispatch to %s failed: %s", node_id, exc)
         return _dispatch_failed(node_id)
 
-    # The node is the authoritative require_project gate. Surface ONLY its
-    # coded require_project 400 to the operator; mask every OTHER node outcome
-    # as an opaque 502. Rationale (do not "simplify" by re-emitting the node
+    # Preserve the coded project-required and wrong-executor refusals. Mask
+    # other node failures as an opaque 502. Rationale (do not "simplify" by re-emitting the node
     # status/body generically):
     #   * a node 401 re-emitted here trips authFetch's reactive refresh +
     #     force-logout, dumping a VALID operator to the login overlay and
@@ -1948,6 +1970,17 @@ async def create_workstream(request: Request) -> JSONResponse:
         )
 
     from turnstone.core.auth import REQUIRE_PROJECT_CODE, REQUIRE_PROJECT_ERROR
+
+    if node_body and node_body.get("code") == "wrong_execution_node" and resp.status_code == 409:
+        # Use validated canonical fields, keeping the node's arbitrary error
+        # text behind the existing dispatch boundary.
+        try:
+            required = requested_node_requirement(node_body.get("required_node_id"))
+        except ValueError:
+            required = None
+        if required:
+            error = NodeAffinityError(required)
+            return JSONResponse(error.as_dict(), status_code=error.status_code)
 
     if (
         resp.status_code == 400
@@ -2008,26 +2041,19 @@ async def route_create(request: Request) -> Response:
     if err is not None:
         return _record_route(request, "create", 403, t0, err)
     router: ConsoleRouter | None = request.app.state.router
-    ring_ready = router is not None and router.is_ready()
-    if not ring_ready:
-        # Router cache empty — the collector hasn't published a
-        # services list yet.  One-shot refresh off the event loop
-        # before giving up.
-        if router is not None:
-            await asyncio.to_thread(router.refresh_cache)
-            ring_ready = router.is_ready()
-        if not ring_ready:
-            return _record_route(
-                request,
-                "create",
-                503,
-                t0,
-                JSONResponse(
-                    {"error": "Cluster routing not initialized"},
-                    status_code=503,
-                ),
-            )
-    assert router is not None
+    if router is None:
+        return _record_route(
+            request,
+            "create",
+            503,
+            t0,
+            JSONResponse(
+                {"error": "Cluster routing not initialized"},
+                status_code=503,
+            ),
+        )
+    if not router.is_ready():
+        await asyncio.to_thread(router.refresh_cache)
 
     raw_content_type = request.headers.get("content-type") or ""
     is_multipart = raw_content_type.lower().startswith("multipart/form-data")
@@ -2039,6 +2065,8 @@ async def route_create(request: Request) -> Response:
     # coordinator's spawn_workstream tool especially) can explain why a
     # given node was chosen.  Set on every branch below.
     routing_strategy = "rendezvous"
+    multipart_fork: dict[str, Any] | None = None
+    meta: dict[str, Any] = {}
 
     if is_multipart:
         # Multipart: caller must pass ws_id as a query param. Parse only the
@@ -2072,13 +2100,14 @@ async def route_create(request: Request) -> Response:
         try:
             form = await request.form()
             meta_raw = form.get("meta")
-            meta = json.loads(meta_raw) if isinstance(meta_raw, str) else None
+            parsed_meta = json.loads(meta_raw) if isinstance(meta_raw, str) else None
+            has_files = any(not isinstance(value, str) for value in form.values())
         except Exception:
-            meta = None
+            parsed_meta = None
         finally:
             if form is not None:
                 await form.close()
-        if not isinstance(meta, dict) or meta.get("ws_id") != ws_id:
+        if not isinstance(parsed_meta, dict) or parsed_meta.get("ws_id") != ws_id:
             return _record_route(
                 request,
                 "create",
@@ -2089,8 +2118,50 @@ async def route_create(request: Request) -> Response:
                     status_code=400,
                 ),
             )
+        meta = parsed_meta
+        if meta.get("resume_ws"):
+            if has_files:
+                return _record_route(
+                    request,
+                    "create",
+                    400,
+                    t0,
+                    JSONResponse(
+                        {
+                            "error": "Attachments cannot be combined with resume_ws; fork first, then upload"
+                        },
+                        status_code=400,
+                    ),
+                )
+            # With no uploads there is no binary framing to preserve. Route
+            # metadata-only forks through the common JSON path, which resolves
+            # the exact source and inherits its execution requirement.
+            multipart_fork = meta
+            is_multipart = False
+
+    if is_multipart:
         try:
-            ref = router.route(ws_id)
+            required = requested_node_requirement(
+                meta.get("required_node_id"), meta.get("target_node")
+            )
+        except ValueError as exc:
+            return _record_route(
+                request, "create", 400, t0, JSONResponse({"error": str(exc)}, status_code=400)
+            )
+        try:
+            ref = (
+                router.required_node(required)
+                if required
+                else await _request_route(request, router, ws_id)
+            )
+        except NodeAffinityError as exc:
+            return _record_route(
+                request,
+                "create",
+                exc.status_code,
+                t0,
+                JSONResponse(exc.as_dict(), status_code=exc.status_code),
+            )
         except NoAvailableNodeError:
             return _record_route(
                 request,
@@ -2105,7 +2176,7 @@ async def route_create(request: Request) -> Response:
         # Multipart callers pre-allocate a fresh destination id. Placement is
         # ordinary rendezvous over that id; ``resume`` is reserved for the JSON
         # atomic-fork path keyed by its source workstream.
-        routing_strategy = "rendezvous"
+        routing_strategy = "target_node" if required else "rendezvous"
         # Forward the raw header verbatim — the multipart `boundary=` parameter
         # is case-sensitive and must match the bytes in the body exactly.
         upstream_headers = {**headers, "Content-Type": raw_content_type}
@@ -2127,7 +2198,9 @@ async def route_create(request: Request) -> Response:
                 ),
             )
     else:
-        parsed_body = await read_json_or_400(request)
+        parsed_body = (
+            multipart_fork if multipart_fork is not None else await read_json_or_400(request)
+        )
         if isinstance(parsed_body, JSONResponse):
             return _record_route(request, "create", parsed_body.status_code, t0, parsed_body)
         body = parsed_body
@@ -2185,85 +2258,53 @@ async def route_create(request: Request) -> Response:
                 JSONResponse({"error": "invalid ws_id format"}, status_code=400),
             )
 
-        # ``resume_ws`` supports saved aliases, but rendezvous placement needs
-        # the canonical source id. Resolve before choosing a node and forward
-        # the canonical value so the router and node operate on one identity.
-        if resume_ws:
-            storage, storage_err = require_storage_or_503(request)
-            if storage_err is not None:
-                return _record_route(
-                    request,
-                    "create",
-                    storage_err.status_code,
-                    t0,
-                    storage_err,
-                )
-            try:
-                # Keep the node and console on one precedence rule. A full
-                # workstream id is already canonical when that exact row
-                # exists; only fall back to alias-first resolution when it
-                # does not. Otherwise an alias equal to another row's 32-hex
-                # id can redirect the routed fork before it reaches the node.
-                exact_row = (
-                    await asyncio.to_thread(storage.get_workstream, resume_ws)
-                    if resume_ws_exact or _VALID_CREATE_WS_ID_RE.fullmatch(resume_ws)
-                    else None
-                )
-                canonical_resume = resume_ws if exact_row is not None else None
-                if canonical_resume is None and not resume_ws_exact:
-                    canonical_resume = await asyncio.to_thread(
-                        storage.resolve_workstream, resume_ws
-                    )
-            except Exception:
-                log.warning(
-                    "route_create.resume_lookup_failed source=%s",
-                    resume_ws[:32],
-                    exc_info=True,
-                )
-                return _record_route(
-                    request,
-                    "create",
-                    503,
-                    t0,
-                    JSONResponse({"error": "Storage not available"}, status_code=503),
-                )
-            if not canonical_resume:
-                return _record_route(
-                    request,
-                    "create",
-                    404,
-                    t0,
-                    JSONResponse({"error": "Workstream not found"}, status_code=404),
-                )
-            body["resume_ws"] = canonical_resume
-            # Preserve the resolved identity even if it disappears before the
-            # node's preflight; another row's alias cannot replace this source.
-            body["resume_ws_exact"] = True
-            resume_ws = canonical_resume
+        source_row = await _resolve_fork_source(request, body)
+        if isinstance(source_row, JSONResponse):
+            return _record_route(request, "create", source_row.status_code, t0, source_row)
+        resume_ws = body.get("resume_ws", "")
+        try:
+            explicit_required = requested_node_requirement(
+                body.get("required_node_id"), target_node
+            )
+        except ValueError as exc:
+            return _record_route(
+                request, "create", 400, t0, JSONResponse({"error": str(exc)}, status_code=400)
+            )
+        # Inheritance is resolved again at the node's authorized source read.
+        # Forward only explicit intent, so a stale console snapshot cannot
+        # turn an inherited requirement into an explicit policy override.
+        body["required_node_id"] = explicit_required
+        effective_required = explicit_required or (
+            source_row.get("required_node_id") if source_row else None
+        )
 
         fixed_ws_id = bool(requested_ws_id)
         try:
-            if requested_ws_id:
-                # A caller-selected destination is authoritative. Do not
-                # overwrite it for a target hint or a fork; place it through
-                # the same rendezvous path used for generated destinations.
-                ref = router.route(requested_ws_id)
+            if effective_required:
+                ref = router.required_node(effective_required)
+                if not requested_ws_id and not resume_ws:
+                    ws_id = secrets.token_hex(16)
+                    body["ws_id"] = ws_id
+                pin = bool(explicit_required)
+                routing_strategy = "target_node" if explicit_required else "resume"
+            elif requested_ws_id:
+                ref = await _request_route(request, router, requested_ws_id)
                 routing_strategy = "rendezvous"
             elif resume_ws:
-                ref = router.route(resume_ws)
+                ref = await _request_route(request, router, resume_ws)
                 routing_strategy = "resume"
-            elif target_node:
-                # Brute-force HRW search can take up to _GENERATE_ATTEMPT_CAP
-                # iterations for skewed weights; off the event loop.
-                ws_id = await asyncio.to_thread(router.generate_ws_id_for_node, target_node)
-                body["ws_id"] = ws_id
-                ref = router.route(ws_id)
-                pin = True
-                routing_strategy = "target_node"
             else:
                 ws_id = secrets.token_hex(16)
                 body["ws_id"] = ws_id
-                ref = router.route(ws_id)
+                ref = await _request_route(request, router, ws_id)
+        except NodeAffinityError as exc:
+            return _record_route(
+                request,
+                "create",
+                exc.status_code,
+                t0,
+                JSONResponse(exc.as_dict(), status_code=exc.status_code),
+            )
         except NoAvailableNodeError:
             return _record_route(
                 request,
@@ -2300,19 +2341,34 @@ async def route_create(request: Request) -> Response:
             # ordinary generated-id contract here: an atomic registration
             # collision draws another id, while a caller-selected id remains
             # authoritative and returns the node's 409 unchanged.
+            try:
+                collision = resp.status_code == 409 and resp.json() == {
+                    "error": "Workstream already exists"
+                }
+            except ValueError:
+                collision = False
             if (
-                resp.status_code == 409
+                collision
                 and not resume_ws
                 and not fixed_ws_id
                 and collision_retries < _GENERATED_WS_ID_COLLISION_RETRY_CAP
             ):
                 collision_retries += 1
                 try:
-                    if target_node:
-                        ws_id = await asyncio.to_thread(router.generate_ws_id_for_node, target_node)
-                    else:
-                        ws_id = secrets.token_hex(16)
-                    ref = router.route(ws_id)
+                    ws_id = secrets.token_hex(16)
+                    ref = (
+                        router.required_node(effective_required)
+                        if effective_required
+                        else await _request_route(request, router, ws_id)
+                    )
+                except NodeAffinityError as exc:
+                    return _record_route(
+                        request,
+                        "create",
+                        exc.status_code,
+                        t0,
+                        JSONResponse(exc.as_dict(), status_code=exc.status_code),
+                    )
                 except NoAvailableNodeError:
                     return _record_route(
                         request,
@@ -2343,7 +2399,15 @@ async def route_create(request: Request) -> Response:
                 for _ in range(10):
                     ws_id = secrets.token_hex(16)
                     try:
-                        ref = router.route(ws_id)
+                        ref = await _request_route(request, router, ws_id)
+                    except NodeAffinityError as exc:
+                        return _record_route(
+                            request,
+                            "create",
+                            exc.status_code,
+                            t0,
+                            JSONResponse(exc.as_dict(), status_code=exc.status_code),
+                        )
                     except NoAvailableNodeError:
                         break
                     if ref.node_id != failed_node:
@@ -2464,23 +2528,19 @@ async def route_attachment_proxy(request: Request) -> Response:
     method = "attach"
     t0 = time.monotonic()
     router: ConsoleRouter | None = request.app.state.router
-    ring_ready = router is not None and router.is_ready()
-    if not ring_ready:
-        if router is not None:
-            await asyncio.to_thread(router.refresh_cache)
-            ring_ready = router.is_ready()
-        if not ring_ready:
-            return _record_route(
-                request,
-                method,
-                503,
-                t0,
-                JSONResponse(
-                    {"error": "Cluster routing not initialized"},
-                    status_code=503,
-                ),
-            )
-    assert router is not None
+    if router is None:
+        return _record_route(
+            request,
+            method,
+            503,
+            t0,
+            JSONResponse(
+                {"error": "Cluster routing not initialized"},
+                status_code=503,
+            ),
+        )
+    if not router.is_ready():
+        await asyncio.to_thread(router.refresh_cache)
 
     ws_id = request.path_params.get("ws_id", "").strip()
     if not ws_id:
@@ -2492,7 +2552,15 @@ async def route_attachment_proxy(request: Request) -> Response:
             JSONResponse({"error": "ws_id required"}, status_code=400),
         )
     try:
-        ref = router.route(ws_id)
+        ref = await _request_route(request, router, ws_id)
+    except NodeAffinityError as exc:
+        return _record_route(
+            request,
+            method,
+            exc.status_code,
+            t0,
+            JSONResponse(exc.as_dict(), status_code=exc.status_code),
+        )
     except (NoAvailableNodeError, ValueError):
         return _record_route(
             request,
@@ -2606,23 +2674,19 @@ async def route_proxy(request: Request) -> Response:
         if err is not None:
             return _record_route(request, verb, 403, t0, err)
     router: ConsoleRouter | None = request.app.state.router
-    ring_ready = router is not None and router.is_ready()
-    if not ring_ready:
-        if router is not None:
-            await asyncio.to_thread(router.refresh_cache)
-            ring_ready = router.is_ready()
-        if not ring_ready:
-            return _record_route(
-                request,
-                verb,
-                503,
-                t0,
-                JSONResponse(
-                    {"error": "Cluster routing not initialized"},
-                    status_code=503,
-                ),
-            )
-    assert router is not None
+    if router is None:
+        return _record_route(
+            request,
+            verb,
+            503,
+            t0,
+            JSONResponse(
+                {"error": "Cluster routing not initialized"},
+                status_code=503,
+            ),
+        )
+    if not router.is_ready():
+        await asyncio.to_thread(router.refresh_cache)
 
     try:
         body = await request.json()
@@ -2673,7 +2737,15 @@ async def route_proxy(request: Request) -> Response:
             ),
         )
     try:
-        ref = router.route(ws_id)
+        ref = await _request_route(request, router, ws_id)
+    except NodeAffinityError as exc:
+        return _record_route(
+            request,
+            verb,
+            exc.status_code,
+            t0,
+            JSONResponse(exc.as_dict(), status_code=exc.status_code),
+        )
     except (NoAvailableNodeError, ValueError):
         return _record_route(
             request,
@@ -2722,10 +2794,18 @@ async def route_proxy(request: Request) -> Response:
         # stampede after a node churn doesn't N×-multiply DB reads.
         await asyncio.to_thread(router.force_refresh)
         try:
-            new_ref = router.route(ws_id)
+            new_ref = await _request_route(request, router, ws_id)
+        except NodeAffinityError as exc:
+            return _record_route(
+                request,
+                verb,
+                exc.status_code,
+                t0,
+                JSONResponse(exc.as_dict(), status_code=exc.status_code),
+            )
         except (NoAvailableNodeError, ValueError):
             new_ref = ref
-        if new_ref.node_id != ref.node_id:
+        if (new_ref.node_id, new_ref.url) != (ref.node_id, ref.url):
             try:
                 resp = await client.request(
                     http_method,
@@ -2774,23 +2854,19 @@ async def route_workstream_delete(request: Request) -> Response:
     """
     t0 = time.monotonic()
     router: ConsoleRouter | None = request.app.state.router
-    ring_ready = router is not None and router.is_ready()
-    if not ring_ready:
-        if router is not None:
-            await asyncio.to_thread(router.refresh_cache)
-            ring_ready = router.is_ready()
-        if not ring_ready:
-            return _record_route(
-                request,
-                "delete",
-                503,
-                t0,
-                JSONResponse(
-                    {"error": "Cluster routing not initialized"},
-                    status_code=503,
-                ),
-            )
-    assert router is not None
+    if router is None:
+        return _record_route(
+            request,
+            "delete",
+            503,
+            t0,
+            JSONResponse(
+                {"error": "Cluster routing not initialized"},
+                status_code=503,
+            ),
+        )
+    if not router.is_ready():
+        await asyncio.to_thread(router.refresh_cache)
 
     try:
         body = await request.json()
@@ -2813,7 +2889,15 @@ async def route_workstream_delete(request: Request) -> Response:
             JSONResponse({"error": "ws_id required"}, status_code=400),
         )
     try:
-        ref = router.route(ws_id)
+        ref = await _request_route(request, router, ws_id)
+    except NodeAffinityError as exc:
+        return _record_route(
+            request,
+            "delete",
+            exc.status_code,
+            t0,
+            JSONResponse(exc.as_dict(), status_code=exc.status_code),
+        )
     except (NoAvailableNodeError, ValueError):
         return _record_route(
             request,
@@ -2855,27 +2939,88 @@ async def route_workstream_delete(request: Request) -> Response:
     )
 
 
+async def _resolve_fork_source(
+    request: Request, body: dict[str, Any]
+) -> dict[str, Any] | JSONResponse | None:
+    """Resolve and authorize saved history before exposing its node requirement."""
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
+    source = body.get("resume_ws")
+    exact = body.get("resume_ws_exact", False)
+    if not isinstance(exact, bool):
+        return JSONResponse({"error": "resume_ws_exact must be a boolean"}, status_code=400)
+    if exact and not source:
+        return JSONResponse({"error": "resume_ws_exact requires resume_ws"}, status_code=400)
+    if not source:
+        return None
+    if not isinstance(source, str) or len(source) > 256:
+        return JSONResponse(
+            {"error": "resume_ws must be a string of at most 256 characters"}, status_code=400
+        )
+    storage, error = require_storage_or_503(request)
+    if error is not None:
+        return error
+    if storage is None:
+        return JSONResponse({"error": "Storage not available"}, status_code=503)
+    try:
+        row: dict[str, Any] | None = None
+        if body.get("resume_ws_exact") or _VALID_CREATE_WS_ID_RE.fullmatch(source):
+            row = await asyncio.to_thread(storage.get_workstream, source)
+        if row is None and not body.get("resume_ws_exact"):
+            canonical = await asyncio.to_thread(storage.resolve_workstream, source)
+            row = await asyncio.to_thread(storage.get_workstream, canonical) if canonical else None
+        visibility = WorkstreamProjectVisibility.for_request(request, storage=storage)
+        if (
+            row is None
+            or row.get("state") in {"creating", "deleted"}
+            or not await asyncio.to_thread(
+                visibility.ws_visible,
+                row.get("project_id") or "",
+                ws_owner=row.get("user_id") or "",
+            )
+        ):
+            return JSONResponse({"error": "Workstream not found"}, status_code=404)
+    except Exception:
+        log.warning("route_create.resume_lookup_failed", exc_info=True)
+        return JSONResponse({"error": "Storage not available"}, status_code=503)
+    body["resume_ws"] = row["ws_id"]
+    body["resume_ws_exact"] = True
+    return row
+
+
+async def _request_route(request: Request, router: ConsoleRouter, ws_id: str) -> NodeRef:
+    """Resolve durable policy off-loop, with the request's history visibility."""
+    from turnstone.core.auth import WorkstreamProjectVisibility
+
+    visibility = WorkstreamProjectVisibility.for_request(
+        request, storage=getattr(request.app.state, "auth_storage", None)
+    )
+    return await asyncio.to_thread(
+        router.route,
+        ws_id,
+        can_read=lambda row: visibility.ws_visible(
+            row.get("project_id") or "", ws_owner=row.get("user_id") or ""
+        ),
+    )
+
+
 async def route_lookup(request: Request) -> JSONResponse:
     """GET /v1/api/route — look up which node owns a workstream."""
     t0 = time.monotonic()
     router: ConsoleRouter | None = request.app.state.router
-    ring_ready = router is not None and router.is_ready()
-    if not ring_ready:
-        if router is not None:
-            await asyncio.to_thread(router.refresh_cache)
-            ring_ready = router.is_ready()
-        if not ring_ready:
-            return _record_route(
-                request,
-                "route",
-                503,
-                t0,
-                JSONResponse(
-                    {"error": "Cluster routing not initialized"},
-                    status_code=503,
-                ),
-            )  # type: ignore[return-value]
-    assert router is not None
+    if router is None:
+        return _record_route(
+            request,
+            "route",
+            503,
+            t0,
+            JSONResponse(
+                {"error": "Cluster routing not initialized"},
+                status_code=503,
+            ),
+        )  # type: ignore[return-value]
+    if not router.is_ready():
+        await asyncio.to_thread(router.refresh_cache)
 
     ws_id = request.query_params.get("ws_id", "")
     if not ws_id:
@@ -2891,7 +3036,15 @@ async def route_lookup(request: Request) -> JSONResponse:
         )  # type: ignore[return-value]
 
     try:
-        ref = router.route(ws_id)
+        ref = await _request_route(request, router, ws_id)
+    except NodeAffinityError as exc:
+        return _record_route(
+            request,
+            "route",
+            exc.status_code,
+            t0,
+            JSONResponse(exc.as_dict(), status_code=exc.status_code),
+        )  # type: ignore[return-value]
     except NoAvailableNodeError:
         return _record_route(
             request,
@@ -2926,23 +3079,19 @@ async def route_workstream_live(request: Request) -> Response:
     """
     t0 = time.monotonic()
     router: ConsoleRouter | None = request.app.state.router
-    ring_ready = router is not None and router.is_ready()
-    if not ring_ready:
-        if router is not None:
-            await asyncio.to_thread(router.refresh_cache)
-            ring_ready = router.is_ready()
-        if not ring_ready:
-            return _record_route(
-                request,
-                "live",
-                503,
-                t0,
-                JSONResponse(
-                    {"error": "Cluster routing not initialized"},
-                    status_code=503,
-                ),
-            )
-    assert router is not None
+    if router is None:
+        return _record_route(
+            request,
+            "live",
+            503,
+            t0,
+            JSONResponse(
+                {"error": "Cluster routing not initialized"},
+                status_code=503,
+            ),
+        )
+    if not router.is_ready():
+        await asyncio.to_thread(router.refresh_cache)
 
     ws_id = request.path_params.get("ws_id", "").strip()
     if not ws_id:
@@ -2955,7 +3104,15 @@ async def route_workstream_live(request: Request) -> Response:
         )
 
     try:
-        ref = router.route(ws_id)
+        ref = await _request_route(request, router, ws_id)
+    except NodeAffinityError as exc:
+        return _record_route(
+            request,
+            "live",
+            exc.status_code,
+            t0,
+            JSONResponse(exc.as_dict(), status_code=exc.status_code),
+        )
     except (NoAvailableNodeError, ValueError):
         return _record_route(
             request,
@@ -3016,7 +3173,7 @@ async def route_workstream_live(request: Request) -> Response:
         # the original miss without another round trip.
         try:
             await asyncio.to_thread(router.force_refresh)
-            refreshed_ref = router.route(ws_id)
+            refreshed_ref = await _request_route(request, router, ws_id)
         except Exception:
             log.warning("route_workstream_live.refresh_failed ws=%s", ws_id[:8], exc_info=True)
             return _record_route(

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1861,14 +1861,8 @@ async def create_workstream(request: Request) -> JSONResponse:
     if effective_required:
         node_id = effective_required
 
-    # Pool — pick any available node
-    if node_id == "pool":
-        node_id = _pick_best_node(collector)
-        if not node_id:
-            return JSONResponse({"error": "No reachable nodes available"}, status_code=503)
-
-    # Auto-select node by most available capacity
-    if not node_id or node_id == "auto":
+    # Automatic placement is a mode only when no node identity is required.
+    if not effective_required and node_id in {"", "auto", "pool"}:
         node_id = _pick_best_node(collector)
         if not node_id:
             return JSONResponse({"error": "No reachable nodes available"}, status_code=503)
@@ -2392,6 +2386,7 @@ async def route_create(request: Request) -> Response:
                 and not pin
                 and not resume_ws
                 and not fixed_ws_id
+                and router.node_count() > 1
             ):
                 capacity_retried = True
                 failed_node = ref.node_id
@@ -2399,6 +2394,8 @@ async def route_create(request: Request) -> Response:
                 for _ in range(10):
                     ws_id = secrets.token_hex(16)
                     try:
+                        if router.rendezvous_node(ws_id).node_id == failed_node:
+                            continue
                         ref = await _request_route(request, router, ws_id)
                     except NodeAffinityError as exc:
                         return _record_route(

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -1356,14 +1356,14 @@ function _wireLauncherToggle() {
 // Node placement from the launcher's node-strategy picker, shared by every
 // kind that runs on a compute node: "node" pins to the chosen node, anything
 // else is "auto" (the console or the scheduler picks the least-loaded node).
-// Pure — returns { placement } or { error } and never touches the DOM or the
-// busy flag, so callers validate BEFORE flipping busy and a missing pick
-// surfaces inline without a stuck spinner.
+// Pure — returns { placement, requiredNodeId? } or { error } without touching
+// the DOM or the busy flag, so callers validate BEFORE flipping busy and a
+// missing pick surfaces inline without a stuck spinner.
 function _resolveNodePlacement(opts) {
   if (opts.node_strategy !== "node") return { placement: "auto" };
   const placement = (opts.node_id || "").trim();
   if (!placement) return { error: "Choose a node, or switch to Least loaded." };
-  return { placement: placement };
+  return { placement: placement, requiredNodeId: placement };
 }
 
 // POST /v1/api/cluster/workstreams/new — the console picks a node and PROXIES
@@ -1392,6 +1392,7 @@ function _createInteractive(opts) {
   setBusy(true);
 
   const body = { node_id: placement };
+  if (placed.requiredNodeId) body.required_node_id = placed.requiredNodeId;
   if (opts.resume_ws) {
     body.resume_ws = opts.resume_ws;
     body.resume_ws_exact = true;

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -103,7 +103,8 @@ const STATE_DISPLAY = {
 const PERSISTENCE_DISPLAY = {
   pending: {
     label: "History save pending",
-    tooltip: "An accepted conversation turn has not reached durable history yet.",
+    tooltip:
+      "An accepted conversation turn has not reached durable history yet.",
   },
   retrying: {
     label: "History save retrying",
@@ -1391,6 +1392,10 @@ function _createInteractive(opts) {
   setBusy(true);
 
   const body = { node_id: placement };
+  if (opts.resume_ws) {
+    body.resume_ws = opts.resume_ws;
+    body.resume_ws_exact = true;
+  }
   if (name) body.name = name;
   if (skill) body.skill = skill;
   if (persona) body.persona = persona;
@@ -2638,16 +2643,42 @@ window.TS_APP.buildNodeInfo = function (node) {
 // The shell's interactive pane factory calls this on first activate (fresh open,
 // saved-row resume, AND reload-rehydrate all funnel through here).
 //
-// Origin-FIRST: POST /open on the hint node (the live / origin / just-created
-// node) — this REUSES a session already loaded there instead of loading a
-// duplicate copy elsewhere, and keeps node affinity (the pane talks directly to
-// /node/{id} for every verb, so load-node == pane-node).  Only when the hint
-// node is gone (404 = not in the registry / 502 = unreachable) or there is no
-// hint do we re-home onto a live rendezvous node via GET /v1/api/route (the
-// router skips dead nodes; persistence is shared ws_id-keyed Postgres, so any
-// live node is state-safe).  Capacity (429) / permission (403) surface as an
-// error — NOT a silent re-home.  Resolves to {nodeId} on success, else {error}.
+// Try the live/origin hint first to reuse an already loaded session. A missing,
+// unreachable, or wrong-node hint requires a fresh route lookup. The router
+// preserves durable node requirements; flexible sessions retain HRW recovery.
+// Both the router and the executing node enforce the requirement.
 window.TS_APP.resolveInteractiveNode = function (wsId, hintNodeId) {
+  const readFailure = function (r) {
+    return Promise.resolve()
+      .then(function () {
+        return r.json();
+      })
+      .catch(function () {
+        return {};
+      })
+      .then(function (data) {
+        const required = data && data.required_node_id;
+        if (
+          data &&
+          ((r.status === 503 && data.code === "required_node_unavailable") ||
+            (r.status === 409 && data.code === "wrong_execution_node")) &&
+          typeof required === "string" &&
+          /^[A-Za-z0-9_.-]{1,256}$/.test(required)
+        ) {
+          return {
+            status: r.status,
+            code: data.code,
+            requiredNodeId: required,
+            error:
+              "This session requires node '" +
+              required +
+              "'. Retry when it returns, or continue elsewhere from saved history.",
+            canContinue: true,
+          };
+        }
+        return { status: r.status };
+      });
+  };
   const openOn = function (nodeId) {
     return authFetch(
       "/node/" +
@@ -2657,29 +2688,29 @@ window.TS_APP.resolveInteractiveNode = function (wsId, hintNodeId) {
         "/open",
       { method: "POST" },
     ).then(function (r) {
-      return r.ok ? { nodeId: nodeId } : { status: r.status };
+      return r.ok ? { nodeId: nodeId } : readFailure(r);
     });
   };
   // Single error surface: the failure is returned as {error} and the interactive
   // pane writes it into its .pane-status line (the pane is always the active tab
   // when it resolves).  No toast — one source of truth, no wording drift.
-  const failResult = function (status) {
+  const failResult = function (res) {
+    if (res.error) return res;
+    const status = res.status;
     if (status === 429)
       return { error: "Node at capacity — close a session and retry." };
     if (status === 403)
       return { error: "You don’t have permission to open this session." };
-    return { error: "Could not open this session (" + status + ")." };
+    return {
+      error: "Could not open this session (" + status + ").",
+      canContinue: status === 502 || status === 503,
+    };
   };
   const routeFallback = function () {
     return authFetch("/v1/api/route?ws_id=" + encodeURIComponent(wsId))
       .then(function (r) {
         if (!r.ok) {
-          return {
-            error:
-              r.status === 503
-                ? "No nodes available to open this session."
-                : "Could not locate the session node (" + r.status + ").",
-          };
+          return readFailure(r).then(failResult);
         }
         return r.json();
       })
@@ -2689,21 +2720,66 @@ window.TS_APP.resolveInteractiveNode = function (wsId, hintNodeId) {
         if (!route.node_id)
           return { error: "Could not locate the session node." };
         return openOn(route.node_id).then(function (res) {
-          return res.nodeId ? res : failResult(res.status);
+          return res.nodeId ? res : failResult(res);
         });
       });
   };
   const flow = hintNodeId
     ? openOn(hintNodeId).then(function (res) {
         if (res.nodeId) return res;
-        // Origin gone -> rendezvous re-home; capacity/permission surface as-is.
-        if (res.status === 404 || res.status === 502) return routeFallback();
-        return failResult(res.status);
+        if (
+          res.status === 404 ||
+          res.status === 502 ||
+          res.code === "wrong_execution_node"
+        )
+          return routeFallback();
+        return failResult(res);
       })
     : routeFallback();
   return flow.catch(function () {
     return { error: "Failed to open this session." };
   });
+};
+
+window.TS_APP.continueInteractiveElsewhere = function (wsId, requiredNodeId) {
+  const dlg = document.getElementById("continue-session-dialog");
+  if (!dlg || dlg.open) return;
+  const select = document.getElementById("continue-session-node");
+  const error = document.getElementById("continue-session-error");
+  const submit = document.getElementById("continue-session-submit");
+  select.replaceChildren(new Option("Choose a destination node", ""));
+  Object.keys((clusterState && clusterState.nodes) || {})
+    .sort()
+    .forEach(function (nodeId) {
+      const node = clusterState.nodes[nodeId];
+      if (
+        nodeId !== "console" &&
+        nodeId !== requiredNodeId &&
+        node.reachable !== false
+      )
+        select.add(new Option(nodeId, nodeId));
+    });
+  error.textContent =
+    select.options.length === 1
+      ? "No other nodes are available. Retry when a node returns."
+      : "";
+  submit.disabled = select.options.length === 1;
+  submit.onclick = function () {
+    if (dlg.hasAttribute("data-busy")) return;
+    _createInteractive({
+      resume_ws: wsId,
+      node_strategy: "node",
+      node_id: select.value,
+      errEl: error,
+      setBusy: function (busy) {
+        window.TurnstoneHatch.setBusy(dlg, busy);
+      },
+      onSuccess: function () {
+        dlg.close();
+      },
+    });
+  };
+  window.TurnstoneHatch.openDialog(dlg);
 };
 // === MCP consent badge (console L-shell) ====================================
 // Mirror of the node dashboard's pending-consent subsystem (ui/static/app.js

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -4187,6 +4187,36 @@
     <script src="/shared/hljs-11.12.0/highlight.min.js"></script>
     <script type="module" src="/shared/renderer.js"></script>
 
+    <dialog
+      class="hatch hatch--dialog"
+      id="continue-session-dialog"
+      aria-labelledby="continue-session-title"
+      aria-describedby="continue-session-description"
+    >
+      <header class="sh-head">
+        <span class="sh-led" aria-hidden="true"></span>
+        <h2 class="sh-title" id="continue-session-title">Continue elsewhere</h2>
+        <button class="sh-x" data-close aria-label="Close">✕</button>
+      </header>
+      <div class="sh-body">
+        <p class="sh-prose" id="continue-session-description">
+          Start a separate conversation from the saved history on another node.
+          The original conversation stays saved. Files on its node and running
+          tools are not transferred.
+        </p>
+        <label for="continue-session-node">Destination node</label>
+        <select id="continue-session-node" autofocus></select>
+        <p id="continue-session-error" class="sh-alert" role="alert"></p>
+      </div>
+      <footer class="sh-foot">
+        <div class="sh-foot-meta"></div>
+        <button class="sh-btn" data-close>Cancel</button>
+        <button id="continue-session-submit" class="sh-btn sh-btn--primary">
+          Create continuation
+        </button>
+      </footer>
+    </dialog>
+
     <!-- Token Created (show-once) Modal -->
     <dialog
       class="hatch hatch--dialog"

--- a/turnstone/core/node_affinity.py
+++ b/turnstone/core/node_affinity.py
@@ -1,0 +1,57 @@
+"""Execution-node eligibility, independent of routing and live ownership."""
+
+from __future__ import annotations
+
+import re
+
+_NODE_ID = re.compile(r"[A-Za-z0-9_.-]{1,256}")
+
+
+class NodeAffinityError(RuntimeError):
+    """The required node is unavailable or differs from this executor."""
+
+    def __init__(self, required_node_id: str, *, unavailable: bool = False) -> None:
+        self.required_node_id = required_node_id
+        self.status_code = 503 if unavailable else 409
+        self.code = "required_node_unavailable" if unavailable else "wrong_execution_node"
+        super().__init__(
+            f"Required node '{required_node_id}' is unavailable. Retry when it returns."
+            if unavailable
+            else f"This workstream must run on node '{required_node_id}'."
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "error": str(self),
+            "code": self.code,
+            "required_node_id": self.required_node_id,
+        }
+
+
+def parse_required_node_id(value: object) -> str | None:
+    """None means unspecified; a supplied requirement must name one node."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or _NODE_ID.fullmatch(value) is None:
+        raise ValueError("required_node_id must be a valid node ID")
+    return value
+
+
+def require_execution_node(required_node_id: str | None, node_id: str | None) -> None:
+    """Check eligibility before constructing or adopting executable state."""
+    if required_node_id and required_node_id != node_id:
+        raise NodeAffinityError(required_node_id)
+
+
+def requested_node_requirement(required: object, target: object = None) -> str | None:
+    """Normalize the shared create field and the console's explicit target."""
+    result = parse_required_node_id(required)
+    if target is None or target == "":
+        return result
+    try:
+        selected = parse_required_node_id(target)
+    except ValueError as exc:
+        raise ValueError("invalid target_node format") from exc
+    if result is not None and result != selected:
+        raise ValueError("target_node and required_node_id must match")
+    return selected

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -6865,6 +6865,10 @@ class ChatSession:
             source_row = get_storage().get_workstream(ws_id)
             if source_row and source_row.get("required_node_id"):
                 raise ValueError("Use atomic workstream creation to fork a node-bound session")
+        else:
+            target_row = get_storage().get_workstream(ws_id)
+            if target_row is not None:
+                require_execution_node(target_row.get("required_node_id"), self._node_id)
         turns = (
             list(_fork_snapshot.turns)
             if _fork_snapshot is not None
@@ -6890,6 +6894,8 @@ class ChatSession:
         resumed_attached_project_id = ""
         resumed_incarnation_token = ""
         if not fork:
+            # History loading can overlap a same-ID replacement. Keep this
+            # authoritative check after loading as well as the cheap preflight.
             storage = get_storage()
             target_row = storage.ensure_workstream_incarnation_snapshot(ws_id)
             if target_row is not None:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -6799,6 +6799,7 @@ class ChatSession:
         *,
         principal_id: str,
         source_reservation_token: str,
+        source_required_node_id: str | None = None,
         trusted_internal: bool = False,
     ) -> ForkCloneSnapshot:
         """Atomically clone, then adopt, one authorized source snapshot."""
@@ -6816,6 +6817,8 @@ class ChatSession:
             project_writable=project_access.project_writable,
             destination_reservation_token=self._fork_reservation_token,
             source_reservation_token=source_reservation_token,
+            source_required_node_id=source_required_node_id,
+            node_id=self._node_id,
         )
         snapshot = storage.clone_workstream(
             source_ws_id,
@@ -6854,6 +6857,14 @@ class ChatSession:
         """
         if _fork_snapshot is not None and not fork:
             raise ValueError("a fork snapshot requires fork=True")
+        from turnstone.core.node_affinity import require_execution_node
+
+        if _fork_snapshot is not None:
+            require_execution_node(_fork_snapshot.required_node_id, self._node_id)
+        elif fork:
+            source_row = get_storage().get_workstream(ws_id)
+            if source_row and source_row.get("required_node_id"):
+                raise ValueError("Use atomic workstream creation to fork a node-bound session")
         turns = (
             list(_fork_snapshot.turns)
             if _fork_snapshot is not None
@@ -6881,6 +6892,8 @@ class ChatSession:
         if not fork:
             storage = get_storage()
             target_row = storage.ensure_workstream_incarnation_snapshot(ws_id)
+            if target_row is not None:
+                require_execution_node(target_row.get("required_node_id"), self._node_id)
             raw_project_id = target_row.get("project_id") if target_row is not None else None
             target_project_id = (
                 raw_project_id.strip()
@@ -28028,6 +28041,8 @@ class ChatSession:
                 self.ui.on_info("\n".join(lines))
 
         elif cmd == "/resume":
+            from turnstone.core.node_affinity import NodeAffinityError
+
             if not arg:
                 self.ui.on_info(
                     "Usage: /resume <alias_or_ws_id>\nUse /workstreams to list available workstreams."
@@ -28045,7 +28060,7 @@ class ChatSession:
                     self._drain_queue_for_identity_swap()
                     try:
                         resumed: bool | None = self.resume(target_id)
-                    except ValueError as exc:
+                    except (ValueError, NodeAffinityError) as exc:
                         # Corrupt stamp or MCP-lever refusal: resume parses
                         # before mutating, so this session is untouched —
                         # report and stay on the current workstream.

--- a/turnstone/core/session_manager.py
+++ b/turnstone/core/session_manager.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 from turnstone.core.adapters._ui_cleanup import _broadcast_ws_closed_to_listeners
 from turnstone.core.log import get_logger
 from turnstone.core.model_registry import ModelClientConstructionError, UnknownModelAliasError
+from turnstone.core.node_affinity import parse_required_node_id, require_execution_node
 from turnstone.core.personas import snapshot_from_config
 from turnstone.core.workstream import (
     Workstream,
@@ -514,6 +515,7 @@ class SessionManager:
         parent_ws_id: str | None = None,
         project_id: str | None = None,
         persona: str = "",
+        required_node_id: str | None = None,
         defer_emit_created: bool = False,
         **extra_session_kwargs: Any,
     ) -> Workstream:
@@ -530,6 +532,7 @@ class SessionManager:
             parent_ws_id=parent_ws_id,
             project_id=project_id,
             persona=persona,
+            required_node_id=required_node_id,
             defer_emit_created=defer_emit_created,
             **extra_session_kwargs,
         )
@@ -548,6 +551,7 @@ class SessionManager:
         parent_ws_id: str | None = None,
         project_id: str | None = None,
         persona: str = "",
+        required_node_id: str | None = None,
         defer_emit_created: bool = False,
         **extra_session_kwargs: Any,
     ) -> Workstream:
@@ -582,6 +586,8 @@ class SessionManager:
         slot is held forever (capacity leak). The HTTP handler bracket
         runs both terminations within a single request lifecycle.
         """
+        required_node_id = parse_required_node_id(required_node_id)
+        require_execution_node(required_node_id, self._node_id)
         requested_ws_id = ws_id
         while True:
             # Caller-chosen ids are contractual and collide loudly. Generated
@@ -651,6 +657,7 @@ class SessionManager:
                     skill_id=skill_id,
                     skill_version=skill_version,
                     fork_reservation_token=fork_reservation_token,
+                    required_node_id=required_node_id,
                 )
                 if inserted is False:
                     raise WorkstreamAlreadyExistsError(f"workstream {ws_id!r} already exists")
@@ -1125,6 +1132,8 @@ class SessionManager:
                 # max_active (evicting an idle peer or raising).
                 if row.get("state") in {"creating", "deleted"}:
                     return None
+
+                require_execution_node(row.get("required_node_id"), self._node_id)
 
                 # Re-check + capacity admission happen inside the helper. The
                 # per-id open lane prevents another opener for this id, while

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -42,6 +42,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from turnstone.core.log import get_logger
+from turnstone.core.node_affinity import NodeAffinityError
 from turnstone.core.session_manager import CloseOutcome, WorkstreamAlreadyExistsError
 from turnstone.core.session_replay import session_replay_preamble
 from turnstone.core.session_ui_base import CrossPrincipalApprovalError
@@ -2128,6 +2129,8 @@ def make_open_handler(
 
         try:
             ws = mgr.open(ws_id)
+        except NodeAffinityError as exc:
+            return JSONResponse(exc.as_dict(), status_code=exc.status_code)
         except ValueError as exc:
             # Session factory misconfig (e.g., a model alias that
             # no longer exists). Surface the factory's remediation
@@ -3458,6 +3461,8 @@ def make_create_handler(
                 raise
         except WorkstreamAlreadyExistsError:
             return JSONResponse({"error": "Workstream already exists"}, status_code=409)
+        except NodeAffinityError as exc:
+            return JSONResponse(exc.as_dict(), status_code=exc.status_code)
         except RuntimeError as exc:
             # ``SessionManager.create`` documents RuntimeError as
             # "manager at capacity" — translate to 429 (rate-limit /
@@ -4923,6 +4928,8 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
         if ws is None:
             try:
                 ws = mgr.open(ws_id)
+            except NodeAffinityError as exc:
+                return JSONResponse(exc.as_dict(), status_code=exc.status_code)
             except ValueError as exc:
                 # Session factory misconfig (e.g. a model alias that no
                 # longer resolves). Surface remediation text as 503

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -1414,6 +1414,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         project_id: str | None = None,
         persona: str | None = None,
         fork_reservation_token: str = "",
+        required_node_id: str | None = None,
     ) -> bool:
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
@@ -1431,6 +1432,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         values = {
             "ws_id": ws_id,
             "node_id": node_id,
+            "required_node_id": required_node_id,
             "user_id": user_id,
             "name": name,
             "state": state,
@@ -4487,6 +4489,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     workstreams.c.updated,
                     workstreams.c.project_id,
                     workstreams.c.persona,
+                    workstreams.c.required_node_id,
                 ).where(workstreams.c.ws_id.in_(clean))
             ).fetchall()
         for r in rows:
@@ -4506,6 +4509,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                 "updated": r[12],
                 "project_id": r[13],
                 "persona": r[14],
+                "required_node_id": r[15],
             }
             out[r[0]] = item
         return out

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -113,6 +113,8 @@ class ForkCloneExpectation:
     project_writable: bool
     destination_reservation_token: str
     source_reservation_token: str
+    source_required_node_id: str | None = None
+    node_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +129,7 @@ class ForkCloneSnapshot:
     turns: tuple[Turn, ...]
     config: dict[str, str]
     project_id: str | None
+    required_node_id: str | None = None
 
 
 class OIDCIdentity(TypedDict):
@@ -1073,6 +1076,7 @@ class StorageBackend(Protocol):
         project_id: str | None = None,
         persona: str | None = None,
         fork_reservation_token: str = "",
+        required_node_id: str | None = None,
     ) -> bool:
         """Create a workstreams row and report whether it was inserted.
 

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -143,6 +143,7 @@ workstreams = sa.Table(
     metadata,
     sa.Column("ws_id", sa.Text, primary_key=True),
     sa.Column("node_id", sa.Text),
+    sa.Column("required_node_id", sa.Text, nullable=True),
     sa.Column("user_id", sa.Text),
     sa.Column("alias", sa.Text, unique=True),
     sa.Column("title", sa.Text),

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -1440,6 +1440,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         project_id: str | None = None,
         persona: str | None = None,
         fork_reservation_token: str = "",
+        required_node_id: str | None = None,
     ) -> bool:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         # Kind validation at the storage edge — third of three layers
@@ -1457,6 +1458,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         values = {
             "ws_id": ws_id,
             "node_id": node_id,
+            "required_node_id": required_node_id,
             "user_id": user_id,
             "alias": alias,
             "title": title,
@@ -4541,6 +4543,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     workstreams.c.updated,
                     workstreams.c.project_id,
                     workstreams.c.persona,
+                    workstreams.c.required_node_id,
                 ).where(workstreams.c.ws_id.in_(clean))
             ).fetchall()
         for r in rows:
@@ -4560,6 +4563,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                 "updated": r[12],
                 "project_id": r[13],
                 "persona": r[14],
+                "required_node_id": r[15],
             }
             out[r[0]] = item
         return out

--- a/turnstone/core/storage/_utils.py
+++ b/turnstone/core/storage/_utils.py
@@ -2738,6 +2738,7 @@ def clone_workstream_transaction(
     if expected_session is not None and (
         not expected_session.source_reservation_token
         or source_reservation_token != expected_session.source_reservation_token
+        or source.get("required_node_id") != expected_session.source_required_node_id
     ):
         # Preflight authorization was for a different durable incarnation.
         # Treat replacement exactly like disappearance so the fork surface is
@@ -2791,6 +2792,11 @@ def clone_workstream_transaction(
         raise ForkDestinationConflictError("fork destination is not available")
     if not trusted_internal and str(destination.get("user_id") or "") != principal_id:
         raise ForkDestinationConflictError("fork destination is not available")
+    required_node_id = destination.get("required_node_id") or source.get("required_node_id")
+    if expected_session is not None:
+        from turnstone.core.node_affinity import require_execution_node
+
+        require_execution_node(required_node_id, expected_session.node_id)
     # Preserve an existing private reservation even for compatibility callers
     # that do not supply a construction witness. Production HTTP forks also
     # compare it to ``expected_session`` below; preservation keeps later
@@ -3033,7 +3039,7 @@ def clone_workstream_transaction(
     updated = conn.execute(
         sa.update(workstreams)
         .where(workstreams.c.ws_id == destination_ws_id)
-        .values(project_id=effective_project_id, updated=now)
+        .values(project_id=effective_project_id, required_node_id=required_node_id, updated=now)
         .returning(workstreams.c.ws_id)
     ).fetchone()
     if updated is None:
@@ -3043,6 +3049,7 @@ def clone_workstream_transaction(
         turns=tuple(final_turns),
         config=dict(source_config),
         project_id=effective_project_id,
+        required_node_id=required_node_id,
     )
 
 

--- a/turnstone/core/storage/migrations/versions/076_workstream_node_affinity.py
+++ b/turnstone/core/storage/migrations/versions/076_workstream_node_affinity.py
@@ -1,0 +1,24 @@
+"""Persist explicit execution-node requirements.
+
+Revision ID: 076
+Revises: 075
+Create Date: 2026-09-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "076"
+down_revision = "075"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workstreams") as batch_op:
+        batch_op.add_column(sa.Column("required_node_id", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workstreams") as batch_op:
+        batch_op.drop_column("required_node_id")

--- a/turnstone/sdk/console.py
+++ b/turnstone/sdk/console.py
@@ -170,6 +170,8 @@ class AsyncTurnstoneConsole(_BaseClient):
         persona: str = "",
         project_id: str = "",
         resume_ws: str = "",
+        resume_ws_exact: bool = False,
+        required_node_id: str | None = None,
         judge_model: str = "",
     ) -> ConsoleCreateWsResponse:
         body: dict[str, Any] = {}
@@ -189,6 +191,10 @@ class AsyncTurnstoneConsole(_BaseClient):
             body["project_id"] = project_id
         if resume_ws:
             body["resume_ws"] = resume_ws
+        if resume_ws_exact:
+            body["resume_ws_exact"] = True
+        if required_node_id is not None:
+            body["required_node_id"] = required_node_id
         if judge_model:
             body["judge_model"] = judge_model
         return await self._request(
@@ -221,6 +227,7 @@ class AsyncTurnstoneConsole(_BaseClient):
         project_id: str = "",
         resume_ws: str = "",
         resume_ws_exact: bool = False,
+        required_node_id: str | None = None,
         judge_model: str = "",
         target_node: str = "",
         user_id: str = "",
@@ -261,6 +268,8 @@ class AsyncTurnstoneConsole(_BaseClient):
             body["resume_ws"] = resume_ws
         if resume_ws_exact:
             body["resume_ws_exact"] = True
+        if required_node_id is not None:
+            body["required_node_id"] = required_node_id
         if judge_model:
             body["judge_model"] = judge_model
         if target_node:
@@ -273,15 +282,6 @@ class AsyncTurnstoneConsole(_BaseClient):
             body["notify_targets"] = notify_targets
 
         if attachments:
-            # The console's multipart route_create routes by `?ws_id=` only —
-            # it does not parse the body to honor `target_node`.  Refuse the
-            # combination at the SDK boundary so callers don't silently get
-            # routed to the wrong node.
-            if target_node:
-                raise ValueError(
-                    "target_node is not supported with attachments; "
-                    "use ws_id (caller-generated to hash to the desired node) instead"
-                )
             if not ws_id:
                 ws_id = secrets.token_hex(16)
             body["ws_id"] = ws_id
@@ -1308,6 +1308,8 @@ class TurnstoneConsole:
         persona: str = "",
         project_id: str = "",
         resume_ws: str = "",
+        resume_ws_exact: bool = False,
+        required_node_id: str | None = None,
         judge_model: str = "",
     ) -> ConsoleCreateWsResponse:
         return self._runner.run(
@@ -1320,6 +1322,8 @@ class TurnstoneConsole:
                 persona=persona,
                 project_id=project_id,
                 resume_ws=resume_ws,
+                resume_ws_exact=resume_ws_exact,
+                required_node_id=required_node_id,
                 judge_model=judge_model,
             )
         )
@@ -1344,6 +1348,7 @@ class TurnstoneConsole:
         project_id: str = "",
         resume_ws: str = "",
         resume_ws_exact: bool = False,
+        required_node_id: str | None = None,
         judge_model: str = "",
         target_node: str = "",
         user_id: str = "",
@@ -1364,6 +1369,7 @@ class TurnstoneConsole:
                 project_id=project_id,
                 resume_ws=resume_ws,
                 resume_ws_exact=resume_ws_exact,
+                required_node_id=required_node_id,
                 judge_model=judge_model,
                 target_node=target_node,
                 user_id=user_id,

--- a/turnstone/sdk/server.py
+++ b/turnstone/sdk/server.py
@@ -111,6 +111,7 @@ class AsyncTurnstoneServer(_BaseClient):
         auto_approve: bool = False,
         resume_ws: str = "",
         resume_ws_exact: bool = False,
+        required_node_id: str | None = None,
         skill: str = "",
         persona: str = "",
         initial_message: str = "",
@@ -154,6 +155,8 @@ class AsyncTurnstoneServer(_BaseClient):
             body["resume_ws"] = resume_ws
         if resume_ws_exact:
             body["resume_ws_exact"] = True
+        if required_node_id is not None:
+            body["required_node_id"] = required_node_id
         if skill:
             body["skill"] = skill
         if persona:
@@ -718,6 +721,7 @@ class TurnstoneServer:
         auto_approve: bool = False,
         resume_ws: str = "",
         resume_ws_exact: bool = False,
+        required_node_id: str | None = None,
         skill: str = "",
         persona: str = "",
         initial_message: str = "",
@@ -737,6 +741,7 @@ class TurnstoneServer:
                 auto_approve=auto_approve,
                 resume_ws=resume_ws,
                 resume_ws_exact=resume_ws_exact,
+                required_node_id=required_node_id,
                 skill=skill,
                 persona=persona,
                 initial_message=initial_message,

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -2547,6 +2547,19 @@ async def _interactive_create_validate_request(
       canonicalized before the workstream reservation is created.
     """
     requested_ws_id = body.get("ws_id", "") or ""
+    from turnstone.core.node_affinity import (
+        NodeAffinityError,
+        requested_node_requirement,
+        require_execution_node,
+    )
+
+    try:
+        body["required_node_id"] = requested_node_requirement(
+            body.get("required_node_id"), body.get("target_node")
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    body.pop("_resume_required_node_id", None)
     if not isinstance(requested_ws_id, str):
         requested_ws_id = ""
     if requested_ws_id and not _VALID_WS_ID.match(requested_ws_id):
@@ -2672,6 +2685,9 @@ async def _interactive_create_validate_request(
         # incarnation inside its transaction, so delete/recreate under the same
         # canonical id cannot inherit the earlier authorization decision.
         body["_resume_incarnation_token"] = str(_src_row.get("fork_reservation_token") or "")
+        body["_resume_required_node_id"] = _src_row.get("required_node_id")
+        if body["required_node_id"] is None:
+            body["required_node_id"] = _src_row.get("required_node_id")
         body["project_id"] = source_project
         resume_inherited_pid = bool(source_project)
     # Project attach gate (explicit or parent-inherited): a project requires
@@ -2718,6 +2734,10 @@ async def _interactive_create_validate_request(
     if tools_err:
         return JSONResponse({"error": tools_err}, status_code=400)
     body["auto_approve_tools"] = auto_approve_tools
+    try:
+        require_execution_node(body["required_node_id"], getattr(request.app.state, "node_id", ""))
+    except NodeAffinityError as exc:
+        return JSONResponse(exc.as_dict(), status_code=exc.status_code)
     return None
 
 
@@ -2762,6 +2782,7 @@ def _interactive_create_build_kwargs(
         "judge_model": body.get("judge_model", "") or None,
         "parent_ws_id": body.get("parent_ws_id") or None,
         "project_id": body.get("project_id") or None,
+        "required_node_id": body.get("required_node_id"),
     }
 
 
@@ -2797,6 +2818,7 @@ async def _interactive_create_pre_commit(
             source_ws_id,
             principal_id=uid,
             source_reservation_token=source_reservation_token,
+            source_required_node_id=body.get("_resume_required_node_id"),
             trusted_internal=False,
         )
         message_count = len(snapshot.turns)
@@ -6547,6 +6569,7 @@ def main() -> None:
     # on demand via POST /v1/api/workstreams.
     if args.resume:
         from turnstone.core.memory import resolve_workstream
+        from turnstone.core.node_affinity import NodeAffinityError
 
         target_id = resolve_workstream(args.resume)
         if not target_id:
@@ -6569,9 +6592,19 @@ def main() -> None:
             raise TypeError(f"Expected WebUI, got {type(ws.ui).__name__}")
         if args.skip_permissions or config_store.get("tools.skip_permissions"):
             ws.ui.auto_approve = True
-        assert ws.session is not None
-        if not ws.session.resume(target_id):
+        if ws.session is None:
+            manager.close(ws.id)
+            log.error("No session available for resume: %s", target_id)
+            sys.exit(1)
+        try:
+            resumed = ws.session.resume(target_id)
+        except NodeAffinityError as exc:
+            manager.close(ws.id)
+            log.error("Cannot resume %s: %s", target_id, exc)
+            sys.exit(1)
+        if not resumed:
             log.error("Workstream '%s' has no messages.", args.resume)
+            manager.close(ws.id)
             sys.exit(1)
         # AFTER the successful resume (mirroring the restore fn's order),
         # so the registration keys on the adopted ``target_id`` — the id

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -852,11 +852,12 @@ async function mountShell() {
     // offer a one-click retry — re-clicking the tab won't re-fire onActivate
     // (PaneManager fires it only on a pane CHANGE), so without this a transient
     // failure would strand the pane until the user closed + reopened it.
-    const showResolveError = (msg, forceResolve) => {
+    const showResolveError = (result, forceResolve) => {
       const el = pane._statusEl;
       if (!el) return;
       el.className = "pane-status pane-status--retry msg error";
-      el.textContent = msg || "Could not connect to this session.";
+      el.textContent =
+        (result && result.error) || "Could not connect to this session.";
       el.title = "Click to retry";
       el.onclick = () => {
         if (pane._ctl || pane._resolving) return;
@@ -866,6 +867,21 @@ async function mountShell() {
         el.textContent = "Connecting…";
         beginConnect(forceResolve);
       };
+      const app = window.TS_APP;
+      if (
+        result &&
+        result.canContinue &&
+        app &&
+        app.continueInteractiveElsewhere
+      ) {
+        const button = make("button", "sh-btn", "Continue elsewhere…");
+        button.type = "button";
+        button.onclick = (event) => {
+          event.stopPropagation();
+          app.continueInteractiveElsewhere(id, result.requiredNodeId);
+        };
+        el.append(button);
+      }
     };
     // First-activate connect.  A LIVE session (Tier-1 already names its node, so
     // it is loaded there) connects DIRECTLY — no /open round-trip; this is the
@@ -891,7 +907,7 @@ async function mountShell() {
         pane._resolving = false;
         if (pane._closed) return; // closed mid-resolve — don't build into a detached body
         if (!res || res.error) {
-          showResolveError(res && res.error, forceResolve);
+          showResolveError(res, forceResolve);
           return;
         }
         buildController(res.nodeId);

--- a/turnstone/tools/spawn_batch.json
+++ b/turnstone/tools/spawn_batch.json
@@ -28,7 +28,7 @@
             },
             "target_node": {
               "type": "string",
-              "description": "Optional node_id hint. Pinning is hard — if the named node has dropped the 120s registry heartbeat between list_nodes and this spawn, the item lands in denied[] with a `No available node for routing` reason. Omit unless the workload truly requires that node."
+              "description": "Optional required node_id, retained after close or restart. An unavailable target puts this item in denied[] without fallback. Omit for flexible placement."
             },
             "persona": {
               "type": "string",

--- a/turnstone/tools/spawn_workstream.json
+++ b/turnstone/tools/spawn_workstream.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn_workstream",
-  "description": "Create a new child workstream, optionally dispatching an initial message. Kick off a focused sub-task on a different skill / model / node while the coordinator stays in charge. The child runs independently — drive it with send_to_workstream / inspect_workstream / close_workstream. Returns `{child_ws_id, name, node_id, routing_strategy}` — pass `child_ws_id` into `wait_for_workstream(ws_ids=[...])` and the other `ws_id`-taking tools. For this tool, `routing_strategy` is `rendezvous` (default placement on the live-node set) or `target_node` (your hint was honored). The returned `node_id` is the spawn-time binding; subsequent ops re-route via rendezvous over the live-node set, so a node join or drop after spawn can shift the active owner. Conversation state lives in storage (the new owner rehydrates lazily). Don't cache `node_id` for long-running callbacks — re-read with inspect_workstream. Lifecycle state (idle / running / etc.) is not in this response — read it via inspect_workstream.",
+  "description": "Create a new child workstream, optionally dispatching an initial message. Kick off a focused sub-task on a different skill / model / node while the coordinator stays in charge. The child runs independently — drive it with send_to_workstream / inspect_workstream / close_workstream. Returns `{child_ws_id, name, node_id, routing_strategy}` — pass `child_ws_id` into `wait_for_workstream(ws_ids=[...])` and the other `ws_id`-taking tools. For this tool, `routing_strategy` is `rendezvous` (default placement on the live-node set) or `target_node` (an explicit execution requirement). An explicit target remains required after close or restart; unavailable targets do not fall back. Automatic placement remains flexible. The returned `node_id` describes placement at creation, not an exclusive ownership lease. Don't cache `node_id` for long-running callbacks — re-read with inspect_workstream. Lifecycle state (idle / running / etc.) is not in this response — read it via inspect_workstream.",
   "parameters": {
     "type": "object",
     "properties": {
@@ -22,7 +22,7 @@
       },
       "target_node": {
         "type": "string",
-        "description": "Optional node_id hint. When provided, the routing proxy pins the workstream to that node by generating a ws_id that rendezvous-hashes onto it. Otherwise rendezvous picks deterministically from the live-node set. CAVEAT: pinning is a hard constraint — if the named node has dropped out of the 120s service-registry heartbeat window between your `list_nodes` call and this spawn, the spawn fails with \"No available node for routing\" rather than falling back. Omit `target_node` if you can tolerate landing on any node; pin only when the workload truly requires that specific node's capabilities/region/tenancy."
+        "description": "Optional required node_id. Execution stays bound to this identity after close, timeout, or restart. An unavailable node fails without fallback. Omit for flexible placement; select a node when its local files, devices, or environment are required."
       },
       "project": {
         "type": "string",


### PR DESCRIPTION
An explicitly targeted host conversation can currently follow rendezvous placement onto a container after the host disappears. Persist `required_node_id` and enforce it in console routing and executor create/open/resume paths, so a missing or unreachable required node leaves the conversation available for retry without silently moving execution.

Forks inherit the source requirement unless the caller explicitly selects a destination for the new ID. The browser's **Continue elsewhere** action uses that existing atomic fork path and preserves the original conversation. Automatic placement remains flexible. Scheduler, Python/TypeScript SDK, API schemas, and deployment documentation carry the same contract.

Migration 076 adds a nullable column without backfilling historical placement. Deploy the updated console and executing nodes before relying on enforcement. This establishes execution eligibility; exclusive ownership and live migration still require the later fenced handoff phase.

Independent reviews covered docs, reuse, simplification, dead code, performance, security, and bugs. All six findings were fixed and independently rechecked. Targeted multipart creates work through the TypeScript SDK, unused hash-targeting ID generation is removed, and literal required node IDs `auto`/`pool` remain identities. Retry candidates use cached hashing before authoritative policy checks. Resume rejects a wrong node before loading history and retains its post-load check against workstream replacement. No new DM/channel authorization weakness was found.

Validation:

- Full Python regression suite on current head `171ac470`: 13,386 passed, 28 skipped, 17 deselected (`not live and not e2e_recovery`). Focused Python/browser and final audit/routing gates also passed.
- [Current-head CI](https://github.com/turnstonelabs/turnstone/actions/runs/33970815023) passed all ten jobs: full Python 3.11/3.12/3.13 and PostgreSQL suites, lint, type checking, security, lockfile, and wheel checks.
- PostgreSQL storage and migration checks: 173 passed, including upgrade/downgrade/upgrade.
- TypeScript SDK: 85 tests, build, and typecheck passed. Ruff lint/formatting and mypy passed. No production assertions added.
- Reran original assignment, lifecycle, browser, failure-routing, and review reproductions. Private-source visibility, forged resume witnesses, destination ownership, clone rollback, unavailable nodes, stale URLs, channel route retention, and startup cleanup are covered.
- Local SQLite probes: one-node create failure uses one policy read instead of eleven; a refused 5,000-message resume avoids loading 19.5 MiB of history. Accepted resumes add one primary-key read to preserve both early and post-load checks.

Fixes #1089.
