### PR TITLE
fix: retire the resume nudge; user-channel advisories never arm the idle wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ frozen.
 
 ### Fixed
 
+- **Reopening a workstream no longer spends a turn on a memory search, and a
+  message sent while it reopens starts its own turn.** Resuming a workstream
+  with saved memories queued a "check your memories" nudge outside any user
+  turn, and the idle wake delivered it on a synthetic empty turn as soon as
+  the workstream went idle. A message sent while that turn ran was queued and
+  handed to the model at the next tool seam as mid-turn "additional context"
+  instead of starting its own turn; channel sessions hit this on nearly every
+  reopen. The nudge is retired: the immutable memory index and the per-turn
+  memory pointers already put the saved context in front of the model.
+  User-channel advisories no longer arm the idle wake at all, so no advisory
+  can manufacture an empty turn ahead of the user's message. Persisted
+  `resume` turns in existing transcripts still render.
 - **One-shot schedules with a non-UTC offset fired at the wrong time
   (#1096).** A one-shot's `at_time` was stored verbatim as its `next_run`,
   which the due query compares as a string against a UTC clock, so an

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -155,7 +155,7 @@ select a larger-context model, or start a new workstream after memory cleanup.
 ### Nudges
 
 The metacognition layer can nudge the model to save memories at appropriate
-moments (e.g., after a correction or when resuming a workstream). Nudges are
+moments (e.g., after a correction or as a task wraps up). Nudges are
 rate-limited by `nudge_cooldown`. Setting `memory.nudges=false` suppresses both
 live memory pointers and memory-directed nudges; it does not remove the
 immutable initial index or the memory tool.

--- a/tests/test_app_js.py
+++ b/tests/test_app_js.py
@@ -537,7 +537,7 @@ def test_retry_walk_skips_operator_context_cards() -> None:
 
 def test_operator_nudge_labels_use_shared_helper() -> None:
     """Operator-context nudge bubbles collapse the metacognition nudge types
-    (including legacy persisted start turns) to one
+    (including legacy persisted start / resume turns) to one
     'metacognition' category via the shared ``utils.js`` ``operatorSourceLabel``
     helper rather than leaking the raw ``_source`` (the 'operator · start'
     regression).  Both panes call the one helper so they can't drift."""

--- a/tests/test_bash_background_tool.py
+++ b/tests/test_bash_background_tool.py
@@ -588,10 +588,12 @@ def test_failed_wake_preserves_chronology_and_stays_wake_quiescent(session, monk
     """Failed-wake recovery invariants: (a) the re-queued external notice
     keeps its seq, so the retry renders it BEFORE a newer event that
     arrived during the failure; (b) NOTHING wake-eligible remains after
-    the failure — external notices demote to quiet and user-channel
-    advisories are dropped outright, because a re-armed WAKE_PENDING gate
-    plus the zero-backoff worker-exit retry would respawn wake workers in
-    an unbounded hot loop against a persistent failure."""
+    the failure — external notices demote to quiet, because a re-armed
+    WAKE_PENDING gate plus the zero-backoff worker-exit retry would
+    respawn wake workers in an unbounded hot loop against a persistent
+    failure.  A user-channel advisory is not the wake's to deliver at
+    all: it is never drained by the wake and stays queued for the user's
+    next real turn."""
     from turnstone.core.nudge_queue import WAKE_PENDING
 
     calls = {"n": 0}
@@ -614,6 +616,9 @@ def test_failed_wake_preserves_chronology_and_stays_wake_quiescent(session, monk
         "a failed wake must not leave wake-eligible entries (respawn hot loop)"
     )
     assert [t for t, _x in session._nudge_queue.pending(channel="quiet")] == ["watch_triggered"]
+    # The user-channel advisory was never the wake's: still queued for the
+    # user seam, untouched by the failure.
+    assert session._nudge_queue.pending(channel="user") == [("correction", "user advisory")]
     # A NEWER event lands after the failure...
     session._nudge_queue.enqueue("watch_triggered", "poll-5", "any")
     session.deliver_wake_nudge_from_queue()

--- a/tests/test_metacognition.py
+++ b/tests/test_metacognition.py
@@ -22,7 +22,6 @@ from turnstone.core.metacognition import (
     NUDGE_IDLE_TASKS_WAIT_SLOT,
     NUDGE_REPEAT,
     NUDGE_REQUIRED_TOOL,
-    NUDGE_RESUME,
     NUDGE_TOOL_ERROR,
     RepeatDetector,
     detect_completion,
@@ -244,14 +243,14 @@ class TestShouldNudge:
         state: dict[str, float] = {}
         assert should_nudge("correction", state, message_count=1, memory_count=0) is False
 
-    def test_resume_requires_memories(self):
-        state: dict[str, float] = {}
-        assert should_nudge("resume", state, message_count=5, memory_count=0) is False
-        assert should_nudge("resume", state, message_count=5, memory_count=3) is True
+    def test_no_type_fires_on_first_message(self):
+        """Every registered type is a live-conversation heuristic: none
+        fires on the first message, memories or not."""
+        from turnstone.core.metacognition import _NUDGE_MAP
 
-    def test_resume_allowed_on_first_message(self):
-        state: dict[str, float] = {}
-        assert should_nudge("resume", state, message_count=1, memory_count=3) is True
+        for nudge_type in _NUDGE_MAP:
+            state: dict[str, float] = {}
+            assert should_nudge(nudge_type, state, message_count=1, memory_count=3) is False
 
     def test_invalid_type(self):
         state: dict[str, float] = {}
@@ -264,9 +263,6 @@ class TestFormatNudge:
 
     def test_denial(self):
         assert format_nudge("denial") == NUDGE_DENIAL
-
-    def test_resume(self):
-        assert format_nudge("resume") == NUDGE_RESUME
 
     def test_completion(self):
         assert format_nudge("completion") == NUDGE_COMPLETION

--- a/tests/test_nudge_queue.py
+++ b/tests/test_nudge_queue.py
@@ -130,7 +130,7 @@ class TestLenAndClear:
         # Metadata and valid_until ride the demotion; USER_DRAIN delivers.
         from turnstone.core.nudge_queue import USER_DRAIN, WAKE_PENDING
 
-        assert not q.has_pending(WAKE_PENDING - {"user"})  # no 'any' left
+        assert not q.has_pending(WAKE_PENDING)  # no 'any' left; 'user' never arms it
         drained = q.drain(USER_DRAIN)
         assert [(t, x, m) for t, x, m in drained] == [
             ("watch_triggered", "w", {"watch_name": "ci"}),

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10807,7 +10807,7 @@ class TestUserAdvisoryCancelClear:
 
     def test_unexpected_exception_clears_user_advisory_buffer(self, tmp_db):
         session = _make_session()
-        session._queue_user_advisory("resume", "leftover")
+        session._queue_user_advisory("completion", "leftover")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
             patch.object(session, "_stream_response", side_effect=RuntimeError("boom")),
@@ -10979,7 +10979,7 @@ class TestDeliverWakeNudge:
     def test_marks_source_tag_on_synthesized_user_msg(self, tmp_db):
         session = _make_session()
         session._title_generated = True
-        session._queue_user_advisory("denial", "leftover")
+        session._nudge_queue.enqueue("idle_children", "leftover", "any")
         with (
             patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -10996,7 +10996,7 @@ class TestDeliverWakeNudge:
     def test_clears_wake_tag_after_success(self, tmp_db):
         session = _make_session()
         session._title_generated = True
-        session._queue_user_advisory("denial", "x")
+        session._nudge_queue.enqueue("idle_children", "x", "any")
         with (
             patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -11021,9 +11021,9 @@ class TestDeliverWakeNudge:
         """
         session = _make_session()
         session._title_generated = True
-        # NUDGE_DENIAL contains "don't modify that file" — would match
-        # the strong-correction `\bdon'?t\b` pattern if re-detected.
-        session._queue_user_advisory("denial", "don't do that next time")
+        # The body contains "don't" — would match the strong-correction
+        # `\bdon'?t\b` pattern if re-detected.
+        session._nudge_queue.enqueue("idle_children", "don't do that next time", "any")
         # Force enough memory + message context that should_nudge would
         # otherwise fire a fresh correction nudge.
         session.messages.append(turn_from_dict({"role": "user", "content": "earlier"}))
@@ -11037,8 +11037,8 @@ class TestDeliverWakeNudge:
         ):
             session.deliver_wake_nudge_from_queue()
         # No fresh correction entry was enqueued during the wake send.
-        # (The original `denial` entry was drained as the wake's
-        # _reminders payload, not re-queued.)
+        # (The original entry was drained onto the wake turn, not
+        # re-queued.)
         assert all(t != "correction" for t, _ in _user_pending(session))
 
     def test_flushed_user_msg_during_wake_does_not_inherit_source_tag(self, tmp_db):
@@ -11105,7 +11105,7 @@ class TestDeliverWakeNudge:
         still cleared by the ``finally`` block.
         """
         session = _make_session()
-        session._queue_user_advisory("denial", "leftover")
+        session._nudge_queue.enqueue("idle_children", "leftover", "any")
         with (
             patch.object(session, "_visible_memory_count", return_value=0),
             patch.object(session, "_stream_response", side_effect=RuntimeError("boom")),
@@ -11115,7 +11115,9 @@ class TestDeliverWakeNudge:
         # The nudge system turn landed and stays (persistent history).
         msgs = dicts_from_turns(session.messages)
         sys_turns = [m for m in msgs if m.get("role") == "system"]
-        assert any(m["_source"] == "denial" and m["content"] == "leftover" for m in sys_turns)
+        assert any(
+            m["_source"] == "idle_children" and m["content"] == "leftover" for m in sys_turns
+        )
         # No legacy delivered flag anywhere.
         assert all("_reminders_delivered" not in m for m in msgs)
         # Wake tag cleared even on exception (finally block).
@@ -11131,7 +11133,7 @@ class TestDeliverWakeNudge:
 
         session = _make_registered_session()
         session._title_generated = True
-        session._queue_user_advisory("denial", "leftover")
+        session._nudge_queue.enqueue("idle_children", "leftover", "any")
         with (
             patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -11157,7 +11159,7 @@ class TestDeliverWakeNudge:
 
         session = _make_registered_session()
         session._title_generated = True
-        session._queue_user_advisory("denial", "do not do that")
+        session._nudge_queue.enqueue("idle_children", "do not do that", "any")
         with (
             patch.object(session, "_stream_response", return_value=make_result("ok")),
             patch.object(session, "_full_messages", return_value=[]),
@@ -11168,7 +11170,9 @@ class TestDeliverWakeNudge:
         ):
             session.deliver_wake_nudge_from_queue()
         rows = get_storage().load_messages(session._ws_id)
-        sys_rows = [r for r in rows if r.get("role") == "system" and r.get("_source") == "denial"]
+        sys_rows = [
+            r for r in rows if r.get("role") == "system" and r.get("_source") == "idle_children"
+        ]
         assert len(sys_rows) == 1
         assert sys_rows[0]["content"] == "do not do that"
 
@@ -13971,3 +13975,69 @@ class TestWhitespaceOnlyBlanknessGates:
             {"call_id": "wf3", "url": "https://example.com/x", "question": "What?"}
         )
         assert answer == "Error: extraction returned no answer"
+
+
+class TestResumeQueuesNoWakeEligibleNudge:
+    """Reopening a workstream must not queue anything the idle wake could
+    deliver on a synthetic empty turn.
+
+    The retired ``resume`` nudge was queued on the ``"user"`` channel from
+    inside :meth:`ChatSession.resume` — outside any send — and ``"user"``
+    was wake-eligible, so the post-reopen IDLE transition spawned a wake
+    whose empty turn held the worker slot while the user's real message
+    arrived, pushing that message into the next tool seam as a mid-turn
+    interjection.  Two pins: ``resume`` leaves the queue empty, and a
+    ``"user"`` entry never arms the wake gate.
+    """
+
+    def test_resume_leaves_nudge_queue_empty(self, tmp_db):
+        from turnstone.core.nudge_queue import WAKE_PENDING
+
+        first = _make_registered_session()
+        first._title_generated = True
+        with (
+            patch.object(first, "_stream_response", return_value=make_result("ok")),
+            patch.object(first, "_visible_memory_count", return_value=0),
+            patch.object(first, "_emit_state"),
+            patch.object(first, "_print_status_line"),
+            patch.object(first, "_update_token_table"),
+        ):
+            first.send("hello")
+
+        second = _make_session()
+        with patch.object(second, "_visible_memory_count", return_value=3):
+            assert second.resume(first._ws_id) is True
+        assert second._nudge_queue.pending() == []
+        assert not second._nudge_queue.has_pending(WAKE_PENDING)
+
+    def test_user_channel_advisory_never_arms_the_wake_gate(self, tmp_db):
+        from turnstone.core.nudge_queue import USER_DRAIN, WAKE_PENDING
+
+        session = _make_session()
+        session._queue_user_advisory("correction", "watch your step")
+        assert not session._nudge_queue.has_pending(WAKE_PENDING)
+        assert [t for t, _x, _m in session._nudge_queue.drain(USER_DRAIN)] == ["correction"]
+
+    def test_wake_leaves_user_channel_entry_for_the_next_real_turn(self, tmp_db):
+        """A wake earned by an external event does not carry a co-queued
+        user-channel advisory along: the wake drains only the wake-eligible
+        channels, and the advisory waits for the user's next real turn."""
+        from turnstone.core.nudge_queue import WAKE_PENDING
+
+        session = _make_registered_session()
+        session._title_generated = True
+        session._queue_user_advisory("correction", "watch your step")
+        session._nudge_queue.enqueue("watch_triggered", "ci went red", "any")
+        with (
+            patch.object(session, "_stream_response", return_value=make_result("ok")),
+            patch.object(session, "_full_messages", return_value=[]),
+            patch.object(session, "_update_token_table"),
+            patch.object(session, "_print_status_line"),
+            patch.object(session, "_emit_state"),
+            patch.object(session, "_visible_memory_count", return_value=0),
+        ):
+            session.deliver_wake_nudge_from_queue()
+        sources = [t.source for t in session.messages if t.role is Role.SYSTEM]
+        assert sources == ["watch_triggered"]
+        assert session._nudge_queue.pending(channel="user") == [("correction", "watch your step")]
+        assert not session._nudge_queue.has_pending(WAKE_PENDING)

--- a/turnstone/core/idle_nudge_watcher.py
+++ b/turnstone/core/idle_nudge_watcher.py
@@ -95,9 +95,9 @@ def wake_workstream_if_pending(
       retracted).  See the predicate's docstring for the staleness
       argument.
     * nothing gate-eligible under ``WAKE_PENDING`` and no compatible
-      interjection claimed by the worker-exit backstop — tool-only/quiet
-      entries belong to the next tool-result seam, not a synthetic empty user
-      turn (``deliver_wake_nudge_from_queue`` would no-op on them).
+      interjection claimed by the worker-exit backstop — tool-only, user-only
+      and quiet entries belong to their next real seam, not a synthetic empty
+      user turn (``deliver_wake_nudge_from_queue`` would no-op on them).
       ``"wake"``-channel entries (the coordinator idle nudges) ARE
       gate-eligible: the wake is the only seam that can deliver them.  The
       interjection claim is session-owned and lock-safe; it refuses budget,
@@ -216,12 +216,12 @@ class IdleNudgeWatcher:
     :func:`wake_workstream_if_pending` (the shared gate — see its
     docstring for the full gate order).  If the workstream's
     :class:`NudgeQueue` has any drainable entry for the wake's drain
-    gate (``WAKE_PENDING`` — channels ``"user"``, ``"any"`` or
-    ``"wake"``), the gate dispatches via ``session_worker.send`` with a
-    no-op ``enqueue`` callback.  Tool-only entries don't fire the wake —
-    they belong to the next tool-result seam, not a synthetic empty
-    user turn — otherwise every IDLE event with a queued tool advisory
-    would spawn a wake daemon that immediately no-ops at
+    gate (``WAKE_PENDING`` — channels ``"any"`` or ``"wake"``), the gate
+    dispatches via ``session_worker.send`` with a no-op ``enqueue``
+    callback.  Tool-only and user-only entries don't fire the wake —
+    they belong to the next tool-result or user seam, not a synthetic
+    empty user turn — otherwise every IDLE event with a queued tool
+    advisory would spawn a wake daemon that immediately no-ops at
     ``deliver_wake_nudge_from_queue``'s drain guard.
 
     This watcher only covers nudges that are already queued when the

--- a/turnstone/core/metacognition.py
+++ b/turnstone/core/metacognition.py
@@ -82,13 +82,6 @@ NUDGE_DENIAL = (
     "If so, save it as a feedback memory for future sessions."
 )
 
-NUDGE_RESUME = (
-    "This workstream has prior conversation history. Before proceeding, "
-    "use memory(action='search') to check for relevant context — there "
-    "may be saved preferences, project notes, or prior decisions that "
-    "apply to this work."
-)
-
 NUDGE_COMPLETION = (
     "The task may be wrapping up. Consider whether there are learnings, "
     "decisions, or user preferences from this session worth persisting "
@@ -152,7 +145,6 @@ NUDGE_TASK_COMPACTION_RESUME = (
 _NUDGE_MAP: dict[str, str] = {
     "correction": NUDGE_CORRECTION,
     "denial": NUDGE_DENIAL,
-    "resume": NUDGE_RESUME,
     "completion": NUDGE_COMPLETION,
     "tool_error": NUDGE_TOOL_ERROR,
     "repeat": NUDGE_REPEAT,
@@ -190,9 +182,7 @@ _NUDGE_MAP: dict[str, str] = {
 # the same "I don't have access" apologies the memory-advisory gating
 # fixed — while behavioural nudges (repeat, compaction_pending,
 # idle_children, watch_triggered) keep firing.
-MEMORY_NUDGE_TYPES: frozenset[str] = frozenset(
-    {"correction", "denial", "resume", "completion", "tool_error"}
-)
+MEMORY_NUDGE_TYPES: frozenset[str] = frozenset({"correction", "denial", "completion", "tool_error"})
 
 # Nudge types whose copy names a specific tool the model is told to call,
 # mapped to that tool.  ``ChatSession._nudges_enabled`` suppresses a type
@@ -1243,21 +1233,17 @@ def nudge_allowed(
 
     Note the gates this applies that a bare ``_cooldown_allows`` peek
     does NOT: unknown type, ``message_count <= 1``, and the memory-count
-    requirements. A caller
-    that charges budget before consulting THIS function would charge on
-    every one of those refusals.
+    requirement. A caller that charges budget before consulting THIS
+    function would charge on every one of those refusals.
     """
     if nudge_type not in _NUDGE_MAP:
         return False
-    # Resume is the sole nudge allowed on the first message: it describes
-    # rehydrated conversation state, not a live user-message heuristic.
-    if message_count <= 1 and nudge_type != "resume":
+    # Every nudge is a live-conversation heuristic: none fires on the
+    # first message.
+    if message_count <= 1:
         return False
     # Tool error nudge only if there are memories to search
     if nudge_type == "tool_error" and memory_count == 0:
-        return False
-    # Resume nudge only if there are memories to recall.
-    if nudge_type == "resume" and memory_count == 0:
         return False
     # Rate limit: one nudge per type per cooldown window
     last = state.get(nudge_type)

--- a/turnstone/core/nudge_queue.py
+++ b/turnstone/core/nudge_queue.py
@@ -11,7 +11,12 @@ the same queue with an explicit ``channel``; consumers
 each drained nudge as a first-class ``{"role": "system"}`` turn.
 
 Channels:
-    * ``"user"`` — only drains at user-turn seams.
+    * ``"user"`` — only drains at user-turn seams, and never justifies
+      one: every producer enqueues inside the send that drains the entry
+      (or a cancel path clears it), so the channel is NOT a member of
+      :data:`WAKE_PENDING`.  A synthetic empty turn manufactured to
+      deliver a user-turn advisory would race the user's own message
+      into the mid-turn interjection seam.
     * ``"tool"`` — only drains at tool-result seams.
     * ``"any"``  — drains at whichever seam fires first (used for
       wake-trigger-driven nudges that should not be pinned to a
@@ -66,10 +71,14 @@ TOOL_DRAIN: frozenset[str] = frozenset({"tool", "any", "quiet"})
 # The idle-wake GATE (``IdleNudgeWatcher``): which pending channels justify
 # waking an idle workstream.  Deliberately excludes ``"quiet"`` — entries a
 # user cancel demoted must ride the next legitimate seam/wake, never cause
-# one, or Stop is followed seconds later by an autonomous resume.
+# one, or Stop is followed seconds later by an autonomous resume.  Likewise
+# excludes ``"user"`` — those entries advise the user's OWN turn and are
+# queued inside the send that drains them; a wake spent delivering one on a
+# synthetic empty turn would race the user's real message into the
+# interjection seam (the retired resume nudge did exactly that on reopen).
 # ``"wake"`` is a member here and NOWHERE else: the wake is both the only
 # seam that may deliver those entries and a seam they justify.
-WAKE_PENDING: frozenset[str] = frozenset({"user", "any", "wake"})
+WAKE_PENDING: frozenset[str] = frozenset({"any", "wake"})
 # The wake-only channel, named once: the idle-nudge producer's enqueue
 # target, the abandoned-generation drop set (dropped, never demoted — see
 # the channel table above), and the interjection handoff's drop set.

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -7137,14 +7137,6 @@ class ChatSession:
                 message_count=len(self.messages),
             )
 
-        if self._nudges_enabled("resume") and should_nudge(
-            "resume",
-            self._metacog_state,
-            message_count=len(self.messages),
-            memory_count=self._visible_memory_count(),
-            cooldown_secs=self._mem_cfg.nudge_cooldown,
-        ):
-            self._queue_user_advisory("resume", format_nudge("resume"))
         if not fork:
             self._follow_watch_registration(old_ws_id)
         self._init_system_messages()
@@ -20504,9 +20496,14 @@ class ChatSession:
         Drains in ``_emit_pending_user_nudges`` and is appended as a
         first-class ``{"role": "system"}`` turn AFTER the user turn.  Used
         for nudges that respond to the user's message: ``correction``,
-        ``resume``, ``completion``. (``denial`` is user
-        behaviour too, but it responds to a specific TOOL BATCH — it
-        rides the tool channel so it lands with the denied results.)
+        ``completion``. (``denial`` is user behaviour too, but it responds
+        to a specific TOOL BATCH — it rides the tool channel so it lands
+        with the denied results.)
+
+        Every caller runs inside the send that drains the entry: the
+        ``"user"`` channel is not wake-eligible (``WAKE_PENDING``), so an
+        entry queued here can never manufacture a synthetic user turn of
+        its own — it waits for the user's real one.
 
         No-ops while the session is inside a wake-driven turn
         (``_wake_source_tag`` set) so model behaviour during the wake
@@ -20536,9 +20533,8 @@ class ChatSession:
         the system turns sit after the user turn they advise (uniform attach
         rule).  Each drained nudge becomes one ``{"role": "system",
         "_source": <nudge_type>, ...}`` turn via :meth:`_append_system_turn`
-        — the source is the nudge type (``correction`` / ``resume`` /
-        ``completion`` / ``idle_children`` /
-        ``watch_triggered``) and any optional metadata (e.g.
+        — the source is the nudge type (``correction`` / ``completion`` /
+        ``idle_children`` / ``watch_triggered``) and any optional metadata (e.g.
         ``watch_triggered``'s ``watch_name``) rides as sibling keys.
         ``_append_system_turn`` persists each row and fires the live
         ``on_system_turn`` SSE hook so reconnecting / multi-tab consumers
@@ -20855,26 +20851,24 @@ class ChatSession:
                 # ``requeue`` keeps seq (a re-queued poll-4 still renders
                 # before poll-5 on the retry) and the ``valid_until``
                 # predicate (a stale notice stays droppable), while quiet
-                # keeps the entry OUT of the wake gate.  A ``"user"``
-                # advisory is deliberately DROPPED instead: re-queueing it
-                # wake-eligible re-arms ``_retry_pending_wake``'s zero-
-                # backoff worker-exit gate — a repeatable pre-consumption
-                # send failure would respawn wake workers in an unbounded
-                # hot loop (persisting an orphan synthetic user turn per
-                # spin).  Losing a generation-scoped metacog hint on a
-                # rare failed wake is the strictly smaller harm.  A
-                # ``"wake"``-channel idle nudge is DROPPED for the union
-                # of both reasons: quiet would deliver it at the user/tool
-                # seams its channel exists to be invisible to, and
-                # re-queueing it wake-eligible is the same hot loop as the
-                # ``"user"`` case.  Dropping a charged entry is this
+                # keeps the entry OUT of the wake gate.  A
+                # ``"wake"``-channel idle nudge is DROPPED instead, for two
+                # reasons: quiet would deliver it at the user/tool seams
+                # its channel exists to be invisible to, and re-queueing it
+                # wake-eligible would re-arm ``_retry_pending_wake``'s
+                # zero-backoff worker-exit gate — a repeatable
+                # pre-consumption send failure would respawn wake workers
+                # in an unbounded hot loop (persisting an orphan synthetic
+                # user turn per spin).  Dropping a charged entry is this
                 # class's standing fail-closed price; the next genuine
-                # idle bracket re-derives it over fresh reads.
+                # idle bracket re-derives it over fresh reads.  (The wake
+                # drains only ``WAKE_PENDING`` and ``QUIET_DRAIN``, so a
+                # ``"user"`` entry never reaches this arm.)
                 for reminder in undelivered:
                     recovered = entry_by_reminder.get(id(reminder))
                     if recovered is None or not recovered.text:
                         continue
-                    if recovered.channel in ("user", WAKE_CHANNEL):
+                    if recovered.channel == WAKE_CHANNEL:
                         log.debug(
                             "wake_nudge.advisory_dropped ws=%s type=%s channel=%s",
                             self._ws_id[:8],

--- a/turnstone/core/tool_advisory.py
+++ b/turnstone/core/tool_advisory.py
@@ -118,7 +118,6 @@ SYSTEM_TURN_SOURCES: Final = frozenset(
         "skill_hint",
         "correction",
         "denial",
-        "resume",
         "completion",
         "tool_error",
         "repeat",

--- a/turnstone/shared_static/utils.js
+++ b/turnstone/shared_static/utils.js
@@ -67,10 +67,12 @@ export function formatCount(n) {
 const OPERATOR_SOURCE_LABELS = {
   correction: "metacognition",
   denial: "metacognition",
-  resume: "metacognition",
   completion: "metacognition",
-  start: "metacognition",
   repeat: "metacognition",
+  // `start` and `resume` are no longer produced, but persisted rows still
+  // carry them and replay through /history, so they keep their label.
+  start: "metacognition",
+  resume: "metacognition",
   tool_error: "tool error",
   skill_hint: "skill hint",
   idle_children: "idle children",


### PR DESCRIPTION
## What

Reopening a workstream with saved memories queued a "check your memories" metacognition nudge on the user channel from `resume()`, outside any send, and the user channel counted toward the idle-wake gate. The post-reopen IDLE transition therefore spawned a synthetic empty-user wake turn whose only purpose was that nudge. A message sent while that turn held the worker slot was queued and drained at the next tool seam as a mid-turn interjection ("additional context ... incorporate if relevant") instead of starting its own turn. Channel gateways hit the bad ordering on nearly every reopen because the route restores synchronously before the gateway's own send lands; the web UI hit it when the user typed during the reopen wake, and otherwise still gained a bogus empty turn plus a memory-search round in history.

## Fix

- The `resume` nudge is retired. The immutable memory index and the per-turn memory pointers already put the saved context in front of the model, so the nudge was spending a turn to rediscover what the prefix already carries.
- With it gone, every remaining user-channel producer enqueues inside the send that drains it, so the user channel leaves `WAKE_PENDING`: a user-turn advisory can never manufacture a synthetic turn ahead of the user's real message. The wake's failure arm loses its now-unreachable user-channel branch.
- Persisted rows with `_source="resume"` keep their frontend label (same precedent as the retired `start` source). No backend reader validates a persisted source, so no migration.
- Mid-turn interjections are untouched: separate queue, same drain seams, same interjection-owns-the-seam handoff at wake time.

## Tests

- Wake-delivery tests move from a user-channel `denial` fixture to an any-channel one.
- New pins: `resume()` leaves nothing wake-eligible; a user-channel entry never arms the gate; a wake earned by an external event leaves a co-queued user-channel entry for the next real turn.

## Verification

- ruff + mypy clean.
- Full non-live suite: 12957 passed, 28 skipped; `tests/test_session.py` separately: 470 passed.
- One review round: no bug, security, or performance findings; one docstring re-wrap applied.

Pre-existing, unchanged: a user-channel advisory co-queued with an external-event wake now waits for the next real send instead of riding the wake. Every user-channel producer drains in-send, so this is unreachable in production; the new test pins the ordering.
