### PR TITLE
fix: unify reasoning indicators and show elapsed time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Turnstone gives LLMs tools — shell, files, search, web, planning — and orche
 - **MCP support** — external tool servers with native deferred loading (Anthropic/OpenAI) or BM25 fallback
 - **Team controls when you need them** — optional RBAC, SSO, tool policies, and audit logs, all stored in your own database
 
+The browser's **Default / Compact** control saves your transcript preference in that browser.
+Compact hides reasoning text and folds completed successful tool details. Both views show a
+**Reasoning** indicator with elapsed seconds while the model prepares its answer. The clock starts
+when the browser observes that phase and continues as reasoning tokens arrive; reconnecting to an
+existing phase starts a new clock if its start was not observed. Completed history has no estimated
+reasoning duration.
+
 <p align="center">
   <img src="docs/diagrams/architecture-overview.svg" alt="Turnstone system architecture" width="960"/>
 </p>

--- a/tests/test_conversation_css.py
+++ b/tests/test_conversation_css.py
@@ -168,10 +168,7 @@ def test_compact_message_density_cannot_match_shell_status_messages() -> None:
     assert prefix + " .msg.reasoning {" in css
     assert prefix + ' .msg.reasoning[data-reasoning-active="true"] {' in css
     assert prefix + ' .msg.reasoning[data-reasoning-active="true"] > .msg-body {' in css
-    assert (
-        prefix + ' .msg.reasoning[data-reasoning-active="true"] > .reasoning-activity-status {'
-        in css
-    )
+    assert ".msg.reasoning > .reasoning-activity-status {" in css
     assert prefix + ' .msg.reasoning[data-reasoning-active="true"] > * {' not in css
     assert ".reasoning-activity-status {" in css
     assert "@keyframes transcript-reasoning-spin" in css

--- a/tests/test_conversation_js.py
+++ b/tests/test_conversation_js.py
@@ -40,7 +40,7 @@ def test_exports_the_shared_helpers() -> None:
         "isConvBatchCompactEligible",
         "isConvVerdictCompactBlocker",
         "markConvRowResultSettled",
-        "setReasoningActivity",
+        "createReasoningActivity",
         "setConvBatchExpanded",
         "setToolOutputReviewState",
     ):
@@ -97,6 +97,119 @@ def test_agent_card_exposes_hidden_context_badge() -> None:
 
 
 @node_skip
+def test_reasoning_activity_clock_handoff_and_cleanup() -> None:
+    script = (
+        FAKE_DOM
+        + f"""
+const conv = await import({json.dumps(_CONVERSATION_JS.as_uri())});
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+let now = 0;
+let nextTimer = 0;
+const timers = new Map();
+Object.defineProperty(globalThis, "performance", {{ value: {{ now: () => now }} }});
+globalThis.setInterval = (callback, delay) => {{
+  assert(delay === 1000, "clock polls more than once per second");
+  timers.set(++nextTimer, callback);
+  return nextTimer;
+}};
+globalThis.clearInterval = (id) => timers.delete(id);
+const advance = (ms) => {{ now += ms; [...timers.values()].forEach((tick) => tick()); }};
+const container = new FakeElement("div");
+html.appendChild(container);
+const activity = conv.createReasoningActivity();
+activity.start(container);
+const status = container.querySelector(".reasoning-activity-status");
+const label = status.querySelector(".reasoning-activity-label");
+const elapsed = status.querySelector(".reasoning-activity-elapsed");
+assert(label.textContent === "Reasoning", "waiting label differs from reasoning");
+assert(label.getAttribute("role") === "status", "announcement role missing");
+assert(label.getAttribute("aria-live") === "polite", "announcement is not polite");
+assert(label.getAttribute("aria-atomic") === "true", "announcement is not atomic");
+assert(label.getAttribute("aria-label") === "Model reasoning in progress", "announcement missing");
+assert(status.getAttribute("aria-live") === null, "clock is inside a live region");
+assert(elapsed.getAttribute("role") === "timer", "clock is not accessible as a timer");
+assert(elapsed.getAttribute("aria-live") === "off", "clock ticks would be announced");
+assert(elapsed.textContent === "0s", "initial time is not zero");
+advance(2500);
+activity.start(container);
+assert(elapsed.textContent === "2s", "duplicate start reset the clock");
+assert(timers.size === 1, "duplicate start allocated another timer");
+
+// thinking_stop arrives before the first reasoning token. It removes the
+// waiting affordance but must preserve the same clock for the handoff.
+activity.hideWaiting();
+assert(status.parentNode === null && timers.size === 0, "waiting timer survived stop");
+advance(1500);
+const reasoning = new FakeElement("div");
+reasoning.setAttribute("role", "article");
+reasoning.setAttribute("aria-label", "reasoning");
+const trace = new FakeElement("div");
+trace.className = "msg-body";
+trace.setAttribute("aria-hidden", "false");
+reasoning.appendChild(trace);
+container.appendChild(reasoning);
+activity.attach(reasoning);
+assert(reasoning.querySelector(".reasoning-activity-status") === status, "handoff replaced status");
+assert(elapsed.textContent === "4s", "handoff lost pre-token time");
+assert(reasoning.dataset.reasoningActive === "true", "active marker missing");
+assert(reasoning.getAttribute("role") === "article", "row role changed");
+assert(reasoning.getAttribute("aria-label") === "reasoning", "row label changed");
+assert(trace.getAttribute("aria-hidden") === "true", "streamed trace is exposed to AT");
+assert(reasoning.children[0] === status, "indicator is below the streamed trace");
+trace.textContent = "first token";
+activity.attach(reasoning);
+activity.hideWaiting();
+assert(timers.size === 1 && status.parentNode === reasoning, "token stopped live reasoning");
+document.documentElement.setAttribute("data-transcript-presentation", "compact");
+advance(2000);
+document.documentElement.removeAttribute("data-transcript-presentation");
+assert(elapsed.textContent === "6s", "mode switch or token reset elapsed time");
+assert(label.textContent === "Reasoning", "clock mutated the live announcement");
+
+// Every pane owns its clock. Finishing one must not cancel its neighbor.
+const other = conv.createReasoningActivity();
+other.start(container);
+const secondStatus = container.querySelectorAll(".reasoning-activity-status")[1];
+assert(timers.size === 2, "second pane did not get an independent clock");
+activity.finish();
+activity.finish();
+assert(timers.size === 1, "finish affected the other pane");
+assert(!Object.hasOwn(reasoning.dataset, "reasoningActive"), "active marker survived finish");
+assert(trace.getAttribute("aria-hidden") === "false", "trace visibility was not restored");
+assert(!reasoning.querySelector(".reasoning-activity-status"), "finished clock survived");
+advance(62000);
+assert(secondStatus.querySelector(".reasoning-activity-elapsed").textContent === "62s", "long duration wrong");
+other.finish();
+assert(timers.size === 0, "finish leaked a timer");
+
+// A snapshot with no observed start begins at zero. Replacing/removing its
+// row must release the old trace and never retain a detached ticking pane.
+const snapshot = new FakeElement("div");
+snapshot.textContent = "snapshot reasoning";
+container.appendChild(snapshot);
+activity.attach(snapshot);
+assert(snapshot.querySelector(".reasoning-activity-elapsed").textContent === "0s", "snapshot invented prior time");
+assert(snapshot.querySelector(".msg-body").textContent === "snapshot reasoning", "legacy text lost");
+advance(1000);
+activity.attach(reasoning);
+assert(snapshot.querySelector(".msg-body").getAttribute("aria-hidden") === null, "old row stayed hidden");
+assert(reasoning.querySelector(".reasoning-activity-elapsed").textContent === "1s", "row replacement reset clock");
+container.remove();
+advance(1000);
+assert(timers.size === 0, "detached pane leaked a clock");
+assert(trace.getAttribute("aria-hidden") === "false", "detached trace was not restored");
+"""
+    )
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+@node_skip
 def test_compact_batch_settlement_disclosure_and_fail_open_behavior() -> None:
     script = (
         FAKE_DOM
@@ -119,42 +232,6 @@ for (const [verdict, expected] of [
     "verdict blocker classification drifted",
   );
 }}
-
-const reasoning = new FakeElement("div");
-reasoning.setAttribute("role", "article");
-reasoning.setAttribute("aria-label", "reasoning");
-const reasoningTrace = new FakeElement("div");
-reasoningTrace.className = "msg-body";
-reasoningTrace.setAttribute("aria-hidden", "false");
-reasoning.appendChild(reasoningTrace);
-assert(conv.setReasoningActivity(reasoning, true), "reasoning did not activate");
-assert(reasoning.dataset.reasoningActive === "true", "activity marker missing");
-assert(reasoning.getAttribute("role") === "article", "row role was replaced");
-assert(
-  reasoning.getAttribute("aria-label") === "reasoning",
-  "row label was replaced",
-);
-assert(reasoning.getAttribute("aria-live") === null, "row became a live region");
-assert(reasoningTrace.getAttribute("aria-hidden") === "true", "streamed trace stayed exposed");
-const reasoningStatus = reasoning.querySelector(".reasoning-activity-status");
-assert(reasoningStatus, "dedicated activity status missing");
-assert(reasoningStatus.parentNode === reasoning, "activity status is not a trace sibling");
-assert(reasoningStatus.getAttribute("role") === "status", "activity role missing");
-assert(reasoningStatus.getAttribute("aria-live") === "polite", "activity live mode missing");
-assert(reasoningStatus.getAttribute("aria-atomic") === "true", "activity status is not atomic");
-assert(
-  reasoningStatus.getAttribute("aria-label") === "Model reasoning in progress",
-  "activity label missing",
-);
-const stableStatusText = reasoningStatus.textContent;
-reasoningTrace.textContent += "first token";
-reasoningTrace.textContent += " second token";
-assert(reasoningStatus.textContent === stableStatusText, "token stream mutated live status");
-assert(!conv.setReasoningActivity(reasoning, true), "duplicate activation transitioned");
-assert(conv.setReasoningActivity(reasoning, false), "reasoning did not settle");
-assert(!Object.hasOwn(reasoning.dataset, "reasoningActive"), "activity marker survived");
-assert(reasoningTrace.getAttribute("aria-hidden") === "false", "trace visibility was not restored");
-assert(!reasoning.querySelector(".reasoning-activity-status"), "activity status survived");
 
 function batchWithRows(count, state = "conv-batch--approved") {{
   const batch = conv.buildConvBatchShell({{

--- a/tests/test_cooperative_compaction.py
+++ b/tests/test_cooperative_compaction.py
@@ -3251,7 +3251,7 @@ class TestCompactionActivityPill:
         assert ui._ws_activity_state == ""
         # Outside a compaction window, thinking writes normally again.
         ui.on_thinking_start()
-        assert ui._ws_current_activity == "Thinking…"
+        assert ui._ws_current_activity == "Reasoning…"
 
     def test_stale_end_leaves_successor_latch_alone(self, session):
         """A force-abandoned compaction's late end must not unlatch — or
@@ -3313,7 +3313,7 @@ class TestCompactionActivityPill:
         assert not ui._compaction_activity_live
         assert ui._ws_current_activity == "Compacting context…"  # no stale restore
         ui.on_thinking_start()  # the live turn recovers the pill
-        assert ui._ws_current_activity == "Thinking…"
+        assert ui._ws_current_activity == "Reasoning…"
 
     def test_superseded_progress_is_swallowed(self, session):
         """An abandoned compaction's progress chatter is dropped at the base
@@ -3403,7 +3403,7 @@ class TestCompactionActivityPill:
         assert ui._ws_activity_state == "tool"
         # And thinking writes work again for the live turn.
         ui.on_thinking_start()
-        assert ui._ws_current_activity == "Thinking…"
+        assert ui._ws_current_activity == "Reasoning…"
         # No live latch: a claim is a no-op (no restore of stale pairs).
         ui._ws_current_activity = "Custom"
         session._claim_generation()

--- a/tests/test_coord_rich_ws_state_payload.py
+++ b/tests/test_coord_rich_ws_state_payload.py
@@ -150,7 +150,7 @@ def test_coord_on_thinking_start_sets_activity() -> None:
     ``activity_state`` to ``"thinking"`` when the model starts."""
     ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
     ui.on_thinking_start()
-    assert ui._ws_current_activity == "Thinking…"
+    assert ui._ws_current_activity == "Reasoning…"
     assert ui._ws_activity_state == "thinking"
 
 
@@ -220,11 +220,11 @@ def test_snapshot_carries_token_and_activity_snapshot() -> None:
             context_window=400,
             effort="medium",
         )
-    ui.on_thinking_start()  # sets activity = "Thinking…"
+    ui.on_thinking_start()  # sets activity = "Reasoning…"
     payload = ui.snapshot_and_consume_state_payload("running")
     assert payload["tokens"] == 100
     assert payload["context_ratio"] == pytest.approx(0.25)
-    assert payload["activity"] == "Thinking…"
+    assert payload["activity"] == "Reasoning…"
     assert payload["activity_state"] == "thinking"
 
 
@@ -325,7 +325,7 @@ def test_coord_adapter_emit_state_passes_rich_payload_to_collector() -> None:
     assert call["state"] == "running"
     assert call["tokens"] == 100
     assert call["context_ratio"] == pytest.approx(0.25)
-    assert call["activity"] == "Thinking…"
+    assert call["activity"] == "Reasoning…"
     assert call["activity_state"] == "thinking"
     # Mid-turn (RUNNING) — content stays accumulated for the eventual IDLE drain.
     assert call["content"] == ""
@@ -380,7 +380,7 @@ def test_coord_ui_broadcast_activity_calls_collector() -> None:
         assert len(recorder.activity_calls) == 1
         call = recorder.activity_calls[0]
         assert call["ws_id"] == "coord-ws"
-        assert call["activity"] == "Thinking…"
+        assert call["activity"] == "Reasoning…"
         assert call["activity_state"] == "thinking"
     finally:
         ConsoleCoordinatorUI._collector = None
@@ -462,13 +462,13 @@ def test_coord_ui_broadcast_activity_failure_does_not_strand_dedup() -> None:
             "next identical tick would be silently suppressed"
         )
         # Tick #2 — same activity tuple. Pre-fix this would no-op
-        # (because dedup state was already (Thinking…, thinking)).
+        # (because dedup state was already (Reasoning…, thinking)).
         # Post-fix it retries; collector succeeds; dedup state lands.
         ui.on_thinking_start()
         assert recorder.update_console_ws_activity.call_count == 2, (
             "second tick was deduped despite the first call failing"
         )
-        assert ui._last_broadcast_activity == ("Thinking…", "thinking")
+        assert ui._last_broadcast_activity == ("Reasoning…", "thinking")
     finally:
         ConsoleCoordinatorUI._collector = None
 
@@ -487,7 +487,7 @@ def test_coord_ui_broadcast_activity_dedup_skips_identical_after_success() -> No
         ui.on_thinking_start()  # tick 2 — same tuple, deduped
         ui.on_thinking_start()  # tick 3 — same tuple, deduped
         assert recorder.update_console_ws_activity.call_count == 1
-        assert ui._last_broadcast_activity == ("Thinking…", "thinking")
+        assert ui._last_broadcast_activity == ("Reasoning…", "thinking")
     finally:
         ConsoleCoordinatorUI._collector = None
 
@@ -613,13 +613,13 @@ def test_snapshot_under_concurrent_writes_does_not_crash() -> None:
 def test_coord_on_stream_end_clears_activity() -> None:
     """Lifted ``on_stream_end`` body clears ``_ws_current_activity``
     and ``_ws_activity_state`` so the dashboard's coord row stops
-    showing the stale 'Thinking…' indicator after the stream
+    showing the stale 'Reasoning…' indicator after the stream
     finishes. Pre-lift coord just enqueued ``stream_end`` without
     touching activity — this test pins the new clear path so a
     future re-stub doesn't silently re-introduce a stuck activity
     indicator."""
     ui = ConsoleCoordinatorUI(ws_id="coord-ws", user_id="u1")
-    ui._ws_current_activity = "Thinking…"
+    ui._ws_current_activity = "Reasoning…"
     ui._ws_activity_state = "thinking"
     ui.on_stream_end()
     assert ui._ws_current_activity == ""

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -1268,7 +1268,7 @@ def test_compact_presentation_coordinator_wiring_and_ordering():
         "registerTranscriptScroller",
         "isConvVerdictCompactBlocker",
         "markConvRowResultSettled",
-        "setReasoningActivity",
+        "createReasoningActivity",
         "setConvBatchExpanded",
     ):
         assert symbol in body
@@ -1343,20 +1343,18 @@ def test_compact_presentation_coordinator_wiring_and_ordering():
     assert "unmountTranscriptPresentation();" in destroy
 
     reasoning = _extract_braced(body, "  function appendReasoningToken(text) {")
-    assert "setReasoningActivity(currentReasoningEl, true)" in reasoning
+    assert "reasoningActivity.attach(currentReasoningEl)" in reasoning
     content = _extract_braced(body, "  function appendContentToken(text) {")
-    assert "setReasoningActivity(currentReasoningEl, false)" in content
+    assert "reasoningActivity.finish()" in content
     finish = _extract_braced(body, "  function finishAssistantStream() {")
-    assert "setReasoningActivity(currentReasoningEl, false)" in finish
+    assert "reasoningActivity.finish()" in finish
     busy = _extract_braced(body, "  function setBusy(b, source) {")
     assert "if (!next) {" in busy
-    assert "setReasoningActivity(currentReasoningEl, false);" in busy
+    assert "reasoningActivity.finish();" in busy
     assert "currentReasoningEl = null;" in busy
     assert 'currentReasoningBuf = "";' in busy
     cancelled = body[body.index('case "cancelled"') : body.index('case "clear_ui"')]
-    assert cancelled.index("setReasoningActivity(currentReasoningEl, false)") < cancelled.index(
-        "if (!busy) break"
-    )
+    assert cancelled.index("reasoningActivity.finish()") < cancelled.index("if (!busy) break")
 
 
 def test_coordinator_close_409_uses_plain_retry_copy():

--- a/tests/test_history_handoff_js.py
+++ b/tests/test_history_handoff_js.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._js_harness_helpers import FAKE_DOM
 from tests._js_harness_helpers import extract_braced as _extract_braced
 from tests._js_harness_helpers import strip_js_comments as _strip_comments
 
@@ -55,6 +56,95 @@ def _as_function(source: str, signature: str) -> str:
     return "function " + extracted
 
 
+@pytest.mark.parametrize("kind", ["interactive", "coordinator"])
+def test_reasoning_indicator_recovers_from_current_state_snapshot(
+    tmp_path: Path, kind: str
+) -> None:
+    """State hints restore initial wait, then yield to a compaction card."""
+    source = (_INTERACTIVE if kind == "interactive" else _COORDINATOR).read_text()
+    signature = "  handleEvent(evt) {" if kind == "interactive" else "  function handleEvent(ev) {"
+    handler = _as_function(source, signature)
+    waiting = _as_function(source, "  addThinkingIndicator() {") if kind == "interactive" else ""
+    compaction = (
+        _as_function(source, "  handleCompactionEvent(evt) {") if kind == "interactive" else ""
+    )
+    module = (_ROOT / "turnstone/shared_static/conversation.js").as_uri()
+    script = FAKE_DOM + "\n" + handler + "\n" + waiting + "\n" + compaction
+    script += (
+        "\nconst { createReasoningActivity, applyCompactionEvent, resetCompactionHolder }"
+        " = await import(%s);\n" % json.dumps(module)
+    )
+    script += r"""
+globalThis.setInterval = () => 1;
+globalThis.clearInterval = () => {};
+const messagesEl = new FakeElement("div");
+html.appendChild(messagesEl);
+const reasoningActivity = createReasoningActivity();
+const compactionHolder = { card: null };
+const renderedSystemEventIds = new Set();
+const statusEl = null;
+let actingUserId = null;
+let currentAssistantEl = null, currentReasoningEl = null;
+let currentAssistantBuf = "", currentReasoningBuf = "";
+function setBusy() {}
+function _scheduleScroll() {}
+const pane = {
+  _reasoningActivity: reasoningActivity,
+  _compaction: compactionHolder,
+  _renderedSystemEventIds: renderedSystemEventIds,
+  messagesEl,
+  currentAssistantEl: null,
+  currentReasoningEl: null,
+  setBusy,
+  scrollToBottom() {},
+  removeEmptyState() {},
+  _handleAgentCompaction() {},
+};
+"""
+    if kind == "interactive":
+        script += "pane.addThinkingIndicator = addThinkingIndicator;\n"
+        script += "pane.handleCompactionEvent = handleCompactionEvent;\n"
+    script += r"""
+const receive = (event) => handleEvent.call(pane, event);
+const status = () => messagesEl.querySelector(".reasoning-activity-status");
+receive({ type: "state_change", state: "thinking" });
+const first = status();
+if (!first) throw new Error("state-only reconnect left the waiting phase invisible");
+receive({ type: "in_progress_snapshot", reasoning: "", content: "" });
+receive({ type: "state_change", state: "thinking" });
+if (status() !== first) throw new Error("empty snapshot or repeated state replaced the clock");
+reasoningActivity.finish();
+
+// Busy tools and compaction have their own activity; neither is reasoning.
+for (const state of ["running", "attention"]) {
+  receive({ type: "state_change", state });
+  if (status()) throw new Error(state + " incorrectly started reasoning");
+}
+// Manual /compact publishes thinking state before its compaction start.
+// Reconnect can instead introduce that card through a progress event.
+for (const phase of ["start", "progress"]) {
+  receive({ type: "state_change", state: "thinking" });
+  const waiting = status();
+  receive({ type: "compaction", target: "task_agent", phase });
+  if (status() !== waiting) throw new Error("nested compaction stopped pane reasoning");
+  receive({ type: "compaction", phase, compaction_id: "manual" });
+  if (!compactionHolder.card) throw new Error("compaction card missing");
+  if (status()) throw new Error("reasoning overlaps the compaction card");
+  receive({ type: "thinking_start" });
+  receive({ type: "state_change", state: "thinking" });
+  if (status()) throw new Error("thinking restarted during compaction");
+  resetCompactionHolder(compactionHolder);
+}
+
+// Replayed busy state during visible answer streaming must not add a clock.
+currentAssistantEl = pane.currentAssistantEl = new FakeElement("div");
+receive({ type: "state_change", state: "thinking" });
+if (status()) throw new Error("answer streaming acquired a reasoning indicator");
+reasoningActivity.finish();
+"""
+    _run_module(tmp_path, script)
+
+
 def test_interactive_stale_backstop_waits_for_replay_tail_runtime(
     tmp_path: Path,
 ) -> None:
@@ -87,7 +177,6 @@ def test_interactive_stale_backstop_waits_for_replay_tail_runtime(
 
     script = """
 function resetCompactionHolder() {}
-function setReasoningActivity() {}
 function streamingRender(body, text) { body.textContent = text; }
 function streamingRenderFinalize(body, text) { body.textContent = text; }
 """
@@ -130,7 +219,7 @@ const pane = {
   setBusy(value) { this.busy = value; },
   _attachRetryToLastAssistant() {},
   _acceptUserTurn(evt) { this.userRows.push(evt.content); },
-  removeThinkingIndicator() {},
+  _reasoningActivity: { finish() {}, hideWaiting() {}, attach() {} },
   removeEmptyState() {},
   scrollToBottom() {},
   _newAssistantBubble() {

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -607,17 +607,17 @@ def test_interactive_refetch_failure_preserves_the_pane() -> None:
 
 def test_per_token_hot_path_avoids_container_scans() -> None:
     """P1 (perf audit): per-token work must stay O(1) in transcript length.
-    The thinking indicator is an instance ref (the class-selector miss walked
-    the whole transcript on EVERY content/reasoning delta); near-bottom state
+    The reasoning activity controller owns its DOM references, so token deltas
+    never search the whole transcript for an indicator; near-bottom state
     comes from the passive scroll listener instead of a forced-layout
     geometry read per event; the scroll pin is rAF-coalesced; per-tool
     row/stream lookups resolve through the self-healing caches."""
     body = _INTERACTIVE.read_text(encoding="utf-8")
     stripped = _strip_comments(body)
-    assert 'querySelector(".thinking-indicator")' not in stripped, (
-        "thinking indicator must use the instance ref, not a container scan"
+    assert 'querySelector(".reasoning-activity-status")' not in stripped, (
+        "reasoning indicator must use owned references, not a container scan"
     )
-    assert "this._thinkingEl" in body
+    assert "this._reasoningActivity" in body
     near = body.index("isNearBottom() {")
     assert "return this._nearBottom;" in body[near : near + 700]
     assert "passive: true" in body
@@ -1452,7 +1452,7 @@ def test_compact_presentation_live_replay_and_lifecycle_wiring() -> None:
         "preserveTranscriptBottomPin",
         "registerTranscriptScroller",
         "markConvRowResultSettled",
-        "setReasoningActivity",
+        "createReasoningActivity",
         "setConvBatchExpanded",
     ):
         assert symbol in body
@@ -1530,14 +1530,14 @@ def test_compact_presentation_live_replay_and_lifecycle_wiring() -> None:
     assert cleanup < body.index("pane._unregisterTranscriptScroller();", cleanup)
 
     reasoning_case = body[body.index('case "reasoning"') : body.index('case "content"')]
-    assert "setReasoningActivity(this.currentReasoningEl, true)" in reasoning_case
+    assert "this._reasoningActivity.attach(this.currentReasoningEl)" in reasoning_case
     assert 'reasoningBody.className = "msg-body"' in reasoning_case
     assert "reasoningBody.textContent += evt.text" in reasoning_case
     assert "this.currentReasoningEl.textContent += evt.text" not in reasoning_case
     content_case = body[body.index('case "content"') : body.index('case "stream_end"')]
-    assert "setReasoningActivity(this.currentReasoningEl, false)" in content_case
+    assert "this._reasoningActivity.finish()" in content_case
     stream_case = body[body.index('case "stream_end"') : body.index('case "in_progress_snapshot"')]
-    assert "setReasoningActivity(this.currentReasoningEl, false)" in stream_case
+    assert "this._reasoningActivity.finish()" in stream_case
 
 
 def test_task_agent_context_badge_is_keyed_idempotent_and_terminal_safe() -> None:

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -47,7 +47,7 @@ import {
   indexLabel,
   isConvVerdictCompactBlocker,
   markConvRowResultSettled,
-  setReasoningActivity,
+  createReasoningActivity,
   setConvBatchExpanded,
   setToolOutputReviewState,
 } from "/shared/conversation.js";
@@ -1943,7 +1943,10 @@ function createCoordinatorPane(root, wsId, opts) {
       const prevBadge = row.querySelector(".conv-verdict");
       if (prevBadge) {
         const prevDetail = prevBadge.nextElementSibling;
-        if (prevDetail && prevDetail.classList.contains("conv-verdict-detail")) {
+        if (
+          prevDetail &&
+          prevDetail.classList.contains("conv-verdict-detail")
+        ) {
           prevDetail.remove();
         }
         prevBadge.remove();
@@ -2518,9 +2521,10 @@ function createCoordinatorPane(root, wsId, opts) {
   let currentAssistantBuf = "";
   let currentReasoningEl = null;
   let currentReasoningBuf = "";
+  const reasoningActivity = createReasoningActivity();
 
   function appendContentToken(text) {
-    setReasoningActivity(currentReasoningEl, false);
+    reasoningActivity.finish();
     if (!currentAssistantEl) {
       currentAssistantEl = appendMsg("assistant", "", { label: "assistant" });
       currentAssistantBuf = "";
@@ -2559,7 +2563,7 @@ function createCoordinatorPane(root, wsId, opts) {
       currentReasoningBuf = "";
       messagesEl.setAttribute("aria-live", "off");
     }
-    setReasoningActivity(currentReasoningEl, true);
+    reasoningActivity.attach(currentReasoningEl);
     currentReasoningBuf += text;
     const body = currentReasoningEl.querySelector(".msg-body");
     if (body) body.textContent = currentReasoningBuf;
@@ -2584,7 +2588,7 @@ function createCoordinatorPane(root, wsId, opts) {
     }
     currentAssistantEl = null;
     currentAssistantBuf = "";
-    setReasoningActivity(currentReasoningEl, false);
+    reasoningActivity.finish();
     currentReasoningEl = null;
     currentReasoningBuf = "";
     messagesEl.setAttribute("aria-live", "polite");
@@ -2657,7 +2661,7 @@ function createCoordinatorPane(root, wsId, opts) {
   function setBusy(b, source) {
     const next = !!b;
     if (!next) {
-      setReasoningActivity(currentReasoningEl, false);
+      reasoningActivity.finish();
       currentReasoningEl = null;
       currentReasoningBuf = "";
     }
@@ -3617,7 +3621,7 @@ function createCoordinatorPane(root, wsId, opts) {
     suspendStream();
     currentAssistantEl = null;
     currentAssistantBuf = "";
-    setReasoningActivity(currentReasoningEl, false);
+    reasoningActivity.finish();
     currentReasoningEl = null;
     currentReasoningBuf = "";
     // Drop the live cursor for the reconnect: the full render below
@@ -3782,6 +3786,15 @@ function createCoordinatorPane(root, wsId, opts) {
 
   function handleEvent(ev) {
     switch (ev.type) {
+      case "thinking_start":
+        if (!compactionHolder.card) {
+          reasoningActivity.start(messagesEl);
+          _scheduleScroll();
+        }
+        break;
+      case "thinking_stop":
+        reasoningActivity.hideWaiting();
+        break;
       case "content":
         appendContentToken(ev.text || "");
         break;
@@ -3802,14 +3815,14 @@ function createCoordinatorPane(root, wsId, opts) {
             });
             messagesEl.setAttribute("aria-live", "off");
           }
-          setReasoningActivity(currentReasoningEl, true);
+          reasoningActivity.attach(currentReasoningEl);
           currentReasoningBuf = ev.reasoning;
           var rbody = currentReasoningEl.querySelector(".msg-body");
           if (rbody) rbody.textContent = currentReasoningBuf;
           _scheduleScroll();
         }
         if (ev.content && ev.content.length > currentAssistantBuf.length) {
-          setReasoningActivity(currentReasoningEl, false);
+          reasoningActivity.finish();
           if (!currentAssistantEl) {
             currentAssistantEl = appendMsg("assistant", "", {
               label: "assistant",
@@ -4061,6 +4074,8 @@ function createCoordinatorPane(root, wsId, opts) {
           onNotice: (msg) => appendText("info", msg, { label: "info" }),
           scroll: () => _scheduleScroll(),
         });
+        // Manual compaction's busy state can start reasoning before this card.
+        if (compactionHolder.card) reasoningActivity.finish();
         break;
       case "connected":
         // First yield from _coord_events_replay — populates the
@@ -4096,7 +4111,7 @@ function createCoordinatorPane(root, wsId, opts) {
         // transitions we didn't initiate (cross-tab cancel, judge
         // reset, idle-after-error). Mirrors the interactive pane.
         if (ev.state === "idle" || ev.state === "error") {
-          setReasoningActivity(currentReasoningEl, false);
+          reasoningActivity.finish();
           setBusy(false);
           // Deferred replay_truncated re-sync: the truncation arrived while a
           // turn was mid-stream (refetching then would have detached the live
@@ -4202,6 +4217,17 @@ function createCoordinatorPane(root, wsId, opts) {
           ev.state === "attention"
         ) {
           setBusy(true);
+          // Fresh state snapshots may precede the first reasoning token and
+          // carry no thinking_start event to recreate the waiting indicator.
+          if (
+            ev.state === "thinking" &&
+            !currentAssistantEl &&
+            !currentReasoningEl &&
+            !compactionHolder.card
+          ) {
+            reasoningActivity.start(messagesEl);
+            _scheduleScroll();
+          }
         }
         break;
       case "rename":
@@ -4246,7 +4272,7 @@ function createCoordinatorPane(root, wsId, opts) {
         // Force Stop after 2s. state_change → idle is what actually
         // clears busy; the 10s safety timer covers the connection-drop
         // case.
-        setReasoningActivity(currentReasoningEl, false);
+        reasoningActivity.finish();
         if (!busy) break;
         clearTimeout(cancelTimeoutId);
         clearTimeout(forceTimeoutId);
@@ -7041,6 +7067,7 @@ function createCoordinatorPane(root, wsId, opts) {
   // per-instance pane must release the stream + every timer/observer or a
   // backgrounded pane keeps an SSE open and fires renders into detached DOM.
   function destroy() {
+    reasoningActivity.finish();
     // Stream + the retry timers (reconnect backoff, degraded catch-up,
     // truncated resync).
     closeStreamTransport();

--- a/turnstone/core/session_ui_base.py
+++ b/turnstone/core/session_ui_base.py
@@ -703,7 +703,7 @@ class SessionUIBase:
         self._ws_activity_state: str = ""
         # Compaction pill window: while True, on_thinking_start leaves the
         # activity alone (the impl's own thinking wrap would otherwise
-        # clobber "Compacting context…" with "Thinking…" milliseconds after
+        # clobber "Compacting context…" with "Reasoning…" milliseconds after
         # the start event set it, for the whole summarize phase).  The end
         # event restores the pre-compaction pair, so a bail can't strand a
         # stale "Compacting context…" on an idle workstream either.
@@ -3991,7 +3991,7 @@ class SessionUIBase:
                 self._ws_turn_content_size,
             )
             if not self._compaction_activity_live:
-                self._ws_current_activity = "Thinking…"
+                self._ws_current_activity = "Reasoning…"
                 self._ws_activity_state = "thinking"
         self._broadcast_activity()
         self._enqueue({"type": "thinking_start"})
@@ -4466,7 +4466,7 @@ class SessionUIBase:
         if phase == "start" and not superseded:
             # The activity pill mirrors on_thinking_start's mechanics but
             # names the actual work — the summarize calls can run for a
-            # while and "Thinking…" undersells what the session is doing.
+            # while and "Reasoning…" undersells what the session is doing.
             # Save the prior pair for the end-side restore, and latch the
             # window so the impl's own on_thinking_start can't clobber it.
             with self._ws_lock:

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -1038,7 +1038,9 @@
 }
 /* Indeterminate state — a single-batch summarization emits no part-k/N
    progress, so the bar sweeps until the end event settles it. */
-.msg.compaction-card .msg-compaction-bar.indeterminate .msg-compaction-bar-fill {
+.msg.compaction-card
+  .msg-compaction-bar.indeterminate
+  .msg-compaction-bar-fill {
   width: 40%;
   animation: compaction-sweep 1.4s ease-in-out infinite;
 }
@@ -1051,7 +1053,9 @@
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .msg.compaction-card .msg-compaction-bar.indeterminate .msg-compaction-bar-fill {
+  .msg.compaction-card
+    .msg-compaction-bar.indeterminate
+    .msg-compaction-bar-fill {
     animation: none;
     width: 100%;
     opacity: 0.4;
@@ -1211,16 +1215,30 @@
   font-style: italic;
 }
 .reasoning-activity-status {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 7px;
+  padding: 6px 14px;
+  color: var(--ink-3);
+  font-size: 11px;
+  font-style: normal;
   white-space: nowrap;
-  border: 0;
+}
+.reasoning-activity-status::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--hair-2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: transcript-reasoning-spin 0.8s linear infinite;
+}
+.reasoning-activity-elapsed {
+  font-variant-numeric: tabular-nums;
+}
+.msg.reasoning > .reasoning-activity-status {
+  padding: 0;
 }
 
 /* Viewer-local compact transcript presentation.  Scope beneath the registered
@@ -1251,38 +1269,6 @@
   > .msg-body {
   display: none;
 }
-:root[data-transcript-presentation="compact"]
-  [data-transcript-root]
-  .msg.reasoning[data-reasoning-active="true"]
-  > .reasoning-activity-status {
-  position: static;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  width: auto;
-  height: auto;
-  padding: 0;
-  margin: 0;
-  overflow: visible;
-  clip: auto;
-  clip-path: none;
-  white-space: normal;
-  border: 0;
-  font-size: 11px;
-}
-:root[data-transcript-presentation="compact"]
-  [data-transcript-root]
-  .msg.reasoning[data-reasoning-active="true"]
-  > .reasoning-activity-status::after {
-  content: "";
-  width: 10px;
-  height: 10px;
-  border: 2px solid var(--hair-2);
-  border-top-color: var(--accent);
-  border-radius: 50%;
-  animation: transcript-reasoning-spin 0.8s linear infinite;
-}
-
 @keyframes transcript-reasoning-spin {
   to {
     transform: rotate(360deg);
@@ -1290,10 +1276,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :root[data-transcript-presentation="compact"]
-    [data-transcript-root]
-    .msg.reasoning[data-reasoning-active="true"]
-    > .reasoning-activity-status::after {
+  .reasoning-activity-status::after {
     animation: none;
   }
 }

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -415,7 +415,6 @@ export function indexLabel(idx, n) {
 // left indent (a real bug if a caller passes pre-indented text).
 // ===========================================================================
 
-const activeReasoningState = new WeakMap();
 const OUTPUT_REVIEW_INCOMPLETE_TEXT = "Output review did not complete";
 
 function _reasoningTrace(row) {
@@ -433,44 +432,105 @@ function _reasoningTrace(row) {
   return trace;
 }
 
-// The streamed trace and the model-activity announcement must be separate
-// accessibility subtrees.  Tokens mutate only the aria-hidden trace while a
-// static sibling status announces once; settlement restores the completed
-// trace for ordinary, non-live navigation.
-export function setReasoningActivity(row, active) {
-  if (!row) return false;
-  if (active) {
-    if (row.dataset.reasoningActive === "true") return false;
-    const trace = _reasoningTrace(row);
-    const status = document.createElement("span");
-    status.className = "reasoning-activity-status";
-    status.setAttribute("role", "status");
-    status.setAttribute("aria-live", "polite");
-    status.setAttribute("aria-atomic", "true");
-    status.setAttribute("aria-label", "Model reasoning in progress");
-    status.textContent = "Reasoning";
-    activeReasoningState.set(row, {
-      trace,
-      traceHidden: trace.getAttribute("aria-hidden"),
-      status,
-    });
-    trace.setAttribute("aria-hidden", "true");
-    row.dataset.reasoningActive = "true";
-    row.appendChild(status);
-    return true;
+// One per pane: the pre-token indicator moves into the reasoning row without
+// restarting its clock. The elapsed time describes this browser's observed
+// phase, not provider compute time; cold history has no invented duration.
+export function createReasoningActivity() {
+  let status = null;
+  let elapsed = null;
+  let startedAt = null;
+  let timer = null;
+  let row = null;
+  let trace = null;
+  let traceHidden = null;
+
+  function stopTimer() {
+    if (timer !== null) clearInterval(timer);
+    timer = null;
   }
-  if (row.dataset.reasoningActive !== "true") return false;
-  delete row.dataset.reasoningActive;
-  const prior = activeReasoningState.get(row) || {};
-  const trace = prior.trace || row.querySelector(".msg-body");
-  if (trace) {
-    if (prior.traceHidden == null) trace.removeAttribute("aria-hidden");
-    else trace.setAttribute("aria-hidden", prior.traceHidden);
+
+  function releaseTrace() {
+    if (!row) return;
+    delete row.dataset.reasoningActive;
+    if (traceHidden === null) trace.removeAttribute("aria-hidden");
+    else trace.setAttribute("aria-hidden", traceHidden);
+    row = trace = null;
+    traceHidden = null;
   }
-  const status = prior.status || row.querySelector(".reasoning-activity-status");
-  if (status) status.remove();
-  activeReasoningState.delete(row);
-  return true;
+
+  function finish() {
+    stopTimer();
+    releaseTrace();
+    if (status) status.remove();
+    status = elapsed = startedAt = null;
+  }
+
+  function tick() {
+    if (!status.isConnected) {
+      finish();
+      return;
+    }
+    const seconds = Math.max(
+      0,
+      Math.floor((performance.now() - startedAt) / 1000),
+    );
+    const text = seconds + "s";
+    if (elapsed.textContent !== text) elapsed.textContent = text;
+  }
+
+  function mount(parent) {
+    if (!status) {
+      startedAt = performance.now();
+      status = document.createElement("span");
+      status.className = "reasoning-activity-status";
+      const label = document.createElement("span");
+      label.className = "reasoning-activity-label";
+      label.setAttribute("role", "status");
+      label.setAttribute("aria-live", "polite");
+      label.setAttribute("aria-atomic", "true");
+      label.setAttribute("aria-label", "Model reasoning in progress");
+      label.textContent = "Reasoning";
+      elapsed = document.createElement("span");
+      elapsed.className = "reasoning-activity-elapsed";
+      // The clock and streamed trace are outside the live announcement.
+      // Neither tokens nor timer ticks should repeatedly interrupt a reader.
+      elapsed.setAttribute("role", "timer");
+      elapsed.setAttribute("aria-live", "off");
+      elapsed.setAttribute("aria-label", "Elapsed reasoning time");
+      elapsed.textContent = "0s";
+      status.append(label, elapsed);
+    }
+    parent.appendChild(status);
+    if (status.isConnected) tick();
+    if (timer === null) timer = setInterval(tick, 1000);
+  }
+
+  return {
+    start(container) {
+      if (status && status.isConnected) return;
+      finish();
+      mount(container);
+    },
+    hideWaiting() {
+      if (row) return;
+      stopTimer();
+      if (status) status.remove();
+      // thinking_stop precedes the first token. Keep the clock origin for
+      // the reasoning handoff; content/terminal events call finish instead.
+    },
+    attach(nextRow) {
+      if (!nextRow || row === nextRow) return;
+      releaseTrace();
+      row = nextRow;
+      trace = _reasoningTrace(row);
+      traceHidden = trace.getAttribute("aria-hidden");
+      trace.setAttribute("aria-hidden", "true");
+      row.dataset.reasoningActive = "true";
+      mount(row);
+      row.appendChild(trace);
+    },
+    finish,
+  };
 }
 
 const COMPACT_BLOCKER_SELECTOR = [
@@ -565,11 +625,7 @@ export function isConvVerdictCompactBlocker(verdict) {
   if (!verdict) return false;
   const risk = normalizeRiskLevel(verdict.risk_level);
   const recommendation = verdict.recommendation || "review";
-  return (
-    risk === "high" ||
-    risk === "critical" ||
-    recommendation !== "approve"
-  );
+  return risk === "high" || risk === "critical" || recommendation !== "approve";
 }
 
 function _playingBatchMedia(batch) {

--- a/turnstone/shared_static/interactive.css
+++ b/turnstone/shared_static/interactive.css
@@ -72,20 +72,6 @@
   letter-spacing: 0.02em;
 }
 
-/* Streaming content — .msg.reasoning (chat.css) styles reasoning
-   bubbles; .reasoning is never emitted on its own, only paired with
-   the .msg base class. */
-.thinking-indicator {
-  color: var(--fg-dim);
-  font-size: 12px;
-  padding: 6px 14px;
-}
-
-.thinking-indicator::after {
-  content: "...";
-  animation: dots 1.5s steps(3, end) infinite;
-}
-
 /* Historical-message attachment pills — beneath the user bubble */
 .msg-user-attach {
   display: flex;

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -43,7 +43,7 @@ import {
   convBatchSummaryText,
   isConvVerdictCompactBlocker,
   markConvRowResultSettled,
-  setReasoningActivity,
+  createReasoningActivity,
   setConvBatchExpanded,
   setToolOutputReviewState,
   batchKicker,
@@ -246,7 +246,6 @@ class Pane {
     // Provenance of the current busy=true (see setBusy): "server" |
     // "optimistic" | null when idle.
     this.busySource = null;
-    this.isThinking = false;
     // Acting user (turn initiator) of the in-flight turn, from state_change
     // events; drives the shared-workstream cross-user send gate. Carries the
     // owner id even single-user (the gate just no-ops — it equals this viewer);
@@ -397,7 +396,7 @@ class Pane {
     this._nearBottom = true;
     this._scrollPinPending = false;
     this._scrollPinForce = false;
-    this._thinkingEl = null;
+    this._reasoningActivity = createReasoningActivity();
     // Compaction lifecycle holder for the shared reducer
     // (conversation.applyCompactionEvent); `card` is the in-progress card
     // between start and end, nulled wherever the transcript DOM is wiped.
@@ -520,7 +519,7 @@ class Pane {
 
   reset() {
     this.currentAssistantEl = null;
-    setReasoningActivity(this.currentReasoningEl, false);
+    this._reasoningActivity.finish();
     this.currentReasoningEl = null;
     this.contentBuffer = "";
     this.setBusy(false);
@@ -600,6 +599,7 @@ class Pane {
   // timer cleanup wired via the queue's onIdle hook).
   setBusy(b, source) {
     const next = !!b;
+    if (!next) this._reasoningActivity.finish();
     // Who asserted busy: "server" (default — state events, thinking_start,
     // every existing/future writer) or "optimistic" (ONLY the send flow's
     // pre-POST flip). The deferred/queue_full settle arms may clear busy
@@ -688,23 +688,9 @@ class Pane {
   }
 
   addThinkingIndicator() {
-    // Instance ref, not a container query: removeThinkingIndicator runs on
-    // EVERY content/reasoning delta, and a class-selector miss walks the
-    // whole transcript subtree — O(N) per streamed token at 5000 messages.
     if (this._compaction.card) return; // the compaction card owns the affordance
-    if (this._thinkingEl) return;
-    const el = document.createElement("div");
-    el.className = "thinking-indicator";
-    el.textContent = "Thinking";
-    this._thinkingEl = el;
-    this.messagesEl.appendChild(el);
+    this._reasoningActivity.start(this.messagesEl);
     this.scrollToBottom();
-  }
-
-  removeThinkingIndicator() {
-    if (!this._thinkingEl) return;
-    this._thinkingEl.remove();
-    this._thinkingEl = null;
   }
 
   addSystemNudgeMarker() {
@@ -795,6 +781,8 @@ class Pane {
       onNotice: (msg) => this.addInfoMessage(msg),
       scroll: (force) => this.scrollToBottom(force),
     });
+    // Manual compaction's busy state can start reasoning before this card.
+    if (this._compaction.card) this._reasoningActivity.finish();
   }
 
   addCommandEcho(text) {
@@ -2335,19 +2323,16 @@ class Pane {
     }
     switch (evt.type) {
       case "thinking_start":
-        this.isThinking = true;
         this.setBusy(true);
         this.removeEmptyState();
         this.addThinkingIndicator();
         break;
 
       case "thinking_stop":
-        this.isThinking = false;
-        this.removeThinkingIndicator();
+        this._reasoningActivity.hideWaiting();
         break;
 
       case "reasoning":
-        this.removeThinkingIndicator();
         let reasoningBody = null;
         if (!this.currentReasoningEl) {
           this.currentReasoningEl = document.createElement("div");
@@ -2359,17 +2344,14 @@ class Pane {
         } else {
           reasoningBody = this.currentReasoningEl.querySelector(".msg-body");
         }
-        setReasoningActivity(this.currentReasoningEl, true);
+        this._reasoningActivity.attach(this.currentReasoningEl);
         if (reasoningBody) reasoningBody.textContent += evt.text;
         this.scrollToBottom();
         break;
 
       case "content":
-        this.removeThinkingIndicator();
-        if (this.currentReasoningEl) {
-          setReasoningActivity(this.currentReasoningEl, false);
-          this.currentReasoningEl = null;
-        }
+        this._reasoningActivity.finish();
+        this.currentReasoningEl = null;
         if (!this.currentAssistantEl) {
           this._newAssistantBubble();
         }
@@ -2404,7 +2386,7 @@ class Pane {
         const doneBuffer = this.contentBuffer;
         this.currentAssistantBodyEl = null;
         this.currentAssistantEl = null;
-        setReasoningActivity(this.currentReasoningEl, false);
+        this._reasoningActivity.finish();
         this.currentReasoningEl = null;
         this.contentBuffer = "";
         // Finalize the completed streaming segment's markdown.  This fires
@@ -2436,7 +2418,7 @@ class Pane {
         // skip overwrite when the current buffer is already at-or-past
         // the snapshot length, so a stale replay can't reset the live-
         // streamed view back to a shorter prefix.
-        this.removeThinkingIndicator();
+        if (evt.reasoning || evt.content) this._reasoningActivity.hideWaiting();
         if (evt.reasoning) {
           let snapshotReasoningBody = null;
           if (!this.currentReasoningEl) {
@@ -2450,7 +2432,7 @@ class Pane {
             snapshotReasoningBody =
               this.currentReasoningEl.querySelector(".msg-body");
           }
-          setReasoningActivity(this.currentReasoningEl, true);
+          this._reasoningActivity.attach(this.currentReasoningEl);
           const curReason = snapshotReasoningBody
             ? snapshotReasoningBody.textContent || ""
             : "";
@@ -2462,13 +2444,11 @@ class Pane {
           }
         }
         if (evt.content) {
+          this._reasoningActivity.finish();
           // Content snapshot supersedes any reasoning bubble — matches
           // the "case content" invariant of clearing currentReasoningEl
           // when content begins.
-          if (this.currentReasoningEl) {
-            setReasoningActivity(this.currentReasoningEl, false);
-            this.currentReasoningEl = null;
-          }
+          this.currentReasoningEl = null;
           if (!this.currentAssistantEl) {
             this._newAssistantBubble();
           }
@@ -2491,7 +2471,7 @@ class Pane {
           this._actingUserId = evt.acting_user_id;
         }
         if (evt.state === "idle" || evt.state === "error") {
-          setReasoningActivity(this.currentReasoningEl, false);
+          this._reasoningActivity.finish();
           this.setBusy(false);
           // A context event received while its call id still resolved to a
           // prior terminal row is retained briefly for a possible successor
@@ -2572,6 +2552,15 @@ class Pane {
           evt.state === "attention"
         ) {
           this.setBusy(true);
+          // A reconnect before the first token has only the current state,
+          // not the earlier thinking_start. Restore its waiting affordance.
+          if (
+            evt.state === "thinking" &&
+            !this.currentAssistantEl &&
+            !this.currentReasoningEl
+          ) {
+            this.addThinkingIndicator();
+          }
         }
         break;
 
@@ -2771,7 +2760,7 @@ class Pane {
         clearTimeout(this._cancelTimeout);
         clearTimeout(this._forceTimeout);
         this.currentAssistantEl = null;
-        setReasoningActivity(this.currentReasoningEl, false);
+        this._reasoningActivity.finish();
         this.currentReasoningEl = null;
         this.contentBuffer = "";
         this.stopBtn.disabled = true;
@@ -3706,7 +3695,7 @@ class Pane {
     // preserves the pane, and preserved DOM keeps valid refs.
     this.currentAssistantEl = null;
     this.currentAssistantBodyEl = null;
-    setReasoningActivity(this.currentReasoningEl, false);
+    this._reasoningActivity.finish();
     this.currentReasoningEl = null;
     this.contentBuffer = "";
     // In-progress compaction card: the transcript wipe orphaned it; live
@@ -3717,7 +3706,6 @@ class Pane {
     this.approvalCycles = new Map();
     this.announcedBlocks = new Map();
     this._syncApprovalState();
-    this._thinkingEl = null;
     this._retryHolderEl = null;
   }
 
@@ -4741,7 +4729,10 @@ class Pane {
     const context = card.context || wrap.querySelector(".conv-agent-context");
     const issue = card.issue || wrap.querySelector(".conv-agent-step-issue");
     if (!toggle || !label) return;
-    const parts = ["Show or hide sub-agent steps", label.textContent || "0 steps"];
+    const parts = [
+      "Show or hide sub-agent steps",
+      label.textContent || "0 steps",
+    ];
     const state = wrap.dataset.state;
     if (state === "running") parts.push("running");
     else if (state === "done") parts.push("done");
@@ -5979,6 +5970,7 @@ function createInteractivePane(root, wsId, opts) {
       clearTimeout(pane._staleRetryTimer);
       pane._staleRetryTimer = null;
     }
+    pane._reasoningActivity.finish();
     pane.disconnectSSE();
     // Detach the visibility handler and clear the hide-close marker: a dead
     // controller must NOT be resurrected by a tab-visibility change.  Without
@@ -6156,6 +6148,7 @@ function createInteractivePane(root, wsId, opts) {
         clearTimeout(pane._staleRetryTimer);
         pane._staleRetryTimer = null;
       }
+      pane._reasoningActivity.finish();
       pane.disconnectSSE();
       // The document-level visibilitychange listener holds a strong ref
       // to the pane — leaving it registered would both leak the pane and

--- a/turnstone/ui/static/style.css
+++ b/turnstone/ui/static/style.css
@@ -125,30 +125,6 @@
   overflow-y: auto;
 }
 
-/* Streaming content — .msg.reasoning (chat.css) styles reasoning
-   bubbles; .reasoning is never emitted on its own, only paired with
-   the .msg base class. */
-.thinking-indicator {
-  color: var(--fg-dim);
-  font-size: 12px;
-  padding: 6px 14px;
-}
-.thinking-indicator::after {
-  content: "...";
-  animation: dots 1.5s steps(3, end) infinite;
-}
-@keyframes dots {
-  0% {
-    content: ".";
-  }
-  33% {
-    content: "..";
-  }
-  66% {
-    content: "...";
-  }
-}
-
 /* ==========================================================================
    Markdown styling
    ========================================================================== */
@@ -1400,10 +1376,6 @@ audio.media-player {
   .tool-output-stream {
     animation: none;
     border-left-color: var(--accent);
-  }
-  .thinking-indicator::after {
-    animation: none;
-    content: "...";
   }
   .ts-approval-btn,
   .ts-approval-feedback,


### PR DESCRIPTION
Browser transcripts use different Thinking and Reasoning indicators without showing elapsed time. Share one **Reasoning** indicator with elapsed seconds across interactive and coordinator panes in both Default and Compact views. The same clock continues from the initial wait into streamed reasoning.

Restore the waiting indicator from current state when reconnecting before the first token, and retire it when content starts, compaction takes over, or the pane finishes, cancels, or closes. Remove the unused Thinking animation and document the presentation behavior.

The clock measures the phase observed by that browser. A fresh connection starts at zero when the original start was not observed; completed history does not gain estimated durations. Internal SSE event names remain unchanged.

Fixes #936.

Validation:

- 330 focused tests passed, including clock continuity, per-pane cleanup, state-only reconnects, and compaction takeover in both panes.
- All 25 `scripts/recovery_e2e.py --scenario all` scenarios passed. The final compaction takeover fix was subsequently checked by the focused suite and real Chrome/SSE probes.
- Browser checks passed for Default/Compact, light/dark, reduced motion, snapshot reload, cancellation, compaction, and destruction, with no browser errors. Independent design review also checked contrast, the accessibility tree, and 320px layout.
- Ruff, formatting, mypy, JS syntax, and Prettier passed. CSS specificity audit has the same 10 pre-existing findings as the base. Full repository pytest was not run.
- Independent design, code-quality, and bug/security reviews completed; findings were fixed and the compaction reproduction was rerun successfully in both panes.
