### PR TITLE
feat(ui): add preview downloads and polish pane styling

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -446,20 +446,21 @@ Show the user rich content in a preview pane beside the conversation.
 | `kind`    | string | no       | Rendering override: `web`, `pdf`, `image`, `table`, `text`, or `markdown`. Detected from the content when omitted. |
 | `title`   | string | no       | Pane header title. Defaults to the page title, filename, or URL. |
 
-- **What it does**: Resolves the target to bytes (URLs fetch through the same
-  SSRF-guarded path as `web_fetch`, screened per redirect hop, honoring the
-  same `tools.allow_private_network` opt-in), classifies the
-  content, stores it content-addressed against the workstream, and opens the
-  frontend preview pane beside the conversation: web pages render in a fully
-  sandboxed iframe (no scripts, opaque origin), PDFs in the browser viewer,
-  images inline, CSV/TSV/JSON as a sortable table, text/markdown rendered. A
-  previewed web page loads none of its remote images or styles by default, so
-  opening it never reveals the viewer to the page's site; a toggle in the pane
-  header turns remote content back on for that preview. The
-  model receives only a one-line confirmation — to reason about content, use
-  `web_fetch` / `read_file` instead. Preview content is size-capped per kind
-  (pages 4 MB, PDFs 32 MB, images 4 MB, tables 2 MB, text 512 KB) and GC'd
-  with the workstream.
+- **What it does**: Resolves the target to bytes (URLs fetch through the same SSRF-guarded path as
+  `web_fetch`, screened per redirect hop, honoring the same `tools.allow_private_network` opt-in),
+  classifies the content, stores it content-addressed against the workstream, and opens the frontend
+  preview pane beside the conversation: web pages render in a fully sandboxed iframe (no scripts,
+  opaque origin), PDFs in the browser viewer, images inline, CSV/TSV/JSON as a sortable table,
+  text/markdown rendered. A previewed web page loads none of its remote images or styles by default,
+  so opening it never reveals the viewer to the page's site; a toggle in the pane header turns
+  remote content back on for that preview. **Download** saves the stored preview file, including the
+  complete CSV/TSV/JSON when the table display is capped or sorted. Text downloads use the preview's
+  UTF-8 encoding; fetched HTML includes its base URL for relative links and assets. Newly stored
+  previews derive their filename from the source where available, independently of the pane title.
+  Downloads reuse that stored name with an ASCII-safe fallback. The model receives only a one-line
+  confirmation — to reason about content, use `web_fetch` / `read_file` instead. Preview content is
+  size-capped per kind (pages 4 MB, PDFs 32 MB, images 4 MB, tables 2 MB, text 512 KB) and GC'd with
+  the workstream.
 - **Auto-approve**: URL targets require confirmation (network access); file
   paths and `attachment:` targets run unprompted (local reads).
 - **Agent availability**: interactive sessions only (not `task_agent`, not

--- a/tests/_js_harness_helpers.py
+++ b/tests/_js_harness_helpers.py
@@ -70,6 +70,10 @@ class FakeElement {
     return child;
   }
   append(...children) { children.forEach((child) => this.appendChild(child)); }
+  replaceChildren(...children) {
+    [...this.children].forEach((child) => child.remove());
+    this.append(...children);
+  }
   remove() {
     if (!this.parentNode) return;
     const i = this.parentNode.children.indexOf(this);

--- a/tests/test_open_preview_tool.py
+++ b/tests/test_open_preview_tool.py
@@ -180,11 +180,29 @@ class TestExecOpenPreview:
         assert descriptor["source"] == "https://acme.com/pricing"
         assert descriptor["content_type"].startswith("text/html")
         assert att.kind == "preview"
+        assert att.filename == "pricing.html"
         # The stored bytes gained a base for relative-asset resolution.
         assert b'<base href="https://acme.com/pricing">' in att.content
         # The live event carried the descriptor.
         results = s.ui.tool_results
         assert results and results[-1][3].get("preview") == descriptor
+
+    def test_url_filename_strips_nul_before_persistence(self, _no_network_screen, monkeypatch):
+        s = _make_session()
+        url = "https://example.com/report%00.pdf"
+        body = b"%PDF-1.4 preview"
+        monkeypatch.setattr(
+            "turnstone.core.session.fetch_with_ssrf_guard",
+            lambda url, **kw: _fake_response(url, body, "application/pdf"),
+        )
+        item = s._prepare_open_preview("c1", {"target": url, "title": "Quarterly report"})
+        _, msg = s._exec_open_preview(item)
+        assert not msg.startswith("Error:")
+        descriptor, att = s._tool_previews["c1"]
+        assert att.filename == "report.pdf"
+        assert att.content == body
+        assert descriptor["source"] == url
+        assert descriptor["title"] == "Quarterly report"
 
     def test_url_userinfo_stripped_from_descriptor(self, _no_network_screen, monkeypatch):
         s = _make_session()
@@ -332,9 +350,10 @@ class TestExecOpenPreview:
         item = s._prepare_open_preview("c1", {"target": "attachment:deadbeef"})
         _, msg = s._exec_open_preview(item)
         assert not msg.startswith("Error:")
-        descriptor, _ = s._tool_previews["c1"]
+        descriptor, att = s._tool_previews["c1"]
         assert descriptor["kind"] == "markdown"
         assert descriptor["title"] == "d.md"
+        assert att.filename == "d.md"
 
     def test_legacy_charset_table_stored_as_utf8(self, monkeypatch):
         # A latin-1 CSV attachment previews as a table, and the executor
@@ -369,8 +388,9 @@ class TestExecOpenPreview:
         p.write_text("a,b\n")
         item = s._prepare_open_preview("c1", {"target": str(p), "title": "Q3 numbers"})
         s._exec_open_preview(item)
-        descriptor, _ = s._tool_previews["c1"]
+        descriptor, att = s._tool_previews["c1"]
         assert descriptor["title"] == "Q3 numbers"
+        assert att.filename == "x.csv"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -9,6 +9,8 @@ attaches.  The tool executor and the HTTP route are covered separately
 
 from __future__ import annotations
 
+import pytest
+
 from turnstone.core.attachments import IMAGE_SIZE_CAP, PDF_SIZE_CAP, TEXT_DOC_SIZE_CAP
 from turnstone.core.preview import (
     PREVIEW_BLOB_KIND,
@@ -18,6 +20,7 @@ from turnstone.core.preview import (
     build_preview_descriptor,
     inject_base_href,
     page_title,
+    preview_filename,
     preview_response_headers,
     resolve_preview_kind,
     transcode_text,
@@ -30,6 +33,34 @@ PNG_1x1 = (
 )
 PDF_MIN = b"%PDF-1.4 fake body"
 HTML_DOC = b"<html><head><title>Acme Pricing</title></head><body>hi</body></html>"
+
+
+@pytest.mark.parametrize(
+    ("name", "mime", "is_url", "expected"),
+    [
+        ("/tmp/results.csv", "text/csv", False, "results.csv"),
+        ("C:\\reports\\notes.md", "text/markdown", False, "notes.md"),
+        ("/tmp/report#2?.txt", "text/plain", False, "report#2?.txt"),
+        (
+            "https://example.com/Q3%20report.pdf?token=x#page=2",
+            "application/pdf",
+            True,
+            "Q3 report.pdf",
+        ),
+        ("https://example.com/report", "application/pdf", True, "report.pdf"),
+        ("https://example.com/report%00.pdf", "application/pdf", True, "report.pdf"),
+        ("https://example.com/%00", "text/plain", True, "preview.txt"),
+        ("https://example.com/", "text/html", True, "preview.html"),
+        ("chart", "image/png", False, "chart.png"),
+        ("data", "application/json", False, "data.json"),
+        ("data", "text/tab-separated-values; charset=utf-8", False, "data.tsv"),
+        ("notes", "text/markdown", False, "notes.md"),
+        ("", "text/plain; charset=utf-8", False, "preview.txt"),
+        ("r" * 150 + ".csv", "text/csv", False, "r" * 116 + ".csv"),
+    ],
+)
+def test_preview_download_filename(name, mime, is_url, expected):
+    assert preview_filename(name, mime, is_url=is_url) == expected
 
 
 class TestResolvePreviewKind:

--- a/tests/test_preview_js.py
+++ b/tests/test_preview_js.py
@@ -1,15 +1,16 @@
-"""Static guards for the preview pane frontend (shared_static/preview.js and
-its wiring through conversation.js / interactive.js / shell.js).
+"""Download behavior and static guards for the shared preview pane frontend.
 
-Same posture as ``test_shell_js.py``: Python-side string-presence assertions
-that catch the silent one-line regression (a renamed export, a dropped
-sandbox attribute, a de-registered pane type).  Parse + sink + var guards for
-``preview.js`` itself live in ``test_shell_js.py``'s bundle sweeps.
+The node harness exercises asynchronous loading, transport context, and history.
+Static assertions cover wiring through conversation.js / interactive.js / shell.js;
+parse and HTML-sink guards live in ``test_shell_js.py``'s bundle sweeps.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+from tests._js_harness_helpers import FAKE_DOM, demodulize, node_skip, run_node_source
 
 _ROOT = Path(__file__).resolve().parent.parent
 _SHARED = _ROOT / "turnstone/shared_static"
@@ -25,6 +26,110 @@ _CONSOLE_INDEX = _ROOT / "turnstone/console/static/index.html"
 
 def _read(p: Path) -> str:
     return p.read_text(encoding="utf-8")
+
+
+def _run_preview(scenario: str) -> None:
+    source = (
+        FAKE_DOM
+        + f"\nconst {{ ShellPane }} = await import({json.dumps(_PANE_JS.as_uri())});\n"
+        + r"""
+const assert = (value, message) => { if (!value) throw new Error(message); };
+const requests = [];
+const timers = [];
+const authFetch = (url) => new Promise((resolve, reject) => requests.push({url, resolve, reject}));
+const redactCredentials = (text) => text;
+globalThis.setTimeout = (fn) => timers.push(fn);
+const flush = () => new Promise(setImmediate);
+const descriptor = (id, kind = "text") => ({attachment_id: id, kind, title: id, source: id});
+const mount = (extra = null) => {
+  const pane = createPreviewPane(extra, {});
+  pane.el = document.createElement("section");
+  pane.bodyEl = document.createElement("div");
+  pane.el.append(pane.bodyEl);
+  pane.onMount();
+  return pane;
+};
+const succeed = async (request, body = "saved bytes") => {
+  request.resolve(new Response(body));
+  await flush();
+};
+const href = (pane) => pane._downloadLink.getAttribute("href");
+"""
+        + demodulize(_PREVIEW_JS)
+        + "\n"
+        + scenario
+    )
+    proc = run_node_source(source)
+    assert proc.returncode == 0, f"preview harness failed:\n{proc.stderr}\n{proc.stdout}"
+
+
+@node_skip
+def test_download_tracks_ready_content_history_and_rehydration() -> None:
+    _run_preview(r"""
+const pane = mount();
+assert(pane._downloadLink.hidden, "empty pane must not offer a download");
+const d = descriptor("same id");
+const a = {base: "/node/node-A", wsId: "ws/A"};
+const b = {base: "/node/node-B", wsId: "ws B"};
+pane.showPreview(d, a);
+assert(!href(pane), "pending file must not be downloadable");
+assert(pane._downloadLink.getAttribute("aria-disabled") === "true", "pending is disabled");
+await succeed(requests.shift());
+const urlA = "/node/node-A/v1/api/workstreams/ws%2FA/attachments/same%20id/content";
+assert(href(pane) === urlA, "download must use the originating transport and encoded path");
+assert(pane._downloadLink.hasAttribute("download"), "download must save rather than navigate");
+assert(!pane._downloadLink.hasAttribute("tabindex"), "ready link must be keyboard reachable");
+pane.showPreview({...d, title: "Updated title"}, a);
+await succeed(requests.shift());
+assert(pane._stack.length === 1, "reopening the same file must not duplicate history");
+assert(pane._titleEl.textContent === "Updated title", "reopening must refresh display metadata");
+pane.showPreview(d, b);
+assert(!href(pane), "changing workstreams must clear the previous download");
+await succeed(requests.shift());
+const urlB = "/node/node-B/v1/api/workstreams/ws%20B/attachments/same%20id/content";
+assert(href(pane) === urlB, "identical bytes on another workstream must use its own context");
+pane._backBtn.click();
+await succeed(requests.shift());
+assert(href(pane) === urlA, "back must restore the prior file and transport");
+pane._fwdBtn.click();
+await succeed(requests.shift());
+assert(href(pane) === urlB, "forward must restore the next file and transport");
+const restored = mount({descriptor: d, ctx: a});
+assert(!href(restored), "restored files must be checked before enabling download");
+await succeed(requests.shift());
+assert(href(restored) === urlA, "reload must restore the download context");
+""")
+
+
+@node_skip
+def test_stale_loads_errors_and_close_cannot_enable_download() -> None:
+    _run_preview(r"""
+const pane = mount();
+const ctx = {base: "", wsId: "ws"};
+pane.showPreview(descriptor("old"), ctx);
+const old = requests.shift();
+pane.showPreview(descriptor("current", "pdf"), ctx);
+await succeed(old);
+assert(!href(pane), "stale text must not enable a download for a pending preview");
+assert(requests[0].url.endsWith("/current/preview?probe=1"), "PDF must preflight");
+await succeed(requests.shift());
+assert(href(pane).endsWith("/current/content"), "probe success must enable the current file");
+pane.showPreview(descriptor("missing"), ctx);
+for (let attempt = 0; attempt < 5; attempt++) {
+  requests.shift().resolve(new Response("missing", {status: 404}));
+  await flush();
+  assert(!href(pane), "unavailable files must remain disabled throughout retries");
+  if (timers.length) timers.shift()();
+}
+assert(pane.bodyEl.querySelector(".preview-error"), "retry exhaustion must show an error");
+pane.bodyEl.querySelector(".preview-error").querySelector("button").click();
+await succeed(requests.shift());
+assert(href(pane).endsWith("/missing/content"), "manual retry must recover the download");
+pane.showPreview(descriptor("closing", "image"), ctx);
+pane.onClose();
+await succeed(requests.shift());
+assert(!href(pane), "a load completing after close must not enable its link");
+""")
 
 
 class TestPreviewPaneModule:

--- a/turnstone/core/preview.py
+++ b/turnstone/core/preview.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import html
 import re
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 from turnstone.core.attachments import (
     ALLOWED_IMAGE_MIMES,
@@ -97,6 +98,36 @@ _KIND_MIMES: dict[str, str] = {
     "text": "text/plain; charset=utf-8",
     "markdown": "text/markdown; charset=utf-8",
 }
+
+
+def preview_filename(name: str, mime: str, *, is_url: bool = False) -> str:
+    """Keep the source basename, with a MIME extension for extensionless targets.
+
+    Display titles are independent of filenames. URL queries never become part
+    of a filename, and truncation preserves its extension. The serving routes
+    apply their usual header sanitization when the file is requested.
+    """
+    if is_url:
+        name = unquote(urlsplit(name).path)
+    # URL escapes can decode to NUL, which PostgreSQL text columns reject.
+    name = name.replace("\x00", "")
+    name = name.replace("\\", "/").rsplit("/", 1)[-1]
+    stem, dot, suffix = name.rpartition(".")
+    if not dot or not stem or not suffix or len(suffix) > 16:
+        stem = name.rstrip(".") or "preview"
+        suffix = {
+            "text/html": "html",
+            "application/pdf": "pdf",
+            "image/png": "png",
+            "image/jpeg": "jpg",
+            "image/gif": "gif",
+            "image/webp": "webp",
+            "text/csv": "csv",
+            "text/tab-separated-values": "tsv",
+            "application/json": "json",
+            "text/markdown": "md",
+        }.get(mime.split(";", 1)[0].strip().lower(), "txt")
+    return f"{stem[: 119 - len(suffix)]}.{suffix}"
 
 
 def _is_utf8_text(data: bytes) -> bool:

--- a/turnstone/core/session.py
+++ b/turnstone/core/session.py
@@ -212,6 +212,7 @@ from turnstone.core.preview import (
     build_preview_descriptor,
     inject_base_href,
     page_title,
+    preview_filename,
     resolve_preview_kind,
     transcode_text,
 )
@@ -27908,12 +27909,12 @@ class ChatSession:
             content_type=stored_mime,
             size=len(body),
         )
-        filename = title if "." in title else f"preview-{kind}"
+        filename = preview_filename(name_hint, stored_mime, is_url=target_kind == "url")
         preview_record = (
             descriptor,
             Attachment(
                 attachment_id=blob_id,
-                filename=filename[:120],
+                filename=filename,
                 mime_type=stored_mime,
                 kind=PREVIEW_BLOB_KIND,
                 content=body,

--- a/turnstone/shared_static/preview.css
+++ b/turnstone/shared_static/preview.css
@@ -9,39 +9,84 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  color: var(--ink);
+  font-family: var(--font-ui);
+}
+
+/* Author display rules must not override the browser's hidden state. */
+.preview-root [hidden] {
+  display: none;
 }
 
 /* ----- header bar ----- */
 .preview-bar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
-  padding: 6px 10px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--hair);
   background: var(--panel);
   flex: none;
 }
 
-.preview-nav {
+.preview-identity {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.preview-history,
+.preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   flex: none;
-  width: 24px;
-  height: 22px;
-  padding: 0;
-  font-size: 10px;
-  line-height: 1;
+}
+.preview-actions {
+  flex-wrap: wrap;
+  max-width: 100%;
+  margin-left: auto;
+}
+
+.preview-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 12px;
+  line-height: 20px;
+  white-space: nowrap;
+  text-decoration: none;
   color: var(--ink-2);
   background: var(--panel-2);
-  border: 1px solid var(--hair);
-  border-radius: 3px;
+  border: 1px solid var(--hair-2);
+  border-radius: var(--r-sm);
   cursor: pointer;
 }
-.preview-nav:hover:not(:disabled) {
-  color: var(--ink-1);
+.preview-action:hover:not(:disabled):not([aria-disabled="true"]) {
+  color: var(--ink);
   border-color: var(--ink-4);
 }
-.preview-nav:disabled {
-  opacity: 0.35;
+.preview-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.preview-action:disabled,
+.preview-action[aria-disabled="true"] {
+  opacity: 0.45;
   cursor: default;
+}
+.preview-nav {
+  flex: none;
+  width: 30px;
+  padding: 0;
+  font-size: 14px;
 }
 
 .preview-kindchip {
@@ -54,50 +99,44 @@
   color: var(--ink-2);
   background: color-mix(in srgb, var(--accent) 18%, transparent);
   border: 1px solid var(--hair);
-  border-radius: 3px;
+  border-radius: var(--r-sm);
 }
 .preview-kindchip:empty {
   display: none;
 }
 
 .preview-titletext {
-  flex: 1 1 auto;
+  flex: 1 1 40px;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
-  color: var(--ink-1);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
 }
 
-.preview-ext {
-  flex: none;
-  font-size: 11px;
-  color: var(--ink-2);
-  text-decoration: none;
-  border-bottom: 1px dotted var(--ink-4);
-}
-.preview-ext:hover {
-  color: var(--ink-1);
-}
-
-/* remote-assets opt-in (web previews) — compact single-row header control */
+/* Web-only options can wrap independently of the header's actions. */
 .preview-assets {
   flex: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  color: var(--ink-2);
-  white-space: nowrap;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink-3);
+  background: var(--panel);
+  border-bottom: 1px solid var(--hair);
   cursor: pointer;
 }
 .preview-assets:hover {
-  color: var(--ink-1);
+  color: var(--ink);
 }
 .preview-assets-box {
   flex: none;
-  margin: 0;
+  margin: 3px 0 0;
+  accent-color: var(--accent);
   cursor: pointer;
 }
 
@@ -122,7 +161,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 12px;
+  padding: 16px;
 }
 .preview-img {
   max-width: 100%;
@@ -131,19 +170,34 @@
 
 .preview-pre {
   margin: 0;
-  padding: 10px 12px;
+  padding: 16px;
   font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1.5;
+  font-size: 12px;
+  line-height: 1.65;
   color: var(--ink-2);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 .preview-markdown {
-  padding: 12px 16px;
-  font-size: 13px;
-  color: var(--ink-1);
+  max-width: 86ch;
+  margin: 0 auto;
+  padding: 16px 20px;
+  font-size: 14px;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+  color: var(--ink);
+}
+.preview-markdown > * + * {
+  margin-top: 12px;
+}
+.preview-markdown ul,
+.preview-markdown ol {
+  padding-left: 20px;
+}
+.preview-markdown a {
+  color: var(--accent);
+  text-underline-offset: 3px;
 }
 /* Code-block chrome + katex display + mermaid: the .msg.assistant-scoped rules
    in shared chat.css don't reach the pane (content is .preview-markdown, not a
@@ -154,16 +208,16 @@
   font-family: var(--font-mono);
   font-size: 0.92em;
   background: color-mix(in srgb, var(--ink-4) 18%, transparent);
-  border-radius: 3px;
+  border-radius: var(--r-sm);
 }
 .preview-markdown pre {
-  padding: 8px;
+  padding: 12px;
   overflow-x: auto;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   background: var(--panel);
   border: 1px solid var(--hair);
-  border-radius: 3px;
+  border-radius: var(--r-sm);
 }
 .preview-markdown pre code {
   padding: 0;
@@ -193,17 +247,18 @@
 /* ----- table kind ----- */
 .preview-tablewrap {
   overflow: auto;
-  padding: 8px;
+  padding: 12px;
 }
 .preview-table {
   border-collapse: collapse;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
+  line-height: 1.5;
   color: var(--ink-2);
 }
 .preview-table th,
 .preview-table td {
-  padding: 3px 8px;
+  padding: 6px 10px;
   border: 1px solid var(--hair);
   text-align: left;
   white-space: nowrap;
@@ -220,10 +275,10 @@
 .preview-th {
   display: block;
   width: 100%;
-  padding: 4px 8px;
+  padding: 6px 10px;
   font: inherit;
   font-weight: 600;
-  color: var(--ink-1);
+  color: var(--ink);
   text-align: left;
   background: none;
   border: 0;
@@ -231,6 +286,10 @@
 }
 .preview-th:hover {
   background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+.preview-th:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .preview-table th[aria-sort] .preview-th::after {
   content: " ▲";
@@ -244,29 +303,22 @@
 .preview-empty,
 .preview-loading,
 .preview-error {
-  padding: 24px 16px;
-  font-size: 12px;
+  max-width: 44ch;
+  margin: 24px auto;
+  padding: 20px 16px;
+  font-size: 13px;
+  line-height: 1.6;
   color: var(--ink-3);
   text-align: center;
+  overflow-wrap: anywhere;
 }
 .preview-error-msg {
-  margin-bottom: 10px;
-}
-.preview-retry {
-  padding: 4px 14px;
-  font-size: 11px;
-  color: var(--ink-1);
-  background: var(--panel);
-  border: 1px solid var(--hair);
-  border-radius: 3px;
-  cursor: pointer;
-}
-.preview-retry:hover {
-  border-color: var(--ink-4);
+  margin-bottom: 12px;
 }
 .preview-note {
-  padding: 6px 12px;
-  font-size: 10px;
+  padding: 8px 12px;
+  font-size: 11px;
+  line-height: 1.5;
   color: var(--ink-3);
   border-top: 1px solid var(--hair);
 }
@@ -287,7 +339,7 @@
   cursor: pointer;
 }
 .conv-preview-chip:hover {
-  color: var(--ink-1);
+  color: var(--ink);
   border-color: var(--ink-4);
 }
 .conv-preview-glyph {

--- a/turnstone/shared_static/preview.js
+++ b/turnstone/shared_static/preview.js
@@ -48,9 +48,17 @@ function make(tag, className, text) {
   return node;
 }
 
+function makeAction(tag, text, label) {
+  const node = make(tag, "preview-action", text);
+  if (tag === "button") node.type = "button";
+  node.title = label;
+  node.setAttribute("aria-label", label);
+  return node;
+}
+
 // The per-workstream serving route for a descriptor, through the originating
 // pane's transport base ("" local, "/node/{id}" console-proxied).
-function previewContentUrl(ctx, descriptor) {
+function previewContentUrl(ctx, descriptor, endpoint = "preview") {
   const base = (ctx && ctx.base) || "";
   const ws = (ctx && ctx.wsId) || "";
   return (
@@ -59,7 +67,8 @@ function previewContentUrl(ctx, descriptor) {
     encodeURIComponent(ws) +
     "/attachments/" +
     encodeURIComponent(descriptor.attachment_id || "") +
-    "/preview"
+    "/" +
+    endpoint
   );
 }
 
@@ -229,6 +238,19 @@ export function createPreviewPane(extra, hostApi) {
     pane._fwdBtn.disabled = pane._idx >= pane._stack.length - 1;
   };
 
+  const setDownloadUrl = (url) => {
+    const link = pane._downloadLink;
+    if (url) {
+      link.setAttribute("href", url);
+      link.removeAttribute("aria-disabled");
+      link.removeAttribute("tabindex");
+    } else {
+      link.removeAttribute("href");
+      link.setAttribute("aria-disabled", "true");
+      link.setAttribute("tabindex", "-1");
+    }
+  };
+
   const renderEmpty = () => {
     pane._contentEl.replaceChildren(
       make(
@@ -242,8 +264,7 @@ export function createPreviewPane(extra, hostApi) {
   const renderError = (message, entry) => {
     const wrap = make("div", "preview-error");
     wrap.append(make("div", "preview-error-msg", message));
-    const retry = make("button", "preview-retry", "Retry");
-    retry.type = "button";
+    const retry = makeAction("button", "Retry", "Retry preview");
     // A manual retry is a single deliberate attempt — no silent backoff run.
     retry.addEventListener("click", () => renderEntry(entry, MAX_AUTO_RETRIES));
     wrap.append(retry);
@@ -410,6 +431,10 @@ export function createPreviewPane(extra, hostApi) {
     const token = ++pane._loadToken;
     const d = entry.descriptor;
     const url = previewContentUrl(entry.ctx, d);
+    pane._downloadLink.hidden = false;
+    setDownloadUrl(null);
+    const ready = () =>
+      setDownloadUrl(previewContentUrl(entry.ctx, d, "content"));
     const failed = (why) => {
       if (token !== pane._loadToken) return;
       if (attempt < MAX_AUTO_RETRIES) {
@@ -427,8 +452,13 @@ export function createPreviewPane(extra, hostApi) {
     pane._kindEl.textContent = d.kind || "";
     // Display strings can be raw URLs — never print embedded credentials.
     // The ext link below keeps the RAW url (it must actually navigate).
-    pane._titleEl.textContent = redactCredentials(d.title || d.source || "");
-    pane._titleEl.title = redactCredentials(d.source || "");
+    const titleText = redactCredentials(d.title || d.source || "");
+    const sourceText = redactCredentials(d.source || "");
+    pane._titleEl.textContent = titleText;
+    pane._titleEl.title =
+      sourceText && sourceText !== titleText
+        ? titleText + "\n" + sourceText
+        : titleText;
     const isWeb = d.kind === "web" && /^https?:\/\//.test(d.source || "");
     pane._extLink.hidden = !isWeb;
     if (isWeb) pane._extLink.href = d.source;
@@ -462,6 +492,7 @@ export function createPreviewPane(extra, hostApi) {
           if (d.kind === "web") renderWeb(srcUrl);
           else if (d.kind === "pdf") renderPdf(srcUrl, d);
           else renderImage(srcUrl, d);
+          ready();
         })
         .catch(() => failed("Could not load the preview."));
       return;
@@ -485,6 +516,7 @@ export function createPreviewPane(extra, hostApi) {
         if (d.kind === "table") renderTable(text, d);
         else if (d.kind === "markdown") renderMarkdownDoc(text);
         else renderText(text);
+        ready();
       })
       .catch(() => failed("Could not load the preview."));
   };
@@ -508,10 +540,13 @@ export function createPreviewPane(extra, hostApi) {
     if (
       top &&
       top.descriptor.attachment_id === descriptor.attachment_id &&
-      top.descriptor.kind === descriptor.kind
+      top.descriptor.kind === descriptor.kind &&
+      (top.ctx?.base || "") === (ctx?.base || "") &&
+      (top.ctx?.wsId || "") === (ctx?.wsId || "")
     ) {
       // Same content re-requested — re-render in place (retry semantics),
-      // don't grow the history with duplicates.
+      // updating its title/source without growing duplicate history entries.
+      top.descriptor = descriptor;
       showAt(pane._idx);
       return;
     }
@@ -526,24 +561,32 @@ export function createPreviewPane(extra, hostApi) {
     const root = make("div", "preview-root");
 
     const bar = make("div", "preview-bar");
-    const back = make("button", "preview-nav", "◀");
-    back.type = "button";
+    const identity = make("div", "preview-identity");
+    const history = make("div", "preview-history");
+    const back = makeAction("button", "←", "Previous preview");
+    back.classList.add("preview-nav");
     back.title = "Previous preview (←)";
-    back.setAttribute("aria-label", "Previous preview");
     back.addEventListener("click", () => showAt(pane._idx - 1));
-    const fwd = make("button", "preview-nav", "▶");
-    fwd.type = "button";
+    const fwd = makeAction("button", "→", "Next preview");
+    fwd.classList.add("preview-nav");
     fwd.title = "Next preview (→)";
-    fwd.setAttribute("aria-label", "Next preview");
     fwd.addEventListener("click", () => showAt(pane._idx + 1));
+    history.append(back, fwd);
     const kind = make("span", "preview-kindchip", "");
     const title = make("span", "preview-titletext", "");
-    const ext = make("a", "preview-ext", "Open in browser ↗");
+    identity.append(history, kind, title);
+    const actions = make("div", "preview-actions");
+    const download = makeAction("a", "↓ Download", "Download preview file");
+    download.setAttribute("download", "");
+    download.hidden = true;
+    const ext = makeAction("a", "Open source ↗", "Open source in a new tab");
     ext.target = "_blank";
     ext.rel = "noopener noreferrer";
     ext.hidden = true;
-    // Remote-assets opt-in — web previews only.  Plain operator language; the
-    // tooltip states the default posture without naming the mechanism.
+    actions.append(download, ext);
+    bar.append(identity, actions);
+    // Web-only options get their own row so the title and actions retain
+    // room in narrow split panes.
     const assets = make("label", "preview-assets");
     assets.title = "Off keeps this preview from contacting the site";
     const assetsBox = make("input", "preview-assets-box");
@@ -561,8 +604,6 @@ export function createPreviewPane(extra, hostApi) {
       if (cur && cur.descriptor.kind === "web")
         renderEntry(cur, MAX_AUTO_RETRIES);
     });
-    bar.append(back, fwd, kind, title, ext, assets);
-
     const content = make("div", "preview-content");
 
     pane._backBtn = back;
@@ -570,11 +611,12 @@ export function createPreviewPane(extra, hostApi) {
     pane._kindEl = kind;
     pane._titleEl = title;
     pane._extLink = ext;
+    pane._downloadLink = download;
     pane._assetsLabel = assets;
     pane._assetsBox = assetsBox;
     pane._contentEl = content;
 
-    root.append(bar, content);
+    root.append(bar, assets, content);
     this.bodyEl.append(root);
 
     // ←/→ walk the preview history while the pane has focus.  The pane hosts


### PR DESCRIPTION
Add a Download action to open_preview that saves the stored file, including
complete table data when the display is sorted or capped. Derive filenames from
the source independently of the pane title, add an extension for extensionless
targets, and remove NUL before persistence. The serving route applies its existing
ASCII filename fallback.

Keep downloads tied to the originating node and workstream through navigation,
reloads, and retries. Group the header controls for narrow panes, separate the
web-assets option, and refine Markdown, table, and theme styling.

Validation:

- 309 focused preview, frontend, and attachment tests passed.
- Python lint, formatting, and full-package type checks passed; JavaScript/CSS
  formatting passed.
- Browser checks passed for six download types, console proxy forwarding, full
  table downloads, and 120 layout checks across both frontends and themes.
- The URL filename regression passed through the real executor and PostgreSQL
  driver. CSS audit results match the base tree.
