### PR TITLE
fix(mcp): separate caller deadlines from server failures

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -818,6 +818,15 @@ MCP-compatible service.
    generic approval preview and `_exec_mcp_tool()` calls `MCPClientManager.call_tool_sync()`,
    which dispatches the call to the background asyncio event loop.
 
+   If the caller's timeout expires, turnstone cancels its local wait without changing
+   the server's circuit-breaker failure count. This also applies to resource reads,
+   prompt retrievals, and calls still waiting for a per-user session lock. Observed
+   transport failures still count. Static reconnection precedes the operation timeout;
+   per-user calls include token lookup, connection, and lock waiting in their budget.
+   A timeout does not confirm remote cancellation: the server may continue working,
+   and timed-out tool calls retain an unknown outcome. A connected server that never
+   answers can continue to consume each caller's timeout budget.
+
 ### Approval behavior
 
 MCP tools **require user approval by default** (`needs_approval: True`). turnstone

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -2840,7 +2840,7 @@ class TestFutureCancellation:
     def test_call_tool_sync_cancels_future_on_timeout(self):
         mgr = self._make_manager_with_session()
         mock_future = MagicMock()
-        mock_future.result.side_effect = concurrent.futures.TimeoutError()
+        mock_future.exception.side_effect = concurrent.futures.TimeoutError()
         with (
             patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
             pytest.raises(TimeoutError, match="timed out"),
@@ -2851,7 +2851,7 @@ class TestFutureCancellation:
     def test_read_resource_sync_cancels_future_on_timeout(self):
         mgr = self._make_manager_with_session()
         mock_future = MagicMock()
-        mock_future.result.side_effect = concurrent.futures.TimeoutError()
+        mock_future.exception.side_effect = concurrent.futures.TimeoutError()
         with (
             patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
             pytest.raises(TimeoutError, match="timed out"),
@@ -2862,7 +2862,7 @@ class TestFutureCancellation:
     def test_get_prompt_sync_cancels_future_on_timeout(self):
         mgr = self._make_manager_with_session()
         mock_future = MagicMock()
-        mock_future.result.side_effect = concurrent.futures.TimeoutError()
+        mock_future.exception.side_effect = concurrent.futures.TimeoutError()
         with (
             patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
             pytest.raises(TimeoutError, match="timed out"),
@@ -2992,21 +2992,23 @@ class TestCircuitBreaker:
         assert "srv" not in mgr._circuit_open_until
         assert "srv" not in mgr._circuit_trip_count
 
-    def test_call_tool_sync_records_failure_on_timeout(self):
+    def test_call_tool_sync_preserves_failure_count_on_caller_timeout(self):
         mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})
         mock_session = MagicMock()
         mock_session.call_tool = MagicMock(return_value="sentinel")
         _seed_static_state(mgr, "test", session=mock_session)
         mgr._loop = MagicMock()
         mgr._tool_map["mcp__test__ping"] = ("test", "ping")
+        mgr._consecutive_failures["test"] = 2
         mock_future = MagicMock()
-        mock_future.result.side_effect = concurrent.futures.TimeoutError()
+        mock_future.exception.side_effect = concurrent.futures.TimeoutError()
         with (
             patch("asyncio.run_coroutine_threadsafe", new=_dispatch_stub(mock_future)),
             pytest.raises(TimeoutError),
         ):
             mgr.call_tool_sync("mcp__test__ping", {}, timeout=1)
-        assert mgr._consecutive_failures.get("test", 0) == 1
+        assert mgr._consecutive_failures["test"] == 2
+        assert "test" not in mgr._circuit_open_until
 
     def test_call_tool_sync_records_success(self):
         mgr = MCPClientManager({"test": {"type": "stdio", "command": "echo"}})

--- a/tests/test_mcp_dispatch_timeouts.py
+++ b/tests/test_mcp_dispatch_timeouts.py
@@ -1,0 +1,192 @@
+"""Foreground MCP deadlines must not be mistaken for server failures."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import anyio
+import pytest
+
+from tests.conftest import _run_on_loop, _seed_static_state, stop_loop_thread
+from turnstone.core.mcp_client import MCPClientManager, PoolEntryState
+
+_KEY = ("user-1", "srv")
+_ROW = {"name": "srv", "transport": "streamable-http", "url": "http://127.0.0.1:1/mcp"}
+_SDK_METHODS = {"tool": "call_tool", "resource": "read_resource", "prompt": "get_prompt"}
+
+
+@pytest.fixture(params=["tool", "resource", "prompt"])
+def kind(request):
+    return request.param
+
+
+@pytest.fixture
+def dispatch_env(monkeypatch):
+    mgr = MCPClientManager({})
+    session = SimpleNamespace(
+        call_tool=AsyncMock(), read_resource=AsyncMock(), get_prompt=AsyncMock()
+    )
+    _seed_static_state(mgr, "srv", session=session)
+    mgr._tool_map["mcp__srv__op"] = ("srv", "op")
+    mgr._resource_map["test://resource"] = ("srv", "test://resource")
+    mgr._prompt_map["mcp__srv__op"] = ("srv", "op")
+    mgr.set_app_state(SimpleNamespace())
+    monkeypatch.setattr(
+        mgr,
+        "_pool_lookup_checked",
+        AsyncMock(return_value=(SimpleNamespace(token="test-token"), None)),
+    )
+    loop = asyncio.new_event_loop()
+    mgr._loop = loop
+    thread = threading.Thread(target=loop.run_forever, daemon=True, name="mcp-deadline-test")
+    thread.start()
+
+    async def seed():
+        entry = PoolEntryState(key=_KEY, open_lock=asyncio.Lock(), session=session)
+        mgr._user_pool_entries[_KEY] = entry
+        return entry
+
+    try:
+        yield mgr, session, _run_on_loop(loop, seed()), loop
+    finally:
+
+        async def drain():
+            tasks = asyncio.all_tasks() - {asyncio.current_task()}
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        _run_on_loop(loop, drain())
+        stop_loop_thread(loop, thread)
+
+
+def _call(mgr: MCPClientManager, kind: str, pooled: bool, *, timeout: int = 5) -> Any:
+    if pooled:
+        kwargs = dict(user_id=_KEY[0], server_name=_KEY[1], server_row=_ROW, timeout=timeout)
+        if kind == "tool":
+            return mgr._dispatch_pool_sync(original_name="op", arguments={}, **kwargs)
+        if kind == "resource":
+            return mgr._dispatch_pool_resource_sync(uri="test://resource", **kwargs)
+        return mgr._dispatch_pool_prompt_sync(original_name="op", arguments={}, **kwargs)
+    if kind == "tool":
+        return mgr.call_tool_sync("mcp__srv__op", {}, timeout=timeout)
+    if kind == "resource":
+        return mgr.read_resource_sync("test://resource", timeout=timeout)
+    return mgr.get_prompt_sync("mcp__srv__op", timeout=timeout)
+
+
+@pytest.mark.parametrize("pooled", [False, True], ids=["static", "pool"])
+def test_caller_deadline_cancels_locally_without_changing_breaker(dispatch_env, kind, pooled):
+    mgr, session, entry, loop = dispatch_env
+    cancelled = threading.Event()
+
+    async def slow(*args, **kwargs):
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    method = getattr(session, _SDK_METHODS[kind])
+    method.side_effect = slow
+    mgr._consecutive_failures["srv"] = 2
+    with pytest.raises(TimeoutError, match="timed out after 1s"):
+        _call(mgr, kind, pooled, timeout=1)
+    assert cancelled.wait(timeout=2)
+
+    async def wait_for_cleanup():
+        while entry.in_flight or entry.open_lock.locked() or mgr._static_servers["srv"].in_flight:
+            await asyncio.sleep(0)
+
+    _run_on_loop(loop, asyncio.wait_for(wait_for_cleanup(), timeout=2))
+    method.assert_awaited_once()
+    assert mgr._consecutive_failures["srv"] == 2
+    assert "srv" not in mgr._circuit_open_until
+    assert entry.session is session
+    assert mgr._static_servers["srv"].session is session
+
+
+@pytest.mark.parametrize("pooled", [False, True], ids=["static", "pool"])
+@pytest.mark.parametrize("error_type", [TimeoutError, anyio.BrokenResourceError])
+def test_operation_failure_preserves_error_and_counts_once(dispatch_env, kind, pooled, error_type):
+    mgr, session, entry, _ = dispatch_env
+    error = error_type("operation failed")
+    getattr(session, _SDK_METHODS[kind]).side_effect = error
+    mgr._consecutive_failures["srv"] = 1
+
+    with pytest.raises(error_type) as caught:
+        _call(mgr, kind, pooled)
+
+    assert caught.value is error
+    assert mgr._consecutive_failures["srv"] == 2
+    state = entry if pooled else mgr._static_servers["srv"]
+    # Static generic operation errors count without transport eviction; the
+    # pool classifier has always treated operation TimeoutError as transport.
+    if pooled or error_type is anyio.BrokenResourceError:
+        assert state.session is None
+    else:
+        assert state.session is session
+
+
+def test_queued_pool_deadline_leaves_holder_and_breaker_untouched(dispatch_env, kind):
+    mgr, session, entry, loop = dispatch_env
+    _run_on_loop(loop, entry.open_lock.acquire())
+    mgr._consecutive_failures["srv"] = 2
+    try:
+        with pytest.raises(TimeoutError, match="timed out after 1s"):
+            _call(mgr, kind, True, timeout=1)
+        assert mgr._consecutive_failures["srv"] == 2
+        assert "srv" not in mgr._circuit_open_until
+        assert entry.session is session
+        assert entry.open_lock.locked()
+        getattr(session, _SDK_METHODS[kind]).assert_not_awaited()
+    finally:
+        loop.call_soon_threadsafe(entry.open_lock.release)
+
+
+@pytest.mark.parametrize("status", [None, 401, 403])
+def test_cancelled_pool_waiter_does_not_borrow_holder_auth(dispatch_env, kind, status, monkeypatch):
+    mgr, session, entry, loop = dispatch_env
+    # Cancellation must never reach auth classification.
+    classify = Mock(wraps=mgr._classify_failure)
+    monkeypatch.setattr(mgr, "_classify_failure", classify)
+    mgr._consecutive_failures["srv"] = 2
+
+    async def scenario():
+        reached = asyncio.Event()
+
+        async def lookup(*args, **kwargs):
+            reached.set()
+            return SimpleNamespace(token="test-token"), None
+
+        monkeypatch.setattr(mgr, "_pool_lookup_checked", lookup)
+        kwargs = dict(user_id=_KEY[0], server_name=_KEY[1], server_row=_ROW)
+        if kind == "tool":
+            op = mgr._dispatch_pool(original_name="op", arguments={}, **kwargs)
+        elif kind == "resource":
+            op = mgr._dispatch_pool_resource(uri="test://resource", **kwargs)
+        else:
+            op = mgr._dispatch_pool_prompt(original_name="op", arguments={}, **kwargs)
+        async with entry.open_lock:
+            task = asyncio.create_task(op)
+            try:
+                await asyncio.wait_for(reached.wait(), timeout=2)
+                entry.auth_capture.status = status
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+                assert entry.session is session
+                assert entry.open_lock.locked()
+                assert entry.auth_capture.status == status
+            finally:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+    _run_on_loop(loop, scenario())
+    classify.assert_not_called()
+    assert mgr._consecutive_failures["srv"] == 2
+    getattr(session, _SDK_METHODS[kind]).assert_not_awaited()

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -1198,7 +1198,7 @@ class TestCrossTaskRetryIsolation:
 
 
 class TestRetryTimeoutBudget:
-    """The retry's ``future.result(timeout=...)`` window MUST be reduced
+    """The retry's synchronous wait window MUST be reduced
     by however long the first attempt consumed before raising
     ``_PoolDispatchRetryRequested``.
 
@@ -1219,7 +1219,7 @@ class TestRetryTimeoutBudget:
         self, running_loop_mgr, storage: SQLiteBackend
     ) -> None:
         """First attempt sleeps ~1s before raising the retry signal; the
-        second attempt's ``future.result(timeout=...)`` MUST receive a
+        second attempt's synchronous wait MUST receive a
         value strictly less than the original ``timeout``.
         """
         from turnstone.core.mcp_client import _PoolDispatchRetryRequested

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -7206,12 +7206,15 @@ class MCPClientManager:
             self._static_session_op(server_name, session.call_tool(original_name, arguments)),
             self._loop,
         )
+        # exception() waits without raising the operation's own TimeoutError.
+        # Only expiry of the caller's wait is neutral for server health.
         try:
-            result = future.result(timeout=timeout)
+            future.exception(timeout=timeout)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP tool call timed out after {timeout}s") from None
+        try:
+            result = future.result()
         except Exception as exc:
             self._record_and_evict_on_dead_transport(server_name, exc)
             raise
@@ -7614,12 +7617,14 @@ class MCPClientManager:
             ),
             self._loop,
         )
+        # Async dispatch accounts for operation failures; local expiry can
+        # mean waiting for the pool lock without ever contacting the server.
         try:
-            return future.result(timeout=timeout)
+            future.exception(timeout=timeout)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP tool call timed out after {original_timeout}s") from None
+        return future.result()
 
     def _dispatch_pool_resource_sync(
         self,
@@ -7706,11 +7711,11 @@ class MCPClientManager:
             self._loop,
         )
         try:
-            return future.result(timeout=timeout)
+            future.exception(timeout=timeout)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP resource read timed out after {original_timeout}s") from None
+        return future.result()
 
     def _dispatch_pool_prompt_sync(
         self,
@@ -7801,13 +7806,13 @@ class MCPClientManager:
             self._loop,
         )
         try:
-            return future.result(timeout=timeout)
+            future.exception(timeout=timeout)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            self._cb_record_failure(server_name)
             raise TimeoutError(
                 f"MCP prompt retrieval timed out after {original_timeout}s"
             ) from None
+        return future.result()
 
     async def _dispatch_pool(
         self,
@@ -7897,6 +7902,10 @@ class MCPClientManager:
                 original_name=original_name,
                 arguments=arguments,
             )
+        except asyncio.CancelledError:
+            # A cancelled lock waiter has not owned this carrier; it may
+            # describe the active caller's auth failure. Never retry or evict.
+            raise
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
             if classification == "auth_401":
@@ -8035,6 +8044,9 @@ class MCPClientManager:
                 access_token=access_token,
                 sdk_call=lambda s: s.read_resource(uri),
             )
+        except asyncio.CancelledError:
+            # Cancellation precedes shared-carrier auth handling; see _dispatch_pool.
+            raise
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
             if classification == "auth_401":
@@ -8158,6 +8170,9 @@ class MCPClientManager:
                 access_token=access_token,
                 sdk_call=lambda s: s.get_prompt(original_name, arguments=arguments),
             )
+        except asyncio.CancelledError:
+            # Cancellation precedes shared-carrier auth handling; see _dispatch_pool.
+            raise
         except BaseException as exc:
             classification = self._classify_failure(exc, capture=capture)
             if classification == "auth_401":
@@ -8869,11 +8884,12 @@ class MCPClientManager:
             self._static_session_op(server_name, session.read_resource(uri)), self._loop
         )
         try:
-            result = future.result(timeout=timeout)
+            future.exception(timeout=timeout)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP resource read timed out after {timeout}s") from None
+        try:
+            result = future.result()
         except Exception as exc:
             self._record_and_evict_on_dead_transport(server_name, exc)
             raise
@@ -8966,11 +8982,12 @@ class MCPClientManager:
             self._loop,
         )
         try:
-            result = future.result(timeout=timeout)
+            future.exception(timeout=timeout)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            self._cb_record_failure(server_name)
             raise TimeoutError(f"MCP prompt retrieval timed out after {timeout}s") from None
+        try:
+            result = future.result()
         except Exception as exc:
             self._record_and_evict_on_dead_transport(server_name, exc)
             raise


### PR DESCRIPTION
Caller timeouts currently increment an MCP server's circuit breaker, even when a call is still waiting for a per-user session lock and has never contacted the server. Treat these deadlines as neutral for server health across tool calls, resource reads, and prompt retrievals. Keep operation-raised timeouts distinct so genuine failures retain their error and accounting.

Propagate pooled cancellation before reading the shared authentication carrier, preventing a cancelled waiter from using the active caller's 401/403 to evict its session or request an auth retry. Existing auth recovery, transport ownership, timeout budgets, and unknown tool outcomes are preserved.

Related to #951. This is the foreground deadline/accounting increment: remote work can still continue after a timeout, and protocol cancellation and durable remote results remain outside this PR. The issue should stay open.

Validation:

- 1,354 MCP and related tests passed, including HTTP auth recovery, transport ownership, health, and flaky-server coverage.
- 78 focused auth/deadline/receipt checks passed again before the PR.
- Original local FastMCP reproduction rerun: zero breaker failures after timeout, local cleanup complete, and the follow-up call succeeds. Remote work still completes as documented.
- Ruff, formatting, package-wide mypy, and `git diff --check` passed. The full repository suite was not run locally.
