### PR TITLE
fix: recover empty conversation completions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1748,6 +1748,19 @@ runs, grace-gated).
 
 Every model call streams (#831); retry lives at two stacked layers:
 
+- **Empty completed responses** — interactive and coordinator conversations
+  share the mid-stream retry budget (at most 2 re-issues) for an ordinary
+  `stop` with no answer or tool call, including reasoning-only output.
+  Each re-issue resends the full context and can repeat its latency and cost;
+  the shared limit bounds attempts, not elapsed time.
+  Automatic recovery requires the prepared request to have no server-side
+  tools; otherwise the conversation enters error immediately. Each completed
+  attempt reports usage, including a same-generation Stop after completion.
+  Rejected usage also updates the existing token-budget checks; exhaustion
+  stops recovery and requires approval on the next send. Discarded reasoning
+  stays out of saved history, and retry exhaustion enters error instead of
+  silently becoming idle. Refusals, output limits, native activity, and
+  continuation signals are excluded.
 - **Caller ladders** — `ChatSession._model_turn_with_retry()` (chat
   loop, one ladder per lane) and the agent `_api_call()` (drained via
   `model_turn`) use the same pattern: 4 total attempts (1 initial + 3 retries,
@@ -1781,7 +1794,11 @@ Every model call streams (#831); retry lives at two stacked layers:
   Any partial tool calls are discarded (their JSON would be malformed),
   causing the `send()` loop to exit cleanly.
 - **`"content_filter"`**: warns via `ui.on_error()` that the response was
-  blocked.
+  blocked. Both intent and output-guard judges reject filtered or truncated
+  responses before parsing a verdict, so JSON quoted in refusal text cannot
+  become an approval. Non-empty Chat refusal text converts an ordinary `stop`
+  to this finish reason. An empty nullable Chat refusal field alone does not;
+  explicit filter finishes and Responses refusal events retain their meaning.
 
 Agent sub-sessions (`_run_agent()`) check `finish_reason` on each
 drained turn and stop the agent early on `"length"` or

--- a/tests/test_832_parity.py
+++ b/tests/test_832_parity.py
@@ -90,6 +90,14 @@ def _apply_ruled_deltas(name: str, baseline: dict[str, Any]) -> dict[str, Any]:
             [["thinking_stop", ""]] + retry_theater + [["stream_end", ""], ["stream_discarded", ""]]
         )
 
+    elif name == "finish_only_no_content":
+        # #1070: an ordinary completed response with no answer is rejected.
+        # This scripted adapter reports no prepared-request tool facts, so
+        # the conversation cannot safely reissue it and fails immediately.
+        expected["raised"] = "_EmptyCompletionError"
+        expected["result"] = None
+        expected["ui_events"] = [["stream_end", ""], ["stream_discarded", ""]]
+
     elif name == "think_tags_split_across_chunks":
         # RULED (#832): the COMMITTED content takes the drain's single
         # blank-edge trim when an inline think tag was consumed; the

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -618,13 +618,11 @@ class TestStreamFlushBeforeToolCalls:
             )
 
         # Two scripted turns: the tool round-trip makes send() loop, and
-        # the follow-up turn must carry a real finish reason — the strict
-        # finish gate (RULED, #832) rejects an exhausted iterator that
-        # used to commit as an empty turn.
+        # the follow-up turn must carry an answer and a real finish reason.
         arm_session(
             session,
             stream_content_then_tool(),
-            iter([StreamChunk(finish_reason="stop")]),
+            iter([StreamChunk(content_delta="Done", finish_reason="stop")]),
         )
         with (
             # Prevent real tool execution (e.g., bash) during this test.
@@ -632,14 +630,14 @@ class TestStreamFlushBeforeToolCalls:
         ):
             session.send("test")
 
-        # All content should have been emitted
-        total = "".join(e[1] for e in events if e[0] == "content")
+        # The first turn's complete content precedes its stream_end, including
+        # the carry flush. The tool follow-up gets a separate answer afterward.
+        stream_end_idx = next(i for i, e in enumerate(events) if e[0] == "stream_end")
+        total = "".join(e[1] for e in events[:stream_end_idx] if e[0] == "content")
         assert total == "Hello world, this is a test message"
 
-        # No content events after stream_end
-        stream_end_idx = next(i for i, e in enumerate(events) if e[0] == "stream_end")
         late_content = [e for e in events[stream_end_idx + 1 :] if e[0] == "content"]
-        assert late_content == [], f"Content after stream_end: {late_content}"
+        assert late_content == [("content", "Done")]
 
 
 class TestStreamAbort:

--- a/tests/test_empty_completion.py
+++ b/tests/test_empty_completion.py
@@ -1,0 +1,718 @@
+"""Completed no-answer responses must not silently park a conversation (#1070)."""
+
+import json
+from contextlib import contextmanager
+from dataclasses import replace
+from unittest.mock import patch
+
+import anthropic
+import httpx
+import httpx2
+import pytest
+from openai import APIConnectionError, OpenAI
+
+from tests._session_helpers import (
+    NullUI,
+    RecordingUI,
+    make_registered_session,
+    replace_session_lane,
+)
+from turnstone.core.memory import load_last_error
+from turnstone.core.providers import create_provider
+from turnstone.core.session import ConversationPersistenceError, GenerationCancelled
+from turnstone.core.trajectory import dicts_from_turns
+from turnstone.core.workstream import WorkstreamKind
+
+_REASONING = "private reasoning sentinel: inspect the completed child and"
+_KINDS = [WorkstreamKind.INTERACTIVE, WorkstreamKind.COORDINATOR]
+# Runtime sample for recovery; every shape in _EMPTY_SHAPES is recoverable.
+_RECOVERY_SHAPES = [
+    ("separate", True),
+    ("separate", False),
+    ("inline", False),
+]
+_EMPTY_SHAPES = _RECOVERY_SHAPES + [
+    ("unclosed", False),
+    ("empty", True),
+    ("whitespace", False),
+]
+
+
+class _UsageUI(RecordingUI):
+    def on_status(self, usage, context_window, effort):
+        self._rec("status", usage)
+
+
+class _CounterUI(NullUI):
+    def __init__(self):
+        super().__init__()
+        self.stream_ends = 0
+        self.stream_discards = 0
+
+    def on_state_change(self, state):
+        pass
+
+    def on_stream_end(self):
+        self.stream_ends += 1
+        super().on_stream_end()
+
+    def on_stream_discarded(self):
+        self.stream_discards += 1
+        super().on_stream_discarded()
+
+
+def _wire(shape, *, finish="stop"):
+    delta = {"content": ""}
+    if shape == "separate":
+        delta["reasoning_content"] = _REASONING
+    elif shape == "inline":
+        delta["content"] = f"<think>{_REASONING}</think>"
+    elif shape == "unclosed":
+        delta["content"] = f"<think>{_REASONING}"
+    elif shape == "whitespace":
+        delta["content"] = " \n\t"
+    elif shape == "answer":
+        delta["content"] = "The work is complete."
+    elif shape == "literal":
+        delta["content"] = "<think>literal text</think>"
+    elif shape == "death":
+        delta["reasoning_content"] = _REASONING
+    elif shape == "tool":
+        delta["tool_calls"] = [
+            {
+                "index": 0,
+                "id": "call-once",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ]
+        finish = "tool_calls"
+    elif shape == "refusal":
+        delta["refusal"] = "Cannot help."
+    header = {
+        "id": "scope-response",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "served-model",
+    }
+    chunks = [
+        {**header, "choices": [{"index": 0, "delta": delta, "finish_reason": None}]},
+        {
+            **header,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish}],
+            "usage": {"prompt_tokens": 24038, "completion_tokens": 43, "total_tokens": 24081},
+        },
+    ]
+    if shape == "death":
+        chunks = chunks[:1]
+    return "".join("data: " + json.dumps(chunk) + "\n\n" for chunk in chunks) + "data: [DONE]\n\n"
+
+
+def _native_wire(family, shape):
+    text = {
+        "answer": "The work is complete.",
+        "separate": _REASONING,
+        "inline": f"<think>{_REASONING}</think>",
+        "unclosed": f"<think>{_REASONING}",
+        "whitespace": " \n\t",
+        "literal": "<think>literal text</think>",
+    }[shape]
+    if family == "openai":
+        output = (
+            {
+                "type": "message",
+                "id": "msg",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+            if shape != "separate"
+            else {
+                "type": "reasoning",
+                "id": "reason",
+                "summary": [{"type": "summary_text", "text": text}],
+            }
+        )
+        events = [
+            {
+                "type": "response.completed",
+                "sequence_number": 1,
+                "response": {
+                    "id": "response",
+                    "object": "response",
+                    "created_at": 0,
+                    "model": "served-model",
+                    "status": "completed",
+                    "output": [output],
+                    "usage": {"input_tokens": 24038, "output_tokens": 43, "total_tokens": 24081},
+                },
+            }
+        ]
+    else:
+        kind = "thinking" if shape == "separate" else "text"
+        events = [
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "message",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "served-model",
+                    "content": [],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 24038, "output_tokens": 0},
+                },
+            },
+            {"type": "content_block_start", "index": 0, "content_block": {"type": kind, kind: ""}},
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": kind + "_delta", kind: text},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 43},
+            },
+            {"type": "message_stop"},
+        ]
+    return "".join(
+        "event: " + event["type"] + "\ndata: " + json.dumps(event) + "\n\n" for event in events
+    )
+
+
+@contextmanager
+def _session(
+    kind,
+    shapes,
+    *,
+    server_parses=True,
+    native=False,
+    finish="stop",
+    ui=None,
+    family="openai-compatible",
+):
+    requests = []
+    http = httpx if family == "anthropic-compatible" else httpx2
+    client_type = anthropic.Anthropic if family == "anthropic-compatible" else OpenAI
+
+    def respond(request):
+        endpoint = {
+            "openai-compatible": "chat/completions",
+            "openai": "responses",
+            "anthropic-compatible": "messages",
+        }[family]
+        assert request.url.path == "/v1/" + endpoint
+        requests.append(json.loads(request.content))
+        index = len(requests) - 1
+        assert index < len(shapes), "unexpected additional provider request"
+        return http.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=(
+                _wire(shapes[index], finish=finish)
+                if family == "openai-compatible"
+                else _native_wire(family, shapes[index])
+            ),
+        )
+
+    ui = ui or _UsageUI()
+    with client_type(
+        api_key="test-only",
+        base_url=(
+            "https://provider.example.com"
+            if family == "anthropic-compatible"
+            else "https://provider.example.com/v1"
+        ),
+        http_client=http.Client(transport=http.MockTransport(respond)),
+        max_retries=0,
+    ) as client:
+        session = make_registered_session(ui=ui, user_id="empty-response-user", kind=kind)
+        session._title_generated = True
+        session._RETRY_BASE_DELAY = 0
+        provider = create_provider(family)
+        replace_session_lane(
+            session,
+            provider=provider,
+            client=client,
+            model="served-model",
+            capabilities=replace(
+                provider.get_capabilities("served-model"),
+                server_parses_reasoning=server_parses,
+                supports_web_search=native,
+            ),
+        )
+        yield session, ui, requests
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+@pytest.mark.parametrize("shape,server_parses", _EMPTY_SHAPES)
+def test_empty_completion_exhaustion(tmp_db, kind, shape, server_parses):
+    with (
+        _session(kind, [shape] * 3, server_parses=server_parses) as (session, ui, requests),
+        pytest.raises(RuntimeError, match="no answer"),
+    ):
+        session.send("Continue the requested work.")
+
+    assert len(requests) == 3
+    assert ui.of("state")[-1] == "error"
+    assert not [turn for turn in session.messages if turn.role == "assistant"]
+    assert ui.kinds().count("stream_end") == 3
+    assert ui.kinds().count("stream_discarded") == 3
+    assert ui.kinds().count("turn_committed") == 0
+    assert len(ui.of("status")) == 3
+    assert sum(usage["completion_tokens"] for usage in ui.of("status")) == 129
+    assert {usage["model"] for usage in ui.of("status")} == {"served-model"}
+    error = load_last_error(session.ws_id)
+    assert error and "no answer" in error
+    assert _REASONING not in error
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+@pytest.mark.parametrize("shape,server_parses", _RECOVERY_SHAPES)
+def test_empty_completion_recovers_once(tmp_db, kind, shape, server_parses):
+    with _session(kind, [shape, "answer"], server_parses=server_parses) as (session, ui, requests):
+        session.send("Continue the requested work.")
+
+    assert len(requests) == 2
+    assert requests[0] == requests[1]
+    assert ui.of("state")[-1] == "idle"
+    assistant = [turn for turn in dicts_from_turns(session.messages) if turn["role"] == "assistant"]
+    assert len(assistant) == 1
+    assert assistant[0]["content"] == "The work is complete."
+    assert ui.kinds().count("turn_committed") == 1
+    assert ui.kinds().count("stream_discarded") == 1
+    assert ui.kinds().count("stream_end") == 2
+    assert len(ui.of("status")) == 2
+    assert not load_last_error(session.ws_id)
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_stop_in_empty_backoff_preserves_marker(tmp_db, kind):
+    with _session(kind, ["separate"]) as (session, ui, requests):
+        original_backoff = session._backoff_or_cancelled
+
+        def stop_in_backoff(delay, generation):
+            session.cancel()
+            original_backoff(delay, generation)
+
+        with patch.object(session, "_backoff_or_cancelled", side_effect=stop_in_backoff):
+            session.send("Continue the requested work.")
+
+    assert len(requests) == 1
+    assert ui.of("state")[-1] == "idle"
+    assistant = [turn for turn in dicts_from_turns(session.messages) if turn["role"] == "assistant"]
+    assert len(assistant) == 1
+    assert "cancel" in assistant[0]["content"].lower()
+    assert _REASONING not in assistant[0]["content"]
+    assert len(ui.of("status")) == 1
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+@pytest.mark.parametrize("family", ["openai-compatible", "openai", "anthropic-compatible"])
+def test_server_parsed_literal_tags_are_an_answer(tmp_db, kind, family):
+    with _session(kind, ["literal"], family=family) as (session, ui, requests):
+        session.send("Explain the literal tags.")
+    assert len(requests) == 1
+    assert session.messages[-1].text == "<think>literal text</think>"
+    assert not ui.of("error")
+
+
+@pytest.mark.parametrize("finish", ["length", "content_filter", "unknown_stop"])
+def test_nonordinary_finish_does_not_reissue(tmp_db, finish):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"], finish=finish) as (
+        session,
+        ui,
+        requests,
+    ):
+        session.send("Continue the requested work.")
+    assert len(requests) == 1
+    assert "stream_discarded" not in ui.kinds()
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_native_search_empty_completion_is_not_reissued(tmp_db, kind):
+    # Keep this tool visible in both kinds; the adapter replaces it with
+    # web_search_options={}, whose empty value still enables native search.
+    with (
+        _session(kind, ["separate"], native=True) as (session, ui, requests),
+        patch.object(
+            session,
+            "_get_active_tools",
+            return_value=[
+                {
+                    "type": "function",
+                    "function": {"name": "web_search", "parameters": {}},
+                }
+            ],
+        ),
+        pytest.raises(RuntimeError, match="server-side tools"),
+    ):
+        session.send("Continue the requested work.")
+    assert len(requests) == 1
+    assert requests[0]["web_search_options"] == {}
+    assert ui.of("state")[-1] == "error"
+    assert len(ui.of("status")) == 1
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_deferred_client_tools_do_not_disable_empty_recovery(tmp_db, kind):
+    with _session(kind, ["separate", "answer"]) as (session, ui, requests):
+        replace_session_lane(
+            session,
+            capabilities=replace(session._get_capabilities(), supports_tool_search=True),
+        )
+        with (
+            patch.object(
+                session,
+                "_get_active_tools",
+                return_value=[
+                    {"type": "function", "function": {"name": "lookup", "parameters": {}}}
+                ],
+            ),
+            patch.object(session, "_get_deferred_names", return_value=frozenset({"lookup"})),
+        ):
+            session.send("Continue the requested work.")
+    assert len(requests) == 2
+    assert requests[0] == requests[1]
+    assert requests[0]["tools"][0]["defer_loading"] is True
+    assert session.messages[-1].text == "The work is complete."
+    assert ui.kinds().count("stream_end") == 2
+
+
+def test_empty_recovery_surfaces_recreate_connection_failure(tmp_db):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"]) as (session, ui, requests):
+        session._MAX_RETRIES = 0
+        provider = session._primary_lane().provider
+        create = provider.create_streaming
+        error = APIConnectionError(
+            request=httpx2.Request("POST", "https://provider.example.com/v1/chat/completions")
+        )
+
+        def recreate(**kwargs):
+            if requests:
+                raise error
+            return create(**kwargs)
+
+        with (
+            patch.object(provider, "create_streaming", side_effect=recreate) as attempts,
+            pytest.raises(APIConnectionError) as caught,
+        ):
+            session.send("Continue the requested work.")
+    assert caught.value is error
+    assert attempts.call_count == 2
+    assert len(requests) == 1
+    assert ui.kinds().count("stream_end") == 1
+    assert ui.kinds().count("stream_discarded") == 1
+    assert not any("no answer" in message for message in ui.of("error"))
+
+
+def test_unknown_request_posture_is_not_assumed_safe(tmp_db):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"]) as (session, ui, requests):
+        provider = session._primary_lane().provider
+        original = provider.create_streaming
+
+        def without_metrics(**kwargs):
+            kwargs.pop("request_metrics_ref", None)
+            return original(**kwargs)
+
+        with (
+            patch.object(provider, "create_streaming", side_effect=without_metrics),
+            pytest.raises(RuntimeError, match="server-side tools"),
+        ):
+            session.send("Continue the requested work.")
+    assert len(requests) == 1
+    assert ui.of("state")[-1] == "error"
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        ["death", "separate", "separate"],
+        ["separate", "death", "separate"],
+    ],
+)
+def test_stream_death_and_empty_completion_share_one_budget(tmp_db, shapes):
+    with (
+        _session(WorkstreamKind.INTERACTIVE, shapes) as (session, ui, requests),
+        pytest.raises(RuntimeError, match="no answer"),
+    ):
+        session.send("Continue the requested work.")
+    assert len(requests) == 3
+    assert ui.of("state")[-1] == "error"
+    assert len(ui.of("status")) == 2
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_empty_recovery_does_not_repeat_committed_tools(tmp_db, kind):
+    with (
+        _session(kind, ["tool", "separate", "answer"]) as (session, ui, requests),
+        patch.object(
+            session,
+            "_execute_tools",
+            return_value=(
+                [("call-once", "lookup receipt")],
+                "",
+            ),
+        ) as execute,
+    ):
+        session.send("Look it up and report back.")
+    execute.assert_called_once()
+    assert len(requests) == 3
+    assert requests[1] == requests[2]
+    assert sum(turn.role == "tool" for turn in session.messages) == 1
+    assert session.messages[-1].text == "The work is complete."
+
+
+def test_refusal_survives_the_main_loop(tmp_db):
+    with _session(WorkstreamKind.INTERACTIVE, ["refusal"]) as (session, ui, requests):
+        session.send("Continue the requested work.")
+    assert len(requests) == 1
+    assert session.messages[-1].text == "[Refused: Cannot help.]"
+    assert ui.of("error")
+    assert "stream_discarded" not in ui.kinds()
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+@pytest.mark.parametrize("stage", ["rejection", "usage", "usage_cancelled"])
+def test_stop_during_empty_rejection_finalizes_display_and_preserves_marker(tmp_db, stage, kind):
+    with _session(kind, ["separate"]) as (session, ui, requests):
+        target = session if stage == "rejection" else ui
+        method = "_remember_serving_failure_context" if stage == "rejection" else "on_status"
+        original = getattr(target, method)
+
+        def stop_at_rejection(*args):
+            original(*args)
+            session.cancel()
+            if stage == "usage_cancelled":
+                raise GenerationCancelled()
+
+        with patch.object(target, method, stop_at_rejection):
+            session.send("Continue the requested work.")
+    assert len(requests) == 1
+    assert session.messages[-1].text == "[generation cancelled before completion]"
+    assert ui.kinds().count("stream_end") == 1
+    assert len(ui.of("status")) == 1
+    assert ui.of("status")[0]["total_tokens"] == 24081
+    assert not ui.of("error")
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_stop_during_armed_transport_death_records_one_marker(tmp_db, kind):
+    with _session(kind, ["death"]) as (session, ui, requests):
+        remember = session._remember_serving_failure_context
+
+        def stop_at_death(error, lane):
+            remember(error, lane)
+            session.cancel()
+
+        with patch.object(session, "_remember_serving_failure_context", stop_at_death):
+            session.send("Continue the requested work.")
+    assert len(requests) == 1
+    assistant = [turn.text for turn in session.messages if turn.role == "assistant"]
+    assert assistant == ["[generation cancelled before completion]"]
+    assert ui.kinds().count("stream_end") == 1
+    assert not ui.of("error")
+
+
+@pytest.mark.parametrize("error_type", [RuntimeError, KeyboardInterrupt])
+@pytest.mark.parametrize("stop", [False, True])
+def test_rejected_usage_callback_failure_finalizes_then_reraises(tmp_db, error_type, stop):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"]) as (session, ui, requests):
+        error = error_type("status callback failed")
+
+        def fail_status(*args):
+            assert session._generation_lock._is_owned()
+            if stop:
+                session.cancel()
+            raise error
+
+        with patch.object(ui, "on_status", fail_status), pytest.raises(error_type) as caught:
+            session.send("Continue the requested work.")
+    assert caught.value is error
+    assert len(requests) == 1
+    assert ui.kinds().count("stream_end") == 1
+    assert ui.kinds().count("stream_discarded") == 1
+    assert not [turn for turn in session.messages if turn.role == "assistant"]
+    assert session._cancelled_partial_msg is None
+
+
+@pytest.mark.parametrize("invalidate", ["supersede", "close"])
+def test_rejected_usage_failure_cannot_finalize_a_successor(tmp_db, invalidate):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"]) as (session, ui, requests):
+        session._generation = 1
+        error = RuntimeError("status callback failed")
+        at_invalidation = []
+
+        def fail_status(*args):
+            if invalidate == "supersede":
+                session._generation += 1
+            else:
+                session._publication_shutdown = True
+            at_invalidation.extend(ui.events)
+            raise error
+
+        with patch.object(ui, "on_status", fail_status), pytest.raises(RuntimeError) as caught:
+            session._stream_response(1)
+    assert caught.value is error
+    assert len(requests) == 1
+    assert ui.events == at_invalidation
+    assert session._cancelled_partial_msg is None
+
+
+def test_rejected_usage_preserves_conversation_persistence_failure(tmp_db):
+    ui = _CounterUI()
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"], ui=ui) as (session, _, requests):
+        error = ConversationPersistenceError("unresolved conversation boundary")
+        remember = session._remember_serving_failure_context
+
+        def poison_at_rejection(exc, lane):
+            remember(exc, lane)
+            session._conversation_persistence_error = error
+
+        with (
+            patch.object(session, "_remember_serving_failure_context", poison_at_rejection),
+            pytest.raises(ConversationPersistenceError) as caught,
+        ):
+            session.send("Continue the requested work.")
+    assert caught.value is error
+    assert session._conversation_persistence_error is error
+    assert len(requests) == 1
+    assert ui.stream_ends == ui.stream_discards == 1
+    assert not [turn for turn in session.messages if turn.role == "assistant"]
+    assert session._cancelled_partial_msg is None
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_rejected_usage_enforces_budget_before_retry_and_next_send(tmp_db, kind):
+    with _session(kind, ["separate"]) as (session, ui, requests):
+        session._token_budget = 1000
+        with pytest.raises(RuntimeError, match="no answer"):
+            session.send("Continue the requested work.")
+        assert len(requests) == 1
+        assert session._budget_warned
+        assert session._budget_exhausted
+        assert len(ui.of("status")) == 1
+        assert not [turn for turn in session.messages if turn.role == "assistant"]
+        with patch.object(ui, "approve_tools", return_value=(False, "")) as approve:
+            session.send("Try again.")
+        assert len(requests) == 1
+        approve.assert_called_once()
+        assert approve.call_args.args[0][0]["func_name"] == "__budget_override__"
+
+
+@pytest.mark.parametrize("budget", [0, 30000])
+def test_rejected_usage_preserves_per_completion_budget_semantics(tmp_db, budget):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"] * 3) as (session, ui, requests):
+        session._token_budget = budget
+        with pytest.raises(RuntimeError, match="no answer"):
+            session.send("Continue the requested work.")
+        assert len(requests) == 3
+        assert len(ui.of("status")) == 3
+        assert not session._budget_exhausted
+        assert session._budget_warned is (budget > 0)
+
+
+@pytest.mark.parametrize("invalidate", ["supersede", "close"])
+def test_invalidated_empty_attempt_cannot_publish_or_retry(tmp_db, invalidate):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate"]) as (session, ui, requests):
+        session._generation = 1
+        remember = session._remember_serving_failure_context
+        at_invalidation = []
+
+        def invalidate_at_rejection(error, lane):
+            remember(error, lane)
+            if invalidate == "supersede":
+                session._generation += 1
+            else:
+                session._publication_shutdown = True
+            at_invalidation.extend(ui.events)
+
+        with (
+            patch.object(session, "_remember_serving_failure_context", invalidate_at_rejection),
+            pytest.raises((GenerationCancelled, RuntimeError)),
+        ):
+            session._stream_response(1)
+    assert len(requests) == 1
+    assert ui.events == at_invalidation
+    assert not ui.of("status")
+    assert session._cancelled_partial_msg is None
+
+
+@pytest.mark.parametrize("storage_fails", [False, True])
+def test_rejected_usage_reaches_live_counters_and_storage_outside_generation_lock(
+    tmp_db, storage_fails
+):
+    from turnstone.core.storage import get_storage
+
+    ui = _CounterUI()
+    storage = get_storage()
+    write_usage = storage.record_usage_event
+    writes = []
+    with _session(WorkstreamKind.INTERACTIVE, ["separate", "answer"], ui=ui) as (
+        session,
+        _,
+        requests,
+    ):
+
+        def record_usage(**kwargs):
+            assert not session._generation_lock._is_owned()
+            writes.append(kwargs)
+            if storage_fails:
+                raise RuntimeError("usage reporting sink failed")
+            write_usage(**kwargs)
+
+        with patch.object(storage, "record_usage_event", side_effect=record_usage):
+            session.send("Continue the requested work.")
+    assert len(requests) == len(writes) == 2
+    assert ui.stream_ends == 2
+    assert ui.stream_discards == 1
+    assert ui._ws_prompt_tokens == 24038 * 2
+    assert ui._ws_completion_tokens == 43 * 2
+    assert {row["model"] for row in writes} == {"served-model"}
+
+
+def test_recovery_after_lane_rebind_reports_the_actual_serving_model(tmp_db):
+    with _session(WorkstreamKind.INTERACTIVE, ["separate", "answer"]) as (session, ui, requests):
+        original_backoff = session._backoff_or_cancelled
+
+        def rebind_in_backoff(delay, generation):
+            replace_session_lane(session, model="replacement-model", alias="replacement")
+            original_backoff(delay, generation)
+
+        with patch.object(session, "_backoff_or_cancelled", side_effect=rebind_in_backoff):
+            session.send("Continue the requested work.")
+    assert [request["model"] for request in requests] == ["served-model", "replacement-model"]
+    assert [usage["model"] for usage in ui.of("status")] == ["served-model", "replacement-model"]
+    assert session.messages[-1].meta.extra["provenance"]["backend_model_id"] == "replacement-model"
+
+
+@pytest.mark.parametrize("family", ["openai", "anthropic-compatible"])
+@pytest.mark.parametrize("kind", _KINDS)
+@pytest.mark.parametrize("recovers", [True, False])
+@pytest.mark.parametrize(
+    "shape,server_parses", [pair for pair in _EMPTY_SHAPES if pair[0] != "empty"]
+)
+def test_native_reasoning_only_completion_uses_the_same_recovery(
+    tmp_db, family, kind, recovers, shape, server_parses
+):
+    shapes = [shape, "answer"] if recovers else [shape] * 3
+    with _session(kind, shapes, family=family, server_parses=server_parses) as (
+        session,
+        ui,
+        requests,
+    ):
+        if recovers:
+            session.send("Continue the requested work.")
+        else:
+            with pytest.raises(RuntimeError, match="no answer"):
+                session.send("Continue the requested work.")
+    assert len(requests) == len(shapes)
+    assert len(ui.of("status")) == len(shapes)
+    assert ui.of("state")[-1] == ("idle" if recovers else "error")
+    assert sum(turn.role == "assistant" for turn in session.messages) == int(recovers)
+    if recovers:
+        assert session.messages[-1].text == "The work is complete."
+        assert requests[0] == requests[1]

--- a/tests/test_history_truncation_handoff.py
+++ b/tests/test_history_truncation_handoff.py
@@ -804,7 +804,7 @@ def test_truncation_counts_only_durable_rows_across_live_only_turns(
 ) -> None:
     """A live-only empty assistant turn must not cost an older durable row.
 
-    The empty completion flows through the real provider path so the
+    An output-limited empty completion flows through the real provider path so the
     admission-site ``no_durable_row`` marker — not test scaffolding — carries
     the live/durable asymmetry into the cut accounting.
     """
@@ -817,7 +817,7 @@ def test_truncation_counts_only_durable_rows_across_live_only_turns(
     arm_session(
         session,
         iter([StreamChunk(content_delta="first answer", finish_reason="stop")]),
-        iter([StreamChunk(finish_reason="stop")]),
+        iter([StreamChunk(finish_reason="length")]),
     )
     session.send("first request")
     session.send("second request")

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -380,11 +380,12 @@ class TestErrorHandling:
         )
         assert result is None
 
-    def test_empty_content_length_stop_no_retry(self):
-        """When finish_reason is 'length', don't retry — return None immediately."""
+    @pytest.mark.parametrize("finish", ["length", "content_filter"])
+    def test_empty_content_nonrecoverable_stop_no_retry(self, finish):
+        """Output limits and safety filters stop the empty-response ladder."""
         provider = _make_mock_provider(response_content="")
         result_mock = _mock_result("", None)
-        result_mock.finish_reason = "length"
+        result_mock.finish_reason = finish
         provider.create_streaming.return_value = as_stream(result_mock)
 
         judge = _make_judge(provider)
@@ -396,6 +397,30 @@ class TestErrorHandling:
         )
         assert result is None
         # Should have been called exactly once — no retries
+        assert provider.create_streaming.call_count == 1
+
+    @pytest.mark.parametrize("finish", ["content_filter", "length"])
+    def test_rejected_response_cannot_execute_judge_tools(self, finish):
+        provider = _make_mock_provider()
+        response = _mock_result(
+            "",
+            [{"id": "read", "function": {"name": "read_file", "arguments": '{"path":"x"}'}}],
+        )
+        response.finish_reason = finish
+        provider.create_streaming.return_value = as_stream(response)
+        judge = _make_judge(provider)
+        execute = MagicMock()
+        judge._exec_read_only_tool = execute
+
+        result = judge._evaluate_single(
+            _make_item(),
+            [{"role": "user", "content": "test"}],
+            cancel_event=None,
+            client=MagicMock(),
+        )
+
+        assert result is None
+        execute.assert_not_called()
         assert provider.create_streaming.call_count == 1
 
 

--- a/tests/test_midstream_retry.py
+++ b/tests/test_midstream_retry.py
@@ -704,9 +704,9 @@ class TestMidStreamRetry:
 
 class TestRecreateWindowClassification:
     """Between a mid-stream death and the next attempt's ``begin_attempt``
-    there is NO live attempt — ``end_attempt`` pronounces the dead one
-    dead the moment its partial is captured.  These pins hold the two
-    failure modes of reading the dead attempt's armed state in that
+    there is NO live attempt — ``end_attempt`` disarms the dead one
+    after its partial is captured and stream_end is emitted. These pins
+    hold the two failure modes of reading the dead attempt's armed state in that
     window (a Stop re-finalizing discarded display state; a walk-preamble
     error replacing the stream death), the two error classes the
     re-issue mask must forward verbatim, and the saw-chunk classifier

--- a/tests/test_model_turn.py
+++ b/tests/test_model_turn.py
@@ -25,7 +25,9 @@ from tests._session_helpers import as_stream
 from turnstone.core.model_turn import (
     ModelAdmissionError,
     ModelLane,
+    ModelTurnResult,
     finalize_provider_blocks,
+    is_empty_completion,
     maybe_attach_vllm_chat_reasoning,
     model_turn,
     resolve_lane,
@@ -42,7 +44,7 @@ from turnstone.core.providers._protocol import (
     serialized_tool_chars,
 )
 from turnstone.core.session import ChatSession
-from turnstone.core.trajectory import AttachmentRef, Role, ToolCall, Turn
+from turnstone.core.trajectory import AttachmentRef, ProviderNative, Role, ToolCall, Turn
 
 
 class _FakeProvider:
@@ -170,6 +172,7 @@ def test_result_carries_exact_serving_tool_definition_size() -> None:
 
     assert result.tool_def_chars == serialized_tool_chars(tools)
     assert result.serving_model == "m"
+    assert result.native_tools_enabled is None
 
 
 def test_result_prefers_final_provider_native_tool_definition_size() -> None:
@@ -178,7 +181,9 @@ def test_result_prefers_final_provider_native_tool_definition_size() -> None:
     class _NativeMetricsProvider(_FakeProvider):
         def create_streaming(self, **kwargs: Any) -> list[StreamChunk]:
             metrics = kwargs["request_metrics_ref"]
-            metrics.append(ProviderRequestMetrics(serialized_tool_chars=1_234))
+            metrics.append(
+                ProviderRequestMetrics(serialized_tool_chars=1_234, native_tools_enabled=True)
+            )
             return super().create_streaming(**kwargs)
 
     provider = _NativeMetricsProvider([CompletionResult(content="ok")])
@@ -189,6 +194,71 @@ def test_result_prefers_final_provider_native_tool_definition_size() -> None:
     )
 
     assert result.tool_def_chars == 1_234
+    assert result.native_tools_enabled is True
+
+
+@pytest.mark.parametrize(
+    "blocks,empty",
+    [
+        ([], True),
+        ([{"type": "thinking", "thinking": "private"}], True),
+        ([{"type": "redacted_thinking", "data": "opaque"}], True),
+        ([{"type": "reasoning", "encrypted_content": "opaque"}], True),
+        ([{"type": "reasoning_text", "text": "private"}], True),
+        ([{"type": "text", "text": " \n"}], True),
+        ([{"type": "text", "text": "<think>private</think>"}], True),
+        ([{"type": "message", "content": []}], True),
+        ([{"type": "message", "content": [{"type": "output_text", "text": " "}]}], True),
+        ([{"type": "message", "content": [{"type": "refusal", "refusal": ""}]}], False),
+        # Known text is a replay mirror; parsed canonical text owns the answer.
+        ([{"type": "message", "content": [{"type": "output_text", "text": "answer"}]}], True),
+        ([{"type": "message", "content": [{"type": "future_output"}]}], False),
+        ([{"type": "message", "content": None}], False),
+        ([{"type": "reasoning"}, {"type": "web_search_call", "id": "search"}], False),
+        ([{"type": "reasoning"}, {"type": "future_output"}], False),
+        ([{"type": "server_tool_use", "name": "code_exec"}], False),
+        ([{"type": "output_text", "text": None}], False),
+        ([{"type": ["malformed"]}], False),
+        (["unknown"], False),
+    ],
+)
+def test_empty_completion_native_output_is_conservative(blocks, empty):
+    result = ModelTurnResult(
+        turn=Turn.assistant(native=ProviderNative("test", tuple(blocks))),
+        finish_reason="stop",
+        usage=None,
+        tool_calls=[],
+    )
+    assert is_empty_completion(result) is empty
+
+
+@pytest.mark.parametrize(
+    "turn,raw_calls",
+    [
+        (Turn.assistant("answer"), []),
+        (
+            Turn.assistant(
+                "<think>literal text</think>",
+                native=ProviderNative(
+                    "anthropic", ({"type": "text", "text": "<think>literal text</think>"},)
+                ),
+            ),
+            [],
+        ),
+        (Turn(Role.ASSISTANT, (AttachmentRef("attachment", "image"),)), []),
+        (Turn.assistant(tool_calls=(ToolCall("call", "lookup", "{}"),)), []),
+        (Turn.assistant(), [{"id": "", "function": {"name": "lookup", "arguments": "{}"}}]),
+    ],
+)
+def test_empty_completion_excludes_answer_attachment_and_either_tool_mirror(turn, raw_calls):
+    result = ModelTurnResult(turn=turn, finish_reason="stop", usage=None, tool_calls=raw_calls)
+    assert not is_empty_completion(result)
+
+
+@pytest.mark.parametrize("finish", ["length", "content_filter", "pause_turn", "unknown"])
+def test_empty_completion_requires_ordinary_stop(finish):
+    result = ModelTurnResult(turn=Turn.assistant(), finish_reason=finish, usage=None, tool_calls=[])
+    assert not is_empty_completion(result)
 
 
 def test_entra_app_lane_resolver_never_issues_placeholder_client() -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,6 +13,7 @@ import pytest
 from tests._session_helpers import fake_anthropic_stream, fake_chat_stream
 from turnstone.core.deadline import DeadlineCancelledError, StreamAbortRef
 from turnstone.core.lowering import repair_wire_messages
+from turnstone.core.providers import create_provider
 from turnstone.core.providers._openai import OpenAIProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
 from turnstone.core.providers._openai_common import (
@@ -34,8 +35,87 @@ from turnstone.core.providers._protocol import (
     ToolCallDelta,
     UsageInfo,
     drain_stream,
+    request_uses_native_tools,
     serialized_tool_chars,
 )
+
+# ---------------------------------------------------------------------------
+# Prepared request facts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("family", ["openai-compatible", "openai", "anthropic-compatible"])
+@pytest.mark.parametrize(
+    "mode", ["none", "client", "search", "deferred", "extra_native", "extra_disable", "mcp"]
+)
+def test_prepared_request_reports_native_tool_posture(family, mode):
+    provider = create_provider(family)
+    client = MagicMock()
+    client.chat.completions.create.return_value = iter([])
+    client.responses.create.return_value = iter([])
+    client.messages.stream.return_value.__enter__.return_value = iter([])
+    tool_name = "web_search" if mode in ("search", "extra_disable") else "lookup"
+    tools = (
+        None
+        if mode == "none"
+        else [
+            {
+                "type": "function",
+                "function": {"name": tool_name, "parameters": {}},
+            }
+        ]
+    )
+    extra = None
+    if mode == "extra_native":
+        extra = {"tools": [{"type": "code_interpreter"}]}
+    elif mode == "extra_disable":
+        extra = {"tools": None, "web_search_options": None}
+    elif mode == "mcp":
+        extra = {
+            "mcp_servers": [{"type": "url", "name": "remote", "url": "https://example.com/mcp"}]
+        }
+    metrics = []
+    stream = provider.create_streaming(
+        client=client,
+        model="test",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        capabilities=ModelCapabilities(
+            supports_web_search=True,
+            supports_tool_search=True,
+        ),
+        deferred_names=frozenset({"lookup"}) if mode == "deferred" else None,
+        extra_params=extra,
+        request_metrics_ref=metrics,
+    )
+    list(stream)
+    # The Responses adapter does not forward extra_params. Its metrics must
+    # describe what was actually prepared, not the caller's requested override.
+    native = mode == "search" or (mode == "deferred" and family != "openai-compatible")
+    if family == "openai":
+        native = native or mode == "extra_disable"
+    else:
+        native = native or mode in ("extra_native", "mcp")
+    assert len(metrics) == 1
+    assert metrics[0].native_tools_enabled is native
+
+
+@pytest.mark.parametrize(
+    "body,native",
+    [
+        ({"tools": [{"type": "function"}]}, False),
+        ({"tools": [{"type": "function", "defer_loading": True}]}, False),
+        ({"extra_body": None}, False),
+        ({"tools": [{}]}, True),
+        ({"tools": ["unknown"]}, True),
+        ({"tools": {"type": "function"}}, True),
+        ({"web_search_options": {}}, True),
+        ({"tools": [{"type": "code_exec"}], "extra_body": {"tools": None}}, False),
+    ],
+)
+def test_native_tool_posture_handles_overrides_and_unknown_shapes(body, native):
+    assert request_uses_native_tools(body) is native
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -3474,11 +3554,11 @@ class TestAnthropicWebSearch:
         assert len(info_chunks) == 1
         assert "test query" in info_chunks[0].info_delta
 
-    def test_pause_turn_normalized_to_stop(self) -> None:
-        """pause_turn stop reason should normalize to 'stop'."""
+    def test_pause_turn_preserved(self) -> None:
+        """A server-tool continuation is distinct from an ordinary stop."""
         from turnstone.core.providers._anthropic import _normalize_finish_reason
 
-        assert _normalize_finish_reason("pause_turn") == "stop"
+        assert _normalize_finish_reason("pause_turn") == "pause_turn"
 
     def test_drained_stream_skips_server_blocks(self) -> None:
         """Server-side blocks surface as transient info (dropped by the
@@ -3826,7 +3906,8 @@ class TestOpenAIWebSearch:
         )
         assert request_metrics == [
             ProviderRequestMetrics(
-                serialized_tool_chars=serialized_tool_chars(call_kwargs.get("tools"))
+                serialized_tool_chars=serialized_tool_chars(call_kwargs.get("tools")),
+                native_tools_enabled=True,
             )
         ]
         assert request_metrics[0].serialized_tool_chars == 0
@@ -6181,15 +6262,16 @@ class TestResponsesDrainedStream:
         assert result.usage.prompt_tokens == 10
         assert result.usage.completion_tokens == 5
 
-    def test_refusal_renders_in_content(self) -> None:
+    @pytest.mark.parametrize("refusal", ["cannot help with that", ""])
+    def test_refusal_renders_in_content(self, refusal: str) -> None:
         # The response.refusal.done handler (CHANGELOG "refusals render in
-        # content") — a refused turn must not drain to empty content.
+        # content") — the event identifies a refusal even when its text is empty.
         events = [
-            SimpleNamespace(type="response.refusal.done", refusal="cannot help with that"),
+            SimpleNamespace(type="response.refusal.done", refusal=refusal),
             *self._make_events(),
         ]
         result = self._drain(events)
-        assert result.content == "[Refused: cannot help with that]"
+        assert result.content == f"[Refused: {refusal}]"
 
     def test_truncation_rebuilds_blocks_from_terminal_response_output(self) -> None:
         # The item being generated at max_output_tokens truncation never

--- a/tests/test_sdk_stream_boundary.py
+++ b/tests/test_sdk_stream_boundary.py
@@ -1,6 +1,6 @@
 """Offline pins of SDK boundary behaviors used by stream error handling.
 
-Five facts, each probed against the REAL SDKs over mock/loopback
+Six facts, each probed against the REAL SDKs over mock/loopback
 transports (no network, no live backend):
 
 1. OpenAI v3's ``max_retries`` covers request time only — a mid-BODY death
@@ -17,6 +17,8 @@ transports (no network, no live backend):
 5. OpenAI v3 raises real HTTP errors before returning a stream, while an HTTP
    200 ``application/json`` response becomes an empty iterator unless the
    adapter rejects it before arming the stream.
+6. Refusal text is visible without inventing an early terminal signal, and
+   neither structured-output judge interprets a filtered response as a verdict.
 
 If an SDK/httpx upgrade changes any of these, the provider boundary and
 ``transport_guarded`` conversion (including the retry gate consuming it) must
@@ -31,6 +33,7 @@ import socket
 import threading
 import time
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import anthropic
 import httpx
@@ -78,6 +81,268 @@ ANTHROPIC_EVENTS = (
     + 'data: {"type":"content_block_delta","index":0,'
     '"delta":{"type":"text_delta","text":"hello"}}' + LF + LF
 )
+
+
+@pytest.mark.parametrize("parts", [["Cannot", " help."], ["", "Cannot", "", " help.", ""]])
+@pytest.mark.parametrize(
+    "ending", ["finish", "finishless", "pre_finish_death", "post_finish_death"]
+)
+@pytest.mark.parametrize("optional_finish", [False, True])
+def test_chat_refusal_is_visible_without_inventing_a_terminal(parts, ending, optional_finish):
+    from turnstone.core.providers import (
+        IncompleteStreamError,
+        ModelCapabilities,
+        create_provider,
+        drain_stream,
+        transport_guarded,
+    )
+
+    chunks = [{"delta": {"refusal": part}, "finish_reason": None} for part in parts]
+    if ending in ("finish", "post_finish_death"):
+        chunks.append({"delta": {}, "finish_reason": "stop"})
+    payload = "".join(
+        "data: "
+        + json.dumps(
+            {
+                "id": "refusal",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": "test",
+                "choices": [{"index": 0, **choice}],
+            }
+        )
+        + "\n\n"
+        for choice in chunks
+    ).encode()
+    body = (
+        _Httpx2DyingStream(payload)
+        if "death" in ending
+        else httpx2.ByteStream(payload + b"data: [DONE]\n\n")
+    )
+    with openai.OpenAI(
+        api_key="test-only",
+        max_retries=0,
+        http_client=httpx2.Client(
+            transport=httpx2.MockTransport(
+                lambda request: httpx2.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    stream=body,
+                )
+            )
+        ),
+    ) as client:
+        stream = create_provider("openai-compatible").create_streaming(
+            client=client,
+            model="test",
+            messages=[{"role": "user", "content": "test"}],
+            capabilities=ModelCapabilities(finish_reason_optional=optional_finish),
+        )
+        if ending == "pre_finish_death" or (ending == "finishless" and not optional_finish):
+            with pytest.raises(IncompleteStreamError):
+                drain_stream(transport_guarded(stream))
+        else:
+            result = drain_stream(transport_guarded(stream))
+            assert result.content == "[Refused: " + "".join(parts) + "]"
+            assert result.finish_reason == "content_filter"
+
+
+@pytest.mark.parametrize("refusal", [None, ""])
+@pytest.mark.parametrize("content", ["Hello world", ""])
+@pytest.mark.parametrize("finish", ["stop", "content_filter", None])
+def test_empty_chat_refusal_field_does_not_rewrite_content_or_finish(refusal, content, finish):
+    from turnstone.core.providers import (
+        IncompleteStreamError,
+        ModelCapabilities,
+        create_provider,
+        drain_stream,
+        transport_guarded,
+    )
+
+    chunks = [({"content": content, "refusal": refusal}, None)]
+    if finish is not None:
+        chunks.append(({}, finish))
+    payload = (
+        "".join(
+            "data: "
+            + json.dumps(
+                {
+                    "id": "empty-refusal",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "test",
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": reason}],
+                }
+            )
+            + "\n\n"
+            for delta, reason in chunks
+        )
+        + "data: [DONE]\n\n"
+    )
+    with openai.OpenAI(
+        api_key="test-only",
+        max_retries=0,
+        http_client=httpx2.Client(
+            transport=httpx2.MockTransport(
+                lambda request: httpx2.Response(
+                    200, headers={"content-type": "text/event-stream"}, text=payload
+                )
+            )
+        ),
+    ) as client:
+        stream = create_provider("openai-compatible").create_streaming(
+            client=client,
+            model="test",
+            messages=[{"role": "user", "content": "test"}],
+            capabilities=ModelCapabilities(finish_reason_optional=finish is None),
+        )
+        if finish is None and not content:
+            # A metadata-only stream still has no evidence of completion;
+            # the compatibility shim requires an actual content chunk.
+            with pytest.raises(IncompleteStreamError):
+                drain_stream(transport_guarded(stream))
+            return
+        result = drain_stream(transport_guarded(stream))
+    assert result.content == content
+    assert result.finish_reason == (finish or "stop")
+
+
+def test_chat_refusal_after_unclosed_inline_reasoning_cannot_be_retried():
+    from turnstone.core.model_turn import ModelLane, is_empty_completion, model_turn
+    from turnstone.core.providers import create_provider
+    from turnstone.core.trajectory import Turn
+
+    deltas = [
+        ({"content": "<think>unfinished reasoning"}, None),
+        ({"refusal": "Cannot help."}, None),
+        ({}, "stop"),
+    ]
+    payload = (
+        "".join(
+            "data: "
+            + json.dumps(
+                {
+                    "id": "refusal",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "test",
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+                }
+            )
+            + "\n\n"
+            for delta, finish in deltas
+        )
+        + "data: [DONE]\n\n"
+    )
+    with openai.OpenAI(
+        api_key="test-only",
+        max_retries=0,
+        http_client=httpx2.Client(
+            transport=httpx2.MockTransport(
+                lambda request: httpx2.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    text=payload,
+                )
+            )
+        ),
+    ) as client:
+        result = model_turn(
+            ModelLane(provider=create_provider("openai-compatible"), client=client, model="test"),
+            [Turn.user("Continue.")],
+        )
+    assert not is_empty_completion(result)
+    assert result.finish_reason == "content_filter"
+
+
+@pytest.mark.parametrize("judge_kind", ["intent", "output"])
+@pytest.mark.parametrize("quoted_verdict", [False, True])
+@pytest.mark.parametrize("finish", ["stop", "length", "content_filter"])
+def test_judges_reject_chat_refusals_before_parsing_or_reprompting(
+    judge_kind, quoted_verdict, finish
+):
+    from turnstone.core.judge import IntentJudge, JudgeConfig
+    from turnstone.core.model_turn import ModelLane, ResolvedModelBinding
+    from turnstone.core.output_guard_judge import OutputGuardJudge
+    from turnstone.core.providers import create_provider
+
+    refusal = "I cannot evaluate this request."
+    if quoted_verdict:
+        refusal += " I cannot return " + json.dumps(
+            {
+                "risk_level": "low" if judge_kind == "intent" else "none",
+                "recommendation": "approve",
+                "confidence": 0.99,
+                "reasoning": "Allowed.",
+                "flags": [],
+            }
+        )
+    requests = []
+
+    def respond(request):
+        requests.append(json.loads(request.content))
+        chunks = [({"refusal": refusal}, None), ({}, finish)]
+        payload = "".join(
+            "data: "
+            + json.dumps(
+                {
+                    "id": "refusal",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "test",
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+                }
+            )
+            + "\n\n"
+            for delta, finish in chunks
+        )
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            text=payload + "data: [DONE]\n\n",
+        )
+
+    with openai.OpenAI(
+        api_key="test-only",
+        max_retries=0,
+        http_client=httpx2.Client(transport=httpx2.MockTransport(respond)),
+    ) as client:
+        provider = create_provider("openai-compatible")
+        binding = ResolvedModelBinding(
+            lane=ModelLane(
+                provider=provider,
+                client=client,
+                model="test",
+                capabilities=provider.get_capabilities("test"),
+            ),
+            config=None,
+            registry_generation=0,
+        )
+        if judge_kind == "intent":
+            judge = IntentJudge(
+                config=JudgeConfig(enabled=True, read_only_tools=False),
+                session_binding=binding,
+            )
+            verdict = judge._evaluate_single(
+                {"func_name": "bash", "func_args": {"command": "ls"}, "call_id": "call"},
+                [{"role": "user", "content": "Inspect the directory."}],
+                None,
+                client,
+                lane=binding.lane,
+            )
+            assert verdict is None
+        else:
+            guard = OutputGuardJudge(
+                config=JudgeConfig(output_guard_llm=True), session_binding=binding
+            )
+            try:
+                with patch.object(guard, "_create_client", return_value=client):
+                    output = guard.evaluate("Untrusted tool output.", func_name="web_fetch")
+                assert not output.succeeded
+                assert output.error == ("length" if finish == "length" else "content_filter")
+            finally:
+                guard.close()
+    assert len(requests) == 1
 
 
 class _DyingStream(httpx.SyncByteStream):

--- a/tests/test_session_replay_reasoning.py
+++ b/tests/test_session_replay_reasoning.py
@@ -457,14 +457,18 @@ class TestSessionToOpenAIResponsesBoundaryIntegration:
 
     def _stub_responses_client(self) -> tuple[MagicMock, dict[str, object]]:
         """Mock OpenAI Responses client.  ``client.responses.create``
-        captures kwargs and returns a stream carrying only the terminal
-        event — the fused create+drain needs a finish reason (a
-        finish-less exhaust is an ``IncompleteStreamError`` post-#832)."""
+        captures kwargs and returns a completed answer. Empty completed
+        replies now enter the conversation's recovery path (#1070)."""
         captured: dict[str, object] = {}
 
         def create(**kwargs: object) -> object:
             captured.update(kwargs)
-            return iter([SimpleNamespace(type="response.completed", response=None)])
+            return iter(
+                [
+                    SimpleNamespace(type="response.output_text.delta", delta="ok"),
+                    SimpleNamespace(type="response.completed", response=None),
+                ]
+            )
 
         client = MagicMock()
         client.responses.create = create

--- a/turnstone/core/judge.py
+++ b/turnstone/core/judge.py
@@ -1835,6 +1835,12 @@ class IntentJudge:
                 elapsed=round(turn_elapsed, 1),
             )
 
+            # Refused or truncated responses cannot authorize a tool, even if
+            # their text happens to contain a complete verdict JSON object.
+            if result.finish_reason in ("content_filter", "length"):
+                log.info("judge.turn.stopped", finish_reason=result.finish_reason, turn=turn + 1)
+                return None
+
             # Reset empty-response counter after any non-empty response
             if result.content or result.tool_calls:
                 empty_retries = 0
@@ -1899,13 +1905,6 @@ class IntentJudge:
                 )
                 turn += 1
                 continue
-
-            # Empty response (0 chars, 0 tools).  If the model hit the
-            # output token limit the finish_reason will be "length" — retrying
-            # with the same prompt and max_tokens is pointless.
-            if result.finish_reason == "length":
-                log.info("judge.empty_response.length_stop", turn=turn + 1)
-                return None
 
             # Transient empty response — retry up to 3 times without
             # consuming the turn budget.

--- a/turnstone/core/model_turn.py
+++ b/turnstone/core/model_turn.py
@@ -65,6 +65,12 @@ from turnstone.core.lowering import (
 # registry — so the provider package stays a plant-layer-only import.
 from turnstone.core.providers import create_provider as create_provider
 from turnstone.core.providers._protocol import (
+    REASONING_BEARING_BLOCK_TYPES,
+    drain_stream,
+    has_reasoning_bearing_block,
+    thinking_off_template_kwargs,
+)
+from turnstone.core.providers._protocol import (
     TRAILING_INFO_SEPARATOR as TRAILING_INFO_SEPARATOR,
 )
 
@@ -88,11 +94,6 @@ from turnstone.core.providers._protocol import (
     UsageInfo as UsageInfo,
 )
 from turnstone.core.providers._protocol import (
-    drain_stream,
-    has_reasoning_bearing_block,
-    thinking_off_template_kwargs,
-)
-from turnstone.core.providers._protocol import (
     folds_trailing_info as folds_trailing_info,
 )
 from turnstone.core.providers._protocol import (
@@ -108,6 +109,7 @@ from turnstone.core.storage._utils import (
 from turnstone.core.trajectory import (
     PROVENANCE_META_KEY,
     ProviderNative,
+    TextBlock,
     ToolCall,
     Turn,
     TurnProvenance,
@@ -1006,11 +1008,48 @@ class ModelTurnResult:
     producer: str = ""
     serving_model: str = ""
     tool_def_chars: int | None = None
+    # None means the adapter did not report its final request's tool posture.
+    native_tools_enabled: bool | None = None
 
     @property
     def content(self) -> str:
         """The assistant text — convenience mirror of ``turn.text``."""
         return self.turn.text
+
+
+def is_empty_completion(result: ModelTurnResult) -> bool:
+    """An ordinary stop with no answer, tool proposal, or other known output.
+
+    Reasoning alone cannot answer the user. Unknown native blocks are preserved
+    as output; this is a structural check, never a judgment of task completion.
+    """
+    if result.finish_reason != "stop" or result.tool_calls or result.turn.tool_calls:
+        return False
+    if any(not isinstance(block, TextBlock) or block.text.strip() for block in result.turn.content):
+        return False
+
+    def reasoning_or_text(block: Any) -> bool:
+        if not isinstance(block, dict):
+            return False
+        kind = block.get("type")
+        if not isinstance(kind, str):
+            return False
+        if kind in REASONING_BEARING_BLOCK_TYPES:
+            return True
+        # Known text blocks are replay copies of the canonical answer checked
+        # above. They still contain any inline thinking tags the drain parsed
+        # out; treating those raw bytes as an answer would bypass recovery.
+        return kind in ("text", "output_text") and isinstance(block.get("text"), str)
+
+    for block in result.turn.native.blocks if result.turn.native else ():
+        if reasoning_or_text(block):
+            continue
+        if isinstance(block, dict) and block.get("type") == "message":
+            parts = block.get("content")
+            if isinstance(parts, list) and all(reasoning_or_text(part) for part in parts):
+                continue
+        return False
+    return True
 
 
 def cap_tool_calls(result: ModelTurnResult, max_calls: int) -> tuple[list[dict[str, Any]], Turn]:
@@ -1538,4 +1577,5 @@ def model_turn(
             if request_metrics
             else serialized_tool_chars(tools)
         ),
+        native_tools_enabled=request_metrics[-1].native_tools_enabled if request_metrics else None,
     )

--- a/turnstone/core/output_guard_judge.py
+++ b/turnstone/core/output_guard_judge.py
@@ -709,6 +709,11 @@ class OutputGuardJudge:
                 verdict_id, call_id, start, f"provider_error: {type(e).__name__}"
             )
 
+        # A refusal, including one cut off by the output limit, may quote valid
+        # verdict JSON without endorsing it. Keep the heuristic disposition.
+        if result.finish_reason in ("content_filter", "length"):
+            return self._error_verdict(verdict_id, call_id, start, result.finish_reason)
+
         content = (result.content or "").strip()
         if not content:
             return self._error_verdict(verdict_id, call_id, start, "empty_response")

--- a/turnstone/core/providers/_anthropic.py
+++ b/turnstone/core/providers/_anthropic.py
@@ -25,6 +25,7 @@ from turnstone.core.providers._protocol import (
     finish_shim_due,
     merge_reasoning_template_kwargs,
     refuse_aborted_request,
+    request_uses_native_tools,
     serialized_tool_chars,
     snap_reasoning_effort,
 )
@@ -989,7 +990,12 @@ class AnthropicProvider:
         if request_metrics_ref is not None:
             request_metrics_ref.append(
                 ProviderRequestMetrics(
-                    serialized_tool_chars=serialized_tool_chars(kwargs.get("tools"))
+                    serialized_tool_chars=serialized_tool_chars(kwargs.get("tools")),
+                    native_tools_enabled=request_uses_native_tools(
+                        # Anthropic client tools may omit type or use "custom".
+                        kwargs,
+                        client_tool_types=(None, "custom"),
+                    ),
                 )
             )
 
@@ -1369,9 +1375,6 @@ def _normalize_finish_reason(reason: str) -> str:
         return "tool_calls"
     if reason == "max_tokens":
         return "length"
-    if reason == "pause_turn":
-        # Server-side tool (web search) paused a long turn; treat as stop
-        return "stop"
     if reason == "refusal":
         # A safety classifier declined the request.  This arrives as a
         # SUCCESSFUL HTTP 200 with content empty (declined before any

--- a/turnstone/core/providers/_openai_chat.py
+++ b/turnstone/core/providers/_openai_chat.py
@@ -20,6 +20,7 @@ from turnstone.core.providers._openai_common import (
     apply_tool_search,
     extract_usage,
     format_citations,
+    format_refusal,
     reject_non_stream_response,
     sanitize_messages,
 )
@@ -32,6 +33,7 @@ from turnstone.core.providers._protocol import (
     finish_shim_due,
     merge_reasoning_template_kwargs,
     refuse_aborted_request,
+    request_uses_native_tools,
     serialized_tool_chars,
 )
 from turnstone.core.trajectory import materialize_attachments
@@ -334,7 +336,8 @@ class OpenAIChatCompletionsProvider:
         if request_metrics_ref is not None:
             request_metrics_ref.append(
                 ProviderRequestMetrics(
-                    serialized_tool_chars=serialized_tool_chars(kwargs.get("tools"))
+                    serialized_tool_chars=serialized_tool_chars(kwargs.get("tools")),
+                    native_tools_enabled=request_uses_native_tools(kwargs),
                 )
             )
 
@@ -375,6 +378,8 @@ class OpenAIChatCompletionsProvider:
         """
         first = True
         annotations: list[Any] = []
+        refusals: list[str] = []
+        refusal_seen = False
         content_len = 0
         reasoning_len = 0
         tool_call_count = 0
@@ -416,6 +421,23 @@ class OpenAIChatCompletionsProvider:
                 sc.content_delta = delta.content
                 content_len += len(delta.content)
 
+            refusal = getattr(delta, "refusal", None)
+            # An empty nullable field alone is not a refusal signal. Explicit
+            # content_filter finishes remain authoritative even without text.
+            if isinstance(refusal, str) and refusal:
+                refusals.append(refusal)
+                refusal_seen = True
+            if sc.finish_reason == "stop" and refusal_seen:
+                # Classify only at a real terminal signal. Inline reasoning
+                # parsing must not turn a refusal into a retryable empty answer.
+                sc.finish_reason = "content_filter"
+                last_finish_reason = sc.finish_reason
+            if sc.finish_reason and refusals:
+                rendered = format_refusal("".join(refusals))
+                sc.content_delta += rendered
+                content_len += len(rendered)
+                refusals.clear()
+
             # Tool calls
             if delta.tool_calls:
                 for tc_delta in delta.tool_calls:
@@ -449,6 +471,13 @@ class OpenAIChatCompletionsProvider:
             if has_content or sc.finish_reason or sc.usage:
                 yield sc
 
+        # A refusal is content, not a terminal signal. Clean finish-less streams
+        # still need the capability shim below; a transport failure never gets here.
+        if refusals:
+            rendered = format_refusal("".join(refusals))
+            content_len += len(rendered)
+            yield StreamChunk(content_delta=rendered, is_first=first)
+
         # Finish-reason-less lax-server tolerance (the deleted non-streaming
         # path's `finish_reason or "stop"` default), armed ONLY by the
         # operator-declared ``finish_reason_optional`` capability: on a
@@ -472,8 +501,8 @@ class OpenAIChatCompletionsProvider:
             finish_seen=last_finish_reason is not None,
             delivered_output=bool(content_len or reasoning_len or tool_call_count),
         ):
-            last_finish_reason = "stop"
-            yield StreamChunk(finish_reason="stop")
+            last_finish_reason = "content_filter" if refusal_seen else "stop"
+            yield StreamChunk(finish_reason=last_finish_reason)
 
         log.debug(
             "openai.chat.response",

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -27,6 +27,12 @@ from turnstone.core.providers._protocol import (
 
 log = structlog.get_logger(__name__)
 
+
+def format_refusal(text: str) -> str:
+    """Keep refusals visible across OpenAI-family streaming and terminal payloads."""
+    return f"[Refused: {text}]"
+
+
 _UPSTREAM_ERROR_BODY_MAX_BYTES = 4096
 _INVALID_UPSTREAM_ERROR_BODY = "<JSON response did not contain a valid error object>"
 _UPSTREAM_RATE_LIMIT_CODES = frozenset(
@@ -567,10 +573,10 @@ def apply_tool_search(
     tools: list[dict[str, Any]] | None,
     deferred_names: frozenset[str] | None = None,
 ) -> list[dict[str, Any]] | None:
-    """Mark deferred tools with ``defer_loading: true`` for native search.
+    """Mark client tools with ``defer_loading: true`` when search is enabled.
 
-    For GPT-5.4+ models that support tool search, OpenAI's API handles
-    discovery automatically — no explicit search tool is needed.
+    This adds only loading metadata. The Responses adapter adds the hosted
+    search tool separately during conversion to its native tool shape.
     """
     if not caps.supports_tool_search or not deferred_names or not tools:
         return tools

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -26,6 +26,7 @@ from turnstone.core.providers._openai_common import (
     extract_usage,
     format_citations,
     format_document_wrapper,
+    format_refusal,
     lookup_openai_capabilities,
     reject_non_stream_response,
     resolve_server_side_tools,
@@ -39,6 +40,7 @@ from turnstone.core.providers._protocol import (
     _join_reasoning_with_cap,
     finish_shim_due,
     refuse_aborted_request,
+    request_uses_native_tools,
     resolve_reasoning_effort,
     serialized_tool_chars,
 )
@@ -51,13 +53,6 @@ log = structlog.get_logger(__name__)
 # condition — the only ones worth retrying (the API's other codes are
 # deterministic request rejections).
 _TRANSIENT_FAILURE_CODES = frozenset({"server_error", "rate_limit_exceeded"})
-
-
-def _format_refusal(text: str) -> str:
-    """Render a refusal part as visible content — ONE format for both the
-    streamed ``response.refusal.done`` event and the terminal-payload
-    harvest, so drained text cannot differ by which path carried it."""
-    return f"[Refused: {text}]"
 
 
 def _extend_message_annotations(item: Any, annotations: list[Any]) -> None:
@@ -576,7 +571,8 @@ class OpenAIResponsesProvider:
         if request_metrics_ref is not None:
             request_metrics_ref.append(
                 ProviderRequestMetrics(
-                    serialized_tool_chars=serialized_tool_chars(kwargs.get("tools"))
+                    serialized_tool_chars=serialized_tool_chars(kwargs.get("tools")),
+                    native_tools_enabled=request_uses_native_tools(kwargs),
                 )
             )
 
@@ -665,7 +661,7 @@ class OpenAIResponsesProvider:
             # double-emit.
             if event_type == "response.refusal.done":
                 refusal_text = getattr(event, "refusal", "")
-                sc = StreamChunk(content_delta=_format_refusal(refusal_text))
+                sc = StreamChunk(content_delta=format_refusal(refusal_text))
                 content_len += len(sc.content_delta)
                 if first:
                     sc.is_first = True
@@ -795,7 +791,7 @@ class OpenAIResponsesProvider:
                             if part.get("type") == "output_text" and part.get("text"):
                                 parts_text.append(part["text"])
                             elif part.get("type") == "refusal" and part.get("refusal"):
-                                parts_text.append(_format_refusal(part["refusal"]))
+                                parts_text.append(format_refusal(part["refusal"]))
                     harvested = "".join(parts_text)
                     if harvested:
                         content_len = len(harvested)

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -47,13 +47,36 @@ class UsageInfo:
 
 @dataclass(frozen=True, slots=True)
 class ProviderRequestMetrics:
-    """Non-sensitive prompt-shape metrics from one prepared provider request.
+    """Non-sensitive facts from one prepared provider request.
 
     Adapters record these only after their provider-native tool conversion is
     complete.  Payloads, headers, and credentials never leave the adapter.
     """
 
     serialized_tool_chars: int = 0
+    native_tools_enabled: bool | None = None
+
+
+def request_uses_native_tools(
+    kwargs: dict[str, Any], *, client_tool_types: tuple[str | None, ...] = ("function",)
+) -> bool:
+    """Conservatively detect server tools in the final request, including overrides.
+
+    An empty web-search configuration enables search. Unknown tool shapes also
+    prevent a caller from assuming that repeating the request has no effects.
+    ``client_tool_types`` lists the adapter's client-executed tool types; ``None``
+    includes dictionaries without a ``type`` key. Deferred loading alone does
+    not execute a tool; hosted discovery has its own server-tool declaration.
+    """
+    body = {**kwargs, **(kwargs.get("extra_body") or {})}
+    if body.get("web_search_options") is not None or body.get("mcp_servers") not in (None, []):
+        return True
+    tools = body.get("tools")
+    if tools is None:
+        return False
+    return not isinstance(tools, list) or any(
+        not isinstance(tool, dict) or tool.get("type") not in client_tool_types for tool in tools
+    )
 
 
 def serialized_tool_chars(tools: Any) -> int:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -171,6 +171,7 @@ from turnstone.core.model_turn import (
     create_provider,
     finalize_provider_blocks,
     folds_trailing_info,
+    is_empty_completion,
     lane_diagnostics,
     lane_error_is_retryable,
     lane_matches_explicit_handles,
@@ -385,6 +386,17 @@ class ConversationPersistenceError(Exception):
 
 class _MalformedToolBatchError(RuntimeError):
     """Provider tool calls cannot be executed without unambiguous identities."""
+
+
+class _EmptyCompletionError(RuntimeError):
+    """A completed response rejected by the conversation's structural policy."""
+
+    def __init__(self, result: ModelTurnResult) -> None:
+        self.result = result
+        message = "Model returned no answer or tool call. Retry the turn or choose another model."
+        if result.native_tools_enabled is not False:
+            message += " Automatic retry was skipped because the request may run server-side tools."
+        super().__init__(message)
 
 
 _CONVERSATION_PERSISTENCE_RETRY_BASE_SECONDS = 1.0
@@ -823,8 +835,9 @@ class _StreamTurnConsumer:
     def end_attempt(self) -> None:
         """Pronounce the current attempt dead: nothing about it may leak.
 
-        The re-issue ladder calls this once a mid-stream death's partial
-        is captured: from here until the next ``begin_attempt`` there is
+        The re-issue ladder calls this after capturing the partial and
+        emitting stream_end, as its call-site sequencing comment explains.
+        From here until the next ``begin_attempt`` there is
         NO live attempt, so ``attempt_armed`` reads False.  Otherwise a
         Stop or a walk-preamble failure landing in the re-create window
         reads the DEAD attempt's armed ref — re-finalizing discarded
@@ -14585,9 +14598,8 @@ class ChatSession:
         # (read off the frame's consumer, never a session slot), so an
         # orphaned generation cannot poison a live one's preservation.
         dead_partial = ""
-        # The armed death whose re-issue is in progress; when the RE-CREATE
-        # phase fails with an unarmed error, the original death is the one
-        # the operator needs to see, not the re-create's.
+        # The armed failure whose re-issue is in progress. A transport death
+        # can explain a later re-create failure; an empty completion cannot.
         last_stream_death: Exception | None = None
         # Provenance of the attempt whose text ``dead_partial`` carries.  A
         # zero-token re-death must not relabel preserved text from the prior
@@ -14617,16 +14629,21 @@ class ChatSession:
             """Hand send()'s cancel handler the retry window's partial.
 
             Runs on a same-generation Stop anywhere in the retry window.
-            Unconditional when no partial was recorded — empty content
-            still takes the cancel handler's marker-as-message branch,
-            preserving the invariant that a cancelled streaming turn
-            always persists the cancellation-marker row.  Backfills a
+            An armed attempt first flushes its display, emits stream_end,
+            records its cancellation partial, and disarms. Keeping it armed
+            until that finalization preserves even a zero-text Stop marker.
+            Once an attempt has streamed, empty content still takes the
+            cancel handler's marker-as-message branch. A Stop before any
+            attempt streams writes no assistant row. Backfills a
             recorded-but-EMPTY partial (a Stop in the re-create/TTFT
             window records the new attempt's empty content) with the
             previous attempt's text: cancel-in-retry preserves the latest
             text the user actually saw.  Never writes for a superseded
             generation — an orphan must not touch the successor's slot.
             """
+            if consumer.attempt_armed:
+                consumer.record_cancelled_partial()
+                consumer.end_attempt()
 
             def _publish_partial() -> None:
                 if (
@@ -14657,6 +14674,11 @@ class ChatSession:
                 allow_cancelled=True,
             )
 
+        def _discard_failed_stream() -> None:
+            """Finalize rejected display state while the caller owns its generation."""
+            self.ui.on_stream_end()
+            self._ui_stream_discarded()
+
         with self._recovered_serving_failures() as recovered_failures:
             while True:
                 try:
@@ -14672,6 +14694,8 @@ class ChatSession:
                     # commits as complete and its tool calls execute.
                     self._check_cancelled(my_generation)
                     consumer.finish_stream()
+                    if is_empty_completion(result):
+                        raise _EmptyCompletionError(result)
                     # Finalization emits terminal warnings/stream_end and may
                     # legalize a truncated result.  Keep that complete policy step
                     # on the same owner rail as the carry flush above so a force
@@ -14690,8 +14714,6 @@ class ChatSession:
                     # after a death) — finalize the streamed display if the
                     # attempt got a stream, then preserve the window's best
                     # partial.
-                    if consumer.attempt_armed:
-                        consumer.record_cancelled_partial()
                     _promote_dead_partial()
                     raise
                 except KeyboardInterrupt:
@@ -14723,13 +14745,39 @@ class ChatSession:
                     dead_partial = new_dead or dead_partial
                     if attempt_provenance is not None and (new_dead or dead_provenance is None):
                         dead_provenance = attempt_provenance
-                    if armed:
-                        # The partial is captured, so there is no live attempt
-                        # until the next ``begin_attempt``: without this, a
-                        # Stop or a walk-preamble failure landing in the
-                        # re-create window reads the DEAD attempt's armed
-                        # state (see ``end_attempt``).
-                        consumer.end_attempt()
+                    if isinstance(e, _EmptyCompletionError) and failed_lane is not None:
+                        # This call completed and was billed. A same-generation
+                        # Stop still accounts for it, like an accepted result;
+                        # supersession and shutdown remain fenced. Budget checks
+                        # do not calibrate or append the rejected answer.
+                        def _commit_usage(
+                            durable: list[Callable[[], None]],
+                            serving_model: str = failed_lane.model,
+                        ) -> None:
+                            self._update_token_budget()
+                            self._print_status_line(
+                                model=serving_model,
+                                deferred_persistence=durable,
+                            )
+
+                        try:
+                            usage_committed = self._commit_for_generation(
+                                my_generation, _commit_usage
+                            )
+                        except GenerationCancelled:
+                            _promote_dead_partial()
+                            raise
+                        except BaseException:
+                            # Usage storage already logs its own failures. A UI
+                            # callback failure or conversation-persistence poison
+                            # must finalize display and remain fatal, including
+                            # when Stop races the failed commit. Never publish
+                            # over a successor or turn this into a cancel marker.
+                            self._publish_for_generation(my_generation, _discard_failed_stream)
+                            raise
+                        if not usage_committed:
+                            _promote_dead_partial()
+                            raise GenerationCancelled() from None
                     if self._cancel_event.is_set():
                         _promote_dead_partial()
                         raise GenerationCancelled() from None
@@ -14747,7 +14795,9 @@ class ChatSession:
                         # ladder + fallbacks.  Mid re-issue it must not MASK
                         # the original stream death (a closed-client re-create
                         # surfaces as a retryable APIConnectionError and would
-                        # replace the operator-actionable wording) — EXCEPT
+                        # replace the operator-actionable wording). An empty
+                        # completion does not explain a failed re-create, so
+                        # its replacement error surfaces as itself. Also exempt
                         # the classes carrying their own remediation: an
                         # overflow surfaces as ITSELF so send()'s
                         # compact-and-retry arm can recover the turn, and an
@@ -14758,6 +14808,7 @@ class ChatSession:
                         # base_url verbatim.
                         if (
                             last_stream_death is None
+                            or isinstance(last_stream_death, _EmptyCompletionError)
                             or isinstance(e, _SELF_SURFACING_ERRORS)
                             or _is_ctx_overflow(e)
                         ):
@@ -14767,7 +14818,7 @@ class ChatSession:
                             error_type=type(e).__name__,
                         )
                         raise last_stream_death from None
-                    # The terminal predicate is the SHARED _stop_retrying,
+                    # Transport failures use the shared _stop_retrying,
                     # capped at _MID_STREAM_RETRIES, judged by the lane that
                     # ACTUALLY armed this stream (a fallback's retryable set
                     # can differ, e.g. ResponsesStreamFailedError).  The
@@ -14778,9 +14829,21 @@ class ChatSession:
                     serving_lane = consumer.lane
                     if serving_lane is None:
                         raise RuntimeError("armed stream has no serving model lane") from e
-                    if self._stop_retrying(
-                        e, attempt, serving_lane, max_retries=self._MID_STREAM_RETRIES
-                    ):
+                    if isinstance(e, _EmptyCompletionError):
+                        # Share the two-reissue budget with transport failures.
+                        # Each reissue resends the full context and can repeat
+                        # its latency/cost; this caps attempts, not wall time.
+                        # Reasoning followed by stop does not establish refusal.
+                        terminal = (
+                            attempt >= self._MID_STREAM_RETRIES
+                            or e.result.native_tools_enabled is not False
+                            or self._budget_exhausted
+                        )
+                    else:
+                        terminal = self._stop_retrying(
+                            e, attempt, serving_lane, max_retries=self._MID_STREAM_RETRIES
+                        )
+                    if terminal:
                         # Terminal: finalize AND discard, exactly like the
                         # retry arm.  Keeping the buffers bought nothing — the
                         # fatal path's _emit_state("error") drains and wipes
@@ -14797,8 +14860,7 @@ class ChatSession:
                             ):
                                 _promote_dead_partial()
                                 raise GenerationCancelled() from None
-                            self.ui.on_stream_end()
-                            self._ui_stream_discarded()
+                            _discard_failed_stream()
                         raise  # fatal path otherwise unchanged
                     # This death supersedes the previous one: drop the older
                     # snapshot here rather than at the ladder's exit, so a long
@@ -14850,10 +14912,19 @@ class ChatSession:
                             _promote_dead_partial()
                             raise GenerationCancelled() from None
                         self.ui.on_stream_end()
+                        notice = (
+                            "model returned no answer"
+                            if isinstance(e, _EmptyCompletionError)
+                            else f"stream died mid-response ({cause})"
+                        )
                         self.ui.on_info(
-                            f"[stream died mid-response ({cause}) — retrying in "
+                            f"[{notice} — retrying in "
                             f"{delay:.0f}s ({attempt}/{self._MID_STREAM_RETRIES})]"
                         )
+                    # Keep the consumer armed until its stream_end is emitted:
+                    # Stop during rejection/usage publication must still flush
+                    # and finalize it. Backoff and re-creation have no live attempt.
+                    consumer.end_attempt()
                     try:
                         self._backoff_or_cancelled(delay, my_generation)
                         # Retry preparation is one generation publication.  A
@@ -15204,14 +15275,18 @@ class ChatSession:
         # _remaining_token_budget() can estimate only the delta.
         self._calibrated_msg_count = len(self.messages)
 
-        # Token budget tracking
-        if self._token_budget > 0:
-            total = prompt_tok + compl_tok
-            if not self._budget_warned and total >= self._token_budget * 0.8:
-                self._budget_warned = True
-                self.ui.on_info(f"Token budget 80% consumed ({total:,}/{self._token_budget:,})")
-            if total >= self._token_budget:
-                self._budget_exhausted = True
+        self._update_token_budget()
+
+    def _update_token_budget(self) -> None:
+        """Apply the per-completion budget to accepted and rejected responses."""
+        if not self._last_usage or self._token_budget <= 0:
+            return
+        total = self._last_usage["prompt_tokens"] + self._last_usage["completion_tokens"]
+        if not self._budget_warned and total >= self._token_budget * 0.8:
+            self._budget_warned = True
+            self.ui.on_info(f"Token budget 80% consumed ({total:,}/{self._token_budget:,})")
+        if total >= self._token_budget:
+            self._budget_exhausted = True
 
     def _print_status_line(
         self,


### PR DESCRIPTION
An ordinary `stop` with no answer or tool call could commit an empty assistant turn and leave a
conversation idle, as reported in #1070. Reject those completions before accepting history and reuse
the shared two-reissue limit in interactive and coordinator sessions. Recovery exhaustion surfaces
an error instead of silently parking the conversation.

Prepared provider requests determine whether server-side tools make automatic replay ineligible.
Rejected completions retain usage accounting, budget enforcement, cancellation markers, and
generation ownership checks. Non-empty Chat refusals remain distinct from empty nullable refusal
fields, Anthropic `pause_turn` stays distinct, and both judges reject filtered or truncated output
before parsing a verdict.

Fixes #1070.

Validation:

- Full CI test selection before rebase: 13,507 passed, 49 skipped, 17 deselected.
- Post-rebase regression suite: 2,170 passed, including all touched tests and session, worker,
  idle-wake, and coordinator-nudge coverage.
- All eight reported-payload replays passed after rebase, covering both workstream kinds, both
  reasoning-parsing modes, recovery, and exhaustion.
- Ruff lint/format and mypy passed after rebase. The rebase preserves the reviewed patch
  (`git range-diff` reports equality).

The reported response was replayed through actual SDKs with mocked transports; the intermittent
live provider trigger remains unreproduced.
