### PR TITLE
fix(mcp): repair OAuth issuer caching and registration

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -42,6 +42,11 @@ Switching `auth_type` away from `oauth_user` / `oauth_obo` **deletes** that serv
    - **Pre-registered** (most common): you create an OAuth client at the authorization server (manually, via admin console, or via Terraform), then paste the `client_id` / `client_secret` into the Turnstone admin form.
    - **Dynamic client registration** (RFC 7591): if the AS supports it and you select that mode in the admin form, Turnstone registers a client at first use and persists the `client_id` automatically.
 
+   For Keycloak dynamic registration, the configured scopes must be permitted by the realm's
+   **Allowed Client Scopes** registration policy. Even `openid` can cause a registration HTTP 400
+   when that policy does not allow it. Leave scopes empty to omit the registration `scope` and use
+   the realm's default client scopes, or configure the policy to permit the scopes you need.
+
 4. **Public callback origin**. Set `[oidc] redirect_base` to the dashboard's
    HTTPS origin, even when users log in with local usernames and passwords.
    Register exactly `https://your-turnstone-host/v1/api/mcp/oauth/callback` at

--- a/scripts/obo-e2e/README.md
+++ b/scripts/obo-e2e/README.md
@@ -111,6 +111,13 @@ the obo harness).
 ./scripts/obo-e2e/oauth_user_e2e.sh
 ```
 
+Results — RUN 2026-09-06, 15 VERIFIED / 0 FAILED (exit 0) after the #1081 and #1082 fixes:
+D4 verifies that the second row persists its issuer when AS metadata is already cached. N2's callback
+makes exactly one token POST with no PRM fetch; the harness now asserts that request list. D3 registers
+a client and completes consent with a token whose audience carries the resource identifier. Discovery,
+consent, refresh, and revocation checks remain verified. The unchanged baseline reproduced both D4 and
+D3 failures before the fixes (13 VERIFIED / 2 FAILED, exit 1).
+
 Results — RUN 2026-09-03, 13 VERIFIED / 2 FAILED (exit 1), reproduced on
 `main` after the discovery rework merged; both failures are
 product findings, not harness defects, and are listed below. VERIFIED: D1
@@ -134,7 +141,7 @@ fallback probed and 404'd, no authorization-server traffic; N2 a real token
 whose `aud` omits the resource refused at the callback with nothing persisted;
 D2 the origin-level fallback accepted for a server that serves only there.
 
-FAILED — product findings:
+Product findings from the 2026-09-03 run:
 
 - **D4 issuer not persisted on a warm metadata cache** (#1081).
   `discover_authorization_server` returns from the in-process metadata-cache hit

--- a/scripts/obo-e2e/oauth_user_e2e.py
+++ b/scripts/obo-e2e/oauth_user_e2e.py
@@ -625,10 +625,10 @@ async def _run(cfg: dict[str, str]) -> None:
                 if done2.status_code == 302
                 and "audience+mismatch" in done2.headers.get("location", "")
                 and not persisted
-                and ("POST", token_endpoint) in calls
+                and calls == [("POST", token_endpoint)]
                 else "FAILED",
                 f"N2 audience mismatch: HTTP {done2.status_code} location={done2.headers.get('location')} "
-                f"persisted={persisted} (want False) wire={calls}",
+                f"persisted={persisted} (want False) wire={calls} (want one token POST, no PRM)",
             )
 
         # D4 — the issuer is persisted on a row whose authorization server is

--- a/tests/test_mcp_oauth_discovery.py
+++ b/tests/test_mcp_oauth_discovery.py
@@ -1083,23 +1083,27 @@ class TestMetadataCache:
                     trusted_hosts=frozenset(),
                     metadata_cache=cache,
                 )
+                cached_entry = (first, time.monotonic() - 60)
+                cache[first.issuer] = cached_entry
                 second = await discover_authorization_server(
                     server_name="srv-x",
                     server_url="https://mcp.example.com/sse",
                     override_url="https://as.example.com",
-                    cached_issuer="https://as.example.com",
+                    cached_issuer=None,
                     http_client=client,
                     storage=storage,
                     server_id="srv-id",
                     trusted_hosts=frozenset(),
                     metadata_cache=cache,
                 )
+                assert cache[first.issuer] == cached_entry
                 return first, second
 
         first, second = asyncio.run(_run())
         assert first.token_endpoint == second.token_endpoint
         # First call hit AS metadata; second call hit the cache.
         assert client.get.call_count == 1
+        storage.update_mcp_server.assert_not_called()
 
     def test_cache_expiry_refetches(self) -> None:
         client = MagicMock(spec=httpx.AsyncClient)
@@ -1136,6 +1140,47 @@ class TestMetadataCache:
         # Stale entry was bypassed -> we hit the network.
         assert client.get.call_count == 1
         assert meta.token_endpoint == "https://as.example.com/token"
+        assert meta is not stale_meta
+        assert cache[meta.issuer][0] is meta
+
+    @pytest.mark.parametrize("cached_issuer", [None, "https://internal.corp.example.com"])
+    def test_failed_metadata_fetch_does_not_persist_issuer(self, cached_issuer: str | None) -> None:
+        doc = _good_as_metadata_doc()
+        doc["code_challenge_methods_supported"] = []
+        client = MagicMock(spec=httpx.AsyncClient)
+        client.get = AsyncMock(
+            side_effect=_router(
+                {
+                    _PATH_PRM: _prm(_SERVER),
+                    _AS_META: _mk_response(200, doc),
+                    "https://as.example.com/.well-known/openid-configuration": _mk_response(404),
+                }
+            )
+        )
+        storage = _mk_storage_mock()
+        cache: dict[str, tuple[ASMetadata, float]] = {}
+
+        async def _run() -> None:
+            with _addr_map_patch({"internal.corp.example.com": ["10.0.0.1"]}):
+                await discover_authorization_server(
+                    server_name="srv-x",
+                    server_url=_SERVER,
+                    override_url=None,
+                    cached_issuer=cached_issuer,
+                    http_client=client,
+                    storage=storage,
+                    server_id="srv-id",
+                    trusted_hosts=frozenset(),
+                    metadata_cache=cache,
+                )
+
+        with pytest.raises(MCPOAuthDiscoveryError, match="S256"):
+            asyncio.run(_run())
+        if cached_issuer:
+            storage.update_mcp_server.assert_called_once_with("srv-id", oauth_as_issuer_cached=None)
+        else:
+            storage.update_mcp_server.assert_not_called()
+        assert cache == {}
 
     def test_persistent_cache_write_on_first_resolution(self) -> None:
         async def _get(url, *args, **kwargs):
@@ -1207,7 +1252,7 @@ class TestCachedIssuerSSRFRevalidation:
     bypass the guard just because the value was already in the row.
     """
 
-    def test_cached_issuer_rejected_clears_row_and_falls_through_to_prm(self) -> None:
+    def test_cached_issuer_rejected_clears_row_and_persists_replacement(self) -> None:
         async def _get(url: str, *args: Any, **kwargs: Any) -> MagicMock:
             if url.endswith("/oauth-protected-resource/sse"):
                 return _mk_response(
@@ -1256,6 +1301,9 @@ class TestCachedIssuerSSRFRevalidation:
             if c.kwargs.get("oauth_as_issuer_cached") is None
         ]
         assert clear_calls, "cached_issuer should have been cleared"
+        storage.update_mcp_server.assert_called_with(
+            "srv-id", oauth_as_issuer_cached="https://as.example.com"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_oauth_handlers.py
+++ b/tests/test_mcp_oauth_handlers.py
@@ -471,6 +471,9 @@ class TestCallback:
 
         assert resp.status_code == 302
         assert resp.headers["location"] == "/admin/mcp-servers"
+        assert http_client_mock.post.call_args.kwargs["data"]["resource"] == (
+            "https://mcp.example.com/sse"
+        )
         # Token row was persisted.
         plain = token_store.get_user_token("user-1", "srv-oauth")
         assert plain is not None
@@ -729,18 +732,22 @@ class TestNoTokenStore:
 
 
 class TestDCR:
+    @pytest.mark.parametrize("scopes", [None, "", "openid profile"])
     def test_registration_endpoint_hit_when_dcr_and_no_client_id(
-        self, storage: SQLiteBackend, http_client_mock: MagicMock
+        self, storage: SQLiteBackend, http_client_mock: MagicMock, scopes: str | None
     ) -> None:
-        _seed_oauth_user_server(
+        server_id = _seed_oauth_user_server(
             storage,
             client_id=None,
             registration_mode="dcr",
         )
+        storage.update_mcp_server(server_id, oauth_scopes=scopes)
         token_store = _make_token_store(storage)
 
         async def _post(url, *args, **kwargs):
             if url.endswith("/register"):
+                if "resource" in kwargs["json"]:
+                    return _mk_response(400, {"error": "invalid_client_metadata"})
                 return _mk_response(
                     201, {"client_id": "dcr-client-xyz", "client_secret": "dcr-secret"}
                 )
@@ -756,6 +763,20 @@ class TestDCR:
             resp = client.get("/v1/api/mcp/oauth/start?server=srv-oauth", follow_redirects=False)
 
         assert resp.status_code == 302
+        http_client_mock.post.assert_awaited_once()
+        body = http_client_mock.post.call_args.kwargs["json"]
+        expected: dict[str, Any] = {
+            "redirect_uris": ["https://testserver/v1/api/mcp/oauth/callback"],
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        }
+        if scopes:
+            expected["scope"] = scopes
+        assert body == expected
+        params = urllib.parse.parse_qs(urllib.parse.urlsplit(resp.headers["location"]).query)
+        assert params["client_id"] == ["dcr-client-xyz"]
+        assert params["resource"] == ["https://mcp.example.com/sse"]
         # client_id was persisted on the row.
         row = storage.get_mcp_server_by_name("srv-oauth")
         assert row is not None

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -27,7 +27,11 @@ import pytest
 
 from tests.conftest import make_mcp_token_cipher
 from turnstone.core.mcp_crypto import MCPTokenStore
-from turnstone.core.mcp_oauth import get_user_access_token
+from turnstone.core.mcp_oauth import (
+    discover_authorization_server,
+    get_user_access_token,
+    get_user_access_token_classified,
+)
 from turnstone.core.storage._sqlite import SQLiteBackend
 
 # Generous CI ceiling — cancel/drain is sub-millisecond on a healthy loop.
@@ -576,6 +580,120 @@ class TestObserveOnlyLookup:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("clear_metadata_cache", [False, True])
+@pytest.mark.parametrize("rejected_issuer", [None, "https://internal.corp.example.com"])
+def test_shared_issuer_refresh_survives_resource_metadata_outage(
+    storage: SQLiteBackend, clear_metadata_cache: bool, rejected_issuer: str | None
+) -> None:
+    """A second server reuses AS metadata, persists its issuer, then refreshes without PRM."""
+    issuer = "https://as.example.com"
+    requests: list[tuple[str, str]] = []
+    prm_available = True
+    servers = {
+        "srv-first": "https://first.example.com/sse",
+        "srv-oauth": "https://mcp.example.com/sse",
+    }
+    prm_urls = {
+        "https://first.example.com/.well-known/oauth-protected-resource/sse": servers["srv-first"],
+        "https://mcp.example.com/.well-known/oauth-protected-resource/sse": servers["srv-oauth"],
+    }
+    metadata_url = f"{issuer}/.well-known/oauth-authorization-server"
+    token_url = f"{issuer}/token"
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        requests.append((request.method, url))
+        if request.method == "GET" and request.url.host != "as.example.com":
+            if not prm_available:
+                return httpx.Response(503)
+            return httpx.Response(
+                200, json={"resource": prm_urls[url], "authorization_servers": [issuer]}
+            )
+        if request.method == "GET" and url == metadata_url:
+            return httpx.Response(200, json=_good_as_metadata_doc())
+        if request.method == "POST" and url == token_url:
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "fresh-bbb",
+                    "refresh_token": "refresh-rotated",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                },
+            )
+        raise AssertionError(f"unexpected request: {request.method} {url}")
+
+    async def _run() -> None:
+        nonlocal prm_available
+        with patch(
+            "socket.getaddrinfo",
+            side_effect=lambda host, *a, **kw: [
+                (
+                    2,
+                    1,
+                    6,
+                    "",
+                    ("10.0.0.1" if host == "internal.corp.example.com" else "93.184.216.34", 0),
+                )
+            ],
+        ):
+            async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+                state = _make_app_state(storage, http_client=client)
+                for name, url in servers.items():
+                    storage.create_mcp_server(
+                        server_id=name,
+                        name=name,
+                        transport="streamable-http",
+                        url=url,
+                        auth_type="oauth_user",
+                        oauth_client_id="client-abc",
+                        oauth_scopes="openid profile",
+                        oauth_audience="https://mcp.example.com",
+                    )
+                    cached_issuer = rejected_issuer if name == "srv-oauth" else None
+                    if cached_issuer:
+                        storage.update_mcp_server(name, oauth_as_issuer_cached=cached_issuer)
+                    await discover_authorization_server(
+                        server_name=name,
+                        server_url=url,
+                        override_url=None,
+                        cached_issuer=cached_issuer,
+                        http_client=client,
+                        storage=storage,
+                        server_id=name,
+                        trusted_hosts=frozenset(),
+                        metadata_cache=state.mcp_oauth_metadata_cache,
+                    )
+                assert requests == [
+                    ("GET", "https://first.example.com/.well-known/oauth-protected-resource/sse"),
+                    ("GET", metadata_url),
+                    ("GET", "https://mcp.example.com/.well-known/oauth-protected-resource/sse"),
+                ]
+                _seed_token(state, expires_in_seconds=-1000)
+                if clear_metadata_cache:
+                    state.mcp_oauth_metadata_cache.clear()
+                requests.clear()
+                prm_available = False
+
+                result = await get_user_access_token_classified(
+                    app_state=state, user_id="user-1", server_name="srv-oauth"
+                )
+
+                assert result.kind == "token", result
+                assert result.token == "fresh-bbb"
+                expected = [("GET", metadata_url)] if clear_metadata_cache else []
+                assert requests == [*expected, ("POST", token_url)]
+                for name in servers:
+                    row = storage.get_mcp_server_by_name(name)
+                    assert row is not None
+                    assert row["oauth_as_issuer_cached"] == issuer
+                token = state.mcp_token_store.get_user_token("user-1", "srv-oauth")
+                assert token is not None
+                assert token["refresh_token"] == "refresh-rotated"
+
+    asyncio.run(_run())
+
+
 class TestUnchangedToken:
     def test_returns_existing_token_when_not_expired(self, storage: SQLiteBackend) -> None:
         _seed_server(storage)
@@ -684,6 +802,7 @@ class TestRefresh:
         assert token == "access-NEW"
         # The refresh endpoint was hit exactly once.
         assert client.post.call_count == 1
+        assert client.post.call_args.kwargs["data"]["resource"] == "https://mcp.example.com/sse"
         # Verify the new tokens were persisted.
         plain = state.mcp_token_store.get_user_token("user-1", "srv-oauth")
         assert plain is not None

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -1154,6 +1154,7 @@ async def discover_authorization_server(
                         server_name=server_name,
                         reason=sanitize_log_text(str(exc)),
                     )
+                    cached_issuer = None
                     if server_id:
                         try:
                             await asyncio.to_thread(
@@ -1185,32 +1186,32 @@ async def discover_authorization_server(
                     server_name=server_name,
                 )
 
-            if metadata_cache is not None:
-                cached = metadata_cache.get(issuer)
-                if cached is not None:
-                    metadata, fetched_at = cached
-                    if time.monotonic() - fetched_at < MCP_OAUTH_DISCOVERY_CACHE_TTL_SECONDS:
-                        return metadata
-
-            # Only an operator-typed issuer carries the opt-in. A cached
-            # issuer was resolved from a PRM document, never from the
-            # override, so it is remote-named and stays strict.
-            metadata = await _fetch_as_metadata(
-                issuer,
-                http_client=http_client,
-                trusted_hosts=trusted_hosts,
-                deadline=deadline,
-                allow_private=allow_private_network and bool(override_url),
-            )
+            cached = metadata_cache.get(issuer) if metadata_cache is not None else None
+            if (
+                cached is not None
+                and time.monotonic() - cached[1] < MCP_OAUTH_DISCOVERY_CACHE_TTL_SECONDS
+            ):
+                metadata = cached[0]
+            else:
+                # Only an operator-typed issuer carries the opt-in. A cached
+                # issuer was resolved from a PRM document, never from the
+                # override, so it is remote-named and stays strict.
+                metadata = await _fetch_as_metadata(
+                    issuer,
+                    http_client=http_client,
+                    trusted_hosts=trusted_hosts,
+                    deadline=deadline,
+                    allow_private=allow_private_network and bool(override_url),
+                )
+                if metadata_cache is not None:
+                    metadata_cache[issuer] = (metadata, time.monotonic())
     except TimeoutError as exc:
         raise MCPOAuthDiscoveryError("discovery exceeded its time budget") from exc
 
-    if metadata_cache is not None:
-        metadata_cache[issuer] = (metadata, time.monotonic())
-
-    # Persist the resolved issuer when the row had no cached value yet,
+    # Persist the resolved issuer when the row had no valid cached value,
+    # including when another row already warmed the AS metadata cache,
     # so subsequent calls skip PRM. We never overwrite an existing
-    # cached_issuer; the console clears it when the server URL or the AS
+    # valid cached_issuer; the console clears it when the server URL or the AS
     # override changes, which is when the cached value stops describing
     # the row.
     if not cached_issuer and not override_url and server_id:
@@ -1462,10 +1463,9 @@ async def register_dynamic_client(
     as_metadata: ASMetadata,
     redirect_uri: str,
     http_client: httpx.AsyncClient,
-    mcp_server_canonical_url: str,
     scopes: str = "",
 ) -> tuple[str, str | None]:
-    """Register a public client at the AS ``registration_endpoint``.
+    """Register a public client using RFC 7591 client metadata.
 
     Returns ``(client_id, client_secret_or_None)``. Empty ``client_secret``
     means the AS issued a public client (preferred for the per-user flow).
@@ -1487,10 +1487,6 @@ async def register_dynamic_client(
     }
     if scopes:
         body["scope"] = scopes
-    if mcp_server_canonical_url:
-        # RFC 8707 audience hint — many AS impls echo this back into
-        # token aud claims.
-        body["resource"] = mcp_server_canonical_url
 
     try:
         resp = await http_client.post(
@@ -4729,7 +4725,6 @@ async def _register_dynamic_client_if_needed(
     as_metadata: ASMetadata,
     server_row: dict[str, Any],
     server_id: str,
-    server_url: str,
     server_name: str,
     user_id: str,
     redirect_uri: str,
@@ -4768,7 +4763,6 @@ async def _register_dynamic_client_if_needed(
                 as_metadata=as_metadata,
                 redirect_uri=redirect_uri,
                 http_client=http_client,
-                mcp_server_canonical_url=server_url,
                 scopes=server_row.get("oauth_scopes") or "",
             )
         except MCPOAuthError as exc:
@@ -5002,7 +4996,6 @@ async def _handle_mcp_oauth_authorize_inner(request: Request) -> Response:
         as_metadata=as_metadata,
         server_row=server_row,
         server_id=server_id,
-        server_url=server_url,
         server_name=server_name,
         user_id=user_id,
         redirect_uri=redirect_uri,


### PR DESCRIPTION
A second MCP server sharing an authorization server now persists its resolved issuer even when metadata is already cached. Discovery also persists a replacement after rejecting an invalid cached issuer. Callback, refresh, and revocation can then use the saved issuer without depending on another protected-resource metadata request.

Dynamic client registration now omits the non-standard `resource` member that caused Keycloak to reject registration. Authorization and token requests retain their resource indicators. Regression tests cover cache expiry, issuer replacement, a metadata outage during refresh, and registration payloads; the OAuth guide documents Keycloak's client-scope policy requirements.

Validation:

- 346 focused OAuth and SSRF tests passed.
- Live Keycloak harness: 15 verified, 0 failed; the unchanged baseline reproduced both reported failures.
- Ruff, formatting, and mypy across all 261 package files passed.
- The full repository test suite was not run locally.

Closes #1081
Closes #1082
