### PR TITLE
feat(providers): add GPT-6 Astra and preserve Responses phases

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -920,27 +920,49 @@ stale lanes, and close its transport after active calls drain; cap-only reloads
 resize the stable alias admission gate without discarding the pool. Calibration
 remains an isolated one-shot client and always closes it after the probe.
 
-**OpenAIProvider** (`_openai.py`): passes messages through unchanged (they are
-already in OpenAI format), including multi-part content blocks (text + images)
-in tool results. Model capability lookup covers GPT-5 through GPT-5.6,
-O-series, and search models (`gpt-5-search-api`) — all with `supports_vision`.
-For search models, injects `web_search_options` and removes the `web_search`
-function tool (the model always searches). Citations from `url_citation`
-annotations are formatted as footnotes. Pre-5.6 GPT-5 models request extended
-prompt-cache retention (`prompt_cache_retention: "24h"`); GPT-5.6 uses
-`prompt_cache_options.ttl: "30m"`. Cache reads and writes are extracted from
-`cached_tokens` and `cache_write_tokens`. Unknown models get permissive
-defaults with `supports_vision=False` and use SearxNG for web search. The
-`openai-compatible` lane never consults this table at all — on either API
-surface (the responses pin is served by a compat-mode
-`OpenAIResponsesProvider`, mirroring `AnthropicProvider(compat=True)`): a
-local server serves whatever the operator named it (vLLM
-`--served-model-name` is a free string), so a prefix collision with a cloud
-model id must not inherit that model's sampling/effort contract — every
-local model gets the plain defaults, commercial prompt-cache controls are not
-injected by model-name prefix, and anything beyond those defaults is declared
-on the model definition (capabilities JSON + `server_compat`), matching the
-`anthropic-compatible` lane.
+**OpenAIResponsesProvider** (`_openai_responses.py`): the commercial `openai` lane always uses
+`/v1/responses`, translating the neutral message projection into Responses input items. The
+capability table covers GPT-5.4, GPT-5.5, GPT-5.6, GPT-6 Astra, search models, and audio roles.
+Captured reasoning items can be replayed when the operator enables reasoning replay. Native
+search replaces a visible client `web_search` tool on search-capable models; citations from
+`url_citation` annotations are formatted as footnotes. Pre-5.6 GPT-5 models request extended
+prompt-cache retention (`prompt_cache_retention: "24h"`); GPT-5.6 and Astra use
+`prompt_cache_options.ttl: "30m"`. Cache reads and writes are extracted from `cached_tokens` and
+`cache_write_tokens`. Unknown models get generic defaults with `supports_vision=False` and use
+client-side web search.
+
+Responses replay preserves native assistant message boundaries, `commentary` / `final_answer`
+phases, and their order among tool calls. Phase preservation does not depend on reasoning replay;
+when reasoning replay is enabled, those items retain their native positions too. The provider
+matches stored message text and call IDs against the lowered canonical history before restoring
+that layout; repaired call arguments come from canonical fields. Generated citation footers remain
+attached once to the last message. If edits make the layout ambiguous, replay uses current text
+without guessing a phase. Explicitly foreign producer metadata is excluded; legacy untagged blocks
+remain readable. See the [Responses input schema][responses-input-schema].
+
+[responses-input-schema]: https://developers.openai.com/api/reference/python/resources/responses/methods/create
+
+GPT-6 Astra (`gpt-6-astra`) has a 1,050,000-token context window, 128,000-token output limit, and
+reasoning levels `low`, `medium`, `high`, `xhigh`, and `max`. Temperature is always omitted.
+An unset effort leaves the server default in charge; the shared effort policy omits unsupported
+`none` and snaps `minimal` to `low`. Vision, native PDF input, tool search, reasoning replay,
+verbosity, and pro mode use the existing Responses paths. Astra also enables
+`supports_mid_conversation_system`: leading system/developer messages become `instructions`, while
+later messages keep their role and position in `input`. The canonical Turn IR is unchanged. Async
+tool execution, WebSocket steering, and `configuration_update` reasoning changes are not enabled.
+See the [OpenAI model guide](https://developers.openai.com/api/docs/guides/latest-model) and
+[model card](https://developers.openai.com/api/docs/models/gpt-6-astra).
+
+The `openai-compatible` lane never consults the commercial table on either API surface. Chat
+Completions uses `OpenAIChatCompletionsProvider`; the Responses pin uses
+`OpenAIResponsesProvider(compat=True)`. A local server serves whatever the operator named it, so a
+prefix collision with a cloud model ID must not inherit its sampling/effort contract. Every local
+model gets plain defaults, commercial prompt-cache controls are not injected by model-name prefix,
+and additional capabilities come from the model definition (`capabilities` JSON + `server_compat`),
+matching the `anthropic-compatible` lane.
+Native mid-conversation system messages remain disabled by default for compatible servers: a
+server's chat template may require system messages at the beginning even when it exposes the
+Responses API. These lanes keep using the existing folded operator reminders.
 
 **AnthropicProvider** (`_anthropic.py`): converts OpenAI-format messages to
 Anthropic content blocks, maps `system`/`developer` roles to the `system`
@@ -1109,7 +1131,7 @@ Three reasoning paths are recognised:
 | Path | Provider | Capture | Persist | Replay |
 |------|----------|---------|---------|--------|
 | 1 | Anthropic Messages API | `thinking_delta` | `provider_blocks` (`type="thinking"`) | Verbatim via `_provider_content` |
-| 2 | OpenAI Responses (gpt-5*, o-series) | `response.reasoning_text.delta` events | `provider_blocks` (`type="reasoning"`) — only when `include=["reasoning.encrypted_content"]` | `ResponseReasoningItemParam` input items |
+| 2 | OpenAI Responses (GPT-5+, o-series) | `response.reasoning_text.delta` events | `provider_blocks` (`type="reasoning"`) — only when `include=["reasoning.encrypted_content"]` | `ResponseReasoningItemParam` input items |
 | 3 | OpenAI Chat Completions (vLLM, llama.cpp, Gemini-compat) | `delta.reasoning_content` Pydantic extras | Synthetic `{type: "reasoning_text", text, source}` block stamped at end-of-stream | None — no API surface for replay on Chat Completions |
 
 Cross-provider safety is enforced by `ANTHROPIC_VALID_BLOCK_TYPES` (a

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -133,13 +133,11 @@ Per-LLM-request token and tool call metrics:
 - **Recording**: `on_status()` in `WebUI` records a `usage_event` after each
   LLM response with prompt/completion tokens, cache tokens, tool call count,
   model, ws_id
-- **Prompt caching**: Anthropic automatic caching (`cache_control: ephemeral`)
-  and OpenAI caching are enabled by default. Pre-5.6 GPT-5 models request
-  `prompt_cache_retention: 24h`; GPT-5.6 uses
-  `prompt_cache_options: {"ttl": "30m"}`. GPT-5.6 cache writes use the
-  provider's 1.25× input-token rate. `cache_creation_tokens` and
-  `cache_read_tokens` are tracked per request in `usage_events` and surfaced
-  in the Usage admin tab
+- **Prompt caching**: Anthropic automatic caching (`cache_control: ephemeral`) and OpenAI caching
+  are enabled by default. Pre-5.6 GPT-5 models request `prompt_cache_retention: 24h`; GPT-5.6 and
+  GPT-6 Astra use `prompt_cache_options: {"ttl": "30m"}`. Their cache writes use the provider's
+  1.25× input-token rate. `cache_creation_tokens` and `cache_read_tokens` are tracked per request in
+  `usage_events` and surfaced in the Usage admin tab
 - **Querying**: `GET /v1/api/admin/usage` with `group_by` (day/hour/model/user)
   and time range filtering — includes cache token aggregates
 - **Prometheus**: `turnstone_tokens_total{type="cache_creation|cache_read"}`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -206,12 +206,11 @@ additional fields in the Models create/edit shelf:
 | Output verbosity | `verbosity` | `low`, `medium`, `high` | Controls answer length independently of reasoning effort. |
 | Reasoning mode | `reasoning_mode` | `standard`, `pro` | Selects standard or higher-compute Pro execution without changing the model ID. |
 
-An empty selection means provider default and omits the capability key. Known
-GPT-5.6 models inherit support from the built-in table without persisting
-redundant support flags. An OpenAI-compatible model pinned to the Responses API
-can opt in with the `supports_verbosity` and `supports_pro_mode` capability
-tiles. Chat Completions and non-Responses providers do not surface or submit
-these controls.
+An empty selection means provider default and omits the capability key. Known GPT-5.6 and GPT-6
+Astra models inherit support from the built-in table without persisting redundant support flags. An
+OpenAI-compatible model pinned to the Responses API can opt in with the `supports_verbosity` and
+`supports_pro_mode` capability tiles. Chat Completions and non-Responses providers do not surface or
+submit these controls.
 
 **Removed settings:** `model.name` and `model.context_window` have been removed
 from ConfigStore. Model names and context windows are now configured per-model

--- a/tests/data/wire_payloads/openai_responses_astra__operator_system.json
+++ b/tests/data/wire_payloads/openai_responses_astra__operator_system.json
@@ -1,0 +1,56 @@
+{
+  "include": [
+    "reasoning.encrypted_content"
+  ],
+  "input": [
+    {
+      "content": "Run the deploy.",
+      "role": "user",
+      "type": "message"
+    },
+    {
+      "arguments": "{}",
+      "call_id": "call_1",
+      "name": "deploy",
+      "type": "function_call"
+    },
+    {
+      "call_id": "call_1",
+      "output": "deployed",
+      "type": "function_call_output"
+    },
+    {
+      "content": "Output-guard: deploy output looked clean.",
+      "role": "system",
+      "type": "message"
+    },
+    {
+      "content": "Great, what's next?",
+      "role": "user",
+      "type": "message"
+    }
+  ],
+  "instructions": "You are a helpful assistant.",
+  "max_output_tokens": 4096,
+  "model": "gpt-6-astra",
+  "prompt_cache_options": {
+    "ttl": "30m"
+  },
+  "reasoning": {
+    "effort": "max"
+  },
+  "store": false,
+  "stream": true,
+  "tools": [
+    {
+      "description": "Deploy the application.",
+      "name": "deploy",
+      "parameters": {
+        "properties": {},
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    }
+  ]
+}

--- a/tests/data/wire_payloads/openai_responses_astra__phased_replay.json
+++ b/tests/data/wire_payloads/openai_responses_astra__phased_replay.json
@@ -1,0 +1,73 @@
+{
+  "include": [
+    "reasoning.encrypted_content"
+  ],
+  "input": [
+    {
+      "content": "Check deployment status.",
+      "role": "user",
+      "type": "message"
+    },
+    {
+      "content": "Checking.",
+      "phase": "commentary",
+      "role": "assistant",
+      "type": "message"
+    },
+    {
+      "encrypted_content": "opaque-status",
+      "id": "rs_status",
+      "summary": [],
+      "type": "reasoning"
+    },
+    {
+      "arguments": "{}",
+      "call_id": "call_status",
+      "name": "status",
+      "type": "function_call"
+    },
+    {
+      "content": " The check is running.",
+      "phase": "final_answer",
+      "role": "assistant",
+      "type": "message"
+    },
+    {
+      "call_id": "call_status",
+      "output": "Healthy",
+      "type": "function_call_output"
+    },
+    {
+      "content": "Output-guard: status output looked clean.",
+      "role": "system",
+      "type": "message"
+    },
+    {
+      "content": "Summarize the result.",
+      "role": "user",
+      "type": "message"
+    }
+  ],
+  "instructions": "You are a helpful assistant.",
+  "max_output_tokens": 4096,
+  "model": "gpt-6-astra",
+  "prompt_cache_options": {
+    "ttl": "30m"
+  },
+  "reasoning": {
+    "effort": "max"
+  },
+  "store": false,
+  "stream": true,
+  "tools": [
+    {
+      "description": "",
+      "name": "status",
+      "parameters": {
+        "type": "object"
+      },
+      "strict": false,
+      "type": "function"
+    }
+  ]
+}

--- a/tests/test_effort_ladder_wire_parity.py
+++ b/tests/test_effort_ladder_wire_parity.py
@@ -172,6 +172,12 @@ SHAPES: tuple[Shape, ...] = (
         _GPT55_CAPS,
         model="gpt-5.5",
     ),
+    Shape(
+        "openai-gpt-6-astra",
+        "openai",
+        create_provider("openai").get_capabilities("gpt-6-astra"),
+        model="gpt-6-astra",
+    ),
     Shape("google-default", "google", _GEMINI_CAPS, model="gemini-3-flash"),
     Shape(
         # GoogleProvider subclasses the chat provider, so a template

--- a/tests/test_provider_openai_astra.py
+++ b/tests/test_provider_openai_astra.py
@@ -1,0 +1,381 @@
+"""Astra's Turn IR, lowering, and real OpenAI SDK boundary (offline)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx2
+import openai
+import pytest
+
+from turnstone.core.lowering import (
+    drop_empty_user_turns,
+    fold_system_turns,
+    repair_wire_messages,
+)
+from turnstone.core.model_turn import ModelLane, model_turn
+from turnstone.core.providers import create_provider, list_known_models, lookup_model_capabilities
+from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+from turnstone.core.trajectory import Turn
+
+
+@pytest.fixture(params=[False, True], ids=["terminal", "streamed"])
+def sdk_boundary(request):
+    requests = []
+    outputs = []
+    streamed = request.param
+
+    def handle(request):
+        assert request.url.path == "/v1/responses"
+        requests.append(json.loads(request.content))
+        output = (
+            outputs.pop(0)
+            if outputs
+            else [
+                {
+                    "type": "message",
+                    "id": "msg_test",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+                }
+            ]
+        )
+        events = []
+        if streamed:
+            for index, item in enumerate(output):
+                if item["type"] == "function_call":
+                    events.extend(
+                        [
+                            {
+                                "type": "response.output_item.added",
+                                "output_index": index,
+                                "item": {**item, "arguments": "", "status": "in_progress"},
+                            },
+                            {
+                                "type": "response.function_call_arguments.delta",
+                                "item_id": item["id"],
+                                "output_index": index,
+                                "delta": item["arguments"],
+                            },
+                        ]
+                    )
+                elif item["type"] == "message":
+                    for content_index, part in enumerate(item["content"]):
+                        events.append(
+                            {
+                                "type": "response.output_text.delta",
+                                "item_id": item["id"],
+                                "output_index": index,
+                                "content_index": content_index,
+                                "delta": part["text"],
+                                "logprobs": [],
+                            }
+                        )
+                events.append(
+                    {"type": "response.output_item.done", "output_index": index, "item": item}
+                )
+        events.append(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_test",
+                    "object": "response",
+                    "created_at": 0,
+                    "model": "gpt-6-astra",
+                    "status": "completed",
+                    "output": output,
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 10,
+                        "total_tokens": 110,
+                        "input_tokens_details": {"cached_tokens": 30, "cache_write_tokens": 70},
+                    },
+                },
+            }
+        )
+        for index, event in enumerate(events):
+            event["sequence_number"] = index
+        return httpx2.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content="".join("data: " + json.dumps(event) + "\n\n" for event in events).encode(),
+        )
+
+    with openai.OpenAI(
+        api_key="test-only",
+        base_url="https://api.example.com/v1",
+        max_retries=0,
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handle)),
+    ) as client:
+        yield client, requests, outputs
+
+
+def _prepare(messages, lane):
+    return repair_wire_messages(
+        drop_empty_user_turns(
+            fold_system_turns(
+                messages,
+                supports_mid_conversation_system=lane.capabilities.supports_mid_conversation_system,
+                nonce="testnonce",
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "effort", [None, "none", "minimal", "low", "medium", "high", "xhigh", "max"]
+)
+def test_sampling_on_real_responses_sdk(sdk_boundary, effort):
+    client, requests, _ = sdk_boundary
+    provider = create_provider("openai", api_surface="chat")
+    caps = provider.get_capabilities("gpt-6-astra")
+    lane = ModelLane(provider, client, "gpt-6-astra", capabilities=caps)
+
+    result = model_turn(lane, [Turn.user("Hello")], temperature=0.7, reasoning_effort=effort)
+
+    sent = requests[0]
+    assert result.turn.text == "ok"
+    assert not {"temperature", "top_p", "top_logprobs", "reasoning_effort"} & sent.keys()
+    if effort in (None, "none"):
+        assert "reasoning" not in sent
+    else:
+        assert sent["reasoning"] == {"effort": "low" if effort == "minimal" else effort}
+    assert sent["store"] is False
+    assert sent["prompt_cache_options"] == {"ttl": "30m"}
+    assert "prompt_cache_retention" not in sent
+
+
+def test_catalog_and_compatible_lane_isolation():
+    assert "gpt-6-astra" in list_known_models("openai")
+    caps = lookup_model_capabilities(provider="openai", model="gpt-6-astra")
+    assert caps is not None
+    assert caps["context_window"] == 1050000
+    assert caps["max_output_tokens"] == 128000
+    assert caps["supports_vision"] and caps["supports_pdf"] and caps["supports_tool_search"]
+    assert caps["server_parses_reasoning"]
+    assert lookup_model_capabilities(provider="openai", model="gpt-6-astra-test-snapshot") == caps
+    for surface in ("chat", "responses"):
+        local = create_provider("openai-compatible", api_surface=surface)
+        local_caps = local.get_capabilities("gpt-6-astra")
+        assert local_caps.supports_temperature
+        assert not local_caps.supports_mid_conversation_system
+        assert local_caps.reasoning_effort_values == ()
+
+
+def test_tool_continuation_preserves_reasoning_and_inline_instructions(sdk_boundary):
+    client, requests, outputs = sdk_boundary
+    provider = create_provider("openai")
+    caps = replace(provider.get_capabilities("gpt-6-astra"), verbosity="low", reasoning_mode="pro")
+    cfg = SimpleNamespace(capabilities={}, server_compat={}, replay_reasoning_to_model=True)
+    registry = MagicMock()
+    registry.get_config.return_value = cfg
+    lane = ModelLane(
+        provider, client, "gpt-6-astra", alias="astra", capabilities=caps, registry=registry
+    )
+    tools = [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}]
+    outputs.append(
+        [
+            {"type": "reasoning", "id": "rs_test", "summary": [], "encrypted_content": "opaque"},
+            {
+                "type": "function_call",
+                "id": "fc_test",
+                "call_id": "call_test",
+                "name": "lookup",
+                "arguments": "{}",
+                "status": "completed",
+            },
+        ]
+    )
+    turns = [Turn.system("Base instructions"), Turn.user("Look it up")]
+    first = model_turn(lane, turns, tools=tools, reasoning_effort="max", prepare_wire=_prepare)
+    assert first.turn.tool_calls[0].id == "call_test"
+    turns.extend(
+        [
+            first.turn,
+            Turn.tool("call_test", "Found it"),
+            Turn.system("Use the result carefully", source="tool_advisory"),
+        ]
+    )
+    before = copy.deepcopy(turns)
+    second = model_turn(lane, turns, tools=tools, reasoning_effort="max", prepare_wire=_prepare)
+
+    sent = requests[1]
+    assert turns == before
+    assert sent["instructions"] == requests[0]["instructions"] == "Base instructions"
+    assert sent["input"] == [
+        {"type": "message", "role": "user", "content": "Look it up"},
+        {"type": "reasoning", "id": "rs_test", "summary": [], "encrypted_content": "opaque"},
+        {"type": "function_call", "call_id": "call_test", "name": "lookup", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_test", "output": "Found it"},
+        {"type": "message", "role": "system", "content": "Use the result carefully"},
+    ]
+    assert sent["include"] == ["reasoning.encrypted_content"]
+    assert sent["reasoning"] == {"effort": "max", "mode": "pro"}
+    assert sent["text"] == {"verbosity": "low"}
+    assert sent["tools"][0]["name"] == "lookup"
+    assert "async" not in sent["tools"][0]
+    assert second.usage.cache_read_tokens == 30
+    assert second.usage.cache_creation_tokens == 70
+
+
+@pytest.mark.parametrize("replay_reasoning", [False, True])
+def test_phased_replay_through_sdk_and_minted_tool_ids(sdk_boundary, replay_reasoning):
+    client, requests, outputs = sdk_boundary
+    provider = create_provider("openai")
+    registry = MagicMock()
+    registry.get_config.return_value = SimpleNamespace(
+        capabilities={}, server_compat={}, replay_reasoning_to_model=replay_reasoning
+    )
+    lane = ModelLane(
+        provider,
+        client,
+        "gpt-6-astra",
+        alias="astra",
+        capabilities=provider.get_capabilities("gpt-6-astra"),
+        registry=registry,
+    )
+    commentary = {
+        "type": "message",
+        "id": "msg_commentary",
+        "role": "assistant",
+        "status": "completed",
+        "phase": "commentary",
+        "content": [{"type": "output_text", "text": "Checking. ", "annotations": []}],
+    }
+    final = {
+        "type": "message",
+        "id": "msg_final",
+        "role": "assistant",
+        "status": "completed",
+        "phase": "final_answer",
+        "content": [
+            {
+                "type": "output_text",
+                "text": "The answer.",
+                "annotations": [
+                    {
+                        "type": "url_citation",
+                        "url": "https://example.com",
+                        "title": "Source",
+                        "start_index": 0,
+                        "end_index": 3,
+                    }
+                ],
+            }
+        ],
+    }
+    outputs.append(
+        [
+            commentary,
+            {"type": "reasoning", "id": "rs_test", "summary": [], "encrypted_content": "opaque"},
+            {
+                "type": "function_call",
+                "id": "fc_test",
+                "call_id": "call_test",
+                "name": "lookup",
+                "arguments": "{}",
+                "status": "completed",
+            },
+            final,
+        ]
+    )
+    turns = [Turn.system("Base"), Turn.user("Find it")]
+    wire_id_map = {}
+    first = model_turn(
+        lane,
+        turns,
+        mint=lambda original: f"agent::{original}",
+        wire_id_map=wire_id_map,
+        prepare_wire=_prepare,
+    )
+    assert first.turn.text == "Checking. The answer.\n\nSources:\n- [Source](https://example.com)"
+    assert first.turn.tool_calls[0].id == "agent::call_test"
+    assert [b["phase"] for b in first.turn.native.blocks if b["type"] == "message"] == [
+        "commentary",
+        "final_answer",
+    ]
+    turns.extend(
+        [
+            first.turn,
+            Turn.tool("agent::call_test", "Found"),
+            Turn.system("Use the result carefully", source="tool_advisory"),
+        ]
+    )
+    before = copy.deepcopy(turns)
+    model_turn(lane, turns, wire_id_map=wire_id_map, prepare_wire=_prepare)
+    assert turns == before
+    items = requests[1]["input"]
+    expected = [
+        {"type": "message", "role": "user", "content": "Find it"},
+        {"type": "message", "role": "assistant", "content": "Checking. ", "phase": "commentary"},
+        {"type": "reasoning", "id": "rs_test", "summary": [], "encrypted_content": "opaque"},
+        {"type": "function_call", "call_id": "call_test", "name": "lookup", "arguments": "{}"},
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": "The answer.\n\nSources:\n- [Source](https://example.com)",
+            "phase": "final_answer",
+        },
+        {"type": "function_call_output", "call_id": "call_test", "output": "Found"},
+        {"type": "message", "role": "system", "content": "Use the result carefully"},
+    ]
+    if not replay_reasoning:
+        expected = [item for item in expected if item["type"] != "reasoning"]
+    assert items == expected
+
+
+@pytest.mark.parametrize("role", ["system", "developer"])
+@pytest.mark.parametrize("native", [False, True])
+def test_instruction_position_and_content_parts(role, native):
+    messages = [
+        {"role": role, "content": "Base"},
+        {"role": role, "content": [{"type": "text", "text": "More base"}]},
+        {"role": "user", "content": "Hello"},
+        {
+            "role": role,
+            "content": [{"type": "text", "text": "First"}, {"type": "text", "text": "Second"}],
+        },
+        {"role": role, "content": "Last"},
+    ]
+    before = copy.deepcopy(messages)
+    instructions, items = OpenAIResponsesProvider._convert_messages(
+        messages, supports_mid_conversation_system=native
+    )
+    assert messages == before
+    if native:
+        assert instructions == "Base\n\nMore base"
+        assert items[1:] == [
+            {"type": "message", "role": role, "content": "First\n\nSecond"},
+            {"type": "message", "role": role, "content": "Last"},
+        ]
+    else:
+        assert instructions == "Base\n\nMore base\n\nFirst\n\nSecond\n\nLast"
+        assert len(items) == 1
+
+
+@pytest.mark.parametrize(
+    "provider_name,model,native",
+    [
+        ("openai", "gpt-6-astra", True),
+        ("openai", "gpt-5.6-sol", False),
+        ("openai-compatible", "gpt-6-astra", False),
+    ],
+)
+def test_serving_lane_controls_system_fold(sdk_boundary, provider_name, model, native):
+    client, requests, _ = sdk_boundary
+    provider = create_provider(provider_name, api_surface="responses")
+    lane = ModelLane(provider, client, model, capabilities=provider.get_capabilities(model))
+    turns = [Turn.user("Hello"), Turn.system("Tail", source="skill_hint")]
+    model_turn(lane, turns, prepare_wire=_prepare)
+    items = requests[0]["input"]
+    if native:
+        assert items[-1] == {"type": "message", "role": "system", "content": "Tail"}
+    else:
+        assert len(items) == 1
+        assert "[start system-reminder_testnonce]" in items[0]["content"]
+        assert "Tail" in items[0]["content"]

--- a/tests/test_provider_openai_responses_phase.py
+++ b/tests/test_provider_openai_responses_phase.py
@@ -1,0 +1,232 @@
+"""Responses phases survive replay without overriding the canonical history."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from turnstone.core.lowering import neutralize_message_fence_markers
+from turnstone.core.providers._openai_responses import OpenAIResponsesProvider
+from turnstone.core.providers._xai import XAIProvider
+
+
+def _message(text, phase, *, annotations=None):
+    return {
+        "type": "message",
+        "id": f"msg_{phase}",
+        "role": "assistant",
+        "status": "completed",
+        "phase": phase,
+        "content": [{"type": "output_text", "text": text, "annotations": annotations or []}],
+    }
+
+
+def _fixture():
+    blocks = [
+        {"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": "enc1"},
+        _message("Checking. ", "commentary"),
+        {"type": "reasoning", "id": "rs_2", "summary": [], "encrypted_content": "enc2"},
+        {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
+        _message("Here is the answer.", "final_answer"),
+    ]
+    return [
+        {
+            "role": "assistant",
+            "content": "Checking. Here is the answer.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "lookup", "arguments": "{}"}}],
+            "_producer": "openai",
+            "_provider_content": blocks,
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "Found it"},
+    ]
+
+
+@pytest.mark.parametrize("replay_reasoning", [False, True])
+def test_ordered_phases_and_canonical_tool_arguments(replay_reasoning):
+    messages = _fixture()
+    # Lowering can repair arguments/name while retaining the provider call ID.
+    messages[0]["tool_calls"][0]["function"] = {"name": "lookup_fixed", "arguments": '{"q":1}'}
+    before = copy.deepcopy(messages)
+    _, items = OpenAIResponsesProvider._convert_messages(
+        messages, replay_reasoning_to_model=replay_reasoning
+    )
+    expected = [
+        {"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": "enc1"},
+        {"type": "message", "role": "assistant", "content": "Checking. ", "phase": "commentary"},
+        {"type": "reasoning", "id": "rs_2", "summary": [], "encrypted_content": "enc2"},
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup_fixed",
+            "arguments": '{"q":1}',
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": "Here is the answer.",
+            "phase": "final_answer",
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "Found it"},
+    ]
+    if not replay_reasoning:
+        expected = [item for item in expected if item["type"] != "reasoning"]
+    assert items == expected
+    assert messages == before
+
+
+@pytest.mark.parametrize(
+    "content", ["Edited answer.", "", "Checking. Here is the answer. New text."]
+)
+def test_edited_text_does_not_replay_stale_content_or_phase(content):
+    messages = _fixture()
+    messages[0]["content"] = content
+    _, items = OpenAIResponsesProvider._convert_messages(messages)
+    assistant = [item for item in items if item.get("role") == "assistant"]
+    assert assistant == (
+        [{"type": "message", "role": "assistant", "content": content}] if content else []
+    )
+
+
+@pytest.mark.parametrize("edit", ["remove", "replace_id", "add"])
+def test_changed_calls_do_not_replay_stale_native_layout(edit):
+    messages = _fixture()
+    if edit == "remove":
+        messages[0]["tool_calls"] = []
+    elif edit == "replace_id":
+        messages[0]["tool_calls"][0]["id"] = "call_new"
+        messages[1]["tool_call_id"] = "call_new"
+    else:
+        messages[0]["tool_calls"].append(
+            {"id": "call_new", "function": {"name": "new_tool", "arguments": "{}"}}
+        )
+    _, items = OpenAIResponsesProvider._convert_messages(messages)
+    assert not any("phase" in item for item in items)
+    assert [item["call_id"] for item in items if item["type"] == "function_call"] == [
+        call["id"] for call in messages[0]["tool_calls"]
+    ]
+
+
+@pytest.mark.parametrize("phase", [None, "future_phase", "commentary", "final_answer"])
+def test_only_known_message_phases_are_projected(phase):
+    _, items = OpenAIResponsesProvider._convert_messages(
+        [{"role": "assistant", "content": "Hi", "_provider_content": [_message("Hi", phase)]}]
+    )
+    expected = {"type": "message", "role": "assistant", "content": "Hi"}
+    if phase in ("commentary", "final_answer"):
+        expected["phase"] = phase
+    assert items == [expected]
+
+
+@pytest.mark.parametrize("producer", [None, "", "openai", "xai", "anthropic"])
+def test_native_metadata_is_scoped_to_producer_with_legacy_fallback(producer):
+    messages = _fixture()
+    if producer is None:
+        del messages[0]["_producer"]
+    else:
+        messages[0]["_producer"] = producer
+    _, items = OpenAIResponsesProvider._convert_messages(messages, replay_reasoning_to_model=True)
+    eligible = producer in (None, "", "openai")
+    assert any("phase" in item for item in items) == eligible
+    assert any(item["type"] == "reasoning" for item in items) == eligible
+
+
+def test_xai_subclass_replays_its_own_native_metadata():
+    messages = _fixture()
+    messages[0]["_producer"] = "xai"
+    payload = XAIProvider()._build_kwargs("grok-4.20", messages, None, 1000, None, None, None)
+    assert [item["phase"] for item in payload["input"] if "phase" in item] == [
+        "commentary",
+        "final_answer",
+    ]
+    assert any(item["type"] == "reasoning" for item in payload["input"])
+
+
+@pytest.mark.parametrize("part", [None, {"type": "output_text", "text": None}, {"type": "unknown"}])
+def test_unrecognized_native_message_content_uses_canonical_fallback(part):
+    messages = _fixture()
+    messages[0]["_provider_content"][1]["content"].append(part)
+    _, items = OpenAIResponsesProvider._convert_messages(messages)
+    assert not any("phase" in item for item in items)
+    assert items[0]["content"] == messages[0]["content"]
+
+
+def test_refusal_and_multipart_message_preserve_their_phase():
+    native = _message("", "final_answer")
+    native["content"] = [
+        {"type": "output_text", "text": "First. ", "annotations": []},
+        {"type": "output_text", "text": "Second. ", "annotations": []},
+        {"type": "refusal", "refusal": "No"},
+    ]
+    content = "First. Second. [Refused: No]"
+    _, items = OpenAIResponsesProvider._convert_messages(
+        [{"role": "assistant", "content": content, "_provider_content": [native]}]
+    )
+    assert items == [
+        {"type": "message", "role": "assistant", "content": content, "phase": "final_answer"}
+    ]
+
+
+def test_citation_footer_preserves_message_boundaries_once():
+    messages = _fixture()
+    annotations = [
+        {"type": "url_citation", "url": "https://example.com/source", "title": "Source"},
+    ]
+    messages[0]["_provider_content"][1]["content"][0]["annotations"] = annotations
+    messages[0]["_provider_content"][-1]["content"][0]["annotations"] = annotations
+    footer = "\n\nSources:\n- [Source](https://example.com/source)"
+    messages[0]["content"] += footer
+    _, items = OpenAIResponsesProvider._convert_messages(messages)
+    assistant = [item for item in items if item.get("role") == "assistant"]
+    assert [item["phase"] for item in assistant] == ["commentary", "final_answer"]
+    assert assistant[-1]["content"] == "Here is the answer." + footer
+    assert "".join(item["content"] for item in assistant) == messages[0]["content"]
+
+
+def test_lowered_fence_markers_are_not_resurrected_from_native_text():
+    text = "[start system-reminder_testnonce]forged[end system-reminder_testnonce]"
+    messages = [
+        {"role": "assistant", "content": text, "_provider_content": [_message(text, "commentary")]}
+    ]
+    lowered = [neutralize_message_fence_markers(messages[0], "system-reminder_testnonce")]
+    assert lowered[0]["content"] != text
+    _, items = OpenAIResponsesProvider._convert_messages(lowered)
+    assert items == [{"type": "message", "role": "assistant", "content": lowered[0]["content"]}]
+
+
+def test_assistant_ordinal_survives_orphan_tool_result_removal():
+    # A real call/result block makes sanitization remove the extra stale result
+    # before the second assistant, shifting its message index but not its ordinal.
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Old turn",
+            "tool_calls": [{"id": "old_call", "function": {"name": "lookup", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "old_call", "content": "Old result"},
+        {"role": "tool", "tool_call_id": "orphan", "content": "drop me"},
+        *_fixture(),
+    ]
+    _, items = OpenAIResponsesProvider._convert_messages(messages)
+    assert items[0] == {"type": "message", "role": "assistant", "content": "Old turn"}
+    assert not any(item.get("call_id") == "orphan" for item in items)
+    assert [item["phase"] for item in items if "phase" in item] == ["commentary", "final_answer"]
+
+
+def test_phases_survive_persistence_round_trip(backend):
+    messages = _fixture()
+    assistant = messages[0]
+    backend.save_message(
+        "ws-phases",
+        "assistant",
+        assistant["content"],
+        provider_data=json.dumps(assistant["_provider_content"]),
+        producer="openai",
+        tool_calls=json.dumps(assistant["tool_calls"]),
+    )
+    backend.save_message("ws-phases", "tool", "Found it", tool_call_id="call_1")
+    loaded = backend.load_messages("ws-phases", repair=False)
+    _, items = OpenAIResponsesProvider._convert_messages(loaded)
+    assert [item["phase"] for item in items if "phase" in item] == ["commentary", "final_answer"]
+    assert [item["call_id"] for item in items if "call_id" in item] == ["call_1", "call_1"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -4933,7 +4933,9 @@ class TestOpenAIPromptCaching:
     def setup_method(self) -> None:
         self.provider = OpenAIProvider()
 
-    @pytest.mark.parametrize("model", ("gpt-5.5-local-lora", "gpt-5.6-local-lora"))
+    @pytest.mark.parametrize(
+        "model", ("gpt-5.5-local-lora", "gpt-5.6-local-lora", "gpt-6-astra-local-lora")
+    )
     def test_chat_compat_streaming_omits_commercial_cache_params(self, model: str) -> None:
         """A local model name must not activate commercial OpenAI cache controls."""
         client = MagicMock()
@@ -5639,7 +5641,7 @@ class TestResponsesParamBuilding:
 
     def test_compat_responses_omits_commercial_cache_params(self) -> None:
         provider = type(self.provider)(compat=True)
-        for model in ("gpt-5.5-local-lora", "gpt-5.6-local-lora"):
+        for model in ("gpt-5.5-local-lora", "gpt-5.6-local-lora", "gpt-6-astra-local-lora"):
             kwargs = provider._build_kwargs(
                 model=model,
                 messages=[{"role": "user", "content": "Hi"}],

--- a/tests/test_wire_payload_golden.py
+++ b/tests/test_wire_payload_golden.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 
 from tests._wire_capture import RecordingClient
-from turnstone.core.lowering import repair_wire_messages
+from turnstone.core.lowering import fold_system_turns, repair_wire_messages
 from turnstone.core.providers._anthropic import AnthropicProvider
 from turnstone.core.providers._google import GoogleProvider
 from turnstone.core.providers._openai_chat import OpenAIChatCompletionsProvider
@@ -359,3 +359,105 @@ def test_wire_payload_openai_verbosity_pro() -> None:
     assert payload["text"] == {"verbosity": "low"}
     assert payload["reasoning"] == {"effort": "high", "mode": "pro"}
     _assert_golden("openai_responses_verbosity_pro__text", payload)
+
+
+def test_wire_payload_openai_astra_operator_system() -> None:
+    """Astra keeps the base prompt stable and operator instructions in place."""
+    provider = OpenAIResponsesProvider()
+    caps = provider.get_capabilities("gpt-6-astra")
+    messages = fold_system_turns(
+        [{"role": "system", "content": "You are a helpful assistant."}, *FIX_OPERATOR_SYSTEM],
+        supports_mid_conversation_system=caps.supports_mid_conversation_system,
+        nonce="testnonce",
+    )
+    payload = _capture(
+        provider,
+        model="gpt-6-astra",
+        messages=messages,
+        caps=caps,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "deploy",
+                    "description": "Deploy the application.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        temperature=0.7,
+        reasoning_effort="max",
+    )
+    assert payload["instructions"] == "You are a helpful assistant."
+    assert payload["input"][3] == {
+        "type": "message",
+        "role": "system",
+        "content": "Output-guard: deploy output looked clean.",
+    }
+    assert "temperature" not in payload
+    _assert_golden("openai_responses_astra__operator_system", payload)
+
+
+def test_wire_payload_openai_astra_phased_replay() -> None:
+    """Native phases/order coexist with tool results and inline instructions."""
+    provider = OpenAIResponsesProvider()
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Check deployment status."},
+        {
+            "role": "assistant",
+            "content": "Checking. The check is running.",
+            "tool_calls": [
+                {"id": "call_status", "function": {"name": "status", "arguments": "{}"}}
+            ],
+            "_producer": "openai",
+            "_provider_content": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Checking.", "annotations": []}],
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_status",
+                    "summary": [],
+                    "encrypted_content": "opaque-status",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_status",
+                    "name": "status",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "phase": "final_answer",
+                    "content": [
+                        {"type": "output_text", "text": " The check is running.", "annotations": []}
+                    ],
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_status", "content": "Healthy"},
+        {"role": "system", "content": "Output-guard: status output looked clean."},
+        {"role": "user", "content": "Summarize the result."},
+    ]
+    payload = _capture(
+        provider,
+        model="gpt-6-astra",
+        messages=fold_system_turns(
+            messages, supports_mid_conversation_system=True, nonce="testnonce"
+        ),
+        reasoning_effort="max",
+        replay_reasoning_to_model=True,
+        tools=[
+            {"type": "function", "function": {"name": "status", "parameters": {"type": "object"}}}
+        ],
+    )
+    assert [item["phase"] for item in payload["input"] if "phase" in item] == [
+        "commentary",
+        "final_answer",
+    ]
+    _assert_golden("openai_responses_astra__phased_replay", payload)

--- a/turnstone/core/lowering.py
+++ b/turnstone/core/lowering.py
@@ -403,7 +403,7 @@ def fold_system_turns(
     before folding so it can never defang a real fence appended here.
 
     Native models (*supports_mid_conversation_system*) keep the turns inline —
-    the Anthropic converter emits them as real ``system`` messages.  Base-prompt
+    the provider converter emits them as real ``system`` messages.  Base-prompt
     system messages (no ``_source``) pass through.  Consecutive operator turns
     fold onto the shared predecessor in order, so the wire never carries two
     adjacent ``system`` messages.  An operator turn with no predecessor (should

--- a/turnstone/core/providers/_openai_common.py
+++ b/turnstone/core/providers/_openai_common.py
@@ -347,6 +347,22 @@ OPENAI_CAPABILITIES: dict[str, ModelCapabilities] = {
         supports_verbosity=True,
         supports_pro_mode=True,
     ),
+    # GPT-6 Astra — Responses is required for tool calling. Reasoning cannot
+    # be disabled, and sampling parameters are rejected at every effort level.
+    # An unspecified effort stays server-selected.
+    "gpt-6-astra": ModelCapabilities(
+        context_window=1050000,
+        max_output_tokens=128000,
+        supports_temperature=False,
+        reasoning_effort_values=("low", "medium", "high", "xhigh", "max"),
+        supports_tool_search=True,
+        supports_vision=True,
+        supports_pdf=True,
+        supports_reasoning_replay=True,
+        supports_mid_conversation_system=True,
+        supports_verbosity=True,
+        supports_pro_mode=True,
+    ),
     # Search models — always search on every request, no reasoning_effort
     "gpt-5-search-api": ModelCapabilities(
         context_window=400000,
@@ -486,13 +502,13 @@ def apply_temperature_and_effort(
 
 
 def apply_cache_retention(kwargs: dict[str, Any], model: str) -> None:
-    """Configure the prompt-cache lifetime supported by each GPT-5 generation.
+    """Configure the prompt-cache lifetime supported by each known generation.
 
-    GPT-5.6 replaces the deprecated ``prompt_cache_retention`` field with
+    GPT-5.6 and Astra replace the deprecated ``prompt_cache_retention`` field with
     ``prompt_cache_options.ttl``; 30 minutes is currently its only accepted
     minimum lifetime.  Earlier GPT-5 models retain the 24-hour policy.
     """
-    if model.startswith("gpt-5.6"):
+    if model.startswith(("gpt-5.6", "gpt-6-astra")):
         kwargs["prompt_cache_options"] = {"ttl": "30m"}
     elif model.startswith("gpt-5"):
         kwargs["prompt_cache_retention"] = "24h"

--- a/turnstone/core/providers/_openai_responses.py
+++ b/turnstone/core/providers/_openai_responses.py
@@ -1,4 +1,4 @@
-"""Responses API provider — for commercial OpenAI models (GPT-5.x, O-series).
+"""Responses API provider — for commercial OpenAI models.
 
 Uses the OpenAI Responses API (``/v1/responses``) which natively supports
 reasoning, tool use, web search, and tool search without the limitations
@@ -8,6 +8,7 @@ of the Chat Completions endpoint.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
@@ -33,12 +34,14 @@ from turnstone.core.providers._openai_common import (
     sanitize_messages,
 )
 from turnstone.core.providers._protocol import (
+    TRAILING_INFO_SEPARATOR,
     ModelCapabilities,
     ProviderRequestMetrics,
     StreamChunk,
     ToolCallDelta,
     _join_reasoning_with_cap,
     finish_shim_due,
+    folds_trailing_info,
     refuse_aborted_request,
     request_uses_native_tools,
     resolve_reasoning_effort,
@@ -183,68 +186,36 @@ class OpenAIResponsesProvider:
         messages: list[dict[str, Any]],
         *,
         replay_reasoning_to_model: bool = False,
+        supports_mid_conversation_system: bool = False,
+        native_producer: str = "openai",
     ) -> tuple[str | None, list[dict[str, Any]]]:
         """Convert Chat Completions messages to Responses API input items.
 
         Returns ``(instructions, input_items)`` where *instructions* is the
         concatenated system/developer messages (or ``None``) and *input_items*
-        is the Responses API ``input`` array.
+        is the Responses API ``input`` array. With native mid-conversation
+        system support, only leading instructions are hoisted; later system
+        and developer messages retain their role and position in ``input``.
 
-        When *replay_reasoning_to_model* is True, stored ``_provider_content``
-        reasoning items (``type=="reasoning"``, captured via
-        ``include=["reasoning.encrypted_content"]`` on a prior turn)
-        are emitted as ``ResponseReasoningItemParam`` input items
-        immediately before the assistant message they belong to.  The
-        SDK explicitly documents this round-trip pattern at
-        ``response_reasoning_item_param.py:33-37``: "Be sure to include
-        these items in your ``input`` to the Responses API for
-        subsequent turns of a conversation if you are manually managing
-        context".  Even with ``store=False``, ``encrypted_content``
-        round-trips correctly per ``response_create_params.py:70-74``.
-
-        When *replay_reasoning_to_model* is False, reasoning items are silently
-        dropped (they were stripped from the wire by ``sanitize_messages``
-        anyway, but we also skip the input-item emission step).
-
-        Default ``False`` differs intentionally from
-        ``AnthropicProvider._convert_messages`` (which defaults
-        ``True``).  Anthropic's default exists for back-compat with
-        pre-Phase-2 callers who never threaded the kwarg; OpenAI
-        Responses replay is brand-new in Phase 3 and has no such
-        legacy.  Production callers (``_build_kwargs``) always pass
-        the resolved flag explicitly, so the default only matters in
-        tests.  Conservative-default-False keeps the persist-only
-        capture path live without forcing a downstream cost on every
-        unaware caller.
+        Native assistant message boundaries and ``phase`` survive when they
+        still match canonical text and call order. Reasoning items are replayed
+        only when *replay_reasoning_to_model* is True; phase is independent of
+        that toggle. Explicitly foreign producer metadata is ignored, while
+        untagged legacy native blocks retain shape-based replay.
         """
-        # Capture ``_provider_content`` reasoning items per ASSISTANT
-        # ORDINAL (not raw message index) BEFORE sanitization strips
-        # the underscore-prefixed key.  Position-by-index would be
-        # unsafe: ``sanitize_messages`` drops orphan tool results
-        # (``_openai_common.py:489-498`` / ``:521-535``) and inserts
-        # synthesized error tool messages for orphaned tool_calls
-        # (``:510-517``).  Either operation shifts subsequent message
-        # indices, so a pre-vs-post-sanitize index match would
-        # silently miss reasoning attachments after any tool-message
-        # repair.  Assistant messages themselves are never dropped or
-        # duplicated by sanitize_messages — only tool messages — so
-        # the n-th assistant in the original list is invariably the
-        # n-th assistant in the sanitized list.  Ordinal-keyed lookup
-        # survives any tool-message length change.
-        reasoning_by_assistant_ordinal: dict[int, list[dict[str, Any]]] = {}
-        if replay_reasoning_to_model:
-            ord_pre = 0
-            for raw_msg in messages:
-                if raw_msg.get("role") != "assistant":
-                    continue
-                pc = raw_msg.get("_provider_content")
-                if isinstance(pc, list):
-                    items_to_replay = [
-                        b for b in pc if isinstance(b, dict) and b.get("type") == "reasoning"
-                    ]
-                    if items_to_replay:
-                        reasoning_by_assistant_ordinal[ord_pre] = items_to_replay
-                ord_pre += 1
+        # Save native blocks before sanitization strips private fields. Key by
+        # assistant ordinal: sanitizer repair inserts/drops tool results, so raw
+        # message indices can shift, but assistants are never dropped/duplicated.
+        native_by_assistant_ordinal: dict[int, list[dict[str, Any]]] = {}
+        ord_pre = 0
+        for raw_msg in messages:
+            if raw_msg.get("role") != "assistant":
+                continue
+            pc = raw_msg.get("_provider_content")
+            producer = raw_msg.get("_producer")
+            if isinstance(pc, list) and (not producer or producer == native_producer):
+                native_by_assistant_ordinal[ord_pre] = [b for b in pc if isinstance(b, dict)]
+            ord_pre += 1
 
         # Skip PDF inlining: this lane has a native ``input_file`` block, so the
         # ``application/pdf`` document part must survive to ``convert_content_parts``
@@ -253,10 +224,6 @@ class OpenAIResponsesProvider:
         messages = sanitize_messages(messages, skip_pdf_inline=True)
         instructions_parts: list[str] = []
         items: list[dict[str, Any]] = []
-        # Track assistant ordinal in the SANITIZED list so the lookup
-        # into reasoning_by_assistant_ordinal stays aligned with the
-        # original-list ordinal.  See the long comment above for why
-        # ordinal is invariant under sanitization.
         assistant_ordinal_post = 0
 
         for msg in messages:
@@ -264,13 +231,25 @@ class OpenAIResponsesProvider:
             content = msg.get("content")
 
             if role in ("system", "developer"):
+                instruction_text: list[str] = []
                 if isinstance(content, str) and content:
-                    instructions_parts.append(content)
+                    instruction_text.append(content)
                 elif isinstance(content, list):
                     # Content parts — extract text
                     for part in content:
                         if isinstance(part, dict) and part.get("type") == "text":
-                            instructions_parts.append(part["text"])
+                            instruction_text.append(part["text"])
+                if instruction_text:
+                    if supports_mid_conversation_system and items:
+                        items.append(
+                            {
+                                "type": "message",
+                                "role": role,
+                                "content": "\n\n".join(instruction_text),
+                            }
+                        )
+                    else:
+                        instructions_parts.extend(instruction_text)
                 continue
 
             if role == "user":
@@ -285,37 +264,14 @@ class OpenAIResponsesProvider:
                 items.append(item)
 
             elif role == "assistant":
-                # Phase 3 reasoning replay: emit stored reasoning items
-                # BEFORE the assistant message they belong to.  The SDK
-                # expects reasoning items to appear in input order
-                # alongside the assistant turn that produced them.
-                for r_item in reasoning_by_assistant_ordinal.get(assistant_ordinal_post, []):
-                    item_for_input = _reasoning_item_for_input(r_item)
-                    if item_for_input is not None:
-                        items.append(item_for_input)
+                items.extend(
+                    _assistant_items_for_input(
+                        msg,
+                        native_by_assistant_ordinal.get(assistant_ordinal_post, []),
+                        replay_reasoning_to_model=replay_reasoning_to_model,
+                    )
+                )
                 assistant_ordinal_post += 1
-
-                # Text content → assistant message (plain string for input)
-                if content:
-                    items.append(
-                        {
-                            "type": "message",
-                            "role": "assistant",
-                            "content": content,
-                        }
-                    )
-
-                # Tool calls → function_call items
-                for tc in msg.get("tool_calls") or []:
-                    func = tc.get("function", {})
-                    items.append(
-                        {
-                            "type": "function_call",
-                            "call_id": tc.get("id", ""),
-                            "name": func.get("name", ""),
-                            "arguments": func.get("arguments", ""),
-                        }
-                    )
 
             elif role == "tool":
                 # Tool result → function_call_output
@@ -429,7 +385,10 @@ class OpenAIResponsesProvider:
         caps = capabilities or self.get_capabilities(model)
 
         instructions, input_items = self._convert_messages(
-            messages, replay_reasoning_to_model=replay_reasoning_to_model
+            messages,
+            replay_reasoning_to_model=replay_reasoning_to_model,
+            supports_mid_conversation_system=caps.supports_mid_conversation_system,
+            native_producer=self.provider_name,
         )
         tools = apply_tool_search(caps, tools, deferred_names)
         converted_tools = self._convert_tools(tools, caps)
@@ -952,6 +911,96 @@ class OpenAIResponsesProvider:
                     if isinstance(text, str) and text:
                         parts.append(text)
         return _join_reasoning_with_cap(parts)
+
+
+def _assistant_items_for_input(
+    message: dict[str, Any],
+    native: list[dict[str, Any]],
+    *,
+    replay_reasoning_to_model: bool,
+) -> list[dict[str, Any]]:
+    """Recover native message phases/order only while canonical history agrees.
+
+    A Turn joins all output messages into one text field. Native blocks retain
+    their boundaries, but may predate edits, fence neutralization, or call repair.
+    Match the text and call IDs before using that layout, and always construct
+    calls from the lowered canonical fields. An ambiguous layout falls back to
+    canonical text/calls with no guessed phase, plus the existing reasoning replay.
+    """
+    content = message.get("content")
+    calls = [
+        {
+            "type": "function_call",
+            "call_id": tc.get("id", ""),
+            "name": tc.get("function", {}).get("name", ""),
+            "arguments": tc.get("function", {}).get("arguments", ""),
+        }
+        for tc in message.get("tool_calls") or []
+    ]
+    reasoning: list[dict[str, Any]] = []
+    ordered: list[dict[str, Any]] = []
+    text_items: list[dict[str, Any]] = []
+    native_call_ids: list[str] = []
+    annotations: list[Any] = []
+    valid_layout = isinstance(content, str)
+    for block in native:
+        kind = block.get("type")
+        if kind == "reasoning" and replay_reasoning_to_model:
+            item = _reasoning_item_for_input(block)
+            if item is not None:
+                reasoning.append(item)
+                ordered.append(item)
+        elif kind == "function_call":
+            if len(native_call_ids) < len(calls):
+                ordered.append(calls[len(native_call_ids)])
+            native_call_ids.append(block.get("call_id", ""))
+        elif kind == "message":
+            parts = block.get("content")
+            if block.get("role") != "assistant" or not isinstance(parts, list):
+                valid_layout = False
+                continue
+            texts: list[str] = []
+            for part in parts:
+                if not isinstance(part, dict):
+                    valid_layout = False
+                elif part.get("type") == "output_text" and isinstance(part.get("text"), str):
+                    texts.append(part["text"])
+                    annotations.extend(
+                        SimpleNamespace(**ann)
+                        for ann in part.get("annotations") or []
+                        if isinstance(ann, dict)
+                    )
+                elif part.get("type") == "refusal" and isinstance(part.get("refusal"), str):
+                    texts.append(format_refusal(part["refusal"]))
+                else:
+                    valid_layout = False
+            text = "".join(texts)
+            if text:
+                projected = {"type": "message", "role": "assistant", "content": text}
+                if block.get("phase") in ("commentary", "final_answer"):
+                    projected["phase"] = block["phase"]
+                text_items.append(projected)
+                ordered.append(projected)
+        # Hosted tool output remains omitted, as on the legacy replay path.
+
+    if valid_layout and text_items and native_call_ids == [call["call_id"] for call in calls]:
+        native_text = "".join(item["content"] for item in text_items)
+        if content == native_text:
+            return ordered
+        # Streaming appends a deduplicated citation footer to the canonical text.
+        # Recognize that exact transform; an arbitrary appended edit is ambiguous.
+        footer = format_citations("", annotations).strip()
+        if (
+            footer
+            and folds_trailing_info(native_text)
+            and content == native_text + TRAILING_INFO_SEPARATOR + footer
+        ):
+            text_items[-1]["content"] += TRAILING_INFO_SEPARATOR + footer
+            return ordered
+
+    if content:
+        reasoning.append({"type": "message", "role": "assistant", "content": content})
+    return reasoning + calls
 
 
 def _reasoning_item_for_input(stored: dict[str, Any]) -> dict[str, Any] | None:

--- a/turnstone/core/providers/_protocol.py
+++ b/turnstone/core/providers/_protocol.py
@@ -599,11 +599,11 @@ class ModelCapabilities:
     # Mid-conversation system messages: append ``{"role": "system"}`` to the
     # ``messages`` array (rather than editing the top-level ``system`` field) to
     # add operator-level instructions partway through a session without
-    # invalidating the cached prefix.  When False, ``system``-role messages must
-    # be hoisted into the top-level ``system`` param (the universal fallback).
-    # Available on the Claude API only (NOT Bedrock / Vertex / Foundry), on
-    # every row that sets this flag (validated header-less on claude-opus-4-8;
-    # documented wire surface); no beta header required.
+    # invalidating the cached prefix. When False, lowering folds operator turns
+    # into nonce-fenced reminders on the preceding input turn. Native Anthropic
+    # rows use inline Messages system blocks; native OpenAI Responses rows use
+    # system/developer input messages. Provider converters hoist only leading
+    # instructions on native lanes. No beta header is required.
     supports_mid_conversation_system: bool = False
     # Phase 3 reranker calibration — populated by calibrate-on-detect; read by
     # ChatSession._bm25_rerank_threshold. A non-empty rerank_scale is the

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -8810,7 +8810,7 @@ class ChatSession:
         models get each turn wrapped as a nonce-delimited
         ``[start system-reminder]`` block on the preceding turn; native
         mid-conversation-system models (rows with the capability flag)
-        keep them inline for the Anthropic converter to emit as real
+        keep them inline for the provider converter to emit as real
         ``system`` messages.
 
         Messages without a foldable system turn pass through unchanged


### PR DESCRIPTION
GPT-6 Astra currently falls through to generic commercial OpenAI capabilities, and Responses history replay drops assistant message phases and coalesces message boundaries. This change adds the Astra capability row and preserves the Responses history structure through the existing Turn IR, lowering, and provider path.

- Add documented Astra limits, reasoning efforts, supported output controls, and the current cache policy; omit unsupported sampling parameters.
- Enable positional system/developer input for Astra while keeping leading instructions stable. Compatible servers retain folded operator reminders by default.
- Preserve `commentary` / `final_answer` phases and native item order when stored text and call IDs still match canonical history. Repaired tool arguments and restored IDs remain authoritative; ambiguous edits fall back to current text without a guessed phase. Phase replay is independent of reasoning replay.
- Add Astra goldens for inline system messages and phased replay, plus SDK, lowering, persistence, and compatibility regressions. Update provider documentation.

Async tool calling, WebSocket steering, and reasoning configuration-update events remain outside this change because they need additional pending-call, transport, or persistent-history state.

Validation:

- Full standard non-live SQLite suite: 13,572 passed, 49 skipped, 17 deselected (`-m 'not live and not e2e_recovery'`).
- 865 focused tests passed; Ruff checks and formatting passed; full mypy passed for 261 source files.
- Real OpenAI SDK 3 tests cover streamed and terminal-only capture, citation footers, tool continuations, and minted IDs.
- Six live probes passed against vLLM 0.28.0 serving `qwen3.8-27b`: text, folded instructions, generated tool calls and continuation, seeded Astra phases, and edited-history fallback. An explicit inline-system opt-in returned the server's expected HTTP 400; that capability stays disabled for compatible servers.
- Live evidence covers the compatible Qwen endpoint. Astra itself was validated with official documentation, SDK mocks, and golden payloads; no commercial Astra request was made.
