### PR TITLE
fix(tests): make MCP timeout assertions portable

### DIFF
--- a/tests/test_mcp_dispatch_timeouts.py
+++ b/tests/test_mcp_dispatch_timeouts.py
@@ -121,7 +121,10 @@ def test_operation_failure_preserves_error_and_counts_once(dispatch_env, kind, p
     with pytest.raises(error_type) as caught:
         _call(mgr, kind, pooled)
 
-    assert caught.value is error
+    # Python 3.11/3.12 recreate TimeoutError when bridging asyncio and concurrent futures.
+    # Preserve the operation's type and arguments without requiring object identity.
+    assert caught.type is error_type
+    assert caught.value.args == error.args
     assert mgr._consecutive_failures["srv"] == 2
     state = entry if pooled else mgr._static_servers["srv"]
     # Static generic operation errors count without transport eviction; the


### PR DESCRIPTION
Python 3.11 and 3.12 recreate `TimeoutError` when transferring an asyncio task exception into a concurrent future. The MCP dispatch tests therefore fail their object-identity assertion even when the operation error propagates correctly, causing the [six failures on main](https://github.com/turnstonelabs/turnstone/actions/runs/34009208218/job/101648204127).

Assert the exact exception type and original arguments. The existing failure-count and session-cleanup assertions continue to verify the dispatch behavior.

Validation:

- All 30 dispatch timeout tests pass on Python 3.11.14, 3.12.12, and 3.13.11.
- Full SQLite CI suite with coverage on Python 3.11.14: **13,761 passed, 28 PostgreSQL-only tests skipped, 17 live/recovery tests deselected** in 13m33s.
- Negative control: reintroducing the old caller-timeout classification bug makes all six operation `TimeoutError` cases fail under the revised assertions.
- Repository-wide Ruff checks, formatting, and mypy pass (261 source files).
