### PR TITLE
feat(ui): pending-approval chip in the workstream status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ frozen.
   handles daylight-saving changes correctly. A schedule whose zone the host
   can no longer resolve is disabled with the reason recorded in its run
   history.
+- **Pending-approval chip in the status bar.** When a tool call is waiting on
+  you, the workstream status bar (tokens / tools / turn) shows a sticky
+  "1 approval needed" chip, counting up when parallel task agents open several
+  gates at once, so a prompt that scrolled out of view or sits inside a
+  collapsed agent card is no longer easy to miss. Clicking it scrolls to the
+  card the keyboard shortcuts act on and puts the cursor on it. The
+  coordinator status bar shows the same chip for the coordinator's own
+  transcript, and the "x pending" count beside the coordinator's Children
+  heading becomes the same kind of chip, reading "x approvals": clicking it
+  scrolls the children list to the first child waiting on an approval. The chips and the rail's
+  attention badge share a new ink colour that reads clearly on the light
+  theme, where the old one fell short.
 
 ### Fixed
 

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -1640,3 +1640,371 @@ def test_idle_tasks_card_uses_the_shared_status_label():
     assert "taskStatusLabel(" in body[idx : idx + 1400]
     idx_row = body.index("function renderTaskRow(")
     assert "taskStatusLabel(" in body[idx_row : idx_row + 1400]
+
+
+def test_coordinator_js_status_bar_approval_chip():
+    """The coord status bar carries the same pending-approval chip as the
+    interactive pane.  The coord keeps no cycle map — pending state IS the
+    DOM — so the count is re-derived from ``.conv-batch--pending`` under the
+    transcript at every place that state can change: a pending batch paint
+    (either return path, gated on ``opts.pending`` so a history render's
+    per-batch calls never scan the transcript), the resolve morph, and the
+    history wipe.  The click targets ``_currentPendingBatch`` — the SAME
+    batch the keyboard shortcuts act on — and focuses its head, never an
+    action button.  Asserts string presence only (no JS framework for
+    coord.js)."""
+    from pathlib import Path
+
+    from tests._js_harness_helpers import extract_braced
+
+    body = (
+        Path(__file__).resolve().parent.parent
+        / "turnstone/console/static/coordinator/coordinator.js"
+    ).read_text(encoding="utf-8")
+    assert 'id: "coord-sb-approval",' in body
+    assert 'class: "warn-chip ws-sb-approval",' in body
+    assert "_revealPendingApproval();" in body, "the chip click must route to the reveal"
+    # The chip is a button INSIDE root, which carries the approval keydown
+    # handler: without a guard, Enter on the focused chip approves the batch.
+    assert "if (ae && ae === sbApprovalEl) return;" in body, (
+        "the approval keydown handler must ignore keys originating on the chip"
+    )
+    sync = extract_braced(body, "function _syncApprovalChip() {")
+    assert '".conv-batch.conv-batch--pending"' in sync, (
+        "the count must derive from the transcript's pending batches"
+    )
+    assert "StatusBar.paintApprovalChip(" in sync
+    assert "focusFallbackEl: composer && composer.inputEl" in sync
+    # Every pending-state transition recounts — and only those.
+    append = extract_braced(body, "function appendToolBatch(items, opts) {")
+    upgrade_return = append.index("return existing;")
+    fresh_return = append.index("return batch;")
+    upgrade_recount = append.index("if (opts.pending) _syncApprovalChip();")
+    fresh_recount = append.index("if (opts.pending) _syncApprovalChip();", upgrade_recount + 1)
+    assert upgrade_recount < upgrade_return < fresh_recount < fresh_return, (
+        "each appendToolBatch return path must recount when it can add a pending batch"
+    )
+    assert (
+        "\n    _syncApprovalChip();" not in append and "\n      _syncApprovalChip();" not in append
+    ), (
+        "an unconditional recount in appendToolBatch scans the transcript once per "
+        "replayed batch — quadratic on a long history render"
+    )
+    morph = extract_braced(body, "function _morphBatchResolved(batch, opts) {")
+    assert "_syncApprovalChip();" in morph
+    refetch = extract_braced(body, "async function refetchHistory(seedCursor = false) {")
+    wipe = refetch.index("messagesEl.replaceChildren();")
+    assert wipe < refetch.index("_syncApprovalChip();", wipe), (
+        "the history wipe must recount (a history render never paints a pending batch)"
+    )
+    # Click target == keyboard target, and that target must really be pending.
+    current = extract_braced(body, "function _currentPendingBatch() {")
+    assert 'if (!b.classList.contains("conv-batch--pending")) continue;' in current, (
+        "a resolved batch keeps data-needs-approval on its rows and has no button, "
+        "so without the class check it outranks an older still-pending batch"
+    )
+    reveal = extract_braced(body, "function _revealPendingApproval() {")
+    assert "_currentPendingBatch()" in reveal, "click target must equal the keyboard target"
+    assert "setConvBatchExpanded(batch, true, { blocker: true });" in reveal
+    assert "StatusBar.scrollToApprovalTarget(batch);" in reveal
+    assert "focusConvBatchHead(batch);" in reveal, (
+        "a reveal must land focus on the batch head, never on Approve (Space would fire it)"
+    )
+    assert "_focusBatchPrimary" not in reveal
+    shared = (
+        Path(__file__).resolve().parent.parent / "turnstone/shared_static/conversation.js"
+    ).read_text(encoding="utf-8")
+    assert "export function focusConvBatchHead(batch) {" in shared
+
+
+def test_coordinator_js_children_pending_count_is_a_reveal_chip():
+    """The "x pending" half of the Children heading's "(N · x pending)" count
+    is now a warn chip (the status-bar approval chip's sibling): coloured,
+    clickable, hidden at zero, reading "x approvals".  Its click scrolls the
+    tree to the first child whose approval is pending, flashes the row, and
+    lands temporary focus on the row's approval region or the row — never
+    the child's link or an Approve button.  The count repaints from the
+    live-badge cache helpers, the one place the pending set changes (the
+    bulk live fetch that first discovers a pending approval reaches no
+    render otherwise), and the bulk fetch's row swap goes through the
+    single-row update so it keeps focus, the flash and the visibility
+    observer.  Structural pins; the behavior runs under node below."""
+    from pathlib import Path
+
+    from tests._js_harness_helpers import extract_braced, strip_js_comments
+
+    body = (
+        Path(__file__).resolve().parent.parent
+        / "turnstone/console/static/coordinator/coordinator.js"
+    ).read_text(encoding="utf-8")
+    assert '"coord-children-pending",' in body, "the children section must request the chip"
+    assert 'class: "warn-chip side-count-pending",' in body
+    assert "_revealPendingChild();" in body, "the chip click must route to the reveal"
+    count = extract_braced(body, "function _refreshChildrenCount() {")
+    assert "StatusBar.paintWarnChip(" in count
+    assert 'label: pending + " approval" + (pending === 1 ? "" : "s"),' in count
+    assert "focusFallbackEl: composer && composer.inputEl" in count
+    for helper in (
+        "function _liveBadgeCacheSet(id, entry) {",
+        "function _liveBadgeCacheDelete(id) {",
+        "function _liveBadgeCacheClear() {",
+    ):
+        assert "_refreshChildrenCount();" in extract_braced(body, helper), (
+            f"{helper} mutates the pending set and must repaint the count"
+        )
+    flush = strip_js_comments(extract_braced(body, "async function flushLiveFetches() {"))
+    assert "_updateChildRow(id);" in flush and ".replaceWith(" not in flush, (
+        "the bulk fetch's row swap must go through _updateChildRow (focus, observer, count)"
+    )
+    capture = extract_braced(body, "function _captureRowFocusKey(scopeEl) {")
+    assert 'role: "row"' in capture and 'role: "approval"' in capture
+    restore = extract_braced(body, "function _restoreRowFocus(scopeEl, focusKey) {")
+    assert "focusTemporarily(target);" in restore, (
+        "a role target is a plain div on the fresh row; a raw focus() is a no-op there"
+    )
+    approve = extract_braced(body, "function handleChildApproveRequest(ev) {")
+    assert 'childrenState.set(childId, { ws_id: childId, name: "" });' in approve, (
+        "an approve_request ahead of the first state tick must still have a row to reveal"
+    )
+    assert (
+        'if (child.ws_id && child.ws_id === _flashWsId) row.classList.add("highlight");' in body
+    ), "renderChildRow must re-apply the flash across a row swap"
+    reveal = extract_braced(body, "function _revealPendingChild() {")
+    assert "pendingApprovalIds.has(" in reveal, "the target must come from the pending set"
+    assert "_setSidebarExpanded" not in body, (
+        "a collapsed sidebar hides the chip too, so a reveal never needs to expand it"
+    )
+    assert "StatusBar.scrollToApprovalTarget(row);" in reveal
+    assert "_flashChildRow(row.dataset.wsId);" in reveal
+    assert 'focusTemporarily(row.querySelector(".approval-block") || row);' in reveal
+    assert ".ws-link" not in reveal
+    shared = (
+        Path(__file__).resolve().parent.parent / "turnstone/shared_static/conversation.js"
+    ).read_text(encoding="utf-8")
+    assert "export function focusTemporarily(el) {" in shared
+
+
+def test_coordinator_children_pending_chip_behavior(tmp_path):
+    """Run ``_refreshChildrenCount`` and ``_revealPendingChild`` under node
+    against the fake DOM: the count paints "(N)" plus a chip with the
+    pending count; the reveal targets the FIRST pending row in tree order,
+    expands the sidebar, scrolls, highlights, and focuses the approval
+    region when painted (else the row); zero pending is a no-op."""
+    import shutil
+    import subprocess
+    from pathlib import Path
+
+    import pytest
+
+    from tests._js_harness_helpers import FAKE_DOM, extract_braced
+
+    if shutil.which("node") is None:
+        pytest.skip("node binary not available on PATH")
+    body = (
+        Path(__file__).resolve().parent.parent
+        / "turnstone/console/static/coordinator/coordinator.js"
+    ).read_text(encoding="utf-8")
+    count_fn = extract_braced(body, "function _refreshChildrenCount() {")
+    reveal_fn = extract_braced(body, "function _revealPendingChild() {")
+    flash_fn = extract_braced(body, "function _flashChildRow(wsId) {")
+    unflash_fn = extract_braced(body, "function _unflashChildRow(wsId) {")
+    script = tmp_path / "children_chip.mjs"
+    script.write_text(
+        FAKE_DOM
+        + f"""
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+const painted = [];
+const scrolled = [];
+const focused = [];
+const timers = [];
+globalThis.StatusBar = {{
+  paintWarnChip: (els, n, text) => painted.push({{ els, n, text }}),
+  scrollToApprovalTarget: (el) => scrolled.push(el),
+}};
+globalThis.focusTemporarily = (el) => focused.push(el);
+globalThis.setTimeout = (fn) => {{ timers.push(fn); return timers.length; }};
+globalThis.clearTimeout = () => {{}};
+globalThis.cssEscape = (s) => s;
+globalThis._flashWsId = null;
+globalThis._flashTimer = null;
+globalThis.FLASH_MS = 1200;
+globalThis.composer = {{ inputEl: new FakeElement("textarea") }};
+globalThis.childrenCountEl = new FakeElement("span");
+globalThis.childrenPendingEl = new FakeElement("button");
+globalThis.childrenState = new Map([["a", {{}}], ["b", {{}}], ["c", {{}}]]);
+globalThis.pendingApprovalIds = new Set();
+globalThis.childrenTreeEl = new FakeElement("div");
+html.appendChild(childrenTreeEl);
+function row(id, withBlock) {{
+  const r = new FakeElement("div");
+  r.className = "ch-row";
+  r.dataset.wsId = id;
+  if (withBlock) {{
+    const block = new FakeElement("div");
+    block.className = "approval-block";
+    r.appendChild(block);
+  }}
+  childrenTreeEl.appendChild(r);
+  return r;
+}}
+const rowA = row("a", false);
+const rowB = row("b", true);
+const rowC = row("c", false);
+{count_fn}
+{reveal_fn}
+{flash_fn}
+{unflash_fn}
+
+_refreshChildrenCount();
+assert(childrenCountEl.textContent === "(3)", "count must be the total alone: " + childrenCountEl.textContent);
+assert(painted.length === 1 && painted[0].n === 0, "zero pending paints the chip hidden");
+assert(painted[0].els.chipEl === childrenPendingEl, "the chip element must be the heading button");
+assert(painted[0].els.focusFallbackEl === composer.inputEl, "hidden-under-focus falls back to the composer");
+_revealPendingChild();
+assert(scrolled.length === 0 && focused.length === 0, "zero pending: reveal is a no-op");
+
+pendingApprovalIds.add("c");
+pendingApprovalIds.add("b");
+_refreshChildrenCount();
+assert(painted[1].n === 2 && painted[1].text.label === "2 approvals", "chip must carry the pending count with its noun");
+assert(/first child/.test(painted[1].text.title), "plural title names the first child");
+_revealPendingChild();
+assert(scrolled.length === 1 && scrolled[0] === rowB, "must scroll to the FIRST pending row in tree order");
+assert(rowB.classList.contains("highlight"), "the row must flash");
+assert(_flashWsId === "b", "the flash is held by id so a row swap can re-apply it");
+assert(focused.length === 1 && focused[0] === rowB.children[0], "focus lands on the painted approval region");
+// A live fetch swaps the row mid-flash: the timer strips the class from the
+// row that now carries the id, not the detached one.
+const rowB2 = new FakeElement("div");
+rowB2.className = "ch-row";
+rowB2.dataset.wsId = "b";
+if (rowB2.dataset.wsId === _flashWsId) rowB2.classList.add("highlight");
+rowB.remove();
+childrenTreeEl.appendChild(rowB2);
+assert(rowB2.classList.contains("highlight"), "a re-rendered row inside the window re-applies the flash");
+timers.splice(0).forEach((fn) => fn());
+assert(!rowB2.classList.contains("highlight") && _flashWsId === null, "the flash must clear on the live row");
+
+pendingApprovalIds.delete("b");
+_refreshChildrenCount();
+assert(painted[2].n === 1 && painted[2].text.label === "1 approval", "singular label");
+assert(!/first/.test(painted[2].text.title), "singular title does not say first");
+_revealPendingChild();
+assert(scrolled[1] === rowC, "after b resolves, c is next");
+assert(focused[1] === rowC, "no approval block yet: the row itself takes focus");
+
+// A pending id with no rendered row (tree not loaded) is a no-op.
+pendingApprovalIds.clear();
+pendingApprovalIds.add("zz");
+_revealPendingChild();
+assert(scrolled.length === 2, "unknown row: nothing to scroll to");
+console.log("children chip OK");
+""",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(["node", str(script)], capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0, f"children chip harness failed:\n{proc.stderr}\n{proc.stdout}"
+
+
+def test_coordinator_row_focus_restore_handles_reveal_targets(tmp_path):
+    """``_captureRowFocusKey`` / ``_restoreRowFocus`` survive the row swaps
+    a child state tick or live fetch performs while the Children-heading
+    chip's reveal has parked temporary focus on the row or its approval
+    region: those are captured as roles (their classNames are transient)
+    and restored through ``focusTemporarily`` on the fresh row, while a
+    focused button inside the row still restores by className."""
+    import shutil
+    import subprocess
+    from pathlib import Path
+
+    import pytest
+
+    from tests._js_harness_helpers import FAKE_DOM, extract_braced
+
+    if shutil.which("node") is None:
+        pytest.skip("node binary not available on PATH")
+    body = (
+        Path(__file__).resolve().parent.parent
+        / "turnstone/console/static/coordinator/coordinator.js"
+    ).read_text(encoding="utf-8")
+    capture_fn = extract_braced(body, "function _captureRowFocusKey(scopeEl) {")
+    restore_fn = extract_braced(body, "function _restoreRowFocus(scopeEl, focusKey) {")
+    script = tmp_path / "row_focus.mjs"
+    script.write_text(
+        FAKE_DOM
+        + f"""
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+FakeElement.prototype.matches = function (sel) {{ return this._matches(sel); }};
+const temporary = [];
+globalThis.focusTemporarily = (el) => {{ temporary.push(el); document.activeElement = el; }};
+globalThis.cssEscape = (s) => s;
+{capture_fn}
+{restore_fn}
+const tree = new FakeElement("div");
+html.appendChild(tree);
+function buildRow() {{
+  const row = new FakeElement("div");
+  row.className = "ch-row";
+  row.dataset.wsId = "b";
+  const block = new FakeElement("div");
+  block.className = "approval-block";
+  const btn = new FakeElement("button");
+  btn.className = "approve-btn";
+  block.appendChild(btn);
+  row.appendChild(block);
+  tree.appendChild(row);
+  return {{ row, block, btn }};
+}}
+let a = buildRow();
+
+// Focus on the row itself (reveal without a painted block): role, not class.
+a.row.classList.add("highlight");
+document.activeElement = a.row;
+let key = _captureRowFocusKey(tree);
+assert(key && key.role === "row" && key.wsId === "b", "row focus captures the row role: " + JSON.stringify(key));
+a.row.remove();
+let b = buildRow();
+_restoreRowFocus(tree, key);
+assert(temporary[0] === b.row, "row role restores onto the fresh row with a temporary tabindex");
+
+// Focus on the approval region.
+document.activeElement = b.block;
+key = _captureRowFocusKey(tree);
+assert(key && key.role === "approval", "region focus captures the approval role");
+b.row.remove();
+let c = buildRow();
+_restoreRowFocus(tree, key);
+assert(temporary[1] === c.block, "approval role restores onto the fresh region");
+
+// The region is gone on the resolution swap: the caret stays on the row.
+document.activeElement = c.block;
+key = _captureRowFocusKey(tree);
+c.row.remove();
+const bare = new FakeElement("div");
+bare.className = "ch-row";
+bare.dataset.wsId = "b";
+tree.appendChild(bare);
+_restoreRowFocus(tree, key);
+assert(temporary[2] === bare, "a resolved row without a region takes the focus itself");
+bare.remove();
+c = buildRow();
+
+// Focus on a button inside the row: the className marker path, raw focus.
+document.activeElement = c.btn;
+key = _captureRowFocusKey(tree);
+assert(key && key.marker === "approve-btn" && !key.role, "button focus keeps the className marker");
+c.row.remove();
+let d = buildRow();
+_restoreRowFocus(tree, key);
+assert(document.activeElement === d.btn && temporary.length === 3, "a focusable restores with a plain focus()");
+
+// Focus outside the tree: nothing captured, restore is a no-op.
+document.activeElement = html;
+assert(_captureRowFocusKey(tree) === null, "focus outside the scope captures nothing");
+_restoreRowFocus(tree, null);
+console.log("row focus OK");
+""",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(["node", str(script)], capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0, f"row focus harness failed:\n{proc.stderr}\n{proc.stdout}"

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._js_harness_helpers import FAKE_DOM, node_skip, run_node_source
 from tests._js_harness_helpers import extract_braced as _extract_braced
 from tests._js_harness_helpers import strip_js_comments as _strip_comments
 
@@ -1966,3 +1967,132 @@ def test_orphan_tool_result_does_not_mark_a_batch_failed() -> None:
     assert "!isOrphanResult" in body[guard:stamp], (
         "an orphan result can stamp conv-batch--error on a batch whose own calls all succeeded"
     )
+
+
+def test_status_bar_approval_chip_wired_to_the_cycle_chokepoint() -> None:
+    """The pending-approval chip is painted from ``_syncApprovalState`` — the
+    ONE place approval cycles register, resolve, prune and reset — so every
+    path that changes the count (peer-tab resolution, transcript rebuild,
+    orphan prune) repaints it for free.  It is a button (tabs, clicks) built
+    in ``_createDOM`` ahead of the turn cell, and its click reveals the SAME
+    cycle the keyboard shortcuts act on."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    assert 'this._sbApproval = document.createElement("button");' in body
+    assert 'this._sbApproval.className = "warn-chip ws-sb-approval";' in body, (
+        "the look is the shared .warn-chip; the surface class carries only geometry"
+    )
+    assert "this._sbApproval.hidden = true;" in body
+    assert "this.revealPendingApproval()," in body, (
+        "the chip click must route to revealPendingApproval"
+    )
+    dom = _strip_comments(body)
+    assert dom.index("this.statusBarEl.appendChild(this._sbApproval);") < dom.index(
+        "this.statusBarEl.appendChild(this._sbTurns);"
+    ), "the chip sits before the turn cell so a narrow pane clips the turn first"
+    sync = _extract_braced(body, "_syncApprovalState() {")
+    assert "StatusBar.paintApprovalChip(" in sync, (
+        "the chip must repaint from the approval-state chokepoint"
+    )
+    assert "this.approvalCycles.size," in sync
+    assert "focusFallbackEl: this.inputEl" in sync, (
+        "a chip hidden under keyboard focus must hand focus to the composer"
+    )
+    # The chip is a button INSIDE this.el, which carries the approval keydown
+    # handler: without a target guard, Enter on the focused chip approves the
+    # tool call (and preventDefault swallows the click that would reveal it).
+    assert "if (e.target === this._sbApproval) return;" in body, (
+        "the approval keydown handler must ignore keys originating on the chip"
+    )
+    reveal = _extract_braced(body, "revealPendingApproval() {")
+    assert "this._oldestCycleId()" in reveal, (
+        "click target must equal the keyboard target (the oldest live cycle)"
+    )
+    assert 'agentCard.dataset.collapsed = "false";' in reveal
+    assert "setConvBatchExpanded(batch, true, { blocker: true });" in reveal
+    assert "StatusBar.scrollToApprovalTarget(block);" in reveal
+    assert "fb.focus({ preventScroll: true });" in reveal
+
+
+@node_skip
+def test_reveal_pending_approval_unfolds_and_focuses_the_oldest_cycle() -> None:
+    """Run ``revealPendingApproval`` against the fake DOM: with two live
+    cycles it targets the oldest one whose block is still attached, re-opens
+    the agent card and batch that hold it, scrolls to the row, and focuses
+    its feedback field without a scroll jump."""
+    body = _INTERACTIVE.read_text(encoding="utf-8")
+    reveal = _extract_braced(body, "revealPendingApproval() {")
+    oldest = _extract_braced(body, "_oldestCycleId() {")
+    script = (
+        FAKE_DOM
+        + f"""
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+const scrolled = [];
+const expanded = [];
+globalThis.StatusBar = {{ scrollToApprovalTarget: (el) => scrolled.push(el) }};
+globalThis.setConvBatchExpanded = (batch, open, opts) => expanded.push([batch, open, opts]);
+const proto = {{
+  {reveal},
+  {oldest},
+}};
+
+// Transcript: a parent batch holding a task-agent card, collapsed by the
+// user, with a nested pending row (oldest cycle) — plus a later top-level
+// pending batch (newer cycle).
+const messages = new FakeElement("div");
+html.appendChild(messages);
+const parentBatch = new FakeElement("div");
+parentBatch.className = "conv-batch";
+messages.appendChild(parentBatch);
+const agentCard = new FakeElement("div");
+agentCard.className = "conv-agent";
+agentCard.dataset.collapsed = "true";
+parentBatch.appendChild(agentCard);
+const toggle = new FakeElement("button");
+toggle.className = "conv-agent-toggle";
+toggle.setAttribute("aria-expanded", "false");
+agentCard.appendChild(toggle);
+const nestedRow = new FakeElement("div");
+nestedRow.className = "conv-row";
+agentCard.appendChild(nestedRow);
+const nestedFeedback = new FakeElement("input");
+nestedFeedback.className = "conv-feedback";
+let focusOpts = null;
+nestedFeedback.focus = (opts) => {{ focusOpts = opts; document.activeElement = nestedFeedback; }};
+nestedRow.appendChild(nestedFeedback);
+const laterBatch = new FakeElement("div");
+laterBatch.className = "conv-batch";
+messages.appendChild(laterBatch);
+
+const pane = Object.assign({{ approvalCycles: new Map() }}, proto);
+pane.approvalCycles.set("cycle-old", {{ blockEls: [nestedRow], callIds: ["c1"] }});
+pane.approvalCycles.set("cycle-new", {{ blockEls: [laterBatch], callIds: ["c2"] }});
+
+pane.revealPendingApproval();
+assert(scrolled.length === 1 && scrolled[0] === nestedRow, "must scroll to the OLDEST cycle's row");
+assert(agentCard.dataset.collapsed === "false", "the collapsed agent card must reopen");
+assert(toggle.getAttribute("aria-expanded") === "true", "toggle aria must follow the reopen");
+assert(expanded.length === 1 && expanded[0][0] === parentBatch && expanded[0][1] === true
+  && expanded[0][2].blocker === true, "the enclosing batch must unfold as a blocker");
+assert(document.activeElement === nestedFeedback, "the feedback field must take focus");
+assert(focusOpts && focusOpts.preventScroll === true, "focus must not cut the scroll short");
+
+// The oldest cycle resolves: the next reveal targets the newer top-level batch.
+pane.approvalCycles.delete("cycle-old");
+pane.revealPendingApproval();
+assert(scrolled.length === 2 && scrolled[1] === laterBatch, "must fall through to the next cycle");
+assert(expanded[1][0] === laterBatch, "a top-level batch unfolds itself");
+
+// A cycle whose only block was detached (wiped transcript) reveals nothing.
+laterBatch.remove();
+pane.revealPendingApproval();
+assert(scrolled.length === 2, "a detached block must not be scrolled to");
+
+// No cycles at all is a no-op.
+pane.approvalCycles.clear();
+pane.revealPendingApproval();
+assert(scrolled.length === 2, "no cycles: nothing to reveal");
+console.log("reveal OK");
+"""
+    )
+    proc = run_node_source(script)
+    assert proc.returncode == 0, f"reveal harness failed:\n{proc.stderr}\n{proc.stdout}"

--- a/tests/test_status_bar_js.py
+++ b/tests/test_status_bar_js.py
@@ -1,0 +1,146 @@
+"""Behavioral harness for the shared status-bar formatter's pending-approval
+chip (``turnstone/shared_static/status_bar.js``).
+
+Both the interactive pane and the coordinator dashboard paint the chip
+through ``StatusBar.paintApprovalChip`` and scroll to the card through
+``StatusBar.scrollToApprovalTarget``; the wording, the hidden-at-zero rule,
+and the reduced-motion handling live here once, so they are pinned here
+once, under node with the shared fake DOM.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests._js_harness_helpers import FAKE_DOM, node_skip, run_node_source
+
+pytestmark = node_skip
+
+_ROOT = Path(__file__).resolve().parent.parent
+_STATUS_BAR_JS = _ROOT / "turnstone/shared_static/status_bar.js"
+
+
+def test_paint_approval_chip_counts_and_hides_at_zero() -> None:
+    script = (
+        FAKE_DOM
+        + f"""
+const {{ StatusBar }} = await import({json.dumps(_STATUS_BAR_JS.as_uri())});
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+const chip = new FakeElement("button");
+chip.hidden = true;
+html.appendChild(chip);
+const els = {{ approvalEl: chip }};
+const label = () => chip.children.map((c) => c.textContent).join("");
+
+StatusBar.paintApprovalChip(els, 1);
+assert(chip.hidden === false, "one live cycle must show the chip");
+assert(label() === "⚠ 1 approval needed", "singular wording: " + label());
+assert(chip.title === "Show the pending approval", "singular tooltip: " + chip.title);
+assert(chip.children[0].getAttribute("aria-hidden") === "true", "glyph must be aria-hidden");
+
+StatusBar.paintApprovalChip(els, 3);
+assert(label() === "⚠ 3 approvals needed", "plural wording: " + label());
+assert(chip.title === "Show the pending approvals", "plural tooltip: " + chip.title);
+assert(chip.children.length === 2, "repaint must rewrite the label, not stack spans");
+
+StatusBar.paintApprovalChip(els, 0);
+assert(chip.hidden === true, "zero cycles must hide the chip");
+
+// The generic painter takes the caller's words verbatim (the children
+// heading chip says "2 pending", not "2 approvals needed").
+StatusBar.paintWarnChip({{ chipEl: chip }}, 2, {{ label: "2 pending", title: "Show it" }});
+assert(label() === "⚠ 2 pending", "generic label: " + label());
+assert(chip.title === "Show it", "generic title: " + chip.title);
+
+// Defensive inputs: a missing chip is a no-op, a negative count hides.
+StatusBar.paintApprovalChip({{ approvalEl: null }}, 2);
+StatusBar.paintApprovalChip(els, -1);
+assert(chip.hidden === true, "negative count must hide the chip");
+console.log("approval chip OK");
+"""
+    )
+    proc = run_node_source(script)
+    assert proc.returncode == 0, f"status bar harness failed:\n{proc.stderr}\n{proc.stdout}"
+
+
+def test_hiding_a_focused_chip_hands_focus_to_the_composer() -> None:
+    """A gate resolved from a peer tab (or a transcript rebuild) hides the
+    chip while a keyboard user may be sitting on it.  Focus must move to the
+    surface's composer input instead of dropping to the document body, and
+    only when the chip actually held focus."""
+    script = (
+        FAKE_DOM
+        + f"""
+const {{ StatusBar }} = await import({json.dumps(_STATUS_BAR_JS.as_uri())});
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+const chip = new FakeElement("button");
+chip.hidden = true;
+html.appendChild(chip);
+const input = new FakeElement("textarea");
+html.appendChild(input);
+let inputFocus = null;
+input.focus = (opts) => {{ inputFocus = opts; document.activeElement = input; }};
+const els = {{ approvalEl: chip, focusFallbackEl: input }};
+
+// Focus elsewhere: hiding must not steal it.
+StatusBar.paintApprovalChip(els, 1);
+const elsewhere = new FakeElement("div");
+html.appendChild(elsewhere);
+elsewhere.focus();
+StatusBar.paintApprovalChip(els, 0);
+assert(document.activeElement === elsewhere, "hiding must not move focus from elsewhere");
+assert(inputFocus === null, "composer must not be focused when the chip was not");
+
+// Focus on the chip: hiding hands it to the composer without a scroll jump.
+StatusBar.paintApprovalChip(els, 2);
+chip.focus();
+StatusBar.paintApprovalChip(els, 0);
+assert(document.activeElement === input, "composer must take focus from a hidden chip");
+assert(inputFocus && inputFocus.preventScroll === true, "fallback focus must not scroll");
+
+// Already hidden: a repeat zero paint is a no-op even with focus on the chip.
+inputFocus = null;
+chip.focus();
+StatusBar.paintApprovalChip(els, 0);
+assert(inputFocus === null, "an already-hidden chip must not re-fire the fallback");
+console.log("focus fallback OK");
+"""
+    )
+    proc = run_node_source(script)
+    assert proc.returncode == 0, f"status bar harness failed:\n{proc.stderr}\n{proc.stdout}"
+
+
+def test_scroll_to_approval_target_honors_reduced_motion() -> None:
+    script = (
+        FAKE_DOM
+        + f"""
+const {{ StatusBar }} = await import({json.dumps(_STATUS_BAR_JS.as_uri())});
+const assert = (condition, message) => {{ if (!condition) throw new Error(message); }};
+// A fake element without scrollIntoView (the harness default) is a no-op.
+StatusBar.scrollToApprovalTarget(new FakeElement("div"));
+StatusBar.scrollToApprovalTarget(null);
+
+const calls = [];
+const target = new FakeElement("div");
+target.scrollIntoView = (opts) => calls.push(opts);
+let reduce = false;
+globalThis.window.matchMedia = (q) => ({{ matches: reduce && q.includes("reduced-motion") }});
+
+StatusBar.scrollToApprovalTarget(target);
+assert(calls.length === 1 && calls[0].behavior === "smooth", "default scroll must be smooth");
+assert(calls[0].block === "center", "the card must be centred");
+
+reduce = true;
+StatusBar.scrollToApprovalTarget(target);
+assert(calls[1].behavior === "auto", "reduced motion must drop the smooth scroll");
+
+// A throwing matchMedia (some embedded views) must not block the scroll.
+globalThis.window.matchMedia = () => {{ throw new Error("no media queries"); }};
+StatusBar.scrollToApprovalTarget(target);
+assert(calls.length === 3 && calls[2].behavior === "smooth", "matchMedia failure must fall back");
+console.log("scroll target OK");
+"""
+    )
+    proc = run_node_source(script)
+    assert proc.returncode == 0, f"status bar harness failed:\n{proc.stderr}\n{proc.stdout}"

--- a/turnstone/console/static/coordinator/coord-chrome.css
+++ b/turnstone/console/static/coordinator/coord-chrome.css
@@ -138,14 +138,34 @@
   gap: 6px;
   margin: 8px 0 6px;
 }
+/* min-width: 0 + ellipsis so the heading is what yields under a narrow
+   sidebar — without it the head row's nowrap cells (count, pending chip,
+   refresh) raise the sidebar's min-content floor and the transcript
+   column narrows instead. */
 .coord-sidebar-head .side-label {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   padding: 0;
 }
 .coord-sidebar-head .side-count {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--ink-4);
+}
+/* Children-heading pending chip — the "x pending" half of the old
+   "(N · x pending)" count as a clickable warn chip, now reading
+   "x approvals".  The look is chat.css .warn-chip (shared with the status
+   bar's approval chip); only the geometry lives here.  Hidden at zero via
+   [hidden], so no display.  14px line box + 2px border + 2px padding =
+   18px, inside the head's 22px ghost-button row. */
+.coord-sidebar-head .side-count-pending {
+  padding: 1px 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 14px;
 }
 .coord-sidebar-body {
   flex: 1;

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -49,6 +49,8 @@ import {
   markConvRowResultSettled,
   createReasoningActivity,
   setConvBatchExpanded,
+  focusConvBatchHead,
+  focusTemporarily,
   setToolOutputReviewState,
 } from "/shared/conversation.js";
 import {
@@ -285,6 +287,16 @@ function buildCoordChrome(root, opts) {
         "aria-label": "Tool calls this turn",
         text: "0 tools",
       }),
+      // Pending-approval chip — sticky count of the human gates open in
+      // this transcript, painted by _syncApprovalChip and hidden at zero.
+      // A button: the click brings the batch the keyboard shortcuts act
+      // on into view.  Mirrors the interactive pane's chip.
+      el("button", {
+        id: "coord-sb-approval",
+        class: "warn-chip ws-sb-approval",
+        type: "button",
+        hidden: "",
+      }),
       el("span", {
         id: "coord-sb-turns",
         class: "ws-sb-turns",
@@ -322,11 +334,24 @@ function buildCoordChrome(root, opts) {
     refreshId,
     refreshLabel,
     bodyId,
+    pendingId,
   ) {
     return el("div", { id: wrapId, class: "side-section" }, [
       el("div", { class: "coord-sidebar-head" }, [
         el("h2", { id: headingId, class: "side-label", text: heading }),
         el("span", { id: countId, class: "side-count" }),
+        // Children only: the "N pending" count as a clickable warn chip
+        // (the status-bar approval chip's sibling) that scrolls the tree
+        // to the first child waiting on an approval.  Painted by
+        // _refreshChildrenCount, hidden at zero.
+        pendingId
+          ? el("button", {
+              id: pendingId,
+              class: "warn-chip side-count-pending",
+              type: "button",
+              hidden: "",
+            })
+          : null,
         el("button", {
           type: "button",
           class: "ghost",
@@ -378,6 +403,7 @@ function buildCoordChrome(root, opts) {
         "coord-children-refresh",
         "Refresh children",
         "coord-children-tree",
+        "coord-children-pending",
       ),
       sideSection(
         "coord-tasks-wrap",
@@ -543,6 +569,12 @@ function createCoordinatorPane(root, wsId, opts) {
   const nameEl = root.querySelector("#coord-name");
   const childrenTreeEl = root.querySelector("#coord-children-tree");
   const childrenCountEl = root.querySelector("#coord-children-count");
+  const childrenPendingEl = root.querySelector("#coord-children-pending");
+  if (childrenPendingEl) {
+    childrenPendingEl.addEventListener("click", function () {
+      _revealPendingChild();
+    });
+  }
   const childrenRefreshBtn = root.querySelector("#coord-children-refresh");
   const tasksEl = root.querySelector("#coord-tasks");
   const tasksCountEl = root.querySelector("#coord-tasks-count");
@@ -588,6 +620,10 @@ function createCoordinatorPane(root, wsId, opts) {
         ae.isContentEditable)
     )
       return;
+    // The status-bar chip is a button inside root: Enter on it must reach
+    // its own click (reveal), never the approve arm below — and the
+    // preventDefault there would swallow that click outright.
+    if (ae && ae === sbApprovalEl) return;
     // Ignore browser/OS accelerators (Cmd+D bookmark, Ctrl+D, Alt+D) — only bare
     // keys + Shift+A resolve, else a stray accelerator silently denies the batch.
     if (e.ctrlKey || e.metaKey || e.altKey) return;
@@ -657,6 +693,12 @@ function createCoordinatorPane(root, wsId, opts) {
   const sbTokensEl = root.querySelector("#coord-sb-tokens");
   const sbToolsEl = root.querySelector("#coord-sb-tools");
   const sbTurnsEl = root.querySelector("#coord-sb-turns");
+  const sbApprovalEl = root.querySelector("#coord-sb-approval");
+  if (sbApprovalEl) {
+    sbApprovalEl.addEventListener("click", function () {
+      _revealPendingApproval();
+    });
+  }
   let coordModel = "";
   let coordModelAlias = "";
   let coordEffort = "";
@@ -2164,12 +2206,17 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   // The tool-batch currently awaiting an approval decision (for the keyboard
-  // shortcuts): the last .conv-batch with a still-pending row whose actions
-  // aren't already disabled — i.e. not mid-resolve, so a key never double-fires.
+  // shortcuts and the status-bar chip): the last --pending .conv-batch with a
+  // still-pending row whose actions aren't already disabled — i.e. not
+  // mid-resolve, so a key never double-fires.  The class check matters: a
+  // resolved batch keeps its rows' data-needs-approval (only _refreshRowStatus
+  // clears it) and its status pill has no button, so without it a resolved
+  // batch outranked an older still-pending one and a key 409'd on a stale id.
   function _currentPendingBatch() {
     const batches = messagesEl.querySelectorAll(".conv-batch");
     for (let i = batches.length - 1; i >= 0; i--) {
       const b = batches[i];
+      if (!b.classList.contains("conv-batch--pending")) continue;
       if (!b.querySelector('.conv-row[data-needs-approval="1"][data-call-id]'))
         continue;
       const btn = b.querySelector(".conv-actions button");
@@ -2177,6 +2224,47 @@ function createCoordinatorPane(root, wsId, opts) {
       return b;
     }
     return null;
+  }
+
+  // Status-bar pending-approval chip.  The coord keeps no cycle map (the
+  // interactive pane's approvalCycles); pending state IS the DOM, so the
+  // count is derived from it: every --pending batch in THIS transcript
+  // (child workstreams' gates live in the children tree and the rail, not
+  // here).  Re-derived at the three places pending state changes —
+  // appendToolBatch (paint / replay / upgrade), _morphBatchResolved, and
+  // the refetchHistory wipe (a history render never paints a pending
+  // batch; SSE re-delivers approve_request, which repaints and recounts).
+  // A batch stays counted while its own click is mid-resolve: the server
+  // has not confirmed yet, and approval_resolved morphs it out.
+  function _syncApprovalChip() {
+    if (!sbApprovalEl) return;
+    const n = messagesEl.querySelectorAll(
+      ".conv-batch.conv-batch--pending",
+    ).length;
+    StatusBar.paintApprovalChip(
+      {
+        approvalEl: sbApprovalEl,
+        focusFallbackEl: composer && composer.inputEl,
+      },
+      n,
+    );
+  }
+
+  // Chip click: bring the batch the keyboard shortcuts act on into view and
+  // focus its HEAD, not its primary action — a "show me" click must never
+  // arm Space on Approve.  (The paint-time focus on the primary action stays
+  // where it is; that one follows a judge verdict the reviewer asked for.)
+  // Falls back to any --pending batch (all mid-resolve) so the click never
+  // lands on nothing while the chip is showing.  The head focus uses
+  // preventScroll internally, so the smooth scroll keeps the viewport.
+  function _revealPendingApproval() {
+    const batch =
+      _currentPendingBatch() ||
+      messagesEl.querySelector(".conv-batch.conv-batch--pending");
+    if (!batch) return;
+    setConvBatchExpanded(batch, true, { blocker: true });
+    StatusBar.scrollToApprovalTarget(batch);
+    focusConvBatchHead(batch);
   }
 
   // Build the resolved-state status pill.  Shared between the live
@@ -2238,6 +2326,7 @@ function createCoordinatorPane(root, wsId, opts) {
     const actions = batch.querySelector(".conv-actions");
     if (actions) actions.replaceWith(_buildStatusPill(opts));
     if (activeBatch === batch) activeBatch = null;
+    _syncApprovalChip();
   }
 
   function _focusBatchPrimary(batch, prefer) {
@@ -2408,6 +2497,11 @@ function createCoordinatorPane(root, wsId, opts) {
           _appendJudgePendingLineTo(entry.row);
         }
       });
+      // Only a pending paint can add --pending (the morph is the sole
+      // remover), so the recount is gated on it: a history render calls
+      // this once per tool batch, and an unconditional transcript scan
+      // there is quadratic in a long session.
+      if (opts.pending) _syncApprovalChip();
       return existing;
     }
 
@@ -2510,6 +2604,7 @@ function createCoordinatorPane(root, wsId, opts) {
 
     messagesEl.appendChild(batch);
     _scheduleScroll();
+    if (opts.pending) _syncApprovalChip();
     return batch;
   }
 
@@ -4627,6 +4722,10 @@ function createCoordinatorPane(root, wsId, opts) {
   const _mapSet = Map.prototype.set;
   const _mapDelete = Map.prototype.delete;
   const _mapClear = Map.prototype.clear;
+  // Every mutation repaints the Children-heading count: the pending set
+  // IS that chip's number, and the bulk live fetch (the path that first
+  // discovers a pending approval after load) reaches no render otherwise.
+  // Cheap per call — two sizes, one text write, one two-child lookup.
   function _liveBadgeCacheSet(id, entry) {
     _mapSet.call(liveBadgeCache, id, entry);
     if (entry && entry.live && entry.live.pending_approval) {
@@ -4634,15 +4733,25 @@ function createCoordinatorPane(root, wsId, opts) {
     } else {
       pendingApprovalIds.delete(id);
     }
+    _refreshChildrenCount();
   }
   function _liveBadgeCacheDelete(id) {
     _mapDelete.call(liveBadgeCache, id);
     pendingApprovalIds.delete(id);
+    _refreshChildrenCount();
   }
   function _liveBadgeCacheClear() {
     _mapClear.call(liveBadgeCache);
     pendingApprovalIds.clear();
+    _refreshChildrenCount();
   }
+  // The child row currently flashed by a reveal (the Children-heading
+  // chip).  Held by id, not element: a live-fetch or state tick can
+  // replace the row within the flash window, so renderChildRow re-applies
+  // the class from this and the timer strips it by id.
+  let _flashWsId = null;
+  let _flashTimer = null;
+  const FLASH_MS = 1200;
   // ws_ids currently visible in the viewport — only these trigger
   // live-fetch on SSE state changes.  Populated by an
   // IntersectionObserver attached to each rendered .ch-row so a
@@ -4718,6 +4827,7 @@ function createCoordinatorPane(root, wsId, opts) {
     row.setAttribute("role", "listitem");
     if (state === "closed" || state === "deleted") row.classList.add("closed");
     if (child.ws_id) row.dataset.wsId = child.ws_id;
+    if (child.ws_id && child.ws_id === _flashWsId) row.classList.add("highlight");
 
     const a = document.createElement("a");
     a.className = "ws-link";
@@ -5410,6 +5520,14 @@ function createCoordinatorPane(root, wsId, opts) {
     if (!active || !scopeEl || !scopeEl.contains(active)) return null;
     const row = active.closest(".ch-row");
     if (!row || !row.dataset.wsId) return null;
+    // The row and its approval region take temporary focus from the
+    // Children-heading chip's reveal.  Neither is a stable className
+    // (the row carries a transient flash class, the region a transient
+    // loading class), so they are captured as roles.
+    if (active === row) return { wsId: row.dataset.wsId, role: "row" };
+    if (active.classList && active.classList.contains("approval-block")) {
+      return { wsId: row.dataset.wsId, role: "approval" };
+    }
     return {
       wsId: row.dataset.wsId,
       marker: active.className || active.tagName,
@@ -5422,7 +5540,13 @@ function createCoordinatorPane(root, wsId, opts) {
     const row = scopeEl.matches(sel) ? scopeEl : scopeEl.querySelector(sel);
     if (!row) return;
     let target = null;
-    if (focusKey.marker) {
+    if (focusKey.role === "row") {
+      target = row;
+    } else if (focusKey.role === "approval") {
+      // The block is gone on the resolution swap: keep the caret in the
+      // list on the row rather than dropping it to the document.
+      target = row.querySelector(".approval-block") || row;
+    } else if (focusKey.marker) {
       // CSS.escape can't safely round-trip a class list with spaces,
       // so we walk focusables and string-compare. A future refactor
       // could swap to a stable ``data-focus-key`` attribute on each
@@ -5438,7 +5562,12 @@ function createCoordinatorPane(root, wsId, opts) {
         }
       }
     }
-    if (target) target.focus({ preventScroll: true });
+    if (!target) return;
+    // A role target is a plain div on the fresh row: a raw focus() is a
+    // silent no-op there, so it takes the same temporary tabindex the
+    // reveal gave the original.  Marker targets are natively focusable.
+    if (focusKey.role) focusTemporarily(target);
+    else target.focus({ preventScroll: true });
   }
 
   function _renderChildrenNow() {
@@ -5520,9 +5649,70 @@ function createCoordinatorPane(root, wsId, opts) {
   function _refreshChildrenCount() {
     const total = childrenState.size;
     const pending = pendingApprovalIds.size;
-    childrenCountEl.textContent = total
-      ? "(" + total + (pending > 0 ? " · " + pending + " pending" : "") + ")"
-      : "";
+    childrenCountEl.textContent = total ? "(" + total + ")" : "";
+    // The pending part of the old "(N · x pending)" annotation is now a
+    // warn chip: same words, but coloured and clickable — the click
+    // scrolls the tree to the first child waiting on an approval.
+    StatusBar.paintWarnChip(
+      {
+        chipEl: childrenPendingEl,
+        focusFallbackEl: composer && composer.inputEl,
+      },
+      pending,
+      {
+        label: pending + " approval" + (pending === 1 ? "" : "s"),
+        title:
+          "Show the " +
+          (pending === 1 ? "child" : "first child") +
+          " waiting for approval",
+      },
+    );
+  }
+
+  // Children-heading chip click: the first child row (tree order) whose
+  // approval is pending.  Rows lazy-load their approval block on
+  // visibility, so the row is the reliable target; the block, when
+  // already painted, is the better landing (a labelled region).  Focus is
+  // temporary on the region or the row — never the child's link (Enter
+  // would open it) and never an Approve button (Space would fire it).
+  // No sidebar expand: a collapsed sidebar hides the whole children
+  // section, this chip included, so the click cannot happen there.
+  function _revealPendingChild() {
+    if (!pendingApprovalIds.size) return;
+    const rows = childrenTreeEl.querySelectorAll(".ch-row");
+    let row = null;
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i].dataset.wsId && pendingApprovalIds.has(rows[i].dataset.wsId)) {
+        row = rows[i];
+        break;
+      }
+    }
+    if (!row) return;
+    StatusBar.scrollToApprovalTarget(row);
+    _flashChildRow(row.dataset.wsId);
+    focusTemporarily(row.querySelector(".approval-block") || row);
+  }
+
+  function _flashChildRow(wsId) {
+    if (_flashTimer) clearTimeout(_flashTimer);
+    if (_flashWsId && _flashWsId !== wsId) _unflashChildRow(_flashWsId);
+    _flashWsId = wsId;
+    const row = childrenTreeEl.querySelector(
+      '.ch-row[data-ws-id="' + cssEscape(wsId) + '"]',
+    );
+    if (row) row.classList.add("highlight");
+    _flashTimer = setTimeout(() => {
+      _flashTimer = null;
+      _flashWsId = null;
+      _unflashChildRow(wsId);
+    }, FLASH_MS);
+  }
+
+  function _unflashChildRow(wsId) {
+    const row = childrenTreeEl.querySelector(
+      '.ch-row[data-ws-id="' + cssEscape(wsId) + '"]',
+    );
+    if (row) row.classList.remove("highlight");
   }
 
   function renderTaskRow(task) {
@@ -5758,16 +5948,16 @@ function createCoordinatorPane(root, wsId, opts) {
           permanent: wasDenied,
           sseUpdatedAt: prev ? prev.sseUpdatedAt || 0 : 0,
         });
+        // Through _updateChildRow for its focus capture/restore, observer
+        // rebind and count repaint — the reveal's own scroll brings a row
+        // into view and lands here within the flash window, and a bare
+        // replaceWith dropped the focus it had just placed.  The guard
+        // keeps an absent row a silent skip rather than the full render
+        // _updateChildRow falls back to.
         const row = childrenTreeEl.querySelector(
           '.ch-row[data-ws-id="' + cssEscape(id) + '"]',
         );
-        if (row) {
-          const entry = childrenState.get(id);
-          if (entry) {
-            const replacement = renderChildRow(entry);
-            row.replaceWith(replacement);
-          }
-        }
+        if (row && childrenState.get(id)) _updateChildRow(id);
       });
     } catch (e) {
       // 403 = caller lacks admin.cluster.inspect → mark every pending
@@ -6065,6 +6255,14 @@ function createCoordinatorPane(root, wsId, opts) {
     details.push(detail);
     cachedLive.pending_approval = true;
     cachedLive.pending_approval_details = details;
+    // An approve_request can precede the child's first state tick (and
+    // the /children load).  Seed the entry as handleChildState does so
+    // the Children-heading chip never counts a gate with no row to
+    // reveal; the tick fills in state and node when it lands.
+    if (!childrenState.has(childId)) {
+      childrenState.set(childId, { ws_id: childId, name: "" });
+      _touchChild(childId);
+    }
     _liveBadgeCacheSet(childId, {
       live: cachedLive,
       fetched: cached ? cached.fetched : 0,
@@ -6635,6 +6833,7 @@ function createCoordinatorPane(root, wsId, opts) {
     )
       return;
     messagesEl.replaceChildren();
+    _syncApprovalChip();
     // A full committed-history render repairs any recorded truncation gap —
     // whether this render came from the truncated resync itself or from an
     // unrelated clear_ui rebuild — so it supersedes ALL pending repair

--- a/turnstone/shared_static/base.css
+++ b/turnstone/shared_static/base.css
@@ -117,6 +117,11 @@
   --warn-soft: oklch(0.29 0.07 80);
   --warn-tint: oklch(0.22 0.05 80);
   --warn-tint-border: oklch(0.58 0.15 80);
+  /* Ink for text ON --warn-tint (the rail badge, the status-bar approval
+     chip).  Equals --warn here (6.4:1 on the dark tint) but is a separate
+     token, written out, so a retune of --warn can't drag chip ink with it;
+     in light, --warn itself is only 3.3:1 on the pale tint. */
+  --warn-text: oklch(0.7 0.13 80);
   --err: oklch(0.68 0.17 25);
   --err-soft: oklch(0.29 0.07 25);
   --err-fill: oklch(0.56 0.17 25); /* darker filled red for .risk.crit */
@@ -195,6 +200,7 @@
   --warn-soft: oklch(0.94 0.05 80);
   --warn-tint: oklch(0.92 0.1 80);
   --warn-tint-border: oklch(0.64 0.15 80);
+  --warn-text: oklch(0.44 0.13 80); /* dark amber on pale warn-tint: 6.0:1 */
   --err: oklch(0.5 0.17 25);
   --err-soft: oklch(0.94 0.05 25);
   --err-fill: oklch(0.45 0.17 25);

--- a/turnstone/shared_static/chat.css
+++ b/turnstone/shared_static/chat.css
@@ -2065,6 +2065,60 @@
   white-space: nowrap;
   margin-left: auto;
 }
+/* Pending-approval chip — a sticky, clickable count of the human gates open
+   in THIS pane's transcript.  Parallel task agents make several live at
+   once and the card can sit far off-screen; the click scrolls to the one
+   the keyboard shortcuts act on.  Same tint family and ink as the rail's
+   attention badge (shell.css .rail-badge) — one signal, one look — and it
+   stays at full strength in the disconnected state (the cycle is still
+   live client-side).  Hidden at zero via [hidden]: no display here, so the
+   UA rule keeps winning.
+
+   Geometry: the bar is 22px min-height with 4px vertical padding, a 14px
+   inner box.  12px line box + 2 × 1px border = 14px, so the bar does NOT
+   change height when the chip appears — it is the transcript/composer
+   boundary, and a shift there lands at the very moment the card paints.
+   The 2px focus ring at 1px offset spans y=1..21 inside that 22px.
+
+   Placement: between the tools and turn cells, the bar's only free space
+   (the turn cell carries margin-left: auto), so the chip appears and
+   disappears without moving any other cell.  The price is clip order under
+   a very narrow pane (turn, then this chip, before the ambient cells);
+   the bar is already slicing text mid-glyph below ~360px, and there the
+   card, the rail badge and the announcer still carry the signal. */
+/* .warn-chip is the look — shared with the coordinator's Children-heading
+   pending chip (coord-chrome.css .side-count-pending); each surface adds
+   only its geometry (padding, font size and family, line box). */
+.warn-chip {
+  appearance: none;
+  flex: none;
+  margin: 0;
+  border: 1px solid var(--warn-tint-border);
+  border-radius: var(--r-sm);
+  background: var(--warn-tint);
+  color: var(--warn-text);
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+/* Hover steps the fill toward the ink — a darkening in both themes.
+   (--warn-soft is not a hover token: it is lighter than the tint in light
+   and darker in dark, so it would fade the chip into a white bar.) */
+.warn-chip:hover {
+  background: color-mix(in srgb, var(--warn-tint) 82%, var(--warn));
+}
+.warn-chip:focus-visible {
+  outline: 2px solid var(--warn);
+  outline-offset: 1px;
+}
+/* Family and size as longhands, not the font shorthand: the shorthand
+   would also reset the weight .warn-chip sets. */
+.ws-sb-approval {
+  padding: 0 6px;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 12px;
+}
 .ws-status-bar.ws-sb-warn .ws-sb-tokens {
   color: var(--yellow);
   font-weight: 600;

--- a/turnstone/shared_static/conversation.js
+++ b/turnstone/shared_static/conversation.js
@@ -641,21 +641,33 @@ function _batchHasProtectedFocus(batch) {
   return !head || !head.contains(active);
 }
 
-function _focusConvBatchHead(batch) {
-  const head = _convBatchHead(batch);
-  if (!head || typeof head.focus !== "function") return;
-  const temporary = !head.hasAttribute("tabindex");
-  if (temporary) head.setAttribute("tabindex", "-1");
-  head.focus({ preventScroll: true });
+// Focus a non-interactive element without pre-selecting an answer: a
+// temporary tabindex, so the element takes focus (and a visible ring)
+// while Space and Enter stay unarmed on any action button or link inside
+// it.  The tabindex leaves with the focus, so the element never joins the
+// Tab order.  preventScroll: callers own the viewport (a smooth scroll is
+// usually already running toward the element).
+export function focusTemporarily(el) {
+  if (!el || typeof el.focus !== "function") return;
+  const temporary = !el.hasAttribute("tabindex");
+  if (temporary) el.setAttribute("tabindex", "-1");
+  el.focus({ preventScroll: true });
   if (temporary) {
-    head.addEventListener(
+    el.addEventListener(
       "blur",
       () => {
-        head.removeAttribute("tabindex");
+        el.removeAttribute("tabindex");
       },
       { once: true },
     );
   }
+}
+
+// Focus a batch's head — used when a blocker expansion steals focus from
+// the disclosure, and by the status-bar approval chip's reveal on the
+// coordinator (which has no feedback field to land on).
+export function focusConvBatchHead(batch) {
+  focusTemporarily(_convBatchHead(batch));
 }
 
 function _syncConvBatchDisclosure(batch, expanded) {
@@ -721,7 +733,7 @@ export function setConvBatchExpanded(batch, expanded, options) {
     disclosure &&
     document.activeElement === disclosure
   ) {
-    _focusConvBatchHead(batch);
+    focusConvBatchHead(batch);
   }
   const playing = _playingBatchMedia(batch);
   if (!expanded && !options.manual) {

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -910,11 +910,44 @@ class Pane {
     this.approvalBlockEl = active ? active.blockEls[0] : null;
     this.inputEl.disabled = this.pendingApproval;
     this._reconcileSendDisabled();
+    StatusBar.paintApprovalChip(
+      { approvalEl: this._sbApproval, focusFallbackEl: this.inputEl },
+      this.approvalCycles.size,
+    );
   }
 
   _oldestCycleId() {
     const first = this.approvalCycles.keys().next();
     return first.done ? null : first.value;
+  }
+
+  // Status-bar chip click: bring the card the keyboard shortcuts act on
+  // (the OLDEST live cycle — see the keydown handler) into view and hand
+  // focus to its feedback field, exactly as a freshly painted first cycle
+  // does.  The card may have scrolled far away or, for a task-agent
+  // sub-batch, sit inside an agent card the user re-collapsed after the
+  // approve paint forced it open — unfold both layers first, otherwise
+  // scrollIntoView on a display:none row is a no-op.
+  revealPendingApproval() {
+    const id = this._oldestCycleId();
+    const entry = id ? this.approvalCycles.get(id) : null;
+    const block = entry
+      ? entry.blockEls.find((el) => el && el.isConnected)
+      : null;
+    if (!block) return;
+    const agentCard = block.closest(".conv-agent");
+    if (agentCard) {
+      agentCard.dataset.collapsed = "false";
+      const toggle = agentCard.querySelector(".conv-agent-toggle");
+      if (toggle) toggle.setAttribute("aria-expanded", "true");
+    }
+    const batch = block.closest(".conv-batch");
+    if (batch) setConvBatchExpanded(batch, true, { blocker: true });
+    StatusBar.scrollToApprovalTarget(block);
+    const fb = block.querySelector(".conv-feedback");
+    // preventScroll: the smooth scroll above owns the viewport; a focus
+    // jump would cut it short and land the card at the viewport edge.
+    if (fb) fb.focus({ preventScroll: true });
   }
 
   _registerApprovalCycle(cycleId, blockEls, items) {
@@ -1210,6 +1243,10 @@ class Pane {
     // keys type; elsewhere y|Enter approve, n|Esc deny, a = approve-all.
     this.el.addEventListener("keydown", (e) => {
       if (!this.pendingApproval || !this.approvalBlockEl) return;
+      // The status-bar chip is a button inside this.el: Enter on it must
+      // reach its own click (reveal), never the approve arm below — and
+      // preventDefault here would swallow that click outright.
+      if (e.target === this._sbApproval) return;
       // Keyboard acts on the OLDEST live cycle (the one approvalBlockEl
       // tracks); sibling cards from parallel task agents resolve by
       // their own buttons or become oldest in turn.  When the feedback
@@ -1373,9 +1410,21 @@ class Pane {
     this._sbTurns.className = "ws-sb-turns";
     this._sbTurns.textContent = "turn 0";
     this._sbTurns.setAttribute("aria-label", "Conversation turn");
+    // Pending-approval chip: sticky count of the live human gates in this
+    // transcript, painted by _syncApprovalState (the one approval-state
+    // chokepoint) and hidden at zero.  A button, so it tabs and clicks:
+    // the click brings the card the keyboard shortcuts act on into view.
+    this._sbApproval = document.createElement("button");
+    this._sbApproval.type = "button";
+    this._sbApproval.className = "warn-chip ws-sb-approval";
+    this._sbApproval.hidden = true;
+    this._sbApproval.addEventListener("click", () =>
+      this.revealPendingApproval(),
+    );
 
     this.statusBarEl.appendChild(this._sbTokens);
     this.statusBarEl.appendChild(this._sbTools);
+    this.statusBarEl.appendChild(this._sbApproval);
     this.statusBarEl.appendChild(this._sbTurns);
     this.el.appendChild(this.statusBarEl);
 

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -1247,7 +1247,7 @@
   border-radius: var(--r-sm);
   background: var(--warn-tint);
   border: 1px solid var(--warn-tint-border);
-  color: var(--warn);
+  color: var(--warn-text);
   font-size: 10px;
   line-height: 1.5;
   font-variant-numeric: tabular-nums;

--- a/turnstone/shared_static/status_bar.js
+++ b/turnstone/shared_static/status_bar.js
@@ -9,11 +9,18 @@
  * the same three cells: token / context-window usage with optional
  * effort suffix, tool calls this turn, conversation turn.  (The model
  * cell moved out — both surfaces now show model/effort in the composer chip.)
+ * Beside them sits the pending-approval chip: a sticky, clickable count
+ * of the human gates open in the pane's own transcript, painted from
+ * each surface's approval bookkeeping rather than from an SSE event.
+ * It is one use of the generic warn-chip painter below, which takes its
+ * label and title from the caller; the coordinator's Children heading
+ * paints another (its pending child-approval count).
  *
  * Single source of truth for warn / danger thresholds, prefix glyphs,
- * and effort-suffix rules.  Each surface owns its own DOM (different
- * element ids); the formatter takes the three cell spans + the
- * status-bar root + the SSE event.
+ * effort-suffix rules, the warn-chip build (glyph, hidden-at-zero,
+ * focus hand-off) and the status-bar approval chip's own wording.  Each
+ * surface owns its DOM (different element ids); the formatters take the
+ * elements + the SSE event / count.
  *
  * ES module; window bridge below for the still-classic consumers.
  */
@@ -76,9 +83,107 @@ function resetTokensPlaceholder(tokensEl) {
   if (tokensEl) tokensEl.textContent = "0 / —";
 }
 
+/**
+ * Repaint a clickable warn chip: a count of things waiting on the
+ * operator, hidden at zero (the [hidden] attribute; the chips' CSS sets
+ * no display so the UA rule keeps winning).  The surface owns the click.
+ *
+ * The glyph rides an aria-hidden span so screen readers voice only the
+ * plain sentence (an aria-label on the element would be ignored by
+ * several of them, which then read the raw glyph).  Glyph + label are
+ * built once; repaints only rewrite the label text.
+ *
+ * The count can drop to zero out from under a focused chip (a peer tab
+ * resolves the gate, a transcript rebuild); hiding it then would drop
+ * focus to the document body and restart Tab from the top.
+ * `focusFallbackEl` (the surface's composer input) takes the focus
+ * instead.
+ *
+ * @param {Object} els — { chipEl, focusFallbackEl }
+ * @param {number} count — 0 hides the chip.
+ * @param {Object} text — { label, title } for this count (plain words,
+ *   already pluralized by the caller).
+ */
+function paintWarnChip(els, count, text) {
+  var chip = els && els.chipEl;
+  if (!chip) return;
+  var n = count > 0 ? count : 0;
+  if (n === 0) {
+    var fallback = els.focusFallbackEl;
+    if (
+      !chip.hidden &&
+      fallback &&
+      typeof fallback.focus === "function" &&
+      typeof chip.contains === "function" &&
+      chip.contains(document.activeElement)
+    ) {
+      fallback.focus({ preventScroll: true });
+    }
+    chip.hidden = true;
+    return;
+  }
+  chip.hidden = false;
+  chip.title = text.title;
+  var label = chip.querySelector(".warn-chip-label");
+  if (!label) {
+    var glyph = document.createElement("span");
+    glyph.setAttribute("aria-hidden", "true");
+    glyph.textContent = "⚠ ";
+    label = document.createElement("span");
+    label.className = "warn-chip-label";
+    chip.appendChild(glyph);
+    chip.appendChild(label);
+  }
+  label.textContent = text.label;
+}
+
+/**
+ * Repaint the status bar's pending-approval chip.  `count` is the number
+ * of live human-gated approval cycles in THIS pane's transcript —
+ * parallel task agents make several live at once, and the card that
+ * needs the click can sit far off-screen.  The surface's click scrolls
+ * to the card its keyboard shortcuts would act on, so click target and
+ * key target agree.
+ *
+ * @param {Object} els — { approvalEl, focusFallbackEl }
+ * @param {number} count — live approval cycles (0 hides the chip).
+ */
+function paintApprovalChip(els, count) {
+  if (!els) return;
+  var n = count > 0 ? count : 0;
+  var s = n === 1 ? "" : "s";
+  paintWarnChip({ chipEl: els.approvalEl, focusFallbackEl: els.focusFallbackEl }, n, {
+    label: n + " approval" + s + " needed",
+    title: "Show the pending approval" + s,
+  });
+}
+
+/**
+ * Bring an approval card into view for the chip click.  Smooth unless
+ * the viewer asked for reduced motion; centred so a tall card's action
+ * row and feedback field land on-screen together.  Guarded for the
+ * node harness's fake elements, which have no scrollIntoView.
+ */
+function scrollToApprovalTarget(el) {
+  if (!el || typeof el.scrollIntoView !== "function") return;
+  var reduce = false;
+  try {
+    reduce =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch (_) {
+    reduce = false;
+  }
+  el.scrollIntoView({ behavior: reduce ? "auto" : "smooth", block: "center" });
+}
+
 export const StatusBar = {
   paint: paintStatusBar,
   resetTokensPlaceholder: resetTokensPlaceholder,
+  paintWarnChip: paintWarnChip,
+  paintApprovalChip: paintApprovalChip,
+  scrollToApprovalTarget: scrollToApprovalTarget,
   CTX_WARN_PCT: CTX_WARN_PCT,
   CTX_DANGER_PCT: CTX_DANGER_PCT,
 };


### PR DESCRIPTION
When parallel task agents run in an interactive session, a tool approval
card can land off-screen (the user scrolled up, or the row sits inside a
task-agent card mid-transcript) and the turn stalls on a prompt nobody
sees. The rail badges the workstream but cannot point inside the pane.

Add a sticky chip to the per-workstream status bar, beside the
tokens / tools / turn cells: "1 approval needed", counting up when
several human gates are live at once. It is a button; clicking it
scrolls to the card the keyboard shortcuts act on (the oldest live
cycle in the interactive pane, the current pending batch in the
coordinator), unfolds a re-collapsed agent card or batch around it,
and lands focus on the feedback field (interactive) or the batch head
(coordinator) without a focus-scroll jump. A reveal never focuses an
action button, so a "show me" click cannot arm Space on Approve. Both
surfaces' approval keydown handlers ignore keys originating on the chip:
it sits inside the element that carries them, and Enter on the focused
chip would otherwise approve the call instead of revealing it.

The interactive pane paints the chip from _syncApprovalState, the one
chokepoint every register / resolve / prune / reset path already
funnels through, so peer-tab resolution and transcript rebuilds clear
it for free. The coordinator keeps no cycle map, so its count is
re-derived from the transcript's pending batches where that state can
change: a pending batch paint (gated on opts.pending so a history
render's per-batch calls never scan the transcript), the resolve
morph, and the history wipe. Its "current pending batch" now requires
the pending class as well as a pending row, so the keyboard shortcuts
and the chip stop targeting an already-resolved batch (whose rows keep
data-needs-approval and whose status pill has no button). Scope of the
status-bar chip is the pane's own transcript. A chip hidden under
keyboard focus hands focus to the composer instead of dropping it to
the document body.

Child workstreams' gates keep their own signal, next to the children:
the "x pending" half of the coordinator's "(N · x pending)" Children
count becomes the same kind of chip, coloured and clickable, reading
"x approvals". Its click scrolls the tree to the first child (tree
order) whose approval is pending, flashes the row, and lands temporary
focus on the row's approval region or the row itself, never the
child's link or an Approve button. The count repaints from the
live-badge cache helpers, the one place the pending set changes: the
bulk live fetch that first discovers a pending approval after load
reached no render before, so the old annotation could sit stale. That
fetch's row swap now goes through the single-row update, which keeps
focus, re-attaches the visibility observer to the new row (a swapped
row silently stopped live-fetching before), and repaints the count;
the flash is held by id so a swap inside its window re-applies it. The
row and its approval region are captured as focus roles across a swap,
since their classNames are transient. An approve request that precedes
a child's first state tick seeds its row so the chip never counts a
gate with nowhere to go.

Wording, tooltip, and reduced-motion handling live once in the shared
status-bar module: a generic warn-chip painter that takes its label and
title from the caller, with the approval wording on top. The chips
share one look (a warn-chip base class; each surface adds geometry)
with the rail attention badge's tint, and a new --warn-text ink token
shared with that badge: the base warn colour on the pale light-theme
tint was 3.3:1, below AA at 10px; the new ink reads at 6:1 there and
is unchanged in dark. The status-bar chip's line box is sized so the
bar keeps its 22px height when the chip appears, it stays at full
strength in the disconnected state because the cycle is still live
client-side, and the sidebar heading yields with an ellipsis before
its chip can widen the sidebar.

