### PR TITLE
fix(ui): move pane dismiss controls into tabs

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -395,11 +395,16 @@ The rail is fed by the cluster SSE snapshot and shows:
   coordinator parent and grouped by project when project metadata is visible;
 - permission-filtered Manage groups that open the singleton Admin pane.
 
-Coordinator and interactive conversations open as tabs inside the same shell.
-Interactive panes use the owning node's console proxy, so users do not need
-direct network access to compute-node ports. Split-right and split-down actions
-can display several panes at once. Closing a pane removes only that tab; use the
-pane menu's explicit close or delete action to change the workstream lifecycle.
+Coordinator and interactive conversations open as tabs inside the same shell. Interactive panes use
+the owning node's console proxy, so users do not need direct network access to compute-node ports.
+Split-right and split-down actions can display several panes at once. Each visible pane has a dismiss
+button at the left of its tab: `−` hides a regular split pane while keeping its tab open; `×` closes a
+single pane or a preview. Hovering or focusing the button draws a dashed outline around the affected
+pane, distinct from the active pane's solid accent. The Dashboard can be hidden from a split but cannot
+be closed. Closing a pane removes only that tab; use the pane menu's explicit close or delete action to
+change the workstream lifecycle. When tabs overflow, their strip scrolls horizontally; activating a
+tab or moving keyboard focus to it reveals its label and dismiss control together. When the strip or
+tab widths change, the tab with keyboard focus stays visible; otherwise, the active tab stays visible.
 
 ### Dashboard pane
 

--- a/tests/test_pane_js.py
+++ b/tests/test_pane_js.py
@@ -1,0 +1,276 @@
+"""Pane-manager lifecycle coverage for the tab dismiss controls."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests._js_harness_helpers import FAKE_DOM, node_skip, run_node_source
+
+_PANE_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/pane.js"
+
+
+def _run_panes(scenario: str) -> None:
+    source = (
+        FAKE_DOM
+        + f"\nconst {{ PaneManager, ShellPane }} = await import({json.dumps(_PANE_JS.as_uri())});\n"
+        + r"""
+const assert = (value, message) => { if (!value) throw new Error(message); };
+Object.defineProperties(FakeElement.prototype, {
+  style: {get() { return this._style ??= {}; }},
+  parentElement: {get() { return this.parentNode; }},
+  firstChild: {get() { return this.children[0] || null; }},
+  nextSibling: {get() {
+    const siblings = this.parentNode?.children || [];
+    return siblings[siblings.indexOf(this) + 1] || null;
+  }},
+});
+FakeElement.prototype.insertBefore = function (child, anchor) {
+  if (child.isConnected && child.contains(document.activeElement))
+    document.activeElement = null;
+  child.remove();
+  const index = anchor ? this.children.indexOf(anchor) : this.children.length;
+  assert(index >= 0, "insertBefore anchor must belong to its parent");
+  this.children.splice(index, 0, child);
+  child.parentNode = this;
+  child._setConnected(this.isConnected);
+};
+FakeElement.prototype.removeChild = function (child) { child.remove(); };
+let keyboardFocus = true;
+const emit = (target, type, props = {}, bubbles = true) => {
+  const event = {target, type, preventDefault() {}, ...props};
+  for (let node = target; node; node = bubbles ? node.parentNode : null) {
+    for (const {fn} of node._listeners.get(type) || []) fn(event);
+  }
+};
+FakeElement.prototype.matches = function (selector) {
+  return selector.split(",").some(part => {
+    part = part.trim();
+    if (part === ":focus-visible") return document.activeElement === this && keyboardFocus;
+    if (part === ":hover") return false;
+    return this._matches(part);
+  });
+};
+FakeElement.prototype.focus = function () {
+  const previous = document.activeElement;
+  if (previous === this) return;
+  document.activeElement = this;
+  if (previous) emit(previous, "blur", {}, false);
+  emit(this, "focus", {}, false);
+  emit(this, "focusin");
+};
+const pressKey = (key) => {
+  keyboardFocus = true;
+  emit(document.activeElement, "keydown", {key});
+};
+ResizeObserver.prototype.unobserve = function (target) { this.targets.delete(target); };
+globalThis.sessionStorage = localStorage;
+const tabs = document.createElement("div");
+const panes = document.createElement("div");
+panes.clientWidth = 1400;
+panes.clientHeight = 900;
+document.documentElement.append(tabs, panes);
+const pm = new PaneManager({tabbarEl: tabs, panesEl: panes});
+const activated = [];
+const closed = [];
+for (const type of ["dashboard", "a", "b", "preview"]) {
+  pm.registerType(type, () => {
+    const pane = new ShellPane({type, title: type, closable: type !== "dashboard",
+      ephemeral: type === "preview"});
+    pane.onActivate = () => activated.push(type);
+    pane.onClose = () => closed.push(type);
+    return pane;
+  });
+}
+const dismiss = (pane) => pane.tabEl.parentElement.querySelector(".tab-dismiss");
+const dashboard = pm.openPane("dashboard");
+const a = pm.openPane("a");
+const b = pm.openPane("b");
+const overflowTabs = () => {
+  tabs.clientWidth = 200;
+  tabs.clientLeft = 0;
+  tabs.scrollLeft = 0;
+  tabs.scrollTop = 17;
+  panes.scrollTop = 91;
+  tabs.getBoundingClientRect = () => ({left: 20});
+  const geometry = new Map([[dashboard, [0, 110]], [a, [114, 140]], [b, [258, 150]]]);
+  for (const [pane] of geometry) {
+    pane._tabGroup.getBoundingClientRect = () => {
+      const [offset, width] = geometry.get(pane);
+      const left = 20 + offset - tabs.scrollLeft;
+      return {left, width, right: left + width};
+    };
+  }
+  return geometry;
+};
+"""
+        + scenario
+    )
+    proc = run_node_source(source)
+    assert proc.returncode == 0, f"pane harness failed:\n{proc.stderr}\n{proc.stdout}"
+
+
+@node_skip
+def test_tab_dismiss_hides_without_activating_or_destroying_the_pane() -> None:
+    _run_panes(r"""
+assert(dismiss(a).hidden && !dismiss(b).hidden, "only visible panes offer dismissal");
+assert(dismiss(dashboard).hidden, "background Dashboard cannot be dismissed");
+assert(pm.splitFocused("right", a.id).ok, "split must succeed");
+assert(dismiss(a).textContent === "−" && dismiss(b).textContent === "−", "split hides cells");
+const group = b.tabEl.parentElement;
+assert(group.children[0] === dismiss(b) && group.children[1] === b.tabEl, "dismiss leads select");
+assert(!b.tabEl.contains(dismiss(b)), "buttons must be siblings, never nested");
+assert(!panes.querySelector(".tab-dismiss"), "pane content must contain no dismiss overlay");
+const previousActivations = activated.length;
+dismiss(b).focus();
+dismiss(b).click();
+assert(b.el.hidden && b.el.isConnected && b.tabEl.isConnected, "hide must retain pane and tab");
+assert(!closed.length && activated.length === previousActivations, "hide must not activate target");
+assert(dismiss(b).hidden && dismiss(a).textContent === "✕", "survivor must enter close mode");
+assert(document.activeElement === b.tabEl, "hidden control must return focus to its tab");
+assert(b.tabEl.parentElement === group, "hiding must preserve the tab group");
+pm.activate(b.id);
+assert(!dismiss(b).hidden && dismiss(a).hidden, "tab switching must refresh availability");
+pm.setTabTitle(b.id, "Renamed pane");
+assert(dismiss(b).getAttribute("aria-label").includes("Renamed pane"), "label follows title");
+pm._restoreLayout({type: "split", dir: "row", ratio: 0.5,
+  children: [{type: "leaf", paneId: a.id}, {type: "leaf", paneId: b.id}]});
+assert(!dismiss(a).hidden && dismiss(b).textContent === "−", "restore refreshes dismiss modes");
+pm.unsplit();
+assert(dismiss(a).hidden && dismiss(b).textContent === "✕", "unsplit refreshes dismiss modes");
+""")
+
+
+@node_skip
+def test_tab_dismiss_closes_preview_and_respects_dashboard() -> None:
+    _run_panes(r"""
+const preview = pm.openPaneBeside("preview");
+assert(dismiss(preview).textContent === "✕", "split preview must advertise close");
+const group = preview.tabEl.parentElement;
+dismiss(preview).focus();
+dismiss(preview).click();
+assert(closed.join() === "preview", "preview dismiss must destroy its pane");
+assert(!preview.el.isConnected && !group.isConnected, "close removes content and entire tab group");
+assert(document.activeElement === b.tabEl, "close returns focus to the surviving tab");
+assert(!pm.isSplit() && dismiss(b).textContent === "✕", "preview close must refresh survivor");
+assert(pm.splitFocused("right", dashboard.id).ok, "Dashboard can appear in a split");
+assert(!dismiss(dashboard).hidden && dismiss(dashboard).textContent === "−", "Dashboard can hide");
+dismiss(dashboard).click();
+assert(dashboard.el.isConnected && dashboard.el.hidden, "Dashboard hide must retain its tab");
+pm.activate(dashboard.id);
+assert(dismiss(dashboard).hidden, "single Dashboard must not offer close");
+""")
+
+
+@node_skip
+def test_tab_reconciliation_preserves_focus_order_and_glyphs() -> None:
+    _run_panes(r"""
+b.tabEl.focus();
+pm.activate(b.id);
+assert(document.activeElement === b.tabEl, "refresh must not detach the focused tab");
+const preview = pm.openPane("preview");
+assert(document.activeElement === b.tabEl, "opening a pane must not detach existing tabs");
+assert(tabs.querySelectorAll(".tab").map(el => el.dataset.paneId).join() ===
+  "dashboard,a,b,preview", "groups retain tab order");
+pm.setTabGlyph(b.id, document.createElement("span"));
+assert(b.tabEl.firstChild.classList.contains("tab-glyph"), "state glyph stays in select button");
+assert(dismiss(b).parentElement.children[0] === dismiss(b), "glyph cannot precede dismiss slot");
+dismiss(preview).focus();
+pressKey("ArrowLeft");
+assert(document.activeElement === b.tabEl, "arrows from dismiss must rove between tabs");
+assert(pm.getActive().type === preview.type, "arrow navigation must not activate a pane");
+""")
+
+
+@node_skip
+def test_active_tab_visibility_tracks_activation_and_geometry_changes() -> None:
+    _run_panes(r"""
+const geometry = overflowTabs();
+pm.activate(b.id);
+assert(tabs.scrollLeft === 208, "activation reveals the entire rightmost tab");
+tabs.scrollLeft = 0;
+triggerResize(tabs);
+assert(tabs.scrollLeft === 208, "strip resizing reveals the active tab");
+geometry.set(b, [258, 190]);
+triggerResize(b._tabGroup);
+assert(tabs.scrollLeft === 248, "a growing title remains visible beside its control");
+geometry.set(a, [114, 180]);
+geometry.set(b, [298, 190]);
+triggerResize(a._tabGroup);
+assert(tabs.scrollLeft === 288, "a preceding tab's growth cannot clip the active tab");
+assert(tabs.scrollTop === 17 && panes.scrollTop === 91, "revealing tabs only scrolls horizontally");
+const group = a._tabGroup;
+pm.close(a.id);
+assert(!resizeObservers.some(observer => observer.targets.has(group)), "closed tabs must be unobserved");
+""")
+
+
+@node_skip
+def test_pointer_focus_does_not_scroll_tab_before_click() -> None:
+    _run_panes(r"""
+overflowTabs();
+pm.activate(b.id);
+const scroll = tabs.scrollLeft;
+keyboardFocus = false;
+a.tabEl.focus({preventScroll: true});
+assert(tabs.scrollLeft === scroll, "pointer focus must not move the tab before click lands");
+assert(pm.getActive().type === "b", "pointer focus alone must not activate the tab");
+a.tabEl.click();
+assert(pm.getActive().type === "a", "the subsequent click activates the intended tab");
+assert(tabs.scrollLeft === 114, "activation reveals the tab after the click lands");
+""")
+
+
+@node_skip
+def test_keyboard_focus_stays_visible_when_strip_or_tabs_resize() -> None:
+    _run_panes(r"""
+const geometry = overflowTabs();
+pm.activate(b.id);
+b.tabEl.focus({preventScroll: true});
+pressKey("Home");
+assert(document.activeElement === dashboard.tabEl && tabs.scrollLeft === 0,
+  "Home must reveal the unselected first tab through the focus listener");
+tabs.clientWidth = 180;
+triggerResize(tabs);
+assert(tabs.scrollLeft === 0, "resizing must keep keyboard focus visible before the active tab");
+pressKey("ArrowRight");
+assert(document.activeElement === a.tabEl && tabs.scrollLeft === 74,
+  "arrow navigation reveals the whole focused tab");
+geometry.set(a, [114, 170]);
+geometry.set(b, [288, 150]);
+triggerResize(a._tabGroup);
+assert(tabs.scrollLeft === 104, "title growth must keep the focused tab visible");
+triggerResize(b._tabGroup);
+assert(tabs.scrollLeft === 104, "other title changes must not scroll away from keyboard focus");
+geometry.set(a, [114, 250]);
+triggerResize(a._tabGroup);
+assert(tabs.scrollLeft === 114, "oversized tabs retain their leading control and title start");
+assert(pm.getActive().type === "b", "keyboard focus must not activate its pane");
+assert(tabs.scrollTop === 17 && panes.scrollTop === 91, "focus reveal only scrolls horizontally");
+keyboardFocus = false;
+triggerResize(tabs);
+assert(tabs.scrollLeft === 258, "without keyboard focus, resizing reveals the active tab");
+""")
+
+
+@node_skip
+def test_tablist_owns_only_selection_controls_and_tracks_open_and_close() -> None:
+    _run_panes(r"""
+const list = tabs.querySelector('[role="tablist"]');
+assert(list && list.getAttribute("aria-label") === "Open panes", "tabs have a named tablist");
+assert(!tabs.hasAttribute("role"), "the scroller must not own dismiss buttons as tablist children");
+const owned = () => list.getAttribute("aria-owns").split(" ");
+assert(owned().join() === [dashboard, a, b].map(pane => pane.tabEl.id).join(),
+  "the tablist must own selection controls in tab order");
+for (const pane of [dashboard, a, b]) {
+  assert(!list.contains(dismiss(pane)), "dismiss controls must live outside the tablist");
+  assert(!owned().includes(dismiss(pane).id), "dismiss controls must not be owned by the tablist");
+  assert(pane.tabEl.getAttribute("role") === "tab", "owned controls retain tab semantics");
+}
+const preview = pm.openPane("preview");
+assert(owned().at(-1) === preview.tabEl.id, "opening a pane adds its tab to the tablist");
+pm.close(a.id);
+pm.close(preview.id);
+assert(owned().join() === [dashboard, b].map(pane => pane.tabEl.id).join(),
+  "closing panes removes their ownership references and retains survivor order");
+""")

--- a/tests/test_preview_js.py
+++ b/tests/test_preview_js.py
@@ -281,27 +281,27 @@ class TestEphemeralDismiss:
             "ShellPane must accept and default the ephemeral flag"
         )
 
-    def test_cell_chip_closes_ephemeral_pane_outright(self) -> None:
-        """In a split the ✕ chip normally HIDES the cell (closeCell); for an
+    def test_tab_dismiss_closes_ephemeral_pane_outright(self) -> None:
+        """In a split the dismiss button normally HIDES the cell (closeCell); for an
         ephemeral pane it must fall through to close() — the `!pane.ephemeral`
         guard is what routes it there.  Pin BOTH the guard and where the
         skipped case lands (the else), or gutting the else regresses the fix
         while the guard string survives verbatim."""
         body = _read(_PANE_JS)
         assert "if (this._layout && this._leafFor(pane.id) && !pane.ephemeral)" in body, (
-            "the cell chip must skip closeCell for an ephemeral pane"
+            "tab dismissal must skip closeCell for an ephemeral pane"
         )
         assert "else this.close(pane.id);" in body, (
             "the skipped (ephemeral / single-pane) case must land on close()"
         )
 
-    def test_cell_chip_signals_destruction_for_ephemeral(self) -> None:
-        """The glyph/label must not lie: an ephemeral pane's split chip reads
+    def test_tab_dismiss_signals_destruction_for_ephemeral(self) -> None:
+        """The glyph/label must not lie: an ephemeral pane's dismiss button reads
         as a destructive close (✕ + danger hover + 'Close pane'), never the
         reversible '− / Hide from split'."""
         body = _read(_PANE_JS)
         assert "const destroys = !multi || pane.ephemeral;" in body, (
-            "chip mode must treat ephemeral panes as destructive even in a split"
+            "dismiss mode must treat ephemeral panes as destructive even in a split"
         )
 
     def test_unsplit_closes_ephemeral_non_survivors(self) -> None:

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -1086,22 +1086,22 @@ def test_pane_manager_split_engine() -> None:
     assert "_restoreLayout(data)" in pane and "seen.has(d.paneId)" in pane
     # the visible-but-unfocused tab marker
     assert 'classList.toggle("shown"' in pane
-    # per-pane ✕: split mode hides ONE cell keeping the tab (closeCell), EXCEPT
+    # Tab dismissal: split mode hides ONE cell keeping the tab (closeCell), EXCEPT
     # an ephemeral pane which closes outright; single-pane it closes the pane
     # (withheld from non-closable) — the click decides at click time, the label
-    # tracks the mode.  Manager-injected into the pane SECTION (content
-    # untouched), removed via _clearCellStyle.  Ephemeral-dismiss behaviour has
-    # its own deep coverage in test_preview_js.py::TestEphemeralDismiss.
-    assert "closeCell(paneId)" in pane and "_refreshCellChips()" in pane
-    assert 'b.className = "cell-unsplit"' in pane
-    assert '"Close pane"' in pane, "the single-pane chip mode"
+    # tracks the mode.  Dismiss and select are sibling buttons in the tab.
+    # Lifecycle coverage lives in test_pane_js.py; ephemeral guards also live
+    # in test_preview_js.py::TestEphemeralDismiss.
+    assert "closeCell(paneId)" in pane and "_refreshTabDismiss(pane)" in pane
+    assert 'dismiss.className = "tab-dismiss"' in pane
+    assert "group.append(dismiss, tab)" in pane
+    assert '"Close pane"' in pane, "the single-pane dismiss mode"
     # mode-DISTINCT glyphs (designer P1: identical signifier + locus with a
     # reversible/destructive divergence is a mode-error trap) — a click that
     # cannot be a reversible cell-hide shows ✕, else −.
     assert "const destroys = !multi || pane.ephemeral;" in pane
     assert 'b.textContent = destroys ? "✕" : "−"' in pane
-    assert '"cell-unsplit--close"' in pane
-    assert "this._removeCellChip(pane)" in pane
+    assert '"tab-dismiss--close"' in pane
     # open-beside: the coordinator child-link placement (split right of the
     # focused cell, degrade to the plain swap on deny)
     assert "openPaneBeside(type, id, extra)" in pane
@@ -1117,17 +1117,11 @@ def test_pane_manager_split_engine() -> None:
     # section itself paints UNDER edge-touching children (the status-bar
     # occlusion bug); the ::before bar sits above the ring line
     assert ".panes--split > section.pane.split-focused::after" in css
-    assert ".cell-unsplit" in css, "the per-cell hide-from-split chip style"
-    assert ".cell-unsplit--close:hover" in css, "destructive mode telegraphs on hover"
-    # the pane is the chip's containing block in BOTH modes — unpositioned,
-    # the single-pane chip anchored to the VIEWPORT (offsetParent <body>)
+    assert ".tab-dismiss--close:hover" in css, "destructive mode telegraphs on hover"
+    assert ".tab-dismiss[hidden]" in css, "unavailable controls retain their tab slot"
+    assert ".panes > section.pane.tab-dismiss-target::after" in css
+    # The pane contains its target ring in both modes.
     assert ".panes > section.pane" in css
-    # pane-hosted coordinator sidebar drops below the chip's corner lane —
-    # the chip sat exactly on the Children refresh button (user report)
-    coord_chrome = (_ROOT / "turnstone/console/static/coordinator/coord-chrome.css").read_text(
-        encoding="utf-8"
-    )
-    assert ".pane-body.coord-chrome-root #coord-sidebar.sidebar" in coord_chrome
 
 
 def test_step7_auth_gated_open_pane() -> None:

--- a/turnstone/console/static/coordinator/coord-chrome.css
+++ b/turnstone/console/static/coordinator/coord-chrome.css
@@ -109,16 +109,6 @@
   flex-direction: column;
   min-height: 0;
 }
-/* Pane-hosted: the shell's per-pane ✕/− chip floats in the pane's top-right
-   corner (top 5px + 28px tall) — exactly where this sidebar's toggle row and
-   the Children refresh sit.  Drop the sidebar content below the chip's lane;
-   padding (not margin) keeps the column's left border running the full pane
-   height.  (In practice this is EVERY coordinator — the /coordinator/{ws_id}
-   standalone page is a chip-less direct-URL fallback no UI path navigates to;
-   the .pane-body scope just keeps that lane honest.) */
-.pane-body.coord-chrome-root #coord-sidebar.sidebar {
-  padding-top: 44px;
-}
 #coord-children-wrap {
   min-height: 40%;
   max-height: 60%;

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -45,11 +45,10 @@ export class ShellPane {
     this.glyph = opts.glyph || null; // a single static char shown in the tab (e.g. "◇"); stateful panes use a live .ui-glyph-* instead
     this.stateful = opts.stateful || false; // conversational panes: tab glyph tracks live Tier-1 state (set via setTabGlyph)
     this.closable = opts.closable !== false; // dashboard is not closable
-    // Ephemeral: a pane with no standalone background-tab life.  Dismissing its
-    // split cell (the ✕ chip, or unsplit) CLOSES it — destroy, not the default
-    // hide-and-keep-the-tab — because there is no meaningful re-open-from-tab;
-    // its reopen affordance lives elsewhere (the transcript preview chip).  The
-    // preview singleton sets this; conversational panes do not.
+    // Ephemeral: a pane with no standalone background-tab life.  Dismissing its split cell
+    // (the tab's dismiss button, or unsplit) CLOSES it — destroy, not the default hide-and-keep-the-tab —
+    // because there is no meaningful re-open-from-tab; its reopen affordance lives elsewhere (the
+    // transcript preview chip).  The preview singleton sets this; conversational panes do not.
     this.ephemeral = opts.ephemeral || false;
     // DOM — created and owned by the PaneManager on mount:
     this.el = null; // <section class="pane">
@@ -226,9 +225,6 @@ export class PaneManager {
     opts = opts || {};
     this.tabbarEl = opts.tabbarEl;
     this.panesEl = opts.panesEl;
-    // managed tabs are inserted before this element (the right-floated region /
-    // add-tab affordance), so non-tab tabbar chrome keeps its position.
-    this.tailEl = opts.tailEl || null;
     this.caps = opts.caps || {};
     this.storageKey = opts.storageKey || "ts.shell.panes";
     this._types = new Map(); // type -> factory(id) => ShellPane
@@ -255,14 +251,29 @@ export class PaneManager {
         true,
       );
     }
-    // The tab bar is a WAI-ARIA tablist; arrow keys rove focus across the open
-    // tabs (delegated, so it survives tab reconciliation).
+    // Keep dismiss buttons outside the tablist's accessibility tree.  Its
+    // aria-owns follows tab order while the DOM pairs each tab with its dismiss
+    // button.  Key handling stays on the strip so both buttons can rove focus.
     if (this.tabbarEl) {
-      this.tabbarEl.setAttribute("role", "tablist");
-      this.tabbarEl.setAttribute("aria-label", "Open panes");
+      this._tablistEl = document.createElement("span");
+      this._tablistEl.className = "tablist";
+      this._tablistEl.setAttribute("role", "tablist");
+      this._tablistEl.setAttribute("aria-label", "Open panes");
+      this.tabbarEl.append(this._tablistEl);
       this.tabbarEl.addEventListener("keydown", (e) =>
         this._onTablistKeydown(e),
       );
+      this.tabbarEl.addEventListener("focusin", (e) => {
+        // Pointer focus precedes click: scrolling here can move the button
+        // out from under the pointer before mouseup, losing the click.
+        if (!e.target.matches(":focus-visible")) return;
+        const group = e.target.closest(".tab");
+        if (group) this._revealTab(this._panes.get(group.dataset.paneId));
+      });
+      // Observe the strip and its tabs: viewport/rail resizing changes the
+      // available width, while late titles and glyphs can move the focused tab.
+      this._tabResizeObserver = new ResizeObserver(() => this._revealTab());
+      this._tabResizeObserver.observe(this.tabbarEl);
     }
   }
 
@@ -345,6 +356,7 @@ export class PaneManager {
     if (!pane || text == null || text === "") return;
     pane.title = text;
     if (pane._titleNode) pane._titleNode.textContent = text;
+    if (pane.tabEl) this._refreshTabDismiss(pane);
   }
 
   /** Open panes whose tab shows live Tier-1 state — `{id, rawId}[]` (the shell
@@ -494,8 +506,8 @@ export class PaneManager {
       }
     }
     if (this._layout) this._applyLayout();
-    this._refreshCellChips();
     this._renderTabs();
+    this._revealTab(next);
     this._persist();
     this._notifyActive();
   }
@@ -648,7 +660,7 @@ export class PaneManager {
   }
 
   /** Remove ONE cell from the split — the pane stays open as a (now hidden)
-   *  tab and its sibling absorbs the space.  The per-cell ✕ chip calls this;
+   *  tab and its sibling absorbs the space.  The tab's − button calls this;
    *  distinct from close() (destroys the pane) and unsplit() (collapses every
    *  cell but the focused one). */
   closeCell(paneId) {
@@ -858,7 +870,6 @@ export class PaneManager {
       this._clearCellStyle(p);
       if (keepId) p.el.hidden = p.id !== keepId;
     }
-    this._refreshCellChips(); // the survivor's ✕ flips to close-pane mode
   }
 
   _clearCellStyle(pane) {
@@ -867,63 +878,7 @@ export class PaneManager {
     pane.el.style.width = "";
     pane.el.style.height = "";
     pane.el.classList.remove("split-focused");
-    this._removeCellChip(pane);
-  }
-
-  /** The per-pane ✕ chip, top-right of every VISIBLE pane.  Mode-dependent:
-   *  in a multi-cell split it hides that cell (closeCell — the tab stays);
-   *  single-pane it closes the pane outright (tab and all), so it is withheld
-   *  from non-closable panes (the Dashboard) there.  The click decides at
-   *  CLICK time, the label tracks the mode.  Injected by the MANAGER into the
-   *  pane's section (not bodyEl — pane content is never touched). */
-  _refreshCellChips() {
-    const multi = !!this._layout && this._leaves().length > 1;
-    for (const p of this._panes.values()) {
-      const want =
-        !p.el.hidden && (multi ? !!this._leafFor(p.id) : p.closable !== false);
-      if (want) this._ensureCellChip(p, multi);
-      else this._removeCellChip(p);
-    }
-  }
-
-  _ensureCellChip(pane, multi) {
-    let b = pane._cellChip;
-    if (!b || !b.isConnected) {
-      b = document.createElement("button");
-      b.type = "button";
-      b.className = "cell-unsplit";
-      b.addEventListener("click", () => {
-        // In a multi-cell split the chip HIDES this cell (the tab stays) —
-        // except an ephemeral pane (e.g. the preview), which has no background-
-        // tab life and so closes outright, exactly as it does single-pane.
-        if (this._layout && this._leafFor(pane.id) && !pane.ephemeral)
-          this.closeCell(pane.id);
-        else this.close(pane.id);
-      });
-      pane.el.append(b);
-      pane._cellChip = b;
-    }
-    // Mode-DISTINCT glyphs — an identical signifier at an identical locus with
-    // divergent outcomes is a mode-error trap (split-mode muscle memory would
-    // fire the destructive close): − hides the cell (reversible — the tab
-    // stays), ✕ closes the pane.  The chip DESTROYS whenever the click cannot be
-    // a reversible cell-hide: single-pane always, and an ephemeral pane even in
-    // a split.  Close mode also wears a danger hover (shell.css .cell-unsplit--close).
-    const destroys = !multi || pane.ephemeral;
-    b.textContent = destroys ? "✕" : "−";
-    b.classList.toggle("cell-unsplit--close", destroys);
-    const label = destroys
-      ? "Close pane"
-      : "Hide from split — the tab stays open";
-    b.title = label;
-    b.setAttribute("aria-label", label);
-  }
-
-  _removeCellChip(pane) {
-    if (pane._cellChip) {
-      pane._cellChip.remove();
-      pane._cellChip = null;
-    }
+    pane.el.classList.remove("tab-dismiss-target");
   }
 
   /** Focus follows the pointer between cells: a click anywhere inside a
@@ -931,9 +886,6 @@ export class PaneManager {
    *  stop propagation of bubbled events). */
   _onPanesPointerdown(e) {
     if (!this._layout) return;
-    // The ✕ chip collapses its cell — focusing that cell first would fire a
-    // spurious onActivate on the very pane about to leave the screen.
-    if (e.target.closest && e.target.closest(".cell-unsplit")) return;
     let el = e.target;
     // The ShellPane <section> is the DIRECT child of the host (the interactive
     // pane's inner <div> also carries .pane — walking to the direct child
@@ -1119,37 +1071,107 @@ export class PaneManager {
       const first = this._firstLeaf(tree);
       if (first) this.activate(first.paneId);
     }
-    this._refreshCellChips();
     this._renderTabs(); // pick up the .shown markers
   }
 
   _renderTabs() {
     // Reconcile the managed tabs IN PLACE — never destroy + recreate.  Keeps
     // keyboard focus and click/keydown listeners stable across activate / open /
-    // close, leaves the tail chrome untouched, and is the seam every later pane
-    // type renders its tab through.
-    const anchor =
-      this.tailEl && this.tailEl.parentNode === this.tabbarEl
-        ? this.tailEl
-        : null;
-    for (const paneId of this._order) {
+    // close, and is the seam every pane type renders its tab through.
+    let changed = false;
+    for (const group of this.tabbarEl.querySelectorAll(".tab")) {
+      if (!this._panes.has(group.dataset.paneId)) {
+        this._tabResizeObserver.unobserve(group);
+        group.remove();
+        changed = true;
+      }
+    }
+    let anchor = null;
+    for (const paneId of [...this._order].reverse()) {
       const pane = this._panes.get(paneId);
       const tab = pane.tabEl || this._buildTab(pane);
       this._refreshTab(tab, pane);
-      this.tabbarEl.insertBefore(tab, anchor); // idempotent reorder
+      const group = pane._tabGroup;
+      // Moving even an already-connected node drops native keyboard focus.
+      // Reconcile from the tail and leave correctly placed groups untouched.
+      if (group.parentNode !== this.tabbarEl || group.nextSibling !== anchor) {
+        this.tabbarEl.insertBefore(group, anchor);
+        changed = true;
+      }
+      anchor = group;
     }
-    // Drop tabs whose pane is gone.
-    for (const t of Array.from(
-      this.tabbarEl.querySelectorAll('[role="tab"]'),
-    )) {
-      if (!this._panes.has(t.dataset.paneId)) t.remove();
+    if (changed) {
+      this._tablistEl.setAttribute(
+        "aria-owns",
+        this._order.map((id) => this._panes.get(id).tabEl.id).join(" "),
+      );
+      this._revealTab();
     }
   }
 
+  /** Reveal the complete tab, including its leading dismiss button.  Adjust
+   *  only the strip's horizontal scroll; pane and page scrollers stay put.
+   *  Without an explicit target, preserve keyboard focus before selection. */
+  _revealTab(pane) {
+    if (!pane) {
+      const focused = document.activeElement;
+      const group =
+        this.tabbarEl.contains(focused) &&
+        focused.matches(":focus-visible") &&
+        focused.closest(".tab");
+      pane = this._panes.get(group ? group.dataset.paneId : this._activeId);
+    }
+    const width = this.tabbarEl.clientWidth;
+    if (!pane || !pane._tabGroup || !width) return;
+    const strip = this.tabbarEl.getBoundingClientRect();
+    const tab = pane._tabGroup.getBoundingClientRect();
+    const left = strip.left + this.tabbarEl.clientLeft;
+    const right = left + width;
+    // A tab wider than the strip keeps its leading control and title start.
+    if (tab.left < left || tab.width > width)
+      this.tabbarEl.scrollLeft += tab.left - left;
+    else if (tab.right > right)
+      this.tabbarEl.scrollLeft += tab.right - right;
+  }
+
   _buildTab(pane) {
+    // Dismiss and select are sibling buttons: nesting a dismiss button inside
+    // the role=tab button would create invalid, inaccessible controls.
+    const group = document.createElement("span");
+    group.className = "tab";
+    group.dataset.paneId = pane.id;
+    group.setAttribute("role", "presentation");
+    const dismiss = document.createElement("button");
+    dismiss.type = "button";
+    dismiss.className = "tab-dismiss";
+    dismiss.setAttribute("aria-controls", pane.el.id);
+    dismiss.addEventListener("click", () => {
+      const hadFocus = document.activeElement === dismiss;
+      // A regular split cell is hidden; ephemeral panes close outright.
+      if (this._layout && this._leafFor(pane.id) && !pane.ephemeral)
+        this.closeCell(pane.id);
+      else this.close(pane.id);
+      pane.el.classList.remove("tab-dismiss-target");
+      if (hadFocus) {
+        const next = pane.tabEl.isConnected
+          ? pane
+          : this._panes.get(this._activeId);
+        if (next) next.tabEl.focus({ preventScroll: true });
+      }
+    });
+    const highlight = () => {
+      pane.el.classList.toggle(
+        "tab-dismiss-target",
+        !pane.el.hidden && dismiss.matches(":hover, :focus-visible"),
+      );
+    };
+    for (const event of ["pointerenter", "pointerleave", "focus", "blur"])
+      dismiss.addEventListener(event, highlight);
+    pane._tabGroup = group;
+    pane._dismissBtn = dismiss;
     const tab = document.createElement("button");
     tab.type = "button";
-    tab.className = "tab";
+    tab.className = "tab-select";
     tab.id = "tab-" + cssId(pane.id);
     tab.dataset.paneId = pane.id;
     tab.setAttribute("role", "tab");
@@ -1198,6 +1220,8 @@ export class PaneManager {
       e.preventDefault();
       this._openTabMenu(tab, pane);
     });
+    group.append(dismiss, tab);
+    this._tabResizeObserver.observe(group);
     pane.tabEl = tab;
     return tab;
   }
@@ -1208,10 +1232,31 @@ export class PaneManager {
    *  one (aria-selected stays single — selection means focus). */
   _refreshTab(tab, pane) {
     const active = pane.id === this._activeId;
-    tab.classList.toggle("active", active);
-    tab.classList.toggle("shown", !active && !!this._leafFor(pane.id));
+    pane._tabGroup.classList.toggle("active", active);
+    pane._tabGroup.classList.toggle("shown", !active && !!this._leafFor(pane.id));
     tab.setAttribute("aria-selected", active ? "true" : "false");
     tab.tabIndex = active ? 0 : -1;
+    this._refreshTabDismiss(pane);
+  }
+
+  /** Only visible panes offer dismissal: − hides a regular split cell while
+   *  ✕ closes a single or ephemeral pane.  The leading slot stays reserved
+   *  when unavailable, so hiding a cell cannot move another tab under the pointer. */
+  _refreshTabDismiss(pane) {
+    const multi = !!this._layout && this._leaves().length > 1;
+    const want =
+      !pane.el.hidden && (multi ? !!this._leafFor(pane.id) : pane.closable !== false);
+    const b = pane._dismissBtn;
+    b.hidden = !want;
+    if (!want) pane.el.classList.remove("tab-dismiss-target");
+    const destroys = !multi || pane.ephemeral;
+    b.textContent = destroys ? "✕" : "−";
+    b.classList.toggle("tab-dismiss--close", destroys);
+    const label = destroys
+      ? "Close pane"
+      : "Hide from split — the tab stays open";
+    b.title = label;
+    b.setAttribute("aria-label", label + ": " + pane.title);
   }
 
   /** Roving arrow-key navigation across the open tabs.  Manual activation —
@@ -1219,7 +1264,8 @@ export class PaneManager {
    *  does, so arrow-scrubbing never thrashes a pane's Tier-2 stream. */
   _onTablistKeydown(e) {
     const tabs = Array.from(this.tabbarEl.querySelectorAll('[role="tab"]'));
-    const i = tabs.indexOf(document.activeElement);
+    const group = document.activeElement.closest(".tab");
+    const i = tabs.indexOf(group && group.querySelector('[role="tab"]'));
     if (i < 0) return;
     // ContextMenu key / Shift+F10 opens the focused tab's action menu — keyboard
     // parity with the caret click (the caret itself is a decorative span).
@@ -1242,7 +1288,7 @@ export class PaneManager {
     else if (e.key === "End") j = tabs.length - 1;
     else return;
     e.preventDefault();
-    tabs[j].focus();
+    tabs[j].focus({ preventScroll: true });
   }
 
   /** Open a pane's tab-action dropdown, anchored under its caret.  Generic: the

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -484,22 +484,26 @@
   position: relative;
   z-index: 20;
 }
-/* The tabs live in their own strip (the role=tablist element — the burger and
-   the [+] tail sit OUTSIDE it in .tabbar, see shell.js buildShell).  On mobile
-   the strip is the horizontal scroller, so those stay pinned. */
+/* Tabs and their dismiss buttons scroll together.  The burger and split
+   controls sit outside the strip in .tabbar and stay pinned. */
 .tabstrip {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
+/* The semantic tablist owns only tab-select buttons via aria-owns.  It adds
+   no layout box so each dismiss button stays beside its tab. */
+.tablist { display: contents; }
 .tab {
   position: relative;
   flex: none;
   display: inline-flex;
   align-items: center;
   white-space: nowrap;
-  padding: 6px 11px;
+  padding: 0;
   border-radius: var(--r-md);
   font-size: 12.5px;
   line-height: 1.2;
@@ -510,6 +514,21 @@
   font-family: var(--font-ui);
   /* long workstream names ellipsize (.tab-title) instead of growing the tab */
   max-width: 240px;
+}
+.tab-select {
+  flex: 1;
+  min-width: 0;
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 8px 6px 3px;
+  border: none;
+  border-radius: var(--r-md);
+  background: none;
+  color: inherit;
+  font: inherit;
+  white-space: inherit;
+  cursor: pointer;
 }
 .tab-title {
   flex: 0 1 auto;
@@ -563,7 +582,7 @@
   color: var(--ink-2);
 }
 .tab-caret:hover,
-.tab[aria-expanded="true"] .tab-caret {
+.tab-select[aria-expanded="true"] .tab-caret {
   color: var(--ink);
 }
 .tab-caret:hover {
@@ -791,10 +810,7 @@
 .panes--split {
   position: relative;
 }
-/* The pane is the containing block in BOTH modes: unpositioned, the per-pane
-   ✕ chip's absolute would resolve to the VIEWPORT (offsetParent <body>) and
-   only coincidentally land near the pane corner.  The split rule below wins
-   on specificity while split. */
+/* Contain the tab-dismiss target ring in single-pane mode too. */
 .panes > section.pane {
   position: relative;
 }
@@ -810,21 +826,30 @@
    inset shadow paints in the element's background layer, UNDER any opaque
    child touching the edge — the status bar / composer strip occluded it (the
    reported paint bug).  The overlay sits above pane content (a coordinator
-   overlay label uses z:10) and stays click-transparent. */
-.panes--split > section.pane.split-focused::after {
+   overlay label uses z:10) and stays click-transparent.  A separate dashed
+   outline identifies the tab-dismiss target on hover or keyboard focus;
+   the active split cell keeps its solid accent ring and top bar. */
+.panes--split > section.pane.split-focused::after,
+.panes > section.pane.tab-dismiss-target::after {
   content: "";
   position: absolute;
   inset: 0;
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--accent) 55%, var(--hair-2));
   z-index: 12;
   pointer-events: none;
+}
+.panes--split > section.pane.split-focused::after {
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--accent) 55%, var(--hair-2));
 }
 /* light needs a hotter mix: 55% measured 2.60:1 there (sub-3:1); 75% clears.
    Dark stays 55% (3.75:1) — hotter reads as a heavy border on dark. */
 [data-theme="light"] .panes--split > section.pane.split-focused::after {
   box-shadow: inset 0 0 0 1px
     color-mix(in srgb, var(--accent) 75%, var(--hair-2));
+}
+.panes > section.pane.tab-dismiss-target::after {
+  outline: 1px dashed var(--ink-3);
+  outline-offset: -3px;
 }
 .panes--split > section.pane.split-focused::before {
   content: "";
@@ -837,57 +862,59 @@
   z-index: 13; /* above the ring overlay — a clean bar, not bar-plus-ring-line */
   pointer-events: none;
 }
-/* per-pane dismiss chip (.cell-unsplit) — on every visible pane.  Split mode:
+/* Leading tab dismiss button — available for every visible pane.  Split mode:
    "−" hides this cell (the TAB stays — closeCell), but an ephemeral pane (the
    preview) shows "✕" and closes outright; single-pane: "✕" closes the pane
    (withheld from the unclosable Dashboard).  The destructive "✕" modes wear
-   .cell-unsplit--close.  Shell chrome floating over pane content: elevated panel +
-   hairline so it reads as the shell's, not the conversation's; sits clear of
-   the 2px focus bar and the cell corner. */
-.cell-unsplit {
-  position: absolute;
-  top: 5px;
-  right: 14px; /* clear of the message scroller's scrollbar gutter */
-  z-index: 14;
+   .tab-dismiss--close.  The fixed slot keeps tab positions stable when a pane
+   is hidden or the Dashboard cannot be dismissed. */
+.tab-dismiss {
+  flex: none;
+  margin: 0 1px;
   /* 28px: WCAG 2.5.8's 24px floor + a hair (22px under-shot it) */
   width: 28px;
   height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
-  /* --hair-2 measured ~1.3:1 against the chip bg — an invisible boundary;
-     --ink-4 clears 3:1 in both themes */
-  border: 1px solid var(--ink-4);
+  /* The tab supplies the resting frame; show the button's own boundary on
+     hover/focus while retaining its full hit area in every state. */
+  border: 1px solid transparent;
   border-radius: var(--r-sm);
-  background: var(--panel-2);
+  background: none;
   color: var(--ink-3);
   font-size: 12px;
   line-height: 1;
   cursor: pointer;
   opacity: 0.85;
 }
-.cell-unsplit:hover {
+.tab-dismiss[hidden] {
+  display: flex;
+  visibility: hidden;
+}
+.tab-dismiss:hover {
   opacity: 1;
   color: var(--ink);
   border-color: var(--accent-dim);
 }
 /* the destructive mode (single-pane "Close pane" ✕) telegraphs BEFORE the
    click lands — split-mode muscle memory must not fire it blind */
-.cell-unsplit--close:hover {
+.tab-dismiss--close:hover {
   color: var(--err);
   border-color: var(--err);
 }
-.cell-unsplit:focus-visible {
+.tab-select:focus-visible,
+.tab-dismiss:focus-visible {
   opacity: 1;
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.cell-unsplit--close:focus-visible {
+.tab-dismiss--close:focus-visible {
   outline-color: var(--err);
 }
 /* light resting glyph at .85 sat right at the 3:1 floor with --ink-3 — one
    ink step restores headroom (~4.5:1) without making the chip shout */
-[data-theme="light"] .cell-unsplit {
+[data-theme="light"] .tab-dismiss {
   color: var(--ink-2);
 }
 /* separator — a 7px hit area straddling the cell boundary with a 1px visual
@@ -957,6 +984,7 @@
 .tab.shown:not(.active)::after {
   content: "";
   position: absolute;
+  pointer-events: none;
   left: 8px;
   right: 8px;
   bottom: 2px;
@@ -1492,14 +1520,9 @@
   .app.rail-open .rail-scrim {
     display: block;
   }
-  /* the tab strip scrolls horizontally (burger + [+] stay pinned); tabs
-     tighten so 2-3 stay legible */
+  /* Tabs tighten on mobile so 2-3 stay legible. */
   .tabbar {
     padding: 8px 8px;
-  }
-  .tabstrip {
-    overflow-x: auto;
-    scrollbar-width: thin;
   }
   .tab {
     max-width: 48vw;

--- a/turnstone/shared_static/shell.js
+++ b/turnstone/shared_static/shell.js
@@ -104,11 +104,8 @@ function buildShell(caps) {
   burger.setAttribute("aria-label", "Open navigation");
   burger.setAttribute("aria-controls", "shell-rail");
   burger.setAttribute("aria-expanded", "false");
-  // The tab strip is its OWN element so PaneManager's role="tablist" wraps
-  // ONLY the tabs — the burger and the [+] tail are non-tab focusables and
-  // don't belong inside a tablist's accessibility tree.  It is also the
-  // horizontal scroller on mobile, so burger + [+] stay pinned while tabs
-  // scroll.
+  // Tabs and their dismiss buttons share a horizontal scroller, keeping the
+  // burger and [+] pinned.  PaneManager owns the tablist accessibility tree.
   const tabstrip = make("div", "tabstrip");
   const tail = make("div", "tabbar-right"); // right-floated tab-bar chrome (the [+])
   tabbar.append(burger, tabstrip, tail);
@@ -552,9 +549,7 @@ async function mountShell() {
   };
 
   // ----- PaneManager: one new spine -----
-  // It owns the tabstrip (role=tablist), NOT the whole tab bar: the burger and
-  // the [+] tail live outside the strip so the tablist holds only tabs.  No
-  // tailEl — the strip has no non-tab chrome to anchor before.
+  // It owns the tabstrip; the burger and [+] stay in the surrounding tab bar.
   const pm = new PaneManager({
     tabbarEl: shell.tabstrip,
     panesEl: shell.panes,


### PR DESCRIPTION
Pane dismiss controls currently float over content and can cover Preview's Download action or admin
hatch buttons. Move them into a stable leading slot beside each tab label: `−` hides a regular split
pane while retaining its tab, and `✕` closes a single or ephemeral pane.

Keep the complete tab visible during activation and keyboard navigation, preserve keyboard focus on
resize, and identify the affected pane with a dashed outline. Give tab selection and dismissal
separate accessible controls, remove the obsolete pane overlay and coordinator spacing workaround,
and remove unused tab-tail support.

Validation:

- 363 focused frontend tests passed; package-wide Ruff and mypy passed.
- Native browser checks covered clipped-tab clicks, keyboard focus, dismissal, menus, accessibility
  ownership, and the decorative underline's hit area. Light/dark visual checks passed.
- CSS specificity findings match the existing baseline; JavaScript syntax and whitespace checks pass.

Known CI baseline: current `main` fails six exception-identity assertions in
`tests/test_mcp_dispatch_timeouts.py` on Python 3.11/3.12. This is reproduced separately and documented
in the [main CI run](https://github.com/turnstonelabs/turnstone/actions/runs/34078332604/job/101647982817).
