### PR TITLE
fix: share Docker authentication config across console and nodes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,10 @@ build/
 .venv/
 venv/
 .env
+/config.toml
+/turnstone/deploy/config.toml
+/.turnstone-bootstrap.*/
+/turnstone/deploy/.turnstone-bootstrap.*/
 *.db
 .git/
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@ build/
 .venv/
 venv/
 .env
-# Local compose overrides (e.g. run.sh's node-count limiter, bootstrap output)
+# Private shared bootstrap configuration (dev and production stacks).
+/config.toml
+/turnstone/deploy/config.toml
+/.turnstone-bootstrap.*/
+/turnstone/deploy/.turnstone-bootstrap.*/
+# Local compose overrides (e.g. run.sh's saved choices, bootstrap output)
 compose.override.yaml
 compose.override.yml
 docker-compose.override.yaml

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ LLM; add model backends from the console UI.
 For production (released images from ghcr.io, real secrets required), use the
 bundled stack: `docker compose -f turnstone/deploy/compose.yaml up`.
 
+For optional SSO, per-user MCP OAuth, or model gateway authentication, the
+installer and both stacks support one [shared authentication config](docs/docker.md#shared-bootstrap-config).
+The default local-login setup needs no additional configuration.
+
 See [QUICKSTART.md](QUICKSTART.md) for the install + troubleshooting walkthrough and [docs/docker.md](docs/docker.md) for Docker configuration.
 
 ### Programmatic (SDK)
@@ -148,7 +152,7 @@ with TurnstoneServer("http://localhost:8080", token="tok_xxx") as client:
 
 ## Tools
 
-Built-in tools for shell, files, search, web, memory, notifications, and autonomous sub-agents — plus external tools via [MCP](https://modelcontextprotocol.io/) with native deferred loading. See [docs/tools.md](docs/tools.md) for the full reference and [docs/mcp-registry.md](docs/mcp-registry.md) for MCP configuration.
+Built-in tools for shell, files, search, web, memory, notifications, and autonomous sub-agents — plus external tools via [MCP](https://modelcontextprotocol.io/) with native deferred loading. See [docs/tools.md](docs/tools.md) for the full reference, [docs/mcp-registry.md](docs/mcp-registry.md) for MCP configuration, and [MCP authentication](docs/mcp-oauth.md) for auth choices and remote Docker/GitHub OAuth setup.
 
 ## Architecture
 
@@ -202,6 +206,7 @@ UML diagrams in [`docs/diagrams/`](docs/diagrams/):
 | Eval harness | [docs/eval.md](docs/eval.md) |
 | Tools reference | [docs/tools.md](docs/tools.md) |
 | MCP integration | [docs/mcp-registry.md](docs/mcp-registry.md) |
+| MCP authentication / OAuth | [docs/mcp-oauth.md](docs/mcp-oauth.md) |
 
 ## Requirements
 

--- a/compose.config.yaml
+++ b/compose.config.yaml
@@ -1,0 +1,24 @@
+# Optional shared bootstrap config. See docs/docker.md#shared-bootstrap-config.
+# docker compose -f compose.yaml -f compose.config.yaml up -d
+services:
+  console: &shared-config
+    environment:
+      TURNSTONE_CONFIG: /run/turnstone/config.toml
+    volumes:
+      - type: bind
+        source: ./config.toml
+        target: /run/turnstone/config.toml
+        read_only: true
+        bind:
+          create_host_path: false
+          selinux: z
+  node-1: *shared-config
+  node-2: *shared-config
+  node-3: *shared-config
+  node-4: *shared-config
+  node-5: *shared-config
+  node-6: *shared-config
+  node-7: *shared-config
+  node-8: *shared-config
+  node-9: *shared-config
+  node-10: *shared-config

--- a/docs/console.md
+++ b/docs/console.md
@@ -539,6 +539,9 @@ live; edits apply without restart.
 
 **MCP Servers tab:**
 
+Choose authentication using the [MCP authentication guide](mcp-oauth.md), which
+covers shared tokens, per-user consent, org sign-in, and remote Docker setup.
+
 The tab has two views toggled via a pill control: **Servers** and
 **Registry**.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -83,6 +83,15 @@ base_url = "http://localhost:8000/v1"   # your local model endpoint
 model = "qwen3-32b"
 ```
 
+If the cluster uses OAuth, SSO, or model gateway authentication, also copy
+the applicable `[security]` and `[oidc]` sections from its
+[shared bootstrap config](#shared-bootstrap-config) into this host's file.
+Keep the same encryption key and authentication settings as the console and
+containerized nodes, while retaining this host's database/model settings.
+The Compose overlay only mounts the file into the Compose services; joined
+hosts need their own private copy, updated whenever those shared settings
+change.
+
 Then start the server. The node identity isn't a secret, so it stays on the
 command line:
 
@@ -188,9 +197,148 @@ See [tls.md](tls.md) for details.
 
 ## Configuration
 
-Everything is configured with environment variables in `.env` (copy from
-[`.env.example`](../.env.example)). The dev stack needs none of them — they're
-overrides.
+Container wiring and ports are configured in `.env` (copy from
+[`.env.example`](../.env.example)). The dev stack needs none of them. Bootstrap
+settings such as SSO client credentials and token encryption keys use the
+shared TOML file below.
+
+### Shared bootstrap config
+
+Both stacks ship an optional `compose.config.yaml` overlay. It mounts one
+`config.toml`, beside that stack's `compose.yaml`, read-only at
+`/run/turnstone/config.toml` in the console and **every server node**. Each
+consumer selects that file with `TURNSTONE_CONFIG`. The channel gateway and
+supporting services do not receive it. The default stack needs no TOML file.
+The bind mount refuses a missing source instead of creating a directory.
+
+Use the same file for the authentication features your deployment needs:
+
+| Feature | Shared config and next step |
+|---|---|
+| Local login, API-key models, static MCP credentials | The default install needs no shared authentication config. |
+| Personal MCP accounts (`oauth_user`) | Set the encryption key and HTTPS `redirect_base`; follow [MCP authorization](mcp-oauth.md#remote-docker-setup). Local login is sufficient. |
+| SSO login | Set the `[oidc]` issuer, client ID, client secret, and `redirect_base`; follow [OIDC setup](oidc.md). SSO alone does not capture refresh credentials. |
+| SSO delegation to MCP/model backends | Add the encryption key, opt into `capture_user_credential`, and choose the IdP's `obo_grant_profile`; configure [MCP passthrough](mcp-oauth.md#auth_typeoauth_obo--single-credential-sign-in-passthrough) or [delegated models](oidc.md#model-gateway-credentials). |
+| Application identity for model gateways (`entra_app`) | Use the encryption key and Entra OIDC registration with the `entra` grant profile; configure [model gateway credentials](oidc.md#model-gateway-credentials). User credential capture is unnecessary. |
+
+Each feature also needs its provider registration and permissions. Configure
+MCP servers and model definitions in their admin tabs; model audiences are
+permitted through the runtime setting `model.auth_audience_allowlist`.
+
+**Using `run.sh`:** accept the optional OAuth/SSO shared-config prompt. If no
+`config.toml` exists, the installer asks for the dashboard's HTTPS origin and
+generates one Fernet key, with commented SSO and delegation fields. A new file
+keeps local password login available; SSO and credential capture remain off.
+Create your local admin before filling in SSO credentials, then follow the
+applicable guide above and restart the services after editing the file.
+
+The installer saves the mount alongside the node count in
+`compose.override.yaml`, so later plain `docker compose up -d` commands retain
+both choices. Reruns preserve the file and key; a missing previously enabled
+file requires restoring the backup. An override written by you is left
+intact; use the manual overlay flow below to incorporate it.
+This includes `compose.override.yml` and `docker-compose.override.*` files.
+To disable the installer-managed mount, remove its generated
+`compose.override.yaml`, rerun `run.sh` to reselect your node count, and
+decline shared config; retain the TOML/key backup.
+
+**Manual setup:** work in the directory containing your stack's `compose.yaml`.
+For the dev stack, build the image with `docker compose build` and set:
+
+```bash
+turnstone_image=turnstone:local
+```
+
+For production, work in `turnstone/deploy/` (or the directory where you copied
+the bundled deployment files), provide its required `.env`, and select the
+same image tag as the stack:
+
+```bash
+turnstone_image="$(docker compose config --images | grep -m 1 '^ghcr.io/turnstonelabs/turnstone:')"
+docker pull "$turnstone_image"
+```
+
+Use deployment files and an image from the same Turnstone release. The
+generator below requires the `turnstone.deploy.bootstrap_config` module.
+If an older pinned tag reports that the module is missing, upgrade the image
+or prepare `config.toml` using the fields and key-generation command in
+[`turnstone.example.toml`](../turnstone.example.toml), then follow the
+existing-file ownership instructions below. Preserve any existing key.
+
+This recipe uses GNU `mv` for its `-nT` options. On macOS, use `gmv` from
+[GNU coreutils](https://formulae.brew.sh/formula/coreutils) for the move step;
+the system `mv` does not support `-T`.
+
+To create a **new** config, replace the HTTPS origin in this command with the
+address users actually open. The helper writes privately as the image's
+`turnstone` account, including when Docker maps container UIDs on the host:
+
+```bash
+bootstrap_dir="$(mktemp -d "$PWD/.turnstone-bootstrap.XXXXXX")"
+mkdir -m 0777 -- "$bootstrap_dir/output"
+docker run --rm --network none --user root --entrypoint python \
+  -v "$bootstrap_dir/output:/bootstrap:rw,z" "$turnstone_image" \
+  -m turnstone.deploy.bootstrap_config /bootstrap/config.toml \
+  https://turnstone.example.com --owner turnstone
+mv -nT -- "$bootstrap_dir/output/config.toml" ./config.toml
+rm -rf -- "$bootstrap_dir"
+```
+
+The outer directory stays private (`0700`); only its writable inner directory
+is exposed to the bootstrap container. Other host users cannot traverse the
+outer directory, and the generated key file is `0600` throughout.
+
+The final move uses GNU `mv`'s no-clobber mode and keeps an existing file. To
+reuse an existing configuration, place it at `./config.toml` instead; keep its
+encryption key.
+[`turnstone.example.toml`](../turnstone.example.toml) lists the bootstrap fields.
+The file must be readable by the image's `turnstone` user, with mode `0600`.
+For an existing file with different ownership on ordinary or rootless
+Docker, adjust it through the container:
+
+```bash
+docker run --rm --network none --user root --entrypoint sh \
+  -v "$PWD/config.toml:/run/turnstone/config.toml:rw,z" "$turnstone_image" \
+  -c 'chown turnstone:turnstone /run/turnstone/config.toml && chmod 600 /run/turnstone/config.toml'
+```
+
+With rootful `userns-remap`, an existing host-owned file can lie outside the
+container's UID/GID mapping, so the container cannot change its owner. Use
+host root to assign the service user's mapped UID/GID and mode `0600` instead;
+derive those IDs from your daemon's mapping and the image's `turnstone`
+account. See [Docker's bind-mount ownership requirements](https://docs.docker.com/engine/security/userns-remap/#user-namespace-known-limitations).
+
+Enable the overlay when starting the stack:
+
+```bash
+docker compose -f compose.yaml -f compose.config.yaml up -d
+```
+
+Keep those `-f` arguments on subsequent commands. If you have an existing
+`compose.override.yaml`, include it too: explicit `-f` arguments disable the
+automatic override selection. Do not replace an override containing other
+deployment choices.
+
+Back up `config.toml` privately with the database. Its host owner may be a
+mapped container UID, so host-side edits and backups may require `sudo`.
+After editing only this file, **restart the console and all active server
+nodes** using `docker compose restart` with those service names and the same
+Compose files. A running container can retain the old file after an editor's
+atomic save; restarting the container remounts it and reloads the settings.
+When adding or changing Compose mounts or environment variables, recreate
+the affected services with `up -d --force-recreate` instead; a restart does
+not apply changes to the Compose configuration. Do not generate a new key
+on each node or on each restart.
+
+The key stays out of `.env`, runtime settings, source control, and image build
+contexts. A read-only mount protects against writes, but a shell running as
+the service user can still read it; file-backed secrets are not a sandbox.
+Use the dashboard's HTTPS origin for `redirect_base`. Register the appropriate
+callback with each provider: `/v1/api/auth/oidc/callback` for SSO login and
+`/v1/api/mcp/oauth/callback` for per-user MCP authorization. Both belong on the
+console's public origin, but they serve different registrations. See
+[OIDC setup](oidc.md) and [MCP authorization](mcp-oauth.md) for the remaining
+provider and consent steps.
 
 ### LLM backend
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -1,4 +1,4 @@
-# MCP OAuth — per-user authorization for MCP servers
+# MCP authentication and OAuth setup
 
 Turnstone supports **per-(user, MCP server) OAuth 2.1 + PKCE** delegation so each Turnstone user authorizes a remote MCP server with their own identity, rather than sharing a single bearer token across the deployment. This is the right shape for MCP servers that expose user-specific data (a personal CRM, an email inbox, a calendar) and for MCP servers that want per-user audit attribution.
 
@@ -6,18 +6,27 @@ Per-user OAuth is opt-in per `mcp_servers` row. Local-auth Turnstone installs wi
 
 > **Note**: This is a separate authorization layer from Turnstone's own user authentication. A user who logs into Turnstone with a local username + password can still authorize a per-server OAuth MCP server. OIDC SSO and per-server OAuth are orthogonal.
 
+Docker deployments use one [shared authentication config](docker.md#shared-bootstrap-config)
+for MCP OAuth, SSO, and model delegation. Enable the features you need in that
+file; each server's authorization mode is selected separately in the admin UI.
+
 ---
 
 ## When to use which `auth_type`
 
-The MCP server admin form exposes three authorization modes ("Multitenant Authorization"):
+The MCP server admin form exposes four authorization modes ("Multitenant Authorization"). Choose the transport first:
 
-| `auth_type` | What it means | When to use |
+| Choice | Transport | Identity and setup |
 |---|---|---|
-| `none` | No headers attached. Open MCP server (or one gated by network policy only). | Internal MCP servers on a trusted network. |
-| `static` | One static bearer token, configured per server, sent on every request from every user. | Service-to-service MCP servers where per-user attribution doesn't matter, or single-tenant deployments. |
-| `oauth_user` *(recommended for user-data servers)* | Each user authorizes separately via OAuth 2.1 + PKCE; Turnstone stores per-user tokens encrypted at rest. | MCP servers that expose user-specific data or that want per-user audit attribution. |
-| `oauth_obo` *(sign-in passthrough)* | Each user's Turnstone **org sign-in** (OIDC) mints a per-server access token on demand — no separate per-server consent. One captured credential per user covers every `oauth_obo` server. | Enterprise deployments where the identity provider governs access (Entra, Keycloak) and you want zero per-user connect clicks. See the dedicated section below. |
+| `none` — no authorization | Streamable HTTP or stdio | An open server or one protected by the deployment's network/process access controls. |
+| `static` — static headers | Streamable HTTP | One shared identity for everyone using the server. Configure its headers, such as `Authorization: Bearer <token>`. No per-user consent or OAuth bootstrap is needed. |
+| `oauth_user` — per-user OAuth | Streamable HTTP | Each user connects their own account in the browser. Requires the shared encryption key, HTTPS callback origin, and provider client registration below. Local Turnstone login is sufficient. |
+| `oauth_obo` — sign-in passthrough | Streamable HTTP | Uses each user's organization sign-in and delegated permissions. Requires OIDC credential capture and an Entra/RFC 8693 grant profile; see the dedicated section below. |
+| Server-owned authentication | stdio | Run the server's own login flow or supply its documented credentials/configuration to the child process. Use `none` in Turnstone; HTTP OAuth settings do not authenticate a stdio subprocess. |
+
+For stdio, credentials and any persisted login state must be available on every
+node that launches the process. A shared process login does not become a
+separate identity for each Turnstone user.
 
 Switching `auth_type` away from `oauth_user` / `oauth_obo` **deletes** that server's per-user rows (consents / minted cache) — see the transition table below. Switching back later starts clean: users re-consent (or re-mint) on next use. The admin **bulk-revoke** / **flush cache** affordance clears rows without an auth-type change.
 
@@ -33,7 +42,98 @@ Switching `auth_type` away from `oauth_user` / `oauth_obo` **deletes** that serv
    - **Pre-registered** (most common): you create an OAuth client at the authorization server (manually, via admin console, or via Terraform), then paste the `client_id` / `client_secret` into the Turnstone admin form.
    - **Dynamic client registration** (RFC 7591): if the AS supports it and you select that mode in the admin form, Turnstone registers a client at first use and persists the `client_id` automatically.
 
-4. **Redirect URI** registered at the authorization server: `https://your-turnstone-host/v1/api/mcp/oauth/callback`.
+4. **Public callback origin**. Set `[oidc] redirect_base` to the dashboard's
+   HTTPS origin, even when users log in with local usernames and passwords.
+   Register exactly `https://your-turnstone-host/v1/api/mcp/oauth/callback` at
+   the authorization server. Setting only `redirect_base` does not enable SSO.
+
+## Remote Docker setup
+
+1. Make the dashboard reachable at its final HTTPS address, for example
+   `https://turnstone.example.com`. Configure DNS and a trusted certificate at
+   Caddy or your reverse proxy; proxy the callback path to the **console** along
+   with the rest of the dashboard. Verify that users can open that address and
+   sign in. An internal name such as `http://console:8090` is not the callback
+   origin. See [Docker deployment](docker.md) and [TLS](tls.md).
+2. Enable the [shared bootstrap config](docker.md#shared-bootstrap-config),
+   either through `run.sh`'s optional prompt or the shipped Compose overlay.
+   Its minimal contents are:
+
+   ```toml
+   [security]
+   mcp_token_encryption_key = "<one generated Fernet key, shared by console and all nodes>"
+
+   [oidc]
+   redirect_base = "https://turnstone.example.com"
+   ```
+
+   Keep the key in this file only. Use the generator in the Docker guide rather
+   than copying the placeholder. Recreate the console and every active node
+   when adding the mount; later TOML edits need a restart of those services.
+   The admin Settings tab cannot distribute this key.
+3. Register an OAuth client with the MCP provider. Set its callback URL to
+   **`https://turnstone.example.com/v1/api/mcp/oauth/callback`** (including any
+   explicit port in your origin). This is different from Turnstone's OIDC
+   sign-in callback. The GitHub example below gives the provider fields.
+4. In **MCP Servers → Add Server**, choose **Streamable HTTP** and **Per-user
+   OAuth2.1**. Enter the server URL and provider client details, then save.
+5. Each user connects their own account. An admin can choose **connect** in
+   that server row's action menu; users also receive an inline **Connect** card
+   when a tool needs authorization. Complete the provider's browser consent,
+   then retry the tool. An admin's consent authorizes only that admin.
+
+Scheduled work and Discord/Slack conversations cannot complete browser consent
+inside the run. The user whose Turnstone identity owns the run must connect
+through the web UI first; channel users need their linked Turnstone identity.
+See [headless OAuth operation](operations/mcp-oauth-headless.md).
+
+### GitHub remote MCP example
+
+Use **`https://api.githubcopilot.com/mcp/`** as the Server URL. Register a
+dedicated GitHub App or OAuth App for this Turnstone deployment and select
+**Pre-registered** in Turnstone. GitHub's remote MCP server does not support
+dynamic client registration. Both app types use a client ID and client secret;
+use the app's **Client ID**, not a GitHub App's numeric App ID.
+See GitHub's [host integration guide](https://github.com/github/github-mcp-server/blob/main/docs/host-integration.md).
+
+| Turnstone field | Value |
+|---|---|
+| Transport | Streamable HTTP |
+| Server URL | `https://api.githubcopilot.com/mcp/` |
+| Multitenant Authorization | Per-user OAuth2.1 (`oauth_user`) |
+| Client Registration | Pre-registered |
+| Client ID / Client Secret | From your dedicated GitHub App or OAuth App |
+| Authorization Server URL | Leave blank for metadata discovery |
+| Scopes | Choose for your app type and required tools, as described below |
+
+Set the app's callback to
+`https://turnstone.example.com/v1/api/mcp/oauth/callback`. The client secret
+belongs in Turnstone's encrypted, write-only **Client Secret** field, not in
+static headers. Current discovery handles GitHub's path-bearing metadata;
+the old manual Authorization Server URL workaround is not required. Older
+installations should upgrade the console and nodes to include
+[#1083](https://github.com/turnstonelabs/turnstone/pull/1083), which also requests
+JSON from GitHub's token endpoint.
+
+For a **GitHub App**, configure the app's repository/organization permissions
+and installation access for the tools you intend to use. Leave Turnstone's
+Scopes field empty: GitHub App user tokens use the intersection of app and
+user permissions, rather than OAuth App scopes. Organization installation or
+approval may be required. See [GitHub App user access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app).
+
+For an **OAuth App**, enter space-separated scopes appropriate to the tools:
+for example, `read:org` for organization membership, or `repo` for private
+repository operations. `repo` includes write access; it is not a read-only
+scope. Do not copy a broad scope list for a read-only use case. Consult
+[GitHub's scope reference](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps)
+and your organization's app-access policy.
+
+**PAT fallback:** select **Static headers** with the same remote Server URL
+and set `Authorization: Bearer <your PAT>`. Choose the PAT's repository access
+and permissions for the intended tools. This avoids OAuth setup, but every
+Turnstone user who can use that MCP server acts as the PAT's owner; it is a
+shared credential. GitHub documents PAT support in its
+[host integration guide](https://github.com/github/github-mcp-server/blob/main/docs/host-integration.md).
 
 ---
 
@@ -44,7 +144,7 @@ Switching `auth_type` away from `oauth_user` / `oauth_obo` **deletes** that serv
 | Field | Required | Description |
 |---|---|---|
 | Server URL | Yes | The MCP server's `streamable-http` base URL. For `oauth_user` and `oauth_obo` rows it is stored in canonical form (lower-case scheme and host, default port dropped, a root-only trailing slash dropped, the path otherwise kept exactly as typed) and that value is the RFC 8707 `resource=` sent on every authorize and token request. A fragment or embedded credentials is rejected at save; a row stored before that check keeps working, with both stripped from the identifier at use. |
-| Multitenant Authorization | Yes | `none` / `static` / `oauth_user` (recommended). |
+| Multitenant Authorization | Yes | `none` / `static` / `oauth_user` / `oauth_obo`; choose according to transport and identity needs above. |
 | Authorization Server URL | No | Override for RFC 9728 PRM discovery. Set when your AS endpoint differs from the MCP server URL (e.g., corporate AS protecting a third-party MCP). When unset, Turnstone fetches the server's protected-resource metadata from the RFC 9728 path-specific location first and the origin-level location second, and follows one `WWW-Authenticate` `resource_metadata` challenge per location. Each document must declare the identifier its own URL was derived from — the canonical Server URL at the path-specific location, the bare origin at the origin-level one — so a server that publishes only at the origin while declaring its path-bearing URL needs this override instead. Authorization-server metadata is then tried at the locations MCP lists (RFC 8414 inserted, OpenID Connect inserted, OpenID Connect appended) followed by an appended-form RFC 8414 compatibility probe, and a location wins only after its whole document validates. A document whose `issuer` is not identical to the one requested is skipped — a trailing slash makes it a different identifier, so set this field to the exact spelling the AS publishes; a templated issuer (`{tenantid}`) is accepted and logged. An issuer with a query string or fragment is refused. The resolved issuer is cached on the row and cleared whenever this field or the Server URL changes. Changing this field also purges the server's per-user grants and pending consents — the stored refresh tokens were issued by the previous authorization server — and clears a dynamically registered client id. |
 | Client Registration | Yes (oauth_user) | `preregistered` or `dynamic`. |
 | Client ID | Yes (preregistered) | OAuth 2.0 client ID. Stored unencrypted. |
@@ -96,7 +196,16 @@ mcp_token_encryption_key = "base64-fernet-key"
 # mcp_token_encryption_keys = ["new-key", "old-key"]
 ```
 
-Keep this in `config.toml` rather than environment variables. An in-process LLM with shell-tool access can read the server's environment via `env` / `os.environ` and exfiltrate any secret stored there; secrets in `config.toml` are only loaded into the server at startup and never re-read on a tool-driven path, so a prompt-injection attack against the agent cannot reach them.
+This key is accepted only from `config.toml`, not environment variables or
+DB-backed runtime settings. Use the same keyring on the console and all nodes
+sharing the database, and retain a private backup. Losing it makes stored
+tokens and client secrets undecryptable.
+
+File-backed storage avoids putting the key in inherited process environments.
+It does not isolate the key from a shell running as the same OS user: that
+shell can read the file too. A read-only Docker mount prevents changes, not
+reads. Keep the file outside the mounted workspace and use process/filesystem
+isolation when tools must not be able to access service credentials.
 
 ---
 
@@ -116,6 +225,14 @@ Access is governed **downstream** by the IdP: a user can only mint a token for a
 capture_user_credential = true          # persist the IdP refresh token at login
 obo_grant_profile = "entra"             # "entra" | "rfc8693" — how tokens are minted
 ```
+
+For Docker, edit the existing `[oidc]` section in the
+[shared config](docker.md#shared-bootstrap-config), retaining its encryption
+key. Complete [OIDC provider setup](oidc.md), grant the downstream permissions
+below, then restart the console and active nodes. Users must sign in again
+after capture is enabled to store a refresh credential. OIDC login and
+per-server MCP OAuth have separate callback URLs; OBO uses the OIDC login
+callback and has no per-server browser consent step.
 
 - **`capture_user_credential`** (default `false`): when enabled, Turnstone appends `offline_access` to the login scopes and stores the returned refresh token, encrypted with the same `[security] mcp_token_encryption_key` as `oauth_user` tokens. **The encryption key is required** — Turnstone refuses to start with an `oauth_obo` row (or capture enabled) and no key.
 - **`obo_grant_profile`** picks the mint mechanism (the IdP determines which one is valid; this is deployment-wide, not per-server):
@@ -199,6 +316,8 @@ Every transition that changes what a stored row *means* deletes the rows outrigh
 
 | Symptom | Likely cause | Action |
 |---|---|---|
+| `MCP OAuth is not configured on this node.` / encryption-key configuration hint | Console or node did not load the shared TOML file | Check the read-only mount, `TURNSTONE_CONFIG`, file ownership, and the same key on every consumer; restart after TOML edits or recreate after changing Compose mounts/environment. |
+| OAuth start says the redirect base is not configured | Missing or invalid `[oidc] redirect_base` | Set the public HTTPS origin, with no path/query/fragment, even for local-auth installs; restart the console and nodes. |
 | `mcp_consent_required` even after consenting | Token persistence failed, or refresh-token rejected by AS | Check audit log for `mcp_server.oauth.persist_failed` or `mcp_server.oauth.token_revoked`. Re-consent via settings modal. |
 | `mcp_token_undecryptable_key_unknown` | Encryption key rotated without keeping the previous key in the keyring | Add the previous key back to `mcp_token_encryption_keys` until all rows have been re-encrypted, then drop. |
 | `mcp_oauth_url_insecure` | MCP server URL is `http://` (not `https://`) on a non-loopback host | Use `https://`. Per-user bearers must not transit cleartext. |
@@ -213,4 +332,4 @@ Every transition that changes what a stored row *means* deletes the rows outrigh
 | **`oauth_obo`**: "Sign in to Turnstone again" on one server | Captured credential missing/rejected, or a Conditional Access challenge | User re-logs into Turnstone (re-captures the credential). If it persists, check the IdP grant / CA policy. |
 | **`oauth_obo`**: tools don't appear at all for a user | User has not signed in since `capture_user_credential` was enabled (no credential captured) | User logs out and back in via OIDC so the refresh credential is captured. |
 
-See also: `docs/operations/mcp-oauth-headless.md` for the cron / channel-driven run caveat.
+See also: [headless OAuth operation](operations/mcp-oauth-headless.md) for the cron / channel-driven run caveat.

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -2,6 +2,11 @@
 
 Turnstone integrates with the [official MCP Registry](https://registry.modelcontextprotocol.io) to let administrators discover and install MCP servers directly from the console admin panel.
 
+For static headers, per-user OAuth, sign-in passthrough, and stdio credentials,
+see [MCP authentication and OAuth setup](mcp-oauth.md), including a remote
+Docker/GitHub walkthrough. Installing a registry entry does not authorize each
+user's account.
+
 ## Overview
 
 The MCP Registry is maintained by the [Agentic AI Foundation](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) (Linux Foundation) and serves as the canonical discovery layer for MCP servers. Turnstone queries its REST API (v0.1) for server metadata and provides a one-click install flow.

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -25,9 +25,43 @@ Auth0, OneLogin, and others that publish a
 
 ## Configuration
 
-OIDC is configured via environment variables (preferred) or the `[oidc]`
-section of `config.toml`. Environment variables take precedence when both
-are set.
+Configure OIDC in the `[oidc]` section of the shared `config.toml` used by the
+console and server nodes. Docker deployments can prepare and mount this file
+through the installer's optional OAuth/SSO step or the
+[shared config overlay](docker.md#shared-bootstrap-config). For other
+deployments, select the file with `TURNSTONE_CONFIG` on each process.
+
+### Shared config example
+
+Edit the existing `[oidc]` section in place, preserving other sections and
+the token encryption key. Replace the provider placeholders before enabling
+SSO; create a local admin first.
+
+```toml
+[oidc]
+issuer = "https://identity.example.com"
+client_id = "your-client-id"
+client_secret = "your-client-secret"
+redirect_base = "https://app.example.com"
+provider_name = "SSO"
+password_enabled = true
+capture_user_credential = false
+```
+
+SSO login alone does not need refresh-credential capture. For delegation,
+follow [MCP sign-in passthrough](mcp-oauth.md#auth_typeoauth_obo--single-credential-sign-in-passthrough)
+or [model gateway credentials](#model-gateway-credentials). Both reuse this
+file and the shared token encryption key. After changing bootstrap config,
+restart every consumer. For Docker, restart after TOML edits and recreate
+services after changing Compose mounts or environment variables; see the
+[shared config instructions](docker.md#shared-bootstrap-config).
+
+### Environment variable reference
+
+Environment variables remain supported and take precedence over TOML when
+both are set. Keep the client secret in the private TOML file rather than
+inherited process environments. Setting `TURNSTONE_CONFIG` selects that file;
+the installer does not copy OIDC variables from `.env` into the services.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -42,6 +76,8 @@ are set.
 | `TURNSTONE_OIDC_REDIRECT_BASE` | Yes | — | Externally-reachable origin for the OIDC redirect URI (e.g. `https://app.example.com`). Without this, OIDC will refuse to start. The previous Host-header fallback was unsafe under permissive reverse proxies. |
 | `TURNSTONE_OIDC_TRUSTED_ENDPOINT_HOSTS` | No | — | Comma-separated list of additional hostnames whose endpoints the IdP discovery document is allowed to reference. See [Cross-host endpoints](#cross-host-endpoints). |
 | `TURNSTONE_OIDC_ALLOW_PRIVATE_NETWORK` | No | `false` | Allow the issuer (and its discovered endpoints) to resolve to private/internal addresses — needed for a self-hosted IdP on an internal network. See [Self-hosted and internal IdPs](#self-hosted-and-internal-idps). |
+| `TURNSTONE_OIDC_CAPTURE_USER_CREDENTIAL` | No | `false` | Capture an encrypted refresh credential at SSO login for delegated MCP/model access; requires the shared token encryption key. |
+| `TURNSTONE_OIDC_OBO_GRANT_PROFILE` | No | `entra` | Token minting profile supported by the IdP: `entra` or `rfc8693`. See [MCP delegation](mcp-oauth.md#deployment-configuration-oidc-in-configtoml). |
 
 All four required fields — issuer, client ID, client secret, and
 `TURNSTONE_OIDC_REDIRECT_BASE` — must be set. If any are missing OIDC
@@ -50,19 +86,24 @@ is missing) and the login screen shows only the password form.
 
 ### Redirect base (required)
 
-`TURNSTONE_OIDC_REDIRECT_BASE` pins the redirect URI sent to the identity
-provider to a known externally-visible origin. Set it to the public origin
-of your Turnstone deployment:
+`[oidc] redirect_base` (or `TURNSTONE_OIDC_REDIRECT_BASE`) pins the redirect
+URI sent to the identity provider to a known externally-visible origin. Set
+it to the public origin of your Turnstone deployment:
 
-```bash
-TURNSTONE_OIDC_REDIRECT_BASE=https://app.example.com
+```toml
+[oidc]
+redirect_base = "https://app.example.com"
 ```
 
 The resulting callback URL will be
 `https://app.example.com/v1/api/auth/oidc/callback` — register this as the
 authorized redirect URI in your identity provider.
 
-OIDC will refuse to start when this variable is unset. There is no
+Per-user MCP authorization uses the same origin with a different path,
+`/v1/api/mcp/oauth/callback`, registered with the MCP provider. Setting only
+`redirect_base` supports that flow without enabling SSO.
+
+OIDC will refuse to start when this setting is unset. There is no
 Host-header fallback: a permissive reverse proxy or direct backend access
 would otherwise let an attacker spoof `Host` and steer the IdP redirect
 to a callback origin they control.
@@ -92,8 +133,9 @@ on `graph.microsoft.com`, distinct from the issuer host.)
 For other IdPs whose discovery document references a non-issuer host,
 extend the allow-list explicitly:
 
-```bash
-TURNSTONE_OIDC_TRUSTED_ENDPOINT_HOSTS=token.example.com,keys.example.com
+```toml
+[oidc]
+trusted_endpoint_hosts = ["token.example.com", "keys.example.com"]
 ```
 
 The same scheme / no-userinfo / SSRF rules apply to allow-listed hosts —
@@ -133,11 +175,19 @@ reaches, so an IPv6 transition address (NAT64, 6to4, Teredo) wrapping
 an internal IPv4 is treated exactly as that IPv4 would be. The HTTPS
 requirement and the same-origin endpoint checks are unaffected.
 
-This knob only affects the login-flow IdP configured here. OAuth
-endpoints advertised by remote MCP servers are untrusted input and are
-always held to the strict public-address rule.
+This knob only affects the login-flow IdP configured here. OAuth endpoints
+advertised by remote MCP servers use the separate runtime setting
+[`mcp.oauth_allow_private_network`](mcp-oauth.md#mcp-servers-on-a-private-network),
+which also defaults to the strict public-address rule.
 
 ### Model gateway credentials
+
+For Docker, use the same [shared config](docker.md#shared-bootstrap-config)
+for the console and every node. Enable credential capture for users who
+will use delegated models, and have them sign in again. Application identity
+(`entra_app`) uses the registration's own permissions and needs no user
+credential capture. Configure model auth modes and audiences in the admin
+Models tab, following the runtime settings linked below.
 
 The same OIDC registration can authenticate model gateways. A model definition
 with `auth_mode = "entra_obo"` (Entra grant profile) or `auth_mode =
@@ -196,29 +246,14 @@ start; the console starts but withholds its coordinator subsystem and shows
 the key requirement as the remediation error instead of failing silently at
 call time.
 
-### config.toml alternative
-
-```toml
-[oidc]
-issuer = "https://accounts.google.com"
-client_id = "your-client-id"
-client_secret = "your-client-secret"
-scopes = "openid email profile"
-provider_name = "Google"
-role_claim = "groups"
-password_enabled = true
-redirect_base = "https://app.example.com"
-# Self-hosted IdP on an internal network (see "Self-hosted and internal IdPs")
-allow_private_network = false
-
-[oidc.role_map]
-admin = "builtin-admin"
-engineering = "builtin-operator"
-```
-
 ---
 
 ## Provider-Specific Setup
+
+Merge these fields into your existing `[oidc]` section, retaining its
+`redirect_base` and any delegation settings. Role mappings below are examples;
+choose the group/role claims and Turnstone permissions appropriate to your
+organization.
 
 ### Google
 
@@ -230,11 +265,12 @@ engineering = "builtin-operator"
    `https://your-turnstone-host/v1/api/auth/oidc/callback`
 5. Copy the **Client ID** and **Client secret**
 
-```bash
-TURNSTONE_OIDC_ISSUER=https://accounts.google.com
-TURNSTONE_OIDC_CLIENT_ID=123456789.apps.googleusercontent.com
-TURNSTONE_OIDC_CLIENT_SECRET=GOCSPX-...
-TURNSTONE_OIDC_PROVIDER_NAME=Google
+```toml
+[oidc]
+issuer = "https://accounts.google.com"
+client_id = "123456789.apps.googleusercontent.com"
+client_secret = "GOCSPX-..."
+provider_name = "Google"
 ```
 
 ### Okta
@@ -248,13 +284,14 @@ TURNSTONE_OIDC_PROVIDER_NAME=Google
 5. Note the **Issuer** (your Okta domain, e.g.
    `https://dev-123456.okta.com`)
 
-```bash
-TURNSTONE_OIDC_ISSUER=https://dev-123456.okta.com
-TURNSTONE_OIDC_CLIENT_ID=0oaXXXXXXXXXXXXX
-TURNSTONE_OIDC_CLIENT_SECRET=...
-TURNSTONE_OIDC_PROVIDER_NAME=Okta
-TURNSTONE_OIDC_ROLE_CLAIM=groups
-TURNSTONE_OIDC_ROLE_MAP="admin:builtin-admin,everyone:builtin-operator"
+```toml
+[oidc]
+issuer = "https://dev-123456.okta.com"
+client_id = "0oaXXXXXXXXXXXXX"
+client_secret = "..."
+provider_name = "Okta"
+role_claim = "groups"
+role_map = {admin = "builtin-admin", everyone = "builtin-operator"}
 ```
 
 ### Azure AD (Entra ID)
@@ -267,13 +304,14 @@ TURNSTONE_OIDC_ROLE_MAP="admin:builtin-admin,everyone:builtin-operator"
 4. The issuer URL is
    `https://login.microsoftonline.com/{tenant-id}/v2.0`
 
-```bash
-TURNSTONE_OIDC_ISSUER=https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0
-TURNSTONE_OIDC_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-TURNSTONE_OIDC_CLIENT_SECRET=...
-TURNSTONE_OIDC_PROVIDER_NAME="Azure AD"
-TURNSTONE_OIDC_ROLE_CLAIM=roles
-TURNSTONE_OIDC_ROLE_MAP="Admin:builtin-admin,User:builtin-operator"
+```toml
+[oidc]
+issuer = "https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0"
+client_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+client_secret = "..."
+provider_name = "Azure AD"
+role_claim = "roles"
+role_map = {Admin = "builtin-admin", User = "builtin-operator"}
 ```
 
 ### Keycloak
@@ -287,13 +325,14 @@ TURNSTONE_OIDC_ROLE_MAP="Admin:builtin-admin,User:builtin-operator"
 6. The issuer URL is
    `https://keycloak.example.com/realms/your-realm`
 
-```bash
-TURNSTONE_OIDC_ISSUER=https://keycloak.example.com/realms/your-realm
-TURNSTONE_OIDC_CLIENT_ID=turnstone
-TURNSTONE_OIDC_CLIENT_SECRET=...
-TURNSTONE_OIDC_PROVIDER_NAME=Keycloak
-TURNSTONE_OIDC_ROLE_CLAIM=realm_access.roles
-TURNSTONE_OIDC_ROLE_MAP="admin:builtin-admin,operator:builtin-operator"
+```toml
+[oidc]
+issuer = "https://keycloak.example.com/realms/your-realm"
+client_id = "turnstone"
+client_secret = "..."
+provider_name = "Keycloak"
+role_claim = "realm_access.roles"
+role_map = {admin = "builtin-admin", operator = "builtin-operator"}
 ```
 
 ---
@@ -306,17 +345,23 @@ the `builtin-viewer` role (read-only access) by default.
 
 ### Configuration
 
-Set `TURNSTONE_OIDC_ROLE_CLAIM` to the name of the claim in the ID token
-that contains the user's group or role memberships. Then set
-`TURNSTONE_OIDC_ROLE_MAP` to map claim values to Turnstone role IDs.
+Set `[oidc] role_claim` to the name of the claim in the ID token that
+contains the user's group or role memberships. Then map claim values to
+Turnstone role IDs in `role_map`:
 
-The role map is a comma-separated list of `claim_value:turnstone_role`
-pairs:
+```toml
+[oidc]
+role_claim = "groups"
 
-```bash
-TURNSTONE_OIDC_ROLE_CLAIM=groups
-TURNSTONE_OIDC_ROLE_MAP="admin:builtin-admin,engineering:builtin-operator,viewer:builtin-viewer"
+[oidc.role_map]
+admin = "builtin-admin"
+engineering = "builtin-operator"
+viewer = "builtin-viewer"
 ```
+
+The environment equivalent uses `TURNSTONE_OIDC_ROLE_CLAIM=groups` and a
+comma-separated `TURNSTONE_OIDC_ROLE_MAP` such as
+`admin:builtin-admin,engineering:builtin-operator,viewer:builtin-viewer`.
 
 ### Behavior
 
@@ -383,8 +428,9 @@ every login.
 
 To enforce OIDC for all logins and hide the password form, set:
 
-```bash
-TURNSTONE_OIDC_PASSWORD_ENABLED=false
+```toml
+[oidc]
+password_enabled = false
 ```
 
 In this mode the login screen shows only the "Continue with SSO" button.
@@ -526,18 +572,18 @@ callback validation. Entries are automatically cleaned up after 5 minutes.
 
 ### "OIDC not configured"
 
-All four required environment variables must be set:
-`TURNSTONE_OIDC_ISSUER`, `TURNSTONE_OIDC_CLIENT_ID`,
-`TURNSTONE_OIDC_CLIENT_SECRET`, and `TURNSTONE_OIDC_REDIRECT_BASE`.
-Check that none are empty or whitespace-only.
+All four required `[oidc]` fields must be set: `issuer`, `client_id`,
+`client_secret`, and `redirect_base`. Check that none are empty or
+whitespace-only, that `TURNSTONE_CONFIG` selects the intended file, and that
+no environment overrides replace its values.
 
 ### "OIDC enabled but TURNSTONE_OIDC_REDIRECT_BASE is unset"
 
-This error is logged when the three credential variables are set but
-`TURNSTONE_OIDC_REDIRECT_BASE` is missing. OIDC is disabled at startup
-to prevent Host-header-derived redirect URI spoofing. Set the variable
-to your service's externally-visible origin (e.g.
-`https://app.example.com`) and restart the server. See
+This error is logged when the three credential fields are set but
+`redirect_base` is missing from both TOML and the environment. OIDC is
+disabled at startup to prevent Host-header-derived redirect URI spoofing.
+Set `[oidc] redirect_base` to your service's externally-visible origin
+(e.g. `https://app.example.com`) and restart the consumers. See
 [Redirect base](#redirect-base-required) for the rationale.
 
 ### Discovery silently disables OIDC with "host does not match issuer"
@@ -545,7 +591,7 @@ to your service's externally-visible origin (e.g.
 The IdP discovery document points `token_endpoint`, `jwks_uri`, or
 `userinfo_endpoint` at a hostname that doesn't share the issuer's
 origin. If the IdP is legitimate, add the additional hostname(s) to
-`TURNSTONE_OIDC_TRUSTED_ENDPOINT_HOSTS`. Google is allow-listed
+`[oidc] trusted_endpoint_hosts`. Google and Entra endpoints are allow-listed
 automatically; see [Cross-host endpoints](#cross-host-endpoints).
 
 ### "Login session expired"
@@ -587,9 +633,9 @@ The redirect URI configured at the identity provider must exactly match
 
 Check that:
 
-1. `TURNSTONE_OIDC_ROLE_CLAIM` matches the exact claim name in the ID
+1. `[oidc] role_claim` matches the exact claim name in the ID
    token (case-sensitive)
-2. `TURNSTONE_OIDC_ROLE_MAP` maps the correct claim values to valid
+2. `[oidc] role_map` maps the correct claim values to valid
    Turnstone role IDs
 3. The roles referenced in the map exist in the database (check the
    admin panel > Roles tab)

--- a/docs/security.md
+++ b/docs/security.md
@@ -211,25 +211,18 @@ so the browser is immediately authenticated after setup completes.
 
 Turnstone supports OIDC Authorization Code Flow with PKCE for
 single sign-on with external identity providers (Okta, Azure AD,
-Google, etc.). SSO is opt-in — enabled when the three required
-environment variables are set. Users are auto-provisioned on first
-login.
+Google, etc.). SSO is opt-in. Users are auto-provisioned on first login;
+create a local admin before enabling SSO.
 
 #### Configuration
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `TURNSTONE_OIDC_ISSUER` | Yes | OIDC issuer URL (e.g., `https://accounts.google.com`) |
-| `TURNSTONE_OIDC_CLIENT_ID` | Yes | Client ID from the identity provider |
-| `TURNSTONE_OIDC_CLIENT_SECRET` | Yes | Client secret (confidential client) |
-| `TURNSTONE_OIDC_SCOPES` | No | OIDC scopes (default: `openid email profile`) |
-| `TURNSTONE_OIDC_PROVIDER_NAME` | No | Display name for the SSO button (default: `SSO`) |
-| `TURNSTONE_OIDC_ROLE_CLAIM` | No | Claim name in the ID token for role mapping (e.g., `groups`) |
-| `TURNSTONE_OIDC_ROLE_MAP` | No | Comma-separated `claim_value:role_id` pairs (e.g., `admin:builtin-admin,eng:builtin-operator`) |
-| `TURNSTONE_OIDC_PASSWORD_ENABLED` | No | Set to `false` to hide password login and force SSO-only |
-
-OIDC is enabled when all three required variables (`ISSUER`,
-`CLIENT_ID`, `CLIENT_SECRET`) are set.
+Set `issuer`, `client_id`, `client_secret`, and `redirect_base` in the
+`[oidc]` section of the private TOML config shared by the console and nodes.
+Environment variables remain supported and take precedence over TOML.
+See [OIDC configuration](oidc.md#configuration) for the complete reference,
+provider registration, role mapping, and optional credential delegation.
+Docker deployments use the
+[shared config overlay](docker.md#shared-bootstrap-config).
 
 #### Login flow
 

--- a/run.sh
+++ b/run.sh
@@ -13,10 +13,11 @@
 #   4. builds the image
 #   5. picks free host ports for Caddy (prefers 443) and PostgreSQL
 #   6. writes a .env with a generated JWT secret + Postgres password
-#   7. pins the node count and runs `docker compose up -d`, then prints how to
+#   7. optionally creates shared config.toml for OAuth/SSO and delegation
+#   8. pins the choices and runs `docker compose up -d`, then prints how to
 #      finish setup in the UI
 #
-# Re-running is safe: it updates the checkout and keeps an existing .env.
+# Re-running is safe: it updates the checkout and keeps existing .env/config.toml.
 #
 # Env overrides:
 #   TURNSTONE_DIR     where to clone (default: $HOME/turnstone)
@@ -56,7 +57,7 @@ trap on_error ERR
 ask() {
     local prompt="$1" default="${2:-y}" ans hint
     [ "$default" = y ] && hint="Y/n" || hint="y/N"
-    if [ ! -r /dev/tty ]; then
+    if ! ( : </dev/tty ) 2>/dev/null; then
         warn "non-interactive shell; assuming '$default' for: $prompt"
         [ "$default" = y ]; return
     fi
@@ -285,7 +286,7 @@ ensure_compose() {
 NODE_COUNT=10
 
 pick_node_count() {
-    if [ ! -r /dev/tty ]; then
+    if ! ( : </dev/tty ) 2>/dev/null; then
         info "Non-interactive shell — starting the recommended 10-node cluster."
         return
     fi
@@ -310,34 +311,70 @@ EOF
     info "Will start ${NODE_COUNT} server node(s)."
 }
 
-# Pin the chosen count: park nodes above NODE_COUNT behind the "extra" profile in
-# an auto-loaded compose.override.yaml, so a later *plain* `docker compose up -d`
-# keeps the same count (Compose merges compose.override.yaml automatically). A
-# full (10) choice removes the file. Never clobbers an override we didn't write.
-OVERRIDE_MARKER="# turnstone run.sh — node-count limiter (safe to delete)"
-write_node_override() {
-    local f="$INSTALL_DIR/compose.override.yaml" k
-    if [ -f "$f" ] && ! head -1 "$f" 2>/dev/null | grep -qF "$OVERRIDE_MARKER"; then
-        warn "$f exists and isn't managed by this installer — leaving it as-is."
+# Save choices in the auto-loaded override so plain `docker compose up -d`
+# retains both the node count and optional config. Accept the old marker on
+# upgrades, but never replace an override written by the operator.
+OVERRIDE_MARKER="# turnstone run.sh — saved deployment choices"
+LEGACY_OVERRIDE_MARKER="# turnstone run.sh — node-count limiter (safe to delete)"
+CONFIG_MARKER="# Shared bootstrap config enabled."
+CONFIG_ENABLED=0
+managed_override() {
+    local first
+    first="$(head -1 "$INSTALL_DIR/compose.override.yaml" 2>/dev/null || true)"
+    [ "$first" = "$OVERRIDE_MARKER" ] || [ "$first" = "$LEGACY_OVERRIDE_MARKER" ]
+}
+
+find_custom_override() {
+    local f
+    for f in "$INSTALL_DIR"/{compose,docker-compose}.override.{yaml,yml}; do
+        [ -e "$f" ] || [ -L "$f" ] || continue
+        if [ "$f" = "$INSTALL_DIR/compose.override.yaml" ] && [ ! -L "$f" ] && managed_override; then
+            continue
+        fi
+        printf '%s' "$f"
+        return 0
+    done
+    return 1
+}
+
+write_compose_override() {
+    local f="$INSTALL_DIR/compose.override.yaml" k custom
+    if custom="$(find_custom_override)"; then
+        warn "$custom exists and isn't managed by this installer — leaving it as-is."
         warn "A plain 'docker compose up -d' may not match your ${NODE_COUNT}-node choice."
         return
     fi
-    if [ "$NODE_COUNT" -ge 10 ]; then
+    if [ "$NODE_COUNT" -ge 10 ] && [ "$CONFIG_ENABLED" -eq 0 ]; then
         rm -f "$f"
         return
     fi
     {
         echo "$OVERRIDE_MARKER"
-        echo "# Keeps 'docker compose up -d' at ${NODE_COUNT} node(s). Nodes above"
-        echo "# node-${NODE_COUNT} are parked behind the 'extra' profile:"
-        echo "#   docker compose --profile extra up -d        # start all 10"
-        echo "#   docker compose up -d node-$((NODE_COUNT + 1))                 # start one more"
+        [ "$CONFIG_ENABLED" -eq 0 ] || echo "$CONFIG_MARKER"
+        if [ "$NODE_COUNT" -lt 10 ]; then
+            echo "# Nodes above node-${NODE_COUNT} use the 'extra' profile."
+            echo "# docker compose --profile extra up -d  # start all 10"
+        else
+            echo "# All 10 nodes are enabled."
+        fi
         echo "services:"
-        for k in $(seq $((NODE_COUNT + 1)) 10); do
-            printf '  node-%s: { profiles: ["extra"] }\n' "$k"
+        if [ "$CONFIG_ENABLED" -eq 1 ]; then
+            echo "  console:"
+            echo "    extends: { file: compose.config.yaml, service: console }"
+        fi
+        for k in $(seq 1 10); do
+            if [ "$CONFIG_ENABLED" -eq 1 ] || [ "$k" -gt "$NODE_COUNT" ]; then
+                printf '  node-%s:\n' "$k"
+                if [ "$CONFIG_ENABLED" -eq 1 ]; then
+                    printf '    extends: { file: compose.config.yaml, service: node-%s }\n' "$k"
+                fi
+                if [ "$k" -gt "$NODE_COUNT" ]; then
+                    echo '    profiles: ["extra"]'
+                fi
+            fi
         done
     } >"$f"
-    info "Pinned ${NODE_COUNT} node(s) in $f (a later 'docker compose up -d' honors it)."
+    info "Saved deployment choices in $f (a later 'docker compose up -d' honors them)."
 }
 
 # -- ports --------------------------------------------------------------------
@@ -430,6 +467,74 @@ EOF
     info "Wrote $INSTALL_DIR/.env (generated JWT secret + Postgres password, mode 600)."
 }
 
+# -- optional shared bootstrap config -----------------------------------------
+create_shared_config() {
+    local f="$INSTALL_DIR/config.toml" origin="$1" scratch
+    scratch="$(mktemp -d "$INSTALL_DIR/.turnstone-bootstrap.XXXXXX")"
+    # Only the inner directory is mounted. Its writable mode permits remapped
+    # container root to create the file; the outer 0700 directory prevents
+    # other host users from reaching it.
+    mkdir -m 0777 -- "$scratch/output"
+    # Generate inside the image so ownership matches its non-root user,
+    # including Docker user namespace remapping.
+    if ! $DOCKER run --rm --network none --user root --entrypoint python \
+        -v "$scratch/output:/bootstrap:rw,z" turnstone:local \
+        -m turnstone.deploy.bootstrap_config /bootstrap/config.toml "$origin" --owner turnstone; then
+        rm -rf -- "$scratch"
+        die "Could not create shared config. Check the HTTPS origin and Docker's write access to the install directory."
+    fi
+    # Rename within the same filesystem: hard links can be refused when the
+    # image's UID differs from the installing user's UID.
+    if ! mv -nT -- "$scratch/output/config.toml" "$f" || [ -e "$scratch/output/config.toml" ]; then
+        rm -rf -- "$scratch"
+        die "Could not install $f. Check directory permissions and whether the destination already exists."
+    fi
+    rm -rf -- "$scratch"
+    info "Created $f (mode 600, owned by the container's turnstone user). Back it up privately."
+    info "You may need sudo to edit or back up this file on the host."
+}
+
+prepare_shared_config() {
+    local f="$INSTALL_DIR/config.toml" origin custom
+    if custom="$(find_custom_override)"; then
+        warn "Shared-config setup skipped: $custom is managed by you. See docs/docker.md#shared-bootstrap-config."
+        return
+    fi
+    if managed_override && grep -qxF "$CONFIG_MARKER" "$INSTALL_DIR/compose.override.yaml"; then
+        CONFIG_ENABLED=1
+        # Losing the key must never silently generate a replacement on re-run.
+        [ -f "$f" ] || die "Saved config is missing: $f. Restore it from backup before restarting."
+        info "Keeping shared $f (including its encryption key)."
+    elif ask "Prepare shared config.toml for OAuth/SSO (MCP, login, model gateways)?" n; then
+        CONFIG_ENABLED=1
+        if [ ! -e "$f" ] && [ ! -L "$f" ]; then
+            printf 'Dashboard HTTPS origin (e.g. https://turnstone.example.com): ' >/dev/tty
+            read -r origin </dev/tty || die "A dashboard HTTPS origin is required."
+            create_shared_config "$origin"
+        else
+            info "Keeping existing $f without changing its contents or permissions."
+        fi
+    else
+        return 0
+    fi
+    [ -f "$f" ] || die "Shared config must be a regular file: $f."
+    # Check the actual service user's access before saving the mount or starting
+    # services. Suppress parser details because the document contains secrets.
+    if ! $DOCKER run --rm -i --network none --entrypoint python \
+        -v "$f:/run/turnstone/config.toml:ro,z" turnstone:local - <<'PY'
+import sys
+import tomllib
+try:
+    with open("/run/turnstone/config.toml", "rb") as stream:
+        tomllib.load(stream)
+except (OSError, ValueError):
+    sys.exit("Shared config must be valid TOML readable by the container's turnstone user.")
+PY
+    then
+        die "Cannot load $f. Fix its permissions or TOML before re-running; see docs/docker.md."
+    fi
+}
+
 # -- summary ------------------------------------------------------------------
 print_done() {
     local url scale
@@ -473,6 +578,10 @@ ${GREEN}${BOLD}Turnstone is running${RESET} (${NODE_COUNT} node$([ "$NODE_COUNT"
   Troubleshoot  ${DIM}pipx run --spec turnstone turnstone-doctor --dir $INSTALL_DIR${RESET}
                 LLM-backed diagnostics for this install (read-only; needs Python)
 EOF
+    if [ "$CONFIG_ENABLED" -eq 1 ]; then
+        info "Shared config: $INSTALL_DIR/config.toml (read-only in the console and all nodes)."
+        info "Configure OAuth/SSO and delegation: https://github.com/turnstonelabs/turnstone/blob/main/docs/docker.md#shared-bootstrap-config"
+    fi
 }
 
 # -- main ---------------------------------------------------------------------
@@ -497,7 +606,8 @@ main() {
 
     prepare_env
     info "Ports — dashboard (Caddy): ${CADDY_PORT}, PostgreSQL: 127.0.0.1:${PG_PORT}"
-    write_node_override
+    prepare_shared_config
+    write_compose_override
 
     info "Starting the stack…"
     # Plain `up -d` (honoring compose.override.yaml) + --remove-orphans so a
@@ -509,4 +619,6 @@ main() {
     print_done
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/test_docker_config.py
+++ b/tests/test_docker_config.py
@@ -1,0 +1,387 @@
+"""Shared Docker config: key custody, Compose merging, and installer reruns."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import subprocess
+import threading
+import tomllib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from cryptography.fernet import Fernet
+
+from turnstone.deploy.bootstrap_config import create_config
+
+ROOT = Path(__file__).resolve().parents[1]
+STACKS = (ROOT, ROOT / "turnstone/deploy")
+
+
+@pytest.mark.parametrize("mode", ["local", "sso", "entra", "rfc8693"])
+def test_generated_config_loads_in_runtime(tmp_path, monkeypatch, mode):
+    from turnstone.console.server import create_app as create_console_app
+    from turnstone.core import config
+    from turnstone.core.mcp_crypto import load_mcp_token_cipher_config
+    from turnstone.core.oidc import load_oidc_config
+    from turnstone.server import create_app as create_server_app
+
+    path = tmp_path / "config.toml"
+    create_config(path, "https://turnstone.example.com:8443/")
+    # The generated file is ready for local login. Operators can add SSO and
+    # explicitly opt into delegation in its existing [oidc] section.
+    capture = mode in {"entra", "rfc8693"}
+    if mode != "local":
+        with path.open("a") as stream:
+            stream.write(
+                'issuer = "https://identity.example.com"\n'
+                'client_id = "test-client"\n'
+                'client_secret = "test-secret"\n'
+            )
+            if capture:
+                stream.write(f'capture_user_credential = true\nobo_grant_profile = "{mode}"\n')
+    assert path.stat().st_mode & 0o777 == 0o600
+    document = tomllib.loads(path.read_text())
+    cipher = Fernet(document["security"]["mcp_token_encryption_key"])
+    assert cipher.decrypt(cipher.encrypt(b"saved user token")) == b"saved user token"
+    monkeypatch.setenv("TURNSTONE_CONFIG", str(path))
+    monkeypatch.setattr(config, "_config_path", None)
+    monkeypatch.setattr(config, "_cache", None)
+    for key in os.environ:
+        if key.startswith("TURNSTONE_OIDC_"):
+            monkeypatch.delenv(key)
+    assert load_mcp_token_cipher_config() is not None
+    oidc = load_oidc_config()
+    assert oidc.redirect_base == "https://turnstone.example.com:8443"
+    assert oidc.enabled is (mode != "local")
+    assert oidc.password_enabled
+    assert oidc.capture_user_credential is capture
+    assert ("offline_access" in oidc.scopes.split()) is capture
+    assert oidc.obo_grant_profile == (mode if capture else "entra")
+    if mode != "local":
+        assert oidc.issuer == "https://identity.example.com"
+        assert oidc.client_id == "test-client"
+        assert oidc.client_secret == "test-secret"
+    # Exercise both application constructors without starting services or IdP
+    # discovery: each must select the same bootstrap file and auth settings.
+    node = create_server_app(
+        workstreams=MagicMock(),
+        global_queue=queue.Queue(),
+        global_listeners=[],
+        global_listeners_lock=threading.Lock(),
+        skip_permissions=False,
+    )
+    console = create_console_app(collector=MagicMock())
+    assert node.state.oidc_config == oidc
+    assert console.state.oidc_config == oidc
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://turnstone.example.com",
+        "https://",
+        "https://user:pw@example.com",
+        "https://example.com/path",
+        "https://example.com?",
+        "https://example.com#",
+        "https://example.com?x=1",
+        "https://example.com/#fragment",
+        "https://example.com:invalid",
+        "https://example.com:65536",
+        "https://a\nb.com",
+    ],
+)
+def test_invalid_origin_never_creates_file(tmp_path, origin):
+    path = tmp_path / "config.toml"
+    with pytest.raises(ValueError):
+        create_config(path, origin)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("symlink", [False, True])
+def test_generator_never_replaces_existing_key(tmp_path, symlink):
+    saved = tmp_path / "saved.toml"
+    saved.write_text("saved config and encryption key")
+    target = tmp_path / "config.toml" if symlink else saved
+    if symlink:
+        target.symlink_to(saved)
+    with pytest.raises(FileExistsError):
+        create_config(target, "https://turnstone.example.com")
+    assert saved.read_text() == "saved config and encryption key"
+
+
+def test_failed_ownership_change_removes_new_file(tmp_path, monkeypatch):
+    import pwd
+
+    def refused(*_args):
+        raise PermissionError("cannot set owner")
+
+    monkeypatch.setattr(os, "fchown", refused)
+    path = tmp_path / "config.toml"
+    with pytest.raises(PermissionError):
+        create_config(
+            path, "https://turnstone.example.com", owner=pwd.getpwuid(os.getuid()).pw_name
+        )
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("stack", STACKS, ids=["dev", "production"])
+def test_every_config_consumer_uses_same_readonly_file(stack):
+    base = yaml.safe_load((stack / "compose.yaml").read_text())
+    overlay = yaml.safe_load((stack / "compose.config.yaml").read_text())
+    consumers = {
+        name
+        for name in base["services"]
+        if name == "console" or name == "server" or name.startswith("node-")
+    }
+    assert set(overlay["services"]) == consumers
+    for service in overlay["services"].values():
+        assert service["environment"] == {"TURNSTONE_CONFIG": "/run/turnstone/config.toml"}
+        assert service["volumes"] == [
+            {
+                "type": "bind",
+                "source": "./config.toml",
+                "target": "/run/turnstone/config.toml",
+                "read_only": True,
+                "bind": {"create_host_path": False, "selinux": "z"},
+            }
+        ]
+
+
+def compose_config(stack, tmp_path, *overlays, automatic=False):
+    if (
+        not shutil.which("docker")
+        or subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            timeout=15,
+        ).returncode
+    ):
+        pytest.skip("Docker Compose is not installed")
+    env_file = tmp_path / "compose-test.env"
+    env_file.touch()
+    command = [
+        "docker",
+        "compose",
+        "--env-file",
+        str(env_file),
+        "--profile",
+        "extra",
+    ]
+    if not automatic:
+        command.extend(["-f", str(stack / "compose.yaml")])
+    for overlay in overlays:
+        command.extend(["-f", str(stack / overlay)])
+    result = subprocess.run(
+        [*command, "config", "--format", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=stack,
+        env={
+            "PATH": os.environ["PATH"],
+            "TURNSTONE_JWT_SECRET": "test-secret-" * 4,
+            "POSTGRES_PASSWORD": "test-password",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)["services"]
+
+
+@pytest.mark.parametrize("stack", STACKS, ids=["dev", "production"])
+def test_compose_merges_without_losing_identity_or_volumes(stack, tmp_path):
+    base = compose_config(stack, tmp_path)
+    configured = compose_config(stack, tmp_path, "compose.config.yaml")
+    for name, service in base.items():
+        actual = configured[name]
+        original_env = service.get("environment", {})
+        assert actual.get("environment", {}).items() >= original_env.items()
+        assert all(volume in actual.get("volumes", []) for volume in service.get("volumes", []))
+        mounts = [
+            v for v in actual.get("volumes", []) if v["target"] == "/run/turnstone/config.toml"
+        ]
+        if name == "console" or name == "server" or name.startswith("node-"):
+            assert "TURNSTONE_CONFIG" not in original_env
+            assert mounts[0]["source"] == str(stack / "config.toml")
+            assert mounts[0]["read_only"]
+            assert not mounts[0].get("bind", {}).get("create_host_path", False)
+        else:
+            assert not mounts
+
+
+def run_installer_functions(tmp_path, commands, *, accept=True):
+    ask = 'ask() { return "$ASK_RESULT"; }; ' if accept is not None else ""
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; DOCKER=docker_mock; docker_mock() { cat >/dev/null; }; ' + ask + commands,
+            "installer-test",
+            str(ROOT / "run.sh"),
+        ],
+        env={
+            "PATH": os.environ["PATH"],
+            "TURNSTONE_DIR": str(tmp_path),
+            "ASK_RESULT": "0" if accept else "1",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        start_new_session=True,
+    )
+    return result
+
+
+@pytest.mark.parametrize("node_count", [1, 3, 10])
+def test_installer_keeps_config_when_node_count_changes(tmp_path, node_count):
+    # A path containing spaces exercises both Bash and Compose path handling.
+    install = tmp_path / "install with spaces"
+    install.mkdir()
+    for name in ("compose.yaml", "compose.config.yaml"):
+        shutil.copyfile(ROOT / name, install / name)
+    path = install / "config.toml"
+    create_config(path, "https://turnstone.example.com")
+    with path.open("a") as stream:
+        stream.write(
+            'issuer = "https://identity.example.com"\n'
+            'client_id = "test-client"\n'
+            'client_secret = "private-test-client-secret"\n'
+            'capture_user_credential = true\nobo_grant_profile = "rfc8693"\n'
+        )
+    saved = path.read_bytes()
+    result = run_installer_functions(
+        install,
+        f"NODE_COUNT=2; prepare_shared_config; write_compose_override; NODE_COUNT={node_count}; ask() {{ return 1; }}; prepare_shared_config; write_compose_override",
+    )
+    assert result.returncode == 0, result.stderr
+    assert path.read_bytes() == saved
+    assert "private-test-client-secret" not in result.stdout + result.stderr
+    assert (
+        saved.decode().split('mcp_token_encryption_key = "')[1].split('"')[0]
+        not in result.stdout + result.stderr
+    )
+    services = compose_config(install, tmp_path, automatic=True)
+    for name, service in services.items():
+        if name == "console" or name.startswith("node-"):
+            assert service["environment"]["TURNSTONE_CONFIG"] == "/run/turnstone/config.toml"
+            assert any(
+                v["source"] == str(path) and v["read_only"]
+                for v in service["volumes"]
+                if v["type"] == "bind"
+            )
+        if name.startswith("node-"):
+            assert ("extra" in service.get("profiles", [])) == (int(name[5:]) > node_count)
+
+
+def test_installer_decline_keeps_default_stack(tmp_path):
+    result = run_installer_functions(
+        tmp_path, "NODE_COUNT=10; prepare_shared_config; write_compose_override", accept=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "config.toml").exists()
+    assert not (tmp_path / "compose.override.yaml").exists()
+
+
+def test_noninteractive_installer_defaults_to_no_shared_config(tmp_path):
+    result = run_installer_functions(
+        tmp_path, "NODE_COUNT=10; prepare_shared_config; write_compose_override", accept=None
+    )
+    assert result.returncode == 0, result.stderr
+    assert "assuming 'n'" in result.stderr
+    assert not (tmp_path / "config.toml").exists()
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_installer_private_staging_and_no_clobber(tmp_path, existing):
+    path = tmp_path / "config.toml"
+    if existing:
+        path.write_text("existing config\n")
+    result = run_installer_functions(
+        tmp_path,
+        r"""
+docker_mock() {
+    local stage=""
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = -v ]; then stage="${2%:/bootstrap:rw,z}"; break; fi
+        shift
+    done
+    [ "$(stat -c %a "$stage")" = 777 ] || return 1
+    [ "$(stat -c %a "$(dirname "$stage")")" = 700 ] || return 1
+    (umask 077; printf 'new config\n' >"$stage/config.toml")
+}
+create_shared_config https://turnstone.example.com
+""",
+    )
+    assert (result.returncode != 0) == existing, result.stderr
+    assert path.read_text() == ("existing config\n" if existing else "new config\n")
+    if not existing:
+        assert path.stat().st_mode & 0o777 == 0o600
+    assert not list(tmp_path.glob(".turnstone-bootstrap.*"))
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "compose.override.yaml",
+        "compose.override.yml",
+        "docker-compose.override.yaml",
+        "docker-compose.override.yml",
+    ],
+)
+def test_installer_preserves_custom_override(tmp_path, filename):
+    for name in ("compose.yaml", "compose.config.yaml"):
+        shutil.copyfile(ROOT / name, tmp_path / name)
+    create_config(tmp_path / "config.toml", "https://turnstone.example.com")
+    saved = (tmp_path / "config.toml").read_bytes()
+    path = tmp_path / filename
+    original = "services:\n  node-1:\n    environment: { CUSTOM: keep }\n"
+    path.write_text(original)
+    before = compose_config(tmp_path, tmp_path, automatic=True)
+    result = run_installer_functions(
+        tmp_path, "NODE_COUNT=3; prepare_shared_config; write_compose_override"
+    )
+    assert result.returncode == 0, result.stderr
+    assert path.read_text() == original
+    assert (tmp_path / "config.toml").read_bytes() == saved
+    if filename != "compose.override.yaml":
+        assert not (tmp_path / "compose.override.yaml").exists()
+    assert compose_config(tmp_path, tmp_path, automatic=True) == before
+
+
+@pytest.mark.parametrize("target_exists", [False, True])
+def test_installer_preserves_override_symlinks(tmp_path, target_exists):
+    target = tmp_path / "custom.yaml"
+    if target_exists:
+        target.write_text("# turnstone run.sh — saved deployment choices\n")
+    path = tmp_path / "compose.override.yaml"
+    path.symlink_to(target)
+    result = run_installer_functions(
+        tmp_path, "NODE_COUNT=3; prepare_shared_config; write_compose_override"
+    )
+    assert result.returncode == 0, result.stderr
+    assert path.is_symlink()
+    assert target.exists() == target_exists
+    if target_exists:
+        assert target.read_text() == "# turnstone run.sh — saved deployment choices\n"
+
+
+def test_installer_never_regenerates_missing_saved_key(tmp_path):
+    result = run_installer_functions(
+        tmp_path, "NODE_COUNT=10; CONFIG_ENABLED=1; write_compose_override; prepare_shared_config"
+    )
+    assert result.returncode != 0
+    assert "Restore it from backup" in result.stderr
+    assert not (tmp_path / "config.toml").exists()
+
+
+def test_installer_upgrades_legacy_node_override(tmp_path):
+    path = tmp_path / "compose.override.yaml"
+    path.write_text("# turnstone run.sh — node-count limiter (safe to delete)\nservices: {}\n")
+    result = run_installer_functions(tmp_path, "NODE_COUNT=3; write_compose_override")
+    assert result.returncode == 0, result.stderr
+    assert len(yaml.safe_load(path.read_text())["services"]) == 7

--- a/turnstone.example.toml
+++ b/turnstone.example.toml
@@ -155,6 +155,36 @@
 [mcp]
 # config_path = ""             # Path to MCP servers config file (JSON)
 
+# --- Shared authentication (console and every server node) ---
+# See docs/docker.md#shared-bootstrap-config for OAuth, SSO, and delegation.
+# Keep the same key on every process sharing the database. This key is
+# config-file-only: never put it in .env or the admin Settings table.
+
+[security]
+# Encrypts per-user MCP tokens, captured SSO credentials, and model auth tokens.
+# mcp_token_encryption_key = "" # Generate once; keep a private backup
+# python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+
+[oidc]
+# Shared origin for SSO login and per-user MCP OAuth; setting it alone enables neither.
+# redirect_base = "https://turnstone.example.com" # Origin only, no path/query/fragment
+# MCP callback: https://turnstone.example.com/v1/api/mcp/oauth/callback
+# SSO callback: https://turnstone.example.com/v1/api/auth/oidc/callback
+
+# Optional SSO: configure all three fields after creating a local admin.
+# See docs/oidc.md for provider registration and role mapping.
+# issuer = "https://identity.example.com"
+# client_id = "your-client-id"
+# client_secret = "your-client-secret"
+# provider_name = "SSO"
+# password_enabled = true      # Keep local password login available
+
+# Optional SSO delegation to MCP/model backends. Requires the encryption key
+# above, provider permissions, and the grant profile supported by your IdP.
+# See docs/mcp-oauth.md and docs/oidc.md#model-gateway-credentials.
+# capture_user_credential = false # Set true to capture refresh tokens at login
+# obo_grant_profile = "entra"     # "entra" or "rfc8693"
+
 # --- Server (node, console) ---
 
 [server]

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -2611,6 +2611,14 @@
                   >
                 </label>
               </div>
+              <p class="label-hint">
+                <a
+                  href="https://github.com/turnstonelabs/turnstone/blob/main/docs/mcp-oauth.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Authentication choices and setup guide</a
+                >
+              </p>
               <div id="mcp-oauth-fields" hidden>
                 <p id="mcp-obo-note" class="label-hint" hidden>
                   Each user's org sign-in mints an access token for this server

--- a/turnstone/deploy/bootstrap_config.py
+++ b/turnstone/deploy/bootstrap_config.py
@@ -1,0 +1,80 @@
+"""Create shared OAuth/SSO bootstrap config; used by run.sh and Docker operators."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pwd
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from cryptography.fernet import Fernet
+
+
+def create_config(path: Path, origin: str, *, owner: str | None = None) -> None:
+    """Write once, without exposing the key in output or replacing existing config.
+
+    The Docker bootstrap runs as root and assigns the file to the image's
+    service account, including under user-namespace / rootless UID mapping.
+    """
+    origin = origin.rstrip("/")
+    parsed = urlsplit(origin)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+        or "?" in origin
+        or "#" in origin
+        or any(c.isspace() or ord(c) < 32 or ord(c) == 127 for c in origin)
+    ):
+        raise ValueError("Use an HTTPS origin only, such as https://turnstone.example.com")
+    # urlsplit accepts a non-numeric / out-of-range port until this property is read.
+    _ = parsed.port
+    account = pwd.getpwnam(owner) if owner else None
+    content = (
+        "# Shared by the console and every server node. Back up this file privately.\n"
+        "[security]\n"
+        f'mcp_token_encryption_key = "{Fernet.generate_key().decode()}"\n\n'
+        "[oidc]\n"
+        f"redirect_base = {json.dumps(origin, ensure_ascii=False)}\n"
+        "\n# Optional SSO: configure all three fields after creating a local admin.\n"
+        '# issuer = "https://identity.example.com"\n'
+        '# client_id = "your-client-id"\n'
+        '# client_secret = "your-client-secret"\n'
+        "# password_enabled = true\n"
+        "\n# Optional delegation of SSO credentials to MCP/model backends.\n"
+        "# capture_user_credential = false # Opt in explicitly to store refresh tokens\n"
+        '# obo_grant_profile = "entra"    # "entra" or "rfc8693", depending on the IdP\n'
+        "# Setup: docs/docker.md#shared-bootstrap-config and docs/oidc.md\n"
+    )
+    # O_EXCL also refuses symlinks. Set private permissions before writing secrets.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w") as stream:
+            if account:
+                os.fchown(stream.fileno(), account.pw_uid, account.pw_gid)
+            stream.write(content)
+    except BaseException:
+        path.unlink()
+        raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("origin", help="Public HTTPS origin of the Turnstone dashboard")
+    parser.add_argument("--owner", help="File owner inside the container (use turnstone)")
+    args = parser.parse_args()
+    try:
+        create_config(args.path, args.origin, owner=args.owner)
+    except (OSError, ValueError, KeyError) as exc:
+        parser.exit(1, f"Cannot create shared config: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/turnstone/deploy/compose.config.yaml
+++ b/turnstone/deploy/compose.config.yaml
@@ -1,0 +1,15 @@
+# Optional shared bootstrap config. See docs/docker.md#shared-bootstrap-config.
+# docker compose -f compose.yaml -f compose.config.yaml up -d
+services:
+  console: &shared-config
+    environment:
+      TURNSTONE_CONFIG: /run/turnstone/config.toml
+    volumes:
+      - type: bind
+        source: ./config.toml
+        target: /run/turnstone/config.toml
+        read_only: true
+        bind:
+          create_host_path: false
+          selinux: z
+  server: *shared-config


### PR DESCRIPTION
MCP OAuth needs the same encryption key on the console and every node, plus a public callback origin even when Turnstone uses local login. Both Docker stacks now provide an optional read-only `config.toml` overlay and set `TURNSTONE_CONFIG` for those processes.

`run.sh` can prepare a private, service-owned config file and generate the encryption key once. Reruns preserve the file, shared mount, and chosen node count; missing or unreadable saved files fail with recovery guidance. Private staging and no-clobber installation support differing host/container UIDs. The default installation keeps local login and requires no additional config.

The shared setup guide covers personal MCP accounts, OIDC sign-in, delegated MCP/model access, and Entra application identity. SSO and credential capture remain explicit opt-ins. Examples and entry-point links cover remote Docker/GitHub registration, callback URLs, PAT fallback, browser consent for scheduled/channel runs, bare-metal joins, and restart versus recreate behavior.

Fixes #1062
Fixes #1064

Validation:

- 290 focused tests passed; all 37 installer/config tests passed again after the final documentation and message changes. Coverage includes loading local-login/SSO/Entra/RFC 8693 configs through both application constructors, real Compose rendering, all four automatic override filenames, and reruns preserving credentials.
- Real installer probes passed with ordinary and remapped UIDs, checking private staging, service ownership, read-only mounts, and cleanup. A disposable-container probe confirmed that restarting reloads a file replaced by an atomic save.
- Docker image and wheel builds passed and include the bootstrap helper and overlay. Real Git and Docker ignore checks exclude private config files while preserving unrelated fixtures.
- Ruff, ShellCheck, Bash syntax, strict mypy for the helper, TOML examples, and local documentation links passed.

The full suite, authenticated provider browser flows, and separate rootless/SELinux hosts were not exercised. UID mapping was tested in an isolated user namespace without changing the Docker daemon.

