### PR TITLE
fix(rbac): restore operator history with node authorization checks

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -921,6 +921,10 @@ active, and `conflict` requires operator intervention.
 Returns a list of saved workstreams from the database, ordered by most recently
 updated.
 
+Requires `read` scope and applies creator/project visibility. On a node, this lists interactive
+workstreams. On the console, it includes interactive workstreams and also coordinator rows when the
+caller has `admin.coordinator`. A failed storage query returns 503 rather than an empty list.
+
 **Response:**
 
 ```json
@@ -1596,6 +1600,10 @@ masked as `404`.
 ### `POST /v1/api/workstreams/{ws_id}/delete`
 
 Permanently delete a saved workstream and all its messages from storage.
+
+Requires `write` scope and project access. Deleting a coordinator also requires `admin.coordinator`,
+including through the node endpoint or a console routing proxy. Authorization and deletion use the
+same persisted incarnation snapshot.
 
 **Path parameters:**
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -67,11 +67,14 @@ Scopes are hierarchical — higher scopes imply all lower ones.
 | Method | Path pattern | Required scope | Additional RBAC gate |
 |--------|-------------|----------------|----------------------|
 | GET | Any protected path | `read` | Endpoint-specific where documented |
+| GET | `/api/workstreams/saved` | `read` | Creator/project visibility; console coordinator rows additionally require `admin.coordinator` |
+| GET | `/api/workstreams/{ws_id}` (detail) | `read`; also `write` to reopen a cold session | Project tenancy and kind-specific permission |
 | POST | `/api/command` | `write` | Project tenancy on the target workstream |
 | POST | `/api/workstreams/new`, `/api/cluster/workstreams/new` | `write` | `workstreams.create` or `admin.coordinator` |
 | POST | `/api/workstreams/{ws_id}/close` | `write` | `workstreams.close` or `admin.coordinator` |
 | POST | `/api/workstreams/{ws_id}/approve` | `approve` | `tools.approve` or `admin.coordinator` |
 | POST | `/api/workstreams/{ws_id}/{rewind,retry}` | `write` | `conversation.modify` |
+| POST | `/api/workstreams/{ws_id}/delete` | `write` | Project tenancy; coordinator rows also require `admin.coordinator` |
 | POST | Other `/api/workstreams/{ws_id}/...` mutation endpoints | `write` | Project tenancy and endpoint-specific gates |
 | DELETE | `/api/workstreams/{ws_id}/send` (dequeue), `/api/workstreams/{ws_id}/attachments/{attachment_id}` | `write` | Project tenancy on the target workstream |
 | Any | `/api/admin/*` | `approve` | Matching `admin.*` permission |
@@ -80,6 +83,13 @@ Public paths bypass authentication entirely: `/`, `/health`, `/metrics`,
 `/static/*`, `/shared/*`, `/docs`, `/openapi.json`, `/api/auth/login`,
 `/api/auth/logout`, `/api/auth/status`, `/api/auth/setup`,
 `/api/auth/oidc/authorize`, `/api/auth/oidc/callback`.
+
+Saved interactive history is available to project members without `admin.coordinator` or
+`project.read`. The `server.require_project` setting governs creation and does not restrict reads or
+reopening existing history. Read-only callers can inspect saved metadata and use history/export;
+reopening a saved session and deleting history require write scope. The browser uses the effective
+`scopes` returned by login, refresh, and whoami separately from named RBAC permissions when showing
+these actions.
 
 ### RBAC (Granular Permissions)
 

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -6004,7 +6004,7 @@
         "tags": [
           "Coordinator"
         ],
-        "description": "Returns the persisted coordinator's display fields.  If the session isn't currently in memory the manager rehydrates it before responding; ``500`` on rehydrate failure carries a correlation id matching the server log line.",
+        "description": "Returns the persisted coordinator's display fields.  If the session isn't currently in memory, write scope is additionally required before the manager rehydrates it before responding; ``500`` on rehydrate failure carries a correlation id matching the server log line.",
         "parameters": [
           {
             "name": "ws_id",
@@ -6062,6 +6062,38 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/api/workstreams/saved": {
+      "get": {
+        "summary": "List saved sessions visible to the caller",
+        "operationId": "v1_api_workstreams_saved_get",
+        "tags": [
+          "Workstreams"
+        ],
+        "description": "Requires read scope. Interactive rows use creator/project visibility; coordinator rows additionally require admin.coordinator. A caller without that permission receives only interactive rows.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSavedWorkstreamsResponse"
                 }
               }
             }
@@ -15619,6 +15651,12 @@
             "default": "",
             "title": "Permissions",
             "type": "string"
+          },
+          "scopes": {
+            "default": "",
+            "description": "Comma-separated effective transport scopes",
+            "title": "Scopes",
+            "type": "string"
           }
         },
         "required": [
@@ -15910,6 +15948,151 @@
           "state"
         ],
         "title": "WorkstreamInfo",
+        "type": "object"
+      },
+      "ListSavedWorkstreamsResponse": {
+        "properties": {
+          "workstreams": {
+            "items": {
+              "$ref": "#/components/schemas/SavedWorkstreamInfo"
+            },
+            "title": "Workstreams",
+            "type": "array"
+          }
+        },
+        "required": [
+          "workstreams"
+        ],
+        "title": "ListSavedWorkstreamsResponse",
+        "type": "object"
+      },
+      "SavedWorkstreamInfo": {
+        "properties": {
+          "ws_id": {
+            "title": "Ws Id",
+            "type": "string"
+          },
+          "alias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Alias"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Title"
+          },
+          "created": {
+            "title": "Created",
+            "type": "string"
+          },
+          "updated": {
+            "title": "Updated",
+            "type": "string"
+          },
+          "message_count": {
+            "title": "Message Count",
+            "type": "integer"
+          },
+          "state": {
+            "default": "idle",
+            "title": "State",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/WorkstreamKind",
+            "default": "interactive"
+          },
+          "node_id": {
+            "default": "",
+            "title": "Node Id",
+            "type": "string"
+          },
+          "model_alias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Model Alias"
+          },
+          "launch_skill": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Launch Skill"
+          },
+          "child_count": {
+            "default": 0,
+            "title": "Child Count",
+            "type": "integer"
+          },
+          "context_tokens": {
+            "default": 0,
+            "title": "Context Tokens",
+            "type": "integer"
+          },
+          "context_ratio": {
+            "default": 0.0,
+            "title": "Context Ratio",
+            "type": "number"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Project Id"
+          },
+          "persona": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Persona"
+          }
+        },
+        "required": [
+          "ws_id",
+          "created",
+          "updated",
+          "message_count"
+        ],
+        "title": "SavedWorkstreamInfo",
         "type": "object"
       },
       "UploadAttachmentResponse": {

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -989,7 +989,7 @@
         "tags": [
           "Workstreams"
         ],
-        "description": "Returns the persisted workstream's display fields. If the session isn't currently in memory the manager rehydrates it before responding; ``500`` on rehydrate failure carries a correlation id matching the server log line. Lifted from the coord-only surface in the Stage 2 history/detail verb lift \u2014 interactive previously had no detail endpoint.",
+        "description": "Returns the persisted workstream's display fields. If the session isn't currently in memory, write scope is additionally required before the manager rehydrates it before responding; ``500`` on rehydrate failure carries a correlation id matching the server log line. Lifted from the coord-only surface in the Stage 2 history/detail verb lift \u2014 interactive previously had no detail endpoint.",
         "parameters": [
           {
             "name": "ws_id",
@@ -1013,6 +1013,16 @@
           },
           "400": {
             "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
             "content": {
               "application/json": {
                 "schema": {
@@ -1587,6 +1597,7 @@
         "tags": [
           "Workstreams"
         ],
+        "description": "Lists interactive history visible through creator/project access; requires read scope.",
         "responses": {
           "200": {
             "description": "Success",
@@ -1594,6 +1605,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListSavedWorkstreamsResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4624,6 +4645,12 @@
           "permissions": {
             "default": "",
             "title": "Permissions",
+            "type": "string"
+          },
+          "scopes": {
+            "default": "",
+            "description": "Comma-separated effective transport scopes",
+            "title": "Scopes",
             "type": "string"
           }
         },

--- a/tests/_coord_test_helpers.py
+++ b/tests/_coord_test_helpers.py
@@ -56,7 +56,7 @@ class _AuthMiddleware(BaseHTTPMiddleware):
         if perms or user_id:
             request.state.auth_result = AuthResult(
                 user_id=user_id,
-                scopes=frozenset({"approve"}),
+                scopes=frozenset({"read", "write", "approve"}),
                 token_source="test",
                 permissions=frozenset(p for p in perms.split(",") if p),
             )

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -2550,7 +2550,9 @@ class TestSharedStatic:
         assert "/shared/utils.js" in body
         assert "/shared/toast.js" in body
         assert "/shared/theme.js" in body
-        assert "/shared/auth.js" in body
+        # Auth is imported by the shell; a second script tag creates two modules.
+        assert "/shared/shell.js" in body
+        assert 'from "./auth.js"' in client.get("/shared/shell.js").text
         assert "/shared/kb.js" in body
 
     def test_shared_scripts_load_before_app_js(self, client):

--- a/tests/test_coordinator_end_to_end.py
+++ b/tests/test_coordinator_end_to_end.py
@@ -80,7 +80,7 @@ class _AuthMiddleware(BaseHTTPMiddleware):
         if perms or user_id:
             request.state.auth_result = AuthResult(
                 user_id=user_id,
-                scopes=frozenset({"approve"}),
+                scopes=frozenset({"read", "write", "approve"}),
                 token_source="test",
                 permissions=frozenset(p for p in perms.split(",") if p),
             )

--- a/tests/test_history_authority_js.py
+++ b/tests/test_history_authority_js.py
@@ -1,0 +1,237 @@
+"""Execute shared auth, saved cards, and asynchronous history state under Node."""
+
+from pathlib import Path
+
+from tests._js_harness_helpers import (
+    FAKE_DOM,
+    demodulize,
+    extract_braced,
+    node_skip,
+    run_node_source,
+)
+
+pytestmark = node_skip
+_ROOT = Path(__file__).resolve().parents[1] / "turnstone"
+_SETUP = r"""
+import assert from 'node:assert/strict';
+globalThis.window = {};
+globalThis.BroadcastChannel = undefined;
+globalThis.AbortController = undefined;
+const elements = new Map();
+document.getElementById = id => elements.get(id) || null;
+document.body = new FakeElement('body');
+document.createTextNode = text => Object.assign(new FakeElement('text'), {textContent: text});
+globalThis.Node = FakeElement;
+Object.defineProperty(FakeElement.prototype, 'style', {get() {
+  return this._style ||= {setProperty(name, value) { this[name] = value; }};
+}});
+FakeElement.prototype.insertBefore = function(child) { return this.appendChild(child); };
+const session = new Map();
+globalThis.sessionStorage = {
+  getItem: key => session.get(key) ?? null,
+  setItem: (key, value) => session.set(key, value),
+  removeItem: key => session.delete(key),
+};
+const requests = [];
+globalThis.fetch = url => new Promise(resolve => requests.push({url, resolve}));
+globalThis.setTimeout = () => 1;
+globalThis.clearTimeout = () => {};
+function showToast() {}
+function formatRelativeTime() { return ''; }
+const drain = async () => { for (let i = 0; i < 5; i++) await new Promise(setImmediate); };
+function reply(request, data, status = 200) {
+  request.resolve(new Response(JSON.stringify(data), {status}));
+}
+const operator = {user_id:'operator', scopes:'read,write', permissions:'read,write'};
+const reader = {user_id:'admin', scopes:'read', permissions:'admin.coordinator'};
+function element(id) {
+  const el = new FakeElement('div'); elements.set(id, el); return el;
+}
+function table() {
+  return createSavedTable({
+    columns: [], bodyEl: element('saved-coord-cards'), noun:'session',
+    canActivate: () => hasScope('write'), canDelete: () => hasScope('write'),
+    onActivate: () => { activations++; },
+    delete: {idPrefix:'delete', buttonId:'delete-button', buildDeleteRequest: () => ({url:'/delete'})},
+  });
+}
+let activations = 0;
+"""
+
+
+def _run(body, *, console_loader=False, ui_loader=False):
+    source = FAKE_DOM + _SETUP
+    source += demodulize(_ROOT / "shared_static/auth.js")
+    source += demodulize(_ROOT / "shared_static/cards.js")
+    source += demodulize(_ROOT / "shared_static/list_cache.js")
+    if console_loader:
+        app = (_ROOT / "console/static/app.js").read_text()
+        for name in ("loadSavedCoordinators", "_setSavedError", "_savedAuthChanged"):
+            source += extract_braced(
+                app,
+                f"function {name}() {{"
+                if name != "_setSavedError"
+                else "function _setSavedError(message) {",
+            )
+        source += (
+            "\nlet _savedCoordsInFlight = false, _savedCoordsRetry = false, _coordTable = null;\n"
+        )
+    if ui_loader:
+        app = (_ROOT / "ui/static/app.js").read_text()
+        for signature in (
+            "function _initSavedWsTable() {",
+            "function loadDashboard() {",
+            "function _setSavedWsMessage(text) {",
+        ):
+            source += extract_braced(app, signature)
+        source += "\nlet _wsTable = null, dashboardVisible = false;\n"
+        source += "function makeEmptyState(text) { return new FakeElement('div'); }\n"
+        source += "function renderDashboardTable() {}\n"
+    result = run_node_source(source + "\n" + body)
+    assert result.returncode == 0, result.stderr
+
+
+def test_scope_actions_and_selection_reset():
+    _run(r"""
+reply(requests.shift(), reader); await drain();
+assert.equal(hasPermission('admin.coordinator'), true);
+assert.equal(hasScope('write'), false);
+const button = element('delete-button');
+const saved = table();
+onAuthChange(() => saved.reset());
+saved.setItems([{ws_id:'one', name:'One'}]);
+let row = elements.get('saved-coord-cards').children[0];
+assert.equal(row.getAttribute('role'), 'group');
+assert.equal(row.getAttribute('tabindex'), null);
+assert.equal(row.getAttribute('aria-label'), 'One');
+row.onclick(); row.onkeydown({key:'Enter', preventDefault(){}});
+assert.equal(activations, 0);
+assert.equal(button.style.display, 'none');
+saved.controller.start(); assert.equal(saved.controller.inMode(), false);
+_storePermissions(operator);
+saved.setItems([{ws_id:'one', name:'One'}]);
+row = elements.get('saved-coord-cards').children[0];
+assert.equal(row.getAttribute('role'), 'button'); row.onclick();
+assert.equal(activations, 1); assert.equal(button.style.display, '');
+saved.controller.start(); saved.controller.toggleAll();
+assert.equal(saved.controller.isSelected('one'), true);
+_storePermissions({...operator, scopes:'read'});
+assert.equal(saved.controller.inMode(), false);
+assert.equal(saved.controller.isSelected('one'), false);
+assert.equal(button.style.display, 'none');
+""")
+
+
+def test_auth_response_ordering_without_abort_controller():
+    _run(r"""
+const oldWhoami = requests.shift();
+_scheduleRefreshFromWhoami(); const newWhoami = requests.shift();
+reply(newWhoami, operator); await drain();
+reply(oldWhoami, reader); await drain();
+assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
+const oldRefresh = _tryRefresh(); const oldRequest = requests.shift();
+_invalidateAuth(); _loggedOut = false; _storePermissions(reader);
+const newRefresh = _tryRefresh(); const newRequest = requests.shift();
+reply(oldRequest, operator); await drain();
+assert.equal(await oldRefresh, false);
+assert.equal(sessionStorage.getItem('ts.user_id'), 'admin');
+const coalesced = _tryRefresh(); assert.equal(requests.length, 0);
+reply(newRequest, {...reader, exp:0});
+assert.equal(await newRefresh, true); assert.equal(await coalesced, true);
+const pending = authFetch('/saved').catch(e => e.message);
+const stale = requests.shift(); let finishBody;
+stale.resolve({status:401, clone:() => ({json:() => new Promise(r => {finishBody = r;})})});
+await drain();
+_invalidateAuth(); _loggedOut = false; _storePermissions(operator);
+const generation = authGeneration();
+finishBody({code:'version_mismatch'});
+assert.equal(await pending, 'auth changed');
+assert.equal(authGeneration(), generation);
+assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
+""")
+
+
+def test_saved_requests_cannot_cross_auth_generations():
+    _run(
+        r"""
+reply(requests.shift(), operator); await drain();
+element('saved-coordinators'); element('coord-saved-footer');
+const error = element('coord-saved-error'); element('coord-saved-error-text');
+_coordTable = table(); onAuthChange(_savedAuthChanged);
+loadSavedCoordinators(); loadSavedCoordinators();
+assert.equal(requests.length, 1);
+reply(requests.shift(), {workstreams:[{ws_id:'old'}]}); await drain();
+assert.equal(requests.length, 1); const old = requests.shift();
+_invalidateAuth(); _loggedOut = false; _storePermissions({...operator, user_id:'new'});
+assert.equal(requests.length, 1); const current = requests.shift();
+reply(old, {workstreams:[{ws_id:'stale'}]}); await drain();
+loadSavedCoordinators(); assert.equal(requests.length, 0);
+reply(current, {workstreams:[{ws_id:'current'}]}); await drain();
+assert.equal(elements.get('saved-coord-cards').children[0].dataset.wsId, 'current');
+assert.equal(requests.length, 1);
+reply(requests.shift(), {error:'private diagnostic'}, 503); await drain();
+assert.equal(error.hidden, false);
+assert.equal(elements.get('saved-coord-cards').style.display, 'none');
+loadSavedCoordinators(); reply(requests.shift(), {workstreams:[{ws_id:'recovered'}]});
+await drain(); assert.equal(error.hidden, true);
+assert.equal(elements.get('saved-coord-cards').children[0].dataset.wsId, 'recovered');
+""",
+        console_loader=True,
+    )
+
+
+def test_superseded_refresh_preserves_current_same_user_authority():
+    _run(r"""
+reply(requests.shift(), operator); await drain();
+const pending = authFetch('/saved').catch(e => e.message);
+reply(requests.shift(), {error:'expired'}, 401); await drain();
+const oldRefresh = requests.shift();
+_scheduleRefreshFromWhoami();
+const reduced = {...operator, scopes:'read', permissions:'read'};
+reply(requests.shift(), reduced); await drain();
+reply(oldRefresh, {...reduced, exp:0});
+assert.equal(await pending, 'auth changed');
+assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
+assert.equal(hasScope('write'), false);
+assert.equal(hasScope('read'), true);
+""")
+
+
+def test_standalone_initial_whoami_reloads_saved_history():
+    _run(
+        r"""
+element('dashboard-saved-cards'); element('ws-saved-footer');
+element('ws-pagination'); element('dash-ws-table');
+_initSavedWsTable();
+const whoami = requests.shift();
+loadDashboard();
+const oldDashboard = requests.shift(), oldSaved = requests.shift();
+reply(whoami, operator); await drain();
+assert.equal(requests.length, 2);
+reply(oldDashboard, {workstreams:[]});
+reply(oldSaved, {workstreams:[{ws_id:'stale'}]}); await drain();
+reply(requests.shift(), {workstreams:[]});
+reply(requests.shift(), {workstreams:[{ws_id:'current'}]}); await drain();
+assert.equal(elements.get('dashboard-saved-cards').children[0].dataset.wsId, 'current');
+""",
+        ui_loader=True,
+    )
+
+
+def test_project_cache_reset_discards_rows_and_pending_refetches():
+    _run(r"""
+reply(requests.shift(), operator); await drain();
+const cache = makeListCache({url:'/projects', dataKey:'projects', name:'projects', keyField:'id', fpRow:p=>p.id});
+const oldLoad = cache.refresh(); const old = requests.shift();
+const oldTrailing = cache.refresh({force:true});
+cache.reset();
+const newLoad = cache.refresh(); const current = requests.shift();
+reply(old, {projects:[{id:'secret', name:'Old principal project'}]});
+await oldLoad; await oldTrailing;
+assert.equal(cache.getByKey('secret'), null);
+assert.equal(cache.refresh(), newLoad);
+assert.equal(requests.length, 0);
+reply(current, {projects:[{id:'new'}]}); await newLoad;
+assert.deepEqual(cache.get().map(p=>p.id), ['new']);
+cache.reset(); assert.deepEqual(cache.get(), []); assert.equal(cache.loaded(), false);
+""")

--- a/tests/test_history_authority_js.py
+++ b/tests/test_history_authority_js.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from tests._js_harness_helpers import (
     FAKE_DOM,
     demodulize,
@@ -19,6 +21,7 @@ globalThis.BroadcastChannel = undefined;
 globalThis.AbortController = undefined;
 const elements = new Map();
 document.getElementById = id => elements.get(id) || null;
+document.addEventListener = document.removeEventListener = () => {};
 document.body = new FakeElement('body');
 document.createTextNode = text => Object.assign(new FakeElement('text'), {textContent: text});
 globalThis.Node = FakeElement;
@@ -149,6 +152,102 @@ assert.equal(await pending, 'auth changed');
 assert.equal(authGeneration(), generation);
 assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
 """)
+
+
+@pytest.mark.parametrize("cached_identity", [False, True])
+@pytest.mark.parametrize("refresh_ok", [False, True])
+def test_startup_whoami_401_recovers_pending_requests(cached_identity, refresh_ok):
+    _run(
+        f"const cachedIdentity = {str(cached_identity).lower()};\n"
+        f"const refreshOK = {str(refresh_ok).lower()};\n"
+        + r"""
+if (cachedIdentity) {
+  sessionStorage.setItem('ts.user_id', operator.user_id);
+  sessionStorage.setItem('turnstone_scopes', operator.scopes);
+  sessionStorage.setItem('turnstone_permissions', operator.permissions);
+}
+const overlay = element('login-overlay'); overlay.style.display = 'none';
+const whoami = requests.shift();
+const pending = authFetch('/saved').catch(e => e.message);
+const initial = requests.shift();
+reply(whoami, {error:'expired'}, 401); await drain();
+assert.equal(requests.length, 1, 'whoami must initiate authentication recovery');
+const refresh = requests.shift(); assert.equal(refresh.url, '/v1/api/auth/refresh');
+reply(initial, {error:'expired'}, 401); await drain();
+assert.equal(requests.length, 0, 'parallel 401s must share one refresh');
+reply(refresh, refreshOK ? {...operator, exp:0} : {error:'expired'}, refreshOK ? 200 : 401);
+await drain();
+if (refreshOK) {
+  assert.equal(overlay.style.display, 'none');
+  assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
+  assert.equal(hasScope('write'), true);
+  const retry = requests.shift(); assert.equal(retry.url, '/saved');
+  reply(retry, {workstreams:[]}); assert.equal((await pending).ok, true);
+} else {
+  assert.equal(overlay.style.display, 'flex');
+  assert.equal(sessionStorage.getItem('ts.user_id'), null);
+  assert.equal(hasScope('read'), false);
+  assert.match(await pending, /^auth( changed)?$/);
+  assert.equal(requests.shift().url, '/v1/api/auth/status');
+}
+assert.equal(requests.length, 0);
+"""
+    )
+
+
+def test_whoami_auth_loss_before_login_mount_preserves_upgrade_prompt():
+    _run(r"""
+function escapeHtml(text) { return text; }
+function setSafeHtml(el, html) { el.textContent = html; }
+document.querySelectorAll = () => [];
+const append = document.body.appendChild.bind(document.body);
+document.body.appendChild = el => { elements.set(el.id, el); return append(el); };
+window.location = {search:'', pathname:'/', reload:() => { reloads++; }};
+let reloads = 0;
+['login-box', 'toggle-token', 'setup-fields', 'login-fields', 'token-fields',
+ 'login-toggle', 'login-subtitle', 'login-submit'].forEach(element);
+sessionStorage.setItem('ts.user_id', 'operator');
+reply(requests.shift(), {code:'version_mismatch'}, 401); await drain();
+assert.equal(sessionStorage.getItem('ts.user_id'), null);
+assert.equal(requests.length, 0);
+initLogin();
+assert.equal(elements.get('login-overlay').style.display, 'flex');
+const status = requests.shift(); assert.equal(status.url, '/v1/api/auth/status');
+reply(status, {setup_required:false}); await drain();
+assert.match(elements.get('login-subtitle').textContent, /server was updated/);
+_onSuccess(); assert.equal(reloads, 1);
+""")
+
+
+@pytest.mark.parametrize("stage", ["body", "refresh"])
+def test_superseded_whoami_401_cannot_clear_unchanged_authority(stage):
+    _run(
+        f"const stage = '{stage}';\n"
+        + r"""
+reply(requests.shift(), operator); await drain();
+const overlay = element('login-overlay'); overlay.style.display = 'none';
+_scheduleRefreshFromWhoami(); const oldWhoami = requests.shift();
+let finishBody, oldRefresh;
+if (stage === 'body') {
+  oldWhoami.resolve({status:401, clone:() => ({json:() => new Promise(r => {finishBody = r;})})});
+  await drain();
+} else {
+  reply(oldWhoami, {error:'expired'}, 401); await drain();
+  oldRefresh = requests.shift(); assert.equal(oldRefresh.url, '/v1/api/auth/refresh');
+}
+const generation = authGeneration();
+_scheduleRefreshFromWhoami();
+reply(requests.shift(), operator); await drain();
+assert.equal(authGeneration(), generation, 'unchanged authority does not advance generation');
+if (finishBody) finishBody({code:'version_mismatch'});
+else reply(oldRefresh, {error:'expired'}, 401);
+await drain();
+assert.equal(overlay.style.display, 'none');
+assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
+assert.equal(hasScope('write'), true);
+assert.equal(requests.length, 0, 'superseded whoami must not refresh or open login');
+"""
+    )
 
 
 def test_saved_requests_cannot_cross_auth_generations():

--- a/tests/test_interactive_history_rbac.py
+++ b/tests/test_interactive_history_rbac.py
@@ -1,0 +1,245 @@
+"""History admission and node actions through real auth and migrated storage."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from tests.test_server_authz import _FakeSession, _FakeUI
+from turnstone.console.collector import ClusterCollector
+from turnstone.console.server import create_app as create_console
+from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
+from turnstone.core.auth import JWT_AUD_CONSOLE, JWT_AUD_SERVER, create_jwt, hash_password
+from turnstone.core.config_store import ConfigStore
+from turnstone.core.session_manager import SessionManager
+from turnstone.core.storage import init_storage, reset_storage
+from turnstone.server import create_app as create_node
+
+pytestmark = pytest.mark.anyio
+_SECRET = "history-rbac-test-secret-at-least-32-characters"
+
+
+@pytest.fixture
+async def history_apps(tmp_path):
+    reset_storage()
+    storage = init_storage("sqlite", path=str(tmp_path / "history.db"))
+    password = "history-test-password"
+    password_hash = hash_password(password)
+    for user, role in (("operator", "operator"), ("admin", "admin"), ("viewer", "viewer")):
+        storage.create_user(user, user, user, password_hash)
+        storage.assign_role(user, "builtin-" + role)
+    storage.create_project("shared", "Shared", "admin")
+    storage.add_project_member("shared", "operator")
+    storage.add_project_member("shared", "viewer")
+    storage.create_project("private", "Private", "admin")
+    for ws_id, kind, owner, project in (
+        ("own", "interactive", "operator", "shared"),
+        ("related", "interactive", "admin", "shared"),
+        ("hidden", "interactive", "admin", "private"),
+        ("coordinator", "coordinator", "admin", "shared"),
+        ("legacy", "interactive", "admin", None),
+    ):
+        storage.register_workstream(
+            ws_id, "node-a", name=ws_id, user_id=owner, kind=kind, project_id=project
+        )
+        storage.update_workstream_state(ws_id, "closed")
+        storage.save_message(ws_id, "user", "History for " + ws_id)
+    events = queue.Queue()
+    adapter = InteractiveAdapter(
+        global_queue=events,
+        ui_factory=lambda ws: _FakeUI(ws_id=ws.id, user_id=ws.user_id),
+        session_factory=lambda ui, _model, ws_id, **kw: _FakeSession(ws_id, ui._user_id),
+    )
+    manager = SessionManager(adapter, storage=storage, max_active=10, event_emitter=adapter)
+    node = create_node(
+        workstreams=manager,
+        global_queue=events,
+        global_listeners=[],
+        global_listeners_lock=threading.Lock(),
+        skip_permissions=False,
+        jwt_secret=_SECRET,
+        auth_storage=storage,
+    )
+    collector = MagicMock(spec=ClusterCollector)
+    collector.get_node_detail.return_value = {"server_url": "http://node.test"}
+    router = MagicMock()
+    router.is_ready.return_value = True
+    router.route.return_value = SimpleNamespace(node_id="node-a", url="http://node.test")
+    console = create_console(
+        collector=collector, jwt_secret=_SECRET, auth_storage=storage, router=router
+    )
+    config = ConfigStore(storage)
+    node.state.config_store = console.state.config_store = config
+    async with (
+        httpx.AsyncClient(transport=httpx.ASGITransport(node), base_url="http://node.test") as nc,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(console), base_url="http://console.test"
+        ) as cc,
+    ):
+        console.state.proxy_client = nc
+        for client in (nc, cc):
+            response = await client.post(
+                "/v1/api/auth/login", json={"username": "operator", "password": password}
+            )
+            assert response.status_code == 200
+            assert "admin.coordinator" not in response.json()["permissions"]
+        try:
+            yield SimpleNamespace(
+                node=nc,
+                console=cc,
+                node_app=node,
+                console_app=console,
+                storage=storage,
+                config=config,
+                manager=manager,
+                events=events,
+            )
+        finally:
+            for ws in manager.list_all():
+                manager.close(ws.id)
+    reset_storage()
+
+
+def _headers(user="operator", scopes=("read", "write"), permissions=(), audience=JWT_AUD_SERVER):
+    return {
+        "Authorization": "Bearer "
+        + create_jwt(
+            user_id=user,
+            scopes=frozenset(scopes),
+            permissions=frozenset(permissions),
+            source="test",
+            secret=_SECRET,
+            audience=audience,
+        )
+    }
+
+
+@pytest.mark.parametrize("required", [False, True])
+async def test_operator_discovers_own_and_project_history(history_apps, required):
+    apps = history_apps
+    apps.config.set("server.require_project", required)
+    for client in (apps.console, apps.node):
+        response = await client.get("/v1/api/workstreams/saved")
+        assert response.status_code == 200
+        assert {row["ws_id"] for row in response.json()["workstreams"]} == {
+            "own",
+            "related",
+            "legacy",
+        }
+    proxied = await apps.console.get("/node/node-a/v1/api/workstreams/saved")
+    assert proxied.status_code == 200
+    assert {row["ws_id"] for row in proxied.json()["workstreams"]} == {"own", "related", "legacy"}
+    assert apps.manager.list_all() == []
+    assert (await apps.node.get("/v1/api/workstreams/hidden/history")).status_code == 403
+    assert (await apps.node.get("/v1/api/workstreams/coordinator/history")).status_code == 404
+    assert (await apps.node.get("/v1/api/workstreams/related/history")).status_code == 200
+
+
+async def test_real_close_preserves_discovery_and_emits_event(history_apps):
+    apps = history_apps
+    assert (await apps.node.post("/v1/api/workstreams/related/open")).status_code == 200
+    response = await apps.node.post("/v1/api/workstreams/related/close", json={})
+    assert response.status_code == 200, response.text
+    assert apps.manager.get("related") is None
+    emitted = []
+    while not apps.events.empty():
+        emitted.append(apps.events.get_nowait())
+    assert any(e["type"] == "ws_closed" and e["ws_id"] == "related" for e in emitted)
+    rows = (await apps.console.get("/v1/api/workstreams/saved")).json()["workstreams"]
+    assert "related" in {row["ws_id"] for row in rows}
+    assert (await apps.node.post("/v1/api/workstreams/related/open")).status_code == 200
+
+
+@pytest.mark.parametrize("permission,expected", [(False, 403), (True, 200)])
+@pytest.mark.parametrize("route", ["node", "node_proxy", "route_proxy"])
+async def test_coordinator_delete_requires_its_permission(
+    history_apps, permission, expected, route
+):
+    apps = history_apps
+    client = apps.node if route == "node" else apps.console
+    path = {
+        "node": "/v1/api/workstreams/coordinator/delete",
+        "node_proxy": "/node/node-a/v1/api/workstreams/coordinator/delete",
+        "route_proxy": "/v1/api/route/workstreams/delete",
+    }[route]
+    response = await client.post(
+        path,
+        json={"ws_id": "coordinator"},
+        headers=_headers(
+            permissions=("admin.coordinator",) if permission else (),
+            audience=JWT_AUD_SERVER if route == "node" else JWT_AUD_CONSOLE,
+        ),
+    )
+    assert response.status_code == expected
+    assert (apps.storage.get_workstream("coordinator") is None) == permission
+    assert apps.manager.list_all() == []
+    assert (await apps.node.post("/v1/api/workstreams/related/delete")).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "ws_id,status",
+    [
+        ("related", 403),
+        ("hidden", 403),
+        ("coordinator", 404),
+        ("missing", 404),
+    ],
+)
+async def test_reader_cannot_rehydrate_through_detail(history_apps, ws_id, status):
+    apps = history_apps
+    reader = _headers(user="viewer", scopes=("read",))
+    assert (
+        await apps.node.get(f"/v1/api/workstreams/{ws_id}", headers=reader)
+    ).status_code == status
+    assert apps.manager.list_all() == []
+    for suffix in ("history", "export"):
+        response = await apps.node.get(f"/v1/api/workstreams/related/{suffix}", headers=reader)
+        assert response.status_code == 200
+    assert apps.manager.list_all() == []
+    assert (await apps.node.get("/v1/api/workstreams/related")).status_code == 200
+    assert (await apps.node.get("/v1/api/workstreams/related", headers=reader)).status_code == 200
+
+
+async def test_saved_query_failure_is_unavailable(history_apps, monkeypatch):
+    def fail(**kwargs):
+        raise RuntimeError("private database diagnostic")
+
+    monkeypatch.setattr(history_apps.storage, "list_workstreams_with_history", fail)
+    for client in (history_apps.node, history_apps.console):
+        response = await client.get("/v1/api/workstreams/saved")
+        assert response.status_code == 503
+        assert response.json() == {"error": "Saved sessions unavailable"}
+
+
+async def test_whoami_distinguishes_scopes_from_named_permissions(history_apps):
+    response = await history_apps.node.get(
+        "/v1/api/auth/whoami",
+        headers=_headers(user="admin", scopes=("read",), permissions=("admin.coordinator",)),
+    )
+    assert response.status_code == 200
+    assert response.json()["scopes"] == "read"
+    assert response.json()["permissions"] == "admin.coordinator"
+
+
+async def test_admin_union_and_scope_denials(history_apps):
+    apps = history_apps
+    response = await apps.console.post(
+        "/v1/api/auth/login", json={"username": "admin", "password": "history-test-password"}
+    )
+    assert response.status_code == 200
+    rows = (await apps.console.get("/v1/api/workstreams/saved")).json()["workstreams"]
+    assert {row["ws_id"] for row in rows} == {"own", "related", "hidden", "coordinator", "legacy"}
+    reader = _headers(user="admin", scopes=("read",), permissions=("admin.coordinator",))
+    assert (
+        await apps.node.post("/v1/api/workstreams/coordinator/delete", headers=reader)
+    ).status_code == 403
+    assert (
+        await apps.node.get("/v1/api/workstreams/saved", headers=_headers(scopes=()))
+    ).status_code == 403
+    apps.node.cookies.clear()
+    assert (await apps.node.get("/v1/api/workstreams/saved")).status_code == 401

--- a/tests/test_project_workstream_visibility.py
+++ b/tests/test_project_workstream_visibility.py
@@ -71,8 +71,13 @@ def _request_for(
     uid: str,
     scopes: tuple[str, ...] = (),
     permissions: tuple[str, ...] = (),
+    *,
+    storage: Any = None,
 ) -> Any:
-    return SimpleNamespace(state=SimpleNamespace(auth_result=_FakeAuth(uid, scopes, permissions)))
+    return SimpleNamespace(
+        state=SimpleNamespace(auth_result=_FakeAuth(uid, scopes, permissions)),
+        app=SimpleNamespace(state=SimpleNamespace(auth_storage=storage)),
+    )
 
 
 class TestWsVisiblePredicate:
@@ -393,7 +398,7 @@ class TestSavedListFilter:
             saved_loaded_lookup=None,
         )
 
-        rows = await _collect_saved_rows(cfg, _request_for("bob"))
+        rows = await _collect_saved_rows(cfg, _request_for("bob", storage=storage))
         ids = {r["ws_id"] for r in rows}
         # bob: no membership in p1 — alice's private ws is dropped; the
         # public-project ws, the project-less ws, and bob's own
@@ -403,7 +408,7 @@ class TestSavedListFilter:
         assert by_id["ws-pub"]["project_id"] == "p2"
         assert by_id["ws-plain"]["project_id"] is None
 
-        rows_alice = await _collect_saved_rows(cfg, _request_for("alice"))
+        rows_alice = await _collect_saved_rows(cfg, _request_for("alice", storage=storage))
         assert {r["ws_id"] for r in rows_alice} == {"ws-plain", "ws-priv", "ws-pub", "ws-own"}
 
 
@@ -642,17 +647,17 @@ class TestSavedListPagination:
             saved_loaded_lookup=None,
         )
 
-    def _patch(self, monkeypatch: pytest.MonkeyPatch, rows: list) -> None:
+    def _patch(self, monkeypatch: pytest.MonkeyPatch, rows: list) -> Any:
         def _fake(limit=20, *, kind=None, user_id=None, state=None, offset=0):
             return rows[offset : offset + limit]
 
-        monkeypatch.setattr("turnstone.core.memory.list_workstreams_with_history", _fake)
         vis = WorkstreamProjectVisibility("bob", storage=_fake_storage())  # denies any pid
         monkeypatch.setattr(
             WorkstreamProjectVisibility,
             "for_request",
             classmethod(lambda cls, request, storage=None: vis),
         )
+        return _request_for("bob", storage=SimpleNamespace(list_workstreams_with_history=_fake))
 
     async def test_pages_past_invisible_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from turnstone.core.session_routes import _collect_saved_rows
@@ -660,8 +665,8 @@ class TestSavedListPagination:
         rows = [self._row(i, "ph") for i in range(60)] + [
             self._row(i, None) for i in range(60, 130)
         ]
-        self._patch(monkeypatch, rows)
-        result = await _collect_saved_rows(self._cfg(), MagicMock())
+        request = self._patch(monkeypatch, rows)
+        result = await _collect_saved_rows(self._cfg(), request)
         assert len(result) == 50
         assert result[0]["ws_id"] == "ws-060"
         assert result[-1]["ws_id"] == "ws-109"
@@ -670,6 +675,6 @@ class TestSavedListPagination:
         from turnstone.core.session_routes import _collect_saved_rows
 
         rows = [self._row(i, "ph") for i in range(5000)]
-        self._patch(monkeypatch, rows)
-        result = await _collect_saved_rows(self._cfg(), MagicMock())
+        request = self._patch(monkeypatch, rows)
+        result = await _collect_saved_rows(self._cfg(), request)
         assert result == []

--- a/tests/test_saved_handler_unified.py
+++ b/tests/test_saved_handler_unified.py
@@ -16,6 +16,7 @@ path only reads ``request`` to pass it to ``saved_loaded_lookup`` /
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
@@ -77,9 +78,12 @@ def _row(
 
 
 def _request() -> Request:
-    """A request stub — the saved path only forwards it to the cfg
-    callables the tests supply, so a bare MagicMock suffices."""
-    return MagicMock()
+    """Request carrying the same store used by its visibility checks."""
+    from turnstone.core.storage import get_storage
+
+    request = MagicMock()
+    request.app.state.auth_storage = get_storage()
+    return request
 
 
 async def _body(resp: Response) -> dict[str, Any]:
@@ -151,11 +155,9 @@ def _patch_storage(
             return interactive_rows[offset : offset + limit]
         return []
 
-    # The handler imports the symbol from turnstone.core.memory at call
-    # time, so patch it on that module.
     monkeypatch.setattr(
-        "turnstone.core.memory.list_workstreams_with_history",
-        _fake,
+        "turnstone.core.storage.get_storage",
+        lambda: SimpleNamespace(list_workstreams_with_history=_fake),
     )
     return calls
 
@@ -272,6 +274,53 @@ async def test_unified_saved_passing_gate_returns_merged(monkeypatch: pytest.Mon
     resp = await handler(_request())
     rows = (await _body(resp))["workstreams"]
     assert [r["ws_id"] for r in rows] == ["c" * 32]
+
+
+@pytest.mark.parametrize("status", [401, 403, 503])
+async def test_per_kind_admission_queries_only_authorized_kinds(monkeypatch, status):
+    calls = _patch_storage(
+        monkeypatch,
+        coord_rows=[],
+        interactive_rows=[_row("interactive", kind="interactive", updated="2026-09-07")],
+    )
+    handler = make_unified_saved_handler(
+        [
+            _coord_cfg(permission_gate=lambda request: JSONResponse({}, status_code=status)),
+            _interactive_cfg(),
+        ]
+    )
+    response = await handler(_request())
+    if status == 403:
+        assert response.status_code == 200
+        assert [row["ws_id"] for row in (await _body(response))["workstreams"]] == ["interactive"]
+        assert [call["kind"] for call in calls] == [WorkstreamKind.INTERACTIVE]
+    else:
+        assert response.status_code == status
+        assert calls == []
+
+
+async def test_excluded_kind_still_validates_configuration(monkeypatch):
+    calls = _patch_storage(monkeypatch, coord_rows=[], interactive_rows=[])
+    bad = _coord_cfg(permission_gate=lambda request: JSONResponse({}, status_code=403))
+    object.__setattr__(bad, "list_kind", None)
+    response = await make_unified_saved_handler([bad, _interactive_cfg()])(_request())
+    assert response.status_code == 500
+    assert calls == []
+
+
+async def test_admitted_kind_failure_never_returns_partial_success(monkeypatch):
+    _patch_storage(monkeypatch, coord_rows=[], interactive_rows=[])
+    request = _request()
+
+    def query(**kwargs):
+        if kwargs["kind"] == WorkstreamKind.COORDINATOR:
+            raise RuntimeError("private storage details")
+        return [_row("interactive", kind="interactive", updated="2026-09-07")]
+
+    request.app.state.auth_storage.list_workstreams_with_history = query
+    response = await make_unified_saved_handler([_coord_cfg(), _interactive_cfg()])(request)
+    assert response.status_code == 503
+    assert await _body(response) == {"error": "Saved sessions unavailable"}
 
 
 async def test_unified_saved_500s_on_missing_list_kind(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -15,7 +15,9 @@ import re
 import shutil
 import subprocess
 import tempfile
+from html.parser import HTMLParser
 from pathlib import Path
+from urllib.parse import urljoin, urlsplit
 
 import pytest
 
@@ -172,6 +174,51 @@ def test_console_index_loads_shell_module_and_caps() -> None:
     )
     assert "/shared/shell.css" in body, "console index must link shell.css"
     assert "TURNSTONE_SHELL_CAPS" in body, "console index must set the shell capability flags"
+
+
+@pytest.mark.parametrize("index", [_CONSOLE_INDEX, _UI_INDEX], ids=["console", "node"])
+def test_served_module_graph_has_one_auth_instance(index: Path) -> None:
+    """URL queries identify distinct ESM instances even when file contents match.
+
+    Two auth instances share sessionStorage but own separate change listeners;
+    the first writer can suppress the second instance's login notification.
+    Traverse the actual versioned entry points and static imports as the browser
+    resolves them, so either duplicating auth or losing it fails this guard.
+    """
+    from turnstone.core.web_helpers import version_html
+
+    class ModuleScripts(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.urls: list[str] = []
+
+        def handle_starttag(self, tag, attrs):
+            attrs = dict(attrs)
+            if tag == "script" and attrs.get("type") == "module" and attrs.get("src"):
+                self.urls.append(attrs["src"])
+
+    parser = ModuleScripts()
+    parser.feed(version_html(index.read_text()))
+    pending = [urljoin("https://console.test/", url) for url in parser.urls]
+    seen: set[str] = set()
+    while pending:
+        url = pending.pop()
+        if url in seen:
+            continue
+        seen.add(url)
+        path = urlsplit(url).path
+        source = (
+            _SHARED / path.removeprefix("/shared/")
+            if path.startswith("/shared/")
+            else index.parent / path.removeprefix("/static/")
+        )
+        body = strip_js_comments(source.read_text())
+        imports = re.findall(
+            r"^\s*import\s+(?:[^;]*?\bfrom\s+)?[\"']([^\"']+)[\"']", body, re.MULTILINE
+        )
+        pending.extend(urljoin(url, specifier) for specifier in imports)
+    auth_urls = {url for url in seen if urlsplit(url).path == "/shared/auth.js"}
+    assert len(auth_urls) == 1, auth_urls
 
 
 def test_persona_picker_surfaces_wired() -> None:

--- a/tests/test_workstream_endpoints.py
+++ b/tests/test_workstream_endpoints.py
@@ -61,7 +61,7 @@ class _InjectAuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         request.state.auth_result = AuthResult(
             user_id="test-user",
-            scopes=frozenset({"approve"}),
+            scopes=frozenset({"read", "write", "approve"}),
             token_source="config",
             permissions=frozenset({"read", "write", "approve"}),
         )
@@ -627,11 +627,13 @@ class TestDeleteWorkstream:
         assert r.status_code == 200
         assert r.json()["deleted"] == "ws-flaky"
 
+    @pytest.mark.parametrize("replacement_kind", ["interactive", "coordinator"])
     def test_stale_authorized_delete_leaves_same_id_replacement(
         self,
         delete_client,
         storage,
         monkeypatch,
+        replacement_kind,
     ):
         """An exact delete authorized for a predecessor cannot hit its replacement."""
         client, _ = delete_client
@@ -680,6 +682,7 @@ class TestDeleteWorkstream:
                     "node-2",
                     name="replacement",
                     user_id="other-user",
+                    kind=replacement_kind,
                     fork_reservation_token="replacement-incarnation",
                 )
                 is True
@@ -1290,9 +1293,8 @@ def _interactive_endpoint_cfg(
     """Interactive-shaped cfg wired the same way ``server.py`` does.
 
     Shared by both :func:`_build_history_app` and :func:`_build_detail_app`
-    — every field both factories actually read is present (the detail
-    factory ignores ``list_kind`` since it relies on ``mgr.open()`` for
-    cross-kind isolation, but the field is harmless to set).
+    — every field both factories read is present, including the kind
+    used to distinguish a reader's cold-detail 404 from a scope denial.
 
     The optional ``tenant_check`` lets a regression test wire the same
     cross-tenant gate ``server.py`` uses (``_interactive_tenant_check``)
@@ -2385,9 +2387,8 @@ class TestBuildHistoryToolContentCoercion:
 class TestDetailInteractive:
     """Interactive parity for the lifted ``GET /v1/api/workstreams/{ws_id}``.
 
-    The lifted ``make_detail_handler`` factory never reads storage —
-    cross-kind isolation is enforced inside ``mgr.open()`` and the
-    response is built from in-memory ``Workstream`` fields. The
+    These writer tests exercise cross-kind isolation inside ``mgr.open()``;
+    the response is built from in-memory ``Workstream`` fields. The
     ``mgr.open`` calls are mocked via ``MagicMock`` here, so the
     storage-registry side effect that ``_inject_storage`` would
     otherwise provide is irrelevant; the fixture is intentionally

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -152,6 +152,7 @@ from turnstone.api.server_schemas import (
     CommandRequest,
     DequeueRequest,
     ListAttachmentsResponse,
+    ListSavedWorkstreamsResponse,
     ListSkillSummaryResponse,
     ListWorkstreamsResponse,
     RewindRequest,
@@ -1379,13 +1380,27 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "Get coordinator detail (rehydrates lazily on miss)",
         description=(
             "Returns the persisted coordinator's display fields.  If the "
-            "session isn't currently in memory the manager rehydrates it "
+            "session isn't currently in memory, write scope is additionally "
+            "required before the manager rehydrates it "
             "before responding; ``500`` on rehydrate failure carries a "
             "correlation id matching the server log line."
         ),
         response_model=WorkstreamDetailResponse,
         error_codes=[400, 403, 404, 500, 503],
         tags=["Coordinator"],
+    ),
+    EndpointSpec(
+        "/v1/api/workstreams/saved",
+        "GET",
+        "List saved sessions visible to the caller",
+        description=(
+            "Requires read scope. Interactive rows use creator/project visibility; "
+            "coordinator rows additionally require admin.coordinator. A caller without "
+            "that permission receives only interactive rows."
+        ),
+        response_model=ListSavedWorkstreamsResponse,
+        error_codes=[503],
+        tags=["Workstreams"],
     ),
     EndpointSpec(
         "/v1/api/workstreams/{ws_id}/open",

--- a/turnstone/api/schemas.py
+++ b/turnstone/api/schemas.py
@@ -174,6 +174,7 @@ class AuthWhoamiResponse(BaseModel):
 
     user_id: str
     permissions: str = ""
+    scopes: str = Field(default="", description="Comma-separated effective transport scopes")
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -286,14 +286,15 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "Get workstream detail (rehydrates lazily on miss)",
         description=(
             "Returns the persisted workstream's display fields. If the "
-            "session isn't currently in memory the manager rehydrates it "
+            "session isn't currently in memory, write scope is additionally "
+            "required before the manager rehydrates it "
             "before responding; ``500`` on rehydrate failure carries a "
             "correlation id matching the server log line. Lifted from "
             "the coord-only surface in the Stage 2 history/detail verb "
             "lift — interactive previously had no detail endpoint."
         ),
         response_model=WorkstreamDetailResponse,
-        error_codes=[400, 404, 500, 503],
+        error_codes=[400, 403, 404, 500, 503],
         tags=["Workstreams"],
     ),
     EndpointSpec(
@@ -412,7 +413,9 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "/v1/api/workstreams/saved",
         "GET",
         "List saved workstreams",
+        description="Lists interactive history visible through creator/project access; requires read scope.",
         response_model=ListSavedWorkstreamsResponse,
+        error_codes=[503],
         tags=["Workstreams"],
     ),
     # --- Skills ---

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -16408,8 +16408,8 @@ def create_app(
     # (manager_lookup / tenant_check / labels) are required by the
     # dataclass but never consulted on the read-only saved path — the
     # console mounts no interactive verb handlers, only the merged saved
-    # list. ``permission_gate=None`` because the unified handler gates
-    # once with the operator's ``admin.coordinator`` check.
+    # list. Interactive discovery needs read scope and project visibility;
+    # coordinator admission retains its own named permission gate.
     interactive_saved_cfg = SessionEndpointConfig(
         permission_gate=None,
         manager_lookup=lambda request: (None, None),
@@ -16427,14 +16427,10 @@ def create_app(
         handlers=SharedSessionVerbHandlers(
             list_workstreams=make_list_handler(coord_endpoint_config),  # lifted: shared body
             # Unified saved list: coordinator + interactive in one
-            # response for the L-shell dashboard. Gated once by coord's
-            # existing operator check (``admin.coordinator``) — the
-            # operator already sees every kind, so the merge exposes
-            # nothing new. Each cfg keeps its own per-kind state filter
-            # / warm-pool exclusion.
+            # response for the L-shell dashboard. Each kind retains its
+            # permission, state filter, and warm-pool exclusion.
             list_saved=make_unified_saved_handler(
                 [coord_endpoint_config, interactive_saved_cfg],
-                permission_gate=coord_endpoint_config.permission_gate,
             ),
             create=make_create_handler(  # lifted: shared body
                 coord_endpoint_config,

--- a/turnstone/console/static/app.js
+++ b/turnstone/console/static/app.js
@@ -2359,13 +2359,8 @@ document.addEventListener("keydown", function (e) {
 });
 
 // ---------------------------------------------------------------------------
-// Saved coordinators — closed sessions persisted on disk.  Mirrors the
-// interactive UI's "Saved Workstreams" table (same /shared/cards.js
-// createSavedTable + /shared/cards.css, same response item shape from
-// /v1/api/workstreams/saved), differing only in the CHILDREN column and
-// the body-keyed delete.  Click a row → POST /open then
-// /coordinator/{ws_id}; the lifted detail factory lazily rehydrates from
-// storage on the GET miss.
+// Saved sessions share the standalone table substrate. The server admits
+// each kind independently; activation follows the returned kind and node.
 // ---------------------------------------------------------------------------
 
 // In-flight de-dup for loadSavedCoordinators.  ws_closed events can
@@ -2377,11 +2372,7 @@ let _savedCoordsInFlight = false;
 let _savedCoordsRetry = false;
 
 function loadSavedCoordinators() {
-  // Saved sessions is an operator surface (admin.coordinator) — the unified
-  // list spans BOTH kinds for operators (who already have cluster-wide reach).
-  // Interactive-only users use the launcher, not this list, so the gate stays
-  // admin.coordinator (matching the server gate; a looser gate here would 403).
-  if (!_hasCoordPermission()) return;
+  if (!hasScope("read") || !_coordTable) return;
   // Freeze the list while the user is multi-selecting — re-rendering
   // mid-mode would shuffle the visible page out from under them.  The
   // delete-mode wrapper drains the retry flag on cancel/onClose.
@@ -2394,11 +2385,15 @@ function loadSavedCoordinators() {
     return;
   }
   _savedCoordsInFlight = true;
+  const generation = authGeneration();
   authFetch("/v1/api/workstreams/saved")
     .then(function (r) {
-      return r.ok ? r.json() : { workstreams: [] };
+      if (!r.ok)
+        throw new Error("Could not load saved sessions (" + r.status + ").");
+      return r.json();
     })
     .then(function (data) {
+      if (generation !== authGeneration()) return;
       // Belt-and-braces: if the user entered delete mode while this
       // fetch was already in flight, defer the render — re-rendering
       // mid-selection would shuffle visible cards and reshape selections.
@@ -2407,14 +2402,20 @@ function loadSavedCoordinators() {
         return;
       }
       const saved = data.workstreams || [];
+      _setSavedError("");
       const sec = document.getElementById("saved-coordinators");
       if (sec) sec.style.display = saved.length ? "" : "none";
       _coordTable.setItems(saved);
     })
-    .catch(function () {
-      /* silent — saved list is informational, not load-bearing */
+    .catch(function (error) {
+      if (generation !== authGeneration()) return;
+      _coordTable.setItems([]);
+      _setSavedError(error.message || "Could not load saved sessions.");
+      const sec = document.getElementById("saved-coordinators");
+      if (sec) sec.style.display = "";
     })
     .finally(function () {
+      if (generation !== authGeneration()) return;
       _savedCoordsInFlight = false;
       // If at least one call arrived while we were in flight, fire one
       // catch-up fetch (not N) so the UI reflects the latest state
@@ -2424,6 +2425,38 @@ function loadSavedCoordinators() {
         loadSavedCoordinators();
       }
     });
+}
+
+function _setSavedError(message) {
+  const error = document.getElementById("coord-saved-error");
+  if (error) error.hidden = !message;
+  const text = document.getElementById("coord-saved-error-text");
+  if (text) text.textContent = message;
+  ["saved-coord-cards", "coord-saved-footer"].forEach(function (id) {
+    const element = document.getElementById(id);
+    if (element) element.style.display = message ? "none" : "";
+  });
+}
+
+function _savedAuthChanged() {
+  _savedCoordsInFlight = _savedCoordsRetry = false;
+  _setSavedError("");
+  if (_coordTable) _coordTable.reset();
+  const sec = document.getElementById("saved-coordinators");
+  if (sec) sec.style.display = "none";
+  if (typeof _refreshHomeComposerVisibility === "function") {
+    _refreshHomeComposerVisibility();
+  }
+  loadSavedCoordinators();
+}
+
+function _canActOnSavedSession(session) {
+  return (
+    hasScope("write") &&
+    (session.kind !== "coordinator" ||
+      hasScope("service") ||
+      _hasCoordPermission())
+  );
 }
 
 // Saved Coordinators table — same shared createSavedTable as the server UI
@@ -2470,6 +2503,8 @@ function _initSavedCoordTable() {
     columns: COORD_COLUMNS,
     noun: "session",
     emptyText: "No saved sessions",
+    canActivate: _canActOnSavedSession,
+    canDelete: _canActOnSavedSession,
     activateLabel: function (s) {
       return (
         "Resume " +
@@ -2946,4 +2981,5 @@ window.TS_APP.boot = function () {
     _refreshHomeComposerVisibility();
     loadSavedCoordinators();
   });
+  onAuthChange(_savedAuthChanged);
 };

--- a/turnstone/console/static/index.html
+++ b/turnstone/console/static/index.html
@@ -201,18 +201,29 @@
                 class="saved-filter"
                 type="search"
                 placeholder="Filter by name&#x2026;"
-                aria-label="Filter saved coordinators"
+                aria-label="Filter saved sessions"
                 autocomplete="off"
               />
               <button
                 id="coord-delete-btn"
                 class="ws-delete-btn"
                 onclick="startCoordDeleteMode()"
-                title="Delete coordinators"
+                title="Delete saved sessions"
               >
                 <span aria-hidden="true">&#x1f5d1;</span> Delete
               </button>
             </div>
+          </div>
+          <div
+            id="coord-saved-error"
+            class="dashboard-empty"
+            role="alert"
+            hidden
+          >
+            <span id="coord-saved-error-text"></span>
+            <button class="sh-btn" onclick="loadSavedCoordinators()">
+              Retry
+            </button>
           </div>
           <div class="dash-colheaders" id="coord-saved-colheaders"></div>
           <div
@@ -4176,7 +4187,8 @@
     <script type="module" src="/shared/utils.js"></script>
     <script type="module" src="/shared/cards.js"></script>
     <script type="module" src="/shared/toast.js"></script>
-    <script type="module" src="/shared/auth.js"></script>
+    <!-- cards/shell import auth.js. A separate versioned script URL would
+         create a second auth instance with independent login state. -->
     <script type="module" src="/shared/hatch.js"></script>
     <script type="module" src="/shared/kb.js"></script>
     <script type="module" src="/shared/projects.js"></script>
@@ -4332,7 +4344,7 @@
     >
       <header class="sh-head">
         <span class="sh-led" aria-hidden="true"></span>
-        <h2 class="sh-title" id="coord-delete-title">Delete coordinators</h2>
+        <h2 class="sh-title" id="coord-delete-title">Delete saved sessions</h2>
         <button class="sh-x" data-close aria-label="Close">✕</button>
       </header>
       <div class="sh-body">

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -1940,6 +1940,7 @@ async def handle_auth_whoami(request: Request, cookie_name: str) -> Response:
 
     resp: dict[str, Any] = {
         "user_id": auth_result.user_id,
+        "scopes": ",".join(sorted(auth_result.scopes)),
     }
     # Surface the human username / display name for the UI — ``user_id`` is an
     # opaque uuid, not something to show in the footer.  Best-effort: a storage

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -3750,6 +3750,10 @@ def make_list_handler(cfg: SessionEndpointConfig) -> Handler:
     return list_workstreams_handler
 
 
+class _SavedQueryError(RuntimeError):
+    """The saved-list query failed, rather than returning an empty list."""
+
+
 async def _collect_saved_rows(
     cfg: SessionEndpointConfig,
     request: Request,
@@ -3765,16 +3769,18 @@ async def _collect_saved_rows(
 
     Caller-owned (NOT done here): ``cfg.permission_gate`` and the
     ``cfg.list_kind is None`` misconfig guard — both belong to the
-    handler wrapper so the unified handler can gate once and 500 per
-    cfg before fanning out. ``cfg.list_kind`` is therefore assumed
+    handler wrapper so the unified handler can admit kinds before
+    fanning out. ``cfg.list_kind`` is therefore assumed
     non-``None`` on entry.
     """
     import asyncio
 
     from turnstone.core.auth import WorkstreamProjectVisibility
-    from turnstone.core.memory import list_workstreams_with_history
 
-    visibility = WorkstreamProjectVisibility.for_request(request)
+    storage = getattr(request.app.state, "auth_storage", None)
+    if storage is None:
+        raise _SavedQueryError("Storage unavailable")
+    visibility = WorkstreamProjectVisibility.for_request(request, storage=storage)
 
     def _fetch_visible_rows() -> list[Any]:
         """Page through storage until 50 visible rows (or exhaustion).
@@ -3793,7 +3799,7 @@ async def _collect_saved_rows(
         page = 50
         max_pages = 20
         for _ in range(max_pages):
-            batch = list_workstreams_with_history(
+            batch = storage.list_workstreams_with_history(
                 limit=page,
                 kind=cfg.list_kind,
                 user_id=None,
@@ -3818,7 +3824,11 @@ async def _collect_saved_rows(
         )
         return visible
 
-    rows = await asyncio.to_thread(_fetch_visible_rows)
+    try:
+        rows = await asyncio.to_thread(_fetch_visible_rows)
+    except Exception as exc:
+        log.warning("ws.saved.query_failed kind=%s", cfg.list_kind, exc_info=True)
+        raise _SavedQueryError("Saved sessions unavailable") from exc
 
     # Coord-only: exclude ws_ids currently in the warm pool.
     loaded: set[str] = set()
@@ -3917,8 +3927,8 @@ def make_saved_handler(cfg: SessionEndpointConfig) -> Handler:
       kind classifier.
     - ``cfg.saved_state_filter`` — coord wires ``"closed"`` so only
       explicitly-closed coordinators surface; interactive wires
-      ``None`` (any state except the tombstoned ``deleted`` rows the
-      storage layer already filters).
+      ``None`` (all persisted states except provisional ``creating``;
+      interactive deletion removes the row).
     - ``cfg.saved_loaded_lookup`` — coord-only defence-in-depth
       filter that excludes ws_ids currently in the in-memory pool
       (a row can be ``state='closed'`` briefly while the close-emit
@@ -3966,7 +3976,10 @@ def make_saved_handler(cfg: SessionEndpointConfig) -> Handler:
                 status_code=500,
             )
 
-        result = await _collect_saved_rows(cfg, request)
+        try:
+            result = await _collect_saved_rows(cfg, request)
+        except _SavedQueryError:
+            return JSONResponse({"error": "Saved sessions unavailable"}, status_code=503)
         return JSONResponse({"workstreams": result})
 
     return saved_workstreams_handler
@@ -4005,16 +4018,14 @@ def make_unified_saved_handler(
     so this fans :func:`_collect_saved_rows` over each ``cfg`` (preserving
     every kind's own ``list_kind`` / ``saved_state_filter`` /
     ``saved_loaded_lookup`` semantics — coord keeps its ``state='closed'``
-    + warm-pool exclusion, interactive keeps its all-non-deleted listing),
+    + warm-pool exclusion, interactive keeps its persisted non-creating rows),
     concatenates the rows, and re-sorts the union by ``updated`` descending
     (``updated``-less rows last).
 
-    Permission: a SINGLE ``permission_gate`` runs once up front (the
-    operator gate the console already applies to its coordinator saved
-    list). Per-``cfg`` ``permission_gate`` values are deliberately NOT
-    consulted here — the union is operator-gated as a whole, and the
-    operator already has cluster-wide visibility into every kind, so the
-    merge exposes nothing the per-kind lists didn't.
+    The optional outer gate applies to the whole list. Each kind's own
+    permission gate then controls its admission: a 403 omits that kind
+    before querying storage; authentication and other errors propagate.
+    Admitted rows retain their project visibility checks.
 
     Each ``cfg`` must wire ``list_kind`` (a missing value is a mount-time
     misconfiguration); the handler 500s loud rather than silently
@@ -4044,11 +4055,23 @@ def make_unified_saved_handler(
                     status_code=500,
                 )
 
+        admitted = []
+        for cfg in cfgs:
+            err = cfg.permission_gate(request) if cfg.permission_gate else None
+            if err is not None:
+                if err.status_code == 403:
+                    continue
+                return err
+            admitted.append(cfg)
+
         # The per-kind collections are independent (shared store, no data
         # dependency), so overlap their DB round-trips instead of summing them.
         import asyncio
 
-        parts = await asyncio.gather(*(_collect_saved_rows(cfg, request) for cfg in cfgs))
+        try:
+            parts = await asyncio.gather(*(_collect_saved_rows(cfg, request) for cfg in admitted))
+        except _SavedQueryError:
+            return JSONResponse({"error": "Saved sessions unavailable"}, status_code=503)
         merged: list[dict[str, Any]] = []
         for part in parts:
             merged.extend(part)
@@ -4869,11 +4892,10 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
     correlation-id'd 500 with the per-kind noun in the user-facing
     message.
 
-    Cross-kind isolation is enforced inside ``mgr.open()`` itself —
-    it returns ``None`` for missing rows, kind mismatches, and
-    tombstoned rows; all surface as 404 with ``cfg.not_found_label``.
-    No inline storage check needed (unlike :func:`make_history_handler`)
-    because rehydrate is the existence proof.
+    Loaded metadata needs only read scope. Cold rehydration also requires
+    write scope, just like POST /open. For a reader, a storage check
+    preserves missing/wrong-kind/tombstone 404s before denying rehydration.
+    Writers retain the manager's existence and kind checks.
 
     Per-kind divergence:
 
@@ -4908,17 +4930,8 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
         if not ws_id:
             return JSONResponse({"error": "ws_id is required"}, status_code=400)
 
-        # Cross-tenant gate.  PR 447 added the inline approval payload
-        # (now ``pending_approval_details``) to the response (tool
-        # previews, function arguments, LLM judge reasoning) — a
-        # richer payload than the pre-PR
-        # ``{ws_id, name, state, user_id, kind}`` tuple.  Coord wires
-        # ``tenant_check=None`` (the cluster-wide ``admin.coordinator``
-        # permission_gate covers it); interactive wires
-        # ``_interactive_tenant_check`` so any authenticated user that
-        # GETs another user's ``ws_id`` 404s here instead of reading
-        # the in-flight tool-call payload.  Brings detail in line with
-        # every other lifted session verb.
+        # Both kinds authorize project access before exposing metadata
+        # or the inline pending-approval payload.
         if cfg.tenant_check is not None:
             err_tenant = await asyncio.to_thread(cfg.tenant_check, request, ws_id, mgr)
             if err_tenant is not None:
@@ -4926,6 +4939,27 @@ def make_detail_handler(cfg: SessionEndpointConfig) -> Handler:
 
         ws = mgr.get(ws_id)
         if ws is None:
+            auth = getattr(request.state, "auth_result", None)
+            if auth is None:
+                return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            if not auth.has_scope("write"):
+                storage = getattr(request.app.state, "auth_storage", None)
+                if storage is None or cfg.list_kind is None:
+                    return JSONResponse({"error": "Storage unavailable"}, status_code=503)
+                try:
+                    row = await asyncio.to_thread(storage.get_workstream, ws_id)
+                except Exception:
+                    log.warning("ws.detail.lookup_failed ws=%s", ws_id[:8], exc_info=True)
+                    return JSONResponse({"error": "Storage unavailable"}, status_code=503)
+                if (
+                    row is None
+                    or row.get("kind") != cfg.list_kind
+                    or row.get("state") in {"creating", "deleted"}
+                ):
+                    return JSONResponse({"error": cfg.not_found_label}, status_code=404)
+                return JSONResponse(
+                    {"error": "Reopening a saved session requires write scope"}, status_code=403
+                )
             try:
                 ws = mgr.open(ws_id)
             except NodeAffinityError as exc:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -3257,6 +3257,7 @@ def _audit_workstream_created(
 async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     """POST /v1/api/workstreams/{ws_id}/delete — permanently delete a saved workstream."""
     from turnstone.core.audit import record_audit
+    from turnstone.core.auth import require_permission
     from turnstone.core.log import get_logger
     from turnstone.core.storage._registry import get_storage
 
@@ -3282,6 +3283,14 @@ async def delete_workstream_endpoint(request: Request) -> JSONResponse:
     owner_uid, err = _require_ws_access(request, ws_id, resolved_row=row)
     if err:
         return err
+    # Authorize kind from the same snapshot that fences the deletion.
+    # Both saved tables route here, including coordinator deletions.
+    if row.get("kind") == WorkstreamKind.COORDINATOR:
+        err = require_permission(request, "admin.coordinator")
+        if err is not None:
+            return err
+    elif row.get("kind") != WorkstreamKind.INTERACTIVE:
+        return JSONResponse({"error": "Unsupported workstream kind"}, status_code=403)
     kind: str = ""
     parent_ws_id: str | None = None
     name: str = ""

--- a/turnstone/shared_static/auth.js
+++ b/turnstone/shared_static/auth.js
@@ -66,32 +66,9 @@ export async function authFetch(url, opts) {
     const r = await fetch(url, opts);
     if (epoch !== _authEpoch) throw new Error("auth changed");
     if (r.status === 401) {
-      try {
-        const body = await r.clone().json();
-        if (epoch !== _authEpoch) throw new Error("auth changed");
-        if (body && body.code === "version_mismatch") {
-          _authUpgradeReload = true;
-          showLogin("upgrade");
-          throw new Error("auth");
-        }
-      } catch (e) {
-        if (e.message === "auth" || e.message === "auth changed") throw e;
-      }
-      // Reactive refresh — try once before falling through to login.
-      // Covers cases where the proactive refresh timer didn't fire
-      // (tab restored from disk-cache after expiry, system clock jump,
-      // page first-load with a stale cookie).
-      const generation = authGeneration();
-      if (attempt === 0 && (await _tryRefresh())) {
-        epoch = _authEpoch;
-        continue; // retry the original request with the new cookie
-      }
-      // A concurrent whoami may supersede refresh for the same identity.
-      // Its newly confirmed authority must survive this older request.
-      if (epoch !== _authEpoch || generation !== authGeneration())
-        throw new Error("auth changed");
-      showLogin();
-      throw new Error("auth");
+      await _recoverUnauthorized(r, () => epoch === _authEpoch, attempt === 0);
+      epoch = _authEpoch;
+      continue; // retry the original request with the new cookie
     }
     if (r.status === 429 && attempt < maxRetries) {
       const retryAfter = parseInt(r.headers.get("Retry-After") || "1", 10);
@@ -107,6 +84,33 @@ export async function authFetch(url, opts) {
     if (typeof _ensureSSE === "function") _ensureSSE();
     return r;
   }
+}
+
+// Both API requests and whoami must recover a rejected cookie. Clearing cached
+// identity first would invalidate the API requests that otherwise open login.
+async function _recoverUnauthorized(r, isCurrent, allowRefresh = true) {
+  if (!isCurrent()) throw new Error("auth changed");
+  try {
+    const body = await r.clone().json();
+    if (!isCurrent()) throw new Error("auth changed");
+    if (body && body.code === "version_mismatch") {
+      _authUpgradeReload = true;
+      showLogin("upgrade");
+      throw new Error("auth");
+    }
+  } catch (e) {
+    if (e.message === "auth" || e.message === "auth changed") throw e;
+  }
+  if (!isCurrent()) throw new Error("auth changed");
+  // Reactive refresh covers expired cookies when the proactive timer missed.
+  const generation = authGeneration();
+  if (allowRefresh && (await _tryRefresh())) return;
+  // A concurrent whoami may supersede refresh for the same identity.
+  // Its newly confirmed authority must survive this older request.
+  if (!isCurrent() || generation !== authGeneration())
+    throw new Error("auth changed");
+  showLogin();
+  throw new Error("auth");
 }
 
 // ---------------------------------------------------------------------------
@@ -326,9 +330,8 @@ function _scheduleRefreshAt(epochSeconds) {
 }
 
 function _scheduleRefreshFromWhoami() {
-  // Best-effort — failure here just means no proactive refresh; the
-  // reactive on-401 path still works.  Uses fetch (not authFetch) to
-  // avoid recursion through the on-401 trap.
+  // Network failure just means no proactive refresh. A confirmed 401 uses
+  // the same recovery as authFetch, so startup never depends on response order.
   //
   // Also rehydrates sessionStorage permissions when the cookie outlives
   // the tab session: an existing valid cookie means the user is still
@@ -366,20 +369,25 @@ function _scheduleRefreshFromWhoami() {
     typeof AbortController !== "undefined" ? new AbortController() : null;
   const sequence = ++_whoamiSequence;
   const generation = authGeneration();
+  const isCurrent = () =>
+    !_loggedOut &&
+    generation === authGeneration() &&
+    sequence === _whoamiSequence;
   _whoamiAbort = ctrl;
   fetch("/v1/api/auth/whoami", {
     credentials: "same-origin",
     signal: ctrl ? ctrl.signal : undefined,
   })
-    .then(function (r) {
-      return r.ok ? r.json() : null;
-    })
-    .then(function (data) {
-      if (_loggedOut || generation !== authGeneration()) return;
-      // Bail if a newer call has superseded us — its eventual effects
-      // are the authoritative ones; ours would only clobber.
-      if (sequence !== _whoamiSequence) return;
-      // Treat a non-OK whoami (data === null) as an explicit clear.
+    .then(async function (r) {
+      if (!isCurrent()) return;
+      if (r.status === 401) {
+        await _recoverUnauthorized(r, isCurrent);
+        return; // Refresh owns authority storage, including unchanged identity.
+      }
+      const data = r.ok ? await r.json() : null;
+      // A newer call's effects are authoritative, even if the identity is equal.
+      if (!isCurrent()) return;
+      // Treat another non-OK whoami (data === null) as an explicit clear.
       // _storePermissions(null) removes the key so stale UI gating
       // disappears when the server-side identity is gone (user
       // deleted, role stripped, token revoked between tab close and
@@ -443,6 +451,9 @@ export function initLogin() {
       .catch(function () {
         _onSuccess(); // Proceed even if permissions fetch fails
       });
+  } else if (_loggedOut) {
+    // Authentication can fail before the shell mounts this overlay.
+    showLogin(_authUpgradeReload ? "upgrade" : undefined);
   }
 }
 
@@ -916,10 +927,8 @@ export function logout() {
   });
 }
 
-// Schedule on initial load if already authenticated.  The whoami
-// request silently fails if the cookie is missing or expired, which
-// is the right behaviour — the first authFetch will trigger the
-// login overlay via the existing on-401 path.
+// Rehydrate authority and schedule refresh on initial load. A missing or expired
+// cookie uses the shared recovery path, even if whoami precedes all API responses.
 if (typeof window !== "undefined") {
   _scheduleRefreshFromWhoami();
 }

--- a/turnstone/shared_static/auth.js
+++ b/turnstone/shared_static/auth.js
@@ -33,6 +33,8 @@ const _authChannel =
 if (_authChannel) {
   _authChannel.onmessage = function (e) {
     if (e.data === "login") {
+      _invalidateAuth();
+      _loggedOut = false;
       hideLogin();
       if (typeof window.onLoginSuccess === "function") window.onLoginSuccess();
       _scheduleRefreshFromWhoami();
@@ -58,26 +60,36 @@ export function noteVersionMismatch() {
 
 export async function authFetch(url, opts) {
   const maxRetries = 2;
+  let epoch = _authEpoch;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (epoch !== _authEpoch) throw new Error("auth changed");
     const r = await fetch(url, opts);
+    if (epoch !== _authEpoch) throw new Error("auth changed");
     if (r.status === 401) {
       try {
         const body = await r.clone().json();
+        if (epoch !== _authEpoch) throw new Error("auth changed");
         if (body && body.code === "version_mismatch") {
           _authUpgradeReload = true;
           showLogin("upgrade");
           throw new Error("auth");
         }
       } catch (e) {
-        if (e.message === "auth") throw e;
+        if (e.message === "auth" || e.message === "auth changed") throw e;
       }
       // Reactive refresh — try once before falling through to login.
       // Covers cases where the proactive refresh timer didn't fire
       // (tab restored from disk-cache after expiry, system clock jump,
       // page first-load with a stale cookie).
+      const generation = authGeneration();
       if (attempt === 0 && (await _tryRefresh())) {
+        epoch = _authEpoch;
         continue; // retry the original request with the new cookie
       }
+      // A concurrent whoami may supersede refresh for the same identity.
+      // Its newly confirmed authority must survive this older request.
+      if (epoch !== _authEpoch || generation !== authGeneration())
+        throw new Error("auth changed");
       showLogin();
       throw new Error("auth");
     }
@@ -122,6 +134,48 @@ let _refreshInFlight = null;
 let _loggedOut = false;
 let _refreshAbort = null;
 let _whoamiAbort = null;
+let _refreshSequence = 0;
+let _whoamiSequence = 0;
+let _authGeneration = 0;
+let _authEpoch = 0;
+const _authSubscribers = new Set();
+
+/** Version of the browser's current identity and effective authority. */
+export function authGeneration() {
+  return _authGeneration;
+}
+
+/** Subscribe to identity, permission, scope, or authentication-loss changes. */
+export function onAuthChange(callback) {
+  _authSubscribers.add(callback);
+}
+
+function _publishAuthChange() {
+  _authGeneration++;
+  _authSubscribers.forEach(function (callback) {
+    try {
+      callback();
+    } catch (error) {
+      console.warn("Auth state listener failed", error);
+    }
+  });
+}
+
+function _invalidateAuth() {
+  _authEpoch++;
+  _loggedOut = true;
+  _cancelRefreshTimer();
+  _refreshSequence++;
+  _whoamiSequence++;
+  [_refreshAbort, _whoamiAbort].forEach(function (ctrl) {
+    if (ctrl) ctrl.abort();
+  });
+  _refreshInFlight = _refreshAbort = _whoamiAbort = null;
+  const generation = authGeneration();
+  _storePermissions(null);
+  if (generation === authGeneration()) _publishAuthChange();
+  if (typeof window.onLogout === "function") window.onLogout();
+}
 
 // Permissions-ready: one-shot promise resolved after the initial whoami
 // completes (success OR failure).  Lets permission-gated UI await the
@@ -144,7 +198,7 @@ if (typeof window !== "undefined") {
   window.permissionsReady = _permissionsReady;
 }
 
-// Generic scope check over the permission list this module itself populates
+// Exact named-permission check over the list this module itself populates
 // (sessionStorage "turnstone_permissions", comma-separated).  Absent means
 // DENIED: the key is also absent for a principal holding zero permissions,
 // so granting on absent would hand a control to exactly the caller who
@@ -154,6 +208,13 @@ if (typeof window !== "undefined") {
 export function hasPermission(scope) {
   const perms = sessionStorage.getItem("turnstone_permissions") || "";
   return perms.split(",").indexOf(scope) !== -1;
+}
+
+/** Effective transport scopes supplied by the server, separate from RBAC names. */
+export function hasScope(scope) {
+  return (sessionStorage.getItem("turnstone_scopes") || "")
+    .split(",")
+    .includes(scope);
 }
 
 // Run cb once the initial whoami has settled: via window.permissionsReady
@@ -188,6 +249,8 @@ async function _tryRefresh() {
   }
   _refreshAbort =
     typeof AbortController !== "undefined" ? new AbortController() : null;
+  const sequence = ++_refreshSequence;
+  const generation = authGeneration();
   _refreshInFlight = (async function () {
     try {
       const r = await fetch("/v1/api/auth/refresh", {
@@ -208,7 +271,7 @@ async function _tryRefresh() {
       // reschedule a timer, don't broadcast (would re-arm sibling tabs).
       // The new cookie is harmless — logout's clear-cookie response
       // already overwrote it on the way back from this fetch.
-      if (_loggedOut) return false;
+      if (_loggedOut || generation !== authGeneration()) return false;
       // Consume the refresh response inline.  /refresh returns the same
       // permissions + exp shape as /whoami (auth.py:handle_auth_refresh),
       // so we can populate sessionStorage and reschedule the next refresh
@@ -234,8 +297,10 @@ async function _tryRefresh() {
     } catch (_e) {
       return false;
     } finally {
-      _refreshInFlight = null;
-      _refreshAbort = null;
+      if (sequence === _refreshSequence) {
+        _refreshInFlight = null;
+        _refreshAbort = null;
+      }
     }
   })();
   return await _refreshInFlight;
@@ -287,18 +352,20 @@ function _scheduleRefreshFromWhoami() {
   // clobber the newer one's effects (clearing permissions right after a
   // successful login, or rescheduling off a stale exp).  We abort the
   // prior in-flight whoami before starting a new one AND guard the
-  // post-fetch effects with `_whoamiAbort === ctrl` so a late arrival
+  // post-fetch effects with a request sequence so a late arrival
   // from a superseded call is fully neutralised.
   const prior = _whoamiAbort;
   if (prior) {
     try {
       prior.abort();
     } catch (_e) {
-      /* AbortController not available; the equality check below covers it */
+      /* The sequence check below also covers superseded calls. */
     }
   }
   const ctrl =
     typeof AbortController !== "undefined" ? new AbortController() : null;
+  const sequence = ++_whoamiSequence;
+  const generation = authGeneration();
   _whoamiAbort = ctrl;
   fetch("/v1/api/auth/whoami", {
     credentials: "same-origin",
@@ -308,10 +375,10 @@ function _scheduleRefreshFromWhoami() {
       return r.ok ? r.json() : null;
     })
     .then(function (data) {
-      if (_loggedOut) return;
+      if (_loggedOut || generation !== authGeneration()) return;
       // Bail if a newer call has superseded us — its eventual effects
       // are the authoritative ones; ours would only clobber.
-      if (_whoamiAbort !== ctrl) return;
+      if (sequence !== _whoamiSequence) return;
       // Treat a non-OK whoami (data === null) as an explicit clear.
       // _storePermissions(null) removes the key so stale UI gating
       // disappears when the server-side identity is gone (user
@@ -330,7 +397,7 @@ function _scheduleRefreshFromWhoami() {
     })
     .finally(function () {
       // Only clear if still ours — a newer call may have replaced it.
-      if (_whoamiAbort === ctrl) _whoamiAbort = null;
+      if (sequence === _whoamiSequence) _whoamiAbort = null;
       _markPermissionsReady();
     });
 }
@@ -535,6 +602,7 @@ function _showError(msg) {
 }
 
 export function showLogin(reason, oidcError) {
+  _invalidateAuth();
   const overlay = document.getElementById("login-overlay");
   if (!overlay) return;
   overlay.style.display = "flex";
@@ -758,10 +826,22 @@ function _submitSetup() {
 }
 
 function _storePermissions(data) {
+  const before = [
+    "ts.user_id",
+    "turnstone_permissions",
+    "turnstone_scopes",
+  ].map(function (key) {
+    return sessionStorage.getItem(key);
+  });
   if (data && data.permissions) {
     sessionStorage.setItem("turnstone_permissions", data.permissions);
   } else {
     sessionStorage.removeItem("turnstone_permissions");
+  }
+  if (data && data.scopes) {
+    sessionStorage.setItem("turnstone_scopes", data.scopes);
+  } else {
+    sessionStorage.removeItem("turnstone_scopes");
   }
   // Surface the authenticated identity for the rail footer's user chip.  whoami
   // returns the human `username` (display name) alongside the opaque user_id;
@@ -782,6 +862,13 @@ function _storePermissions(data) {
   } else {
     sessionStorage.removeItem("ts.user_id");
   }
+  const after = ["ts.user_id", "turnstone_permissions", "turnstone_scopes"].map(
+    function (key) {
+      return sessionStorage.getItem(key);
+    },
+  );
+  if (before[0] && before[0] !== after[0]) _authEpoch++;
+  if (JSON.stringify(before) !== JSON.stringify(after)) _publishAuthChange();
 }
 
 function _setBusy(busy, label) {
@@ -820,25 +907,11 @@ function _onSuccess() {
 }
 
 export function logout() {
-  // Set flag + abort in-flight fetches BEFORE the network call so any
-  // concurrent _tryRefresh() / _scheduleRefreshFromWhoami() bails its
-  // post-fetch effects (see _loggedOut handling above).  Without this,
-  // a refresh or whoami already in flight can land after /logout and
-  // re-set the cookie or re-populate sessionStorage permissions.
-  _loggedOut = true;
-  _cancelRefreshTimer();
-  [_refreshAbort, _whoamiAbort].forEach(function (ctrl) {
-    if (!ctrl) return;
-    try {
-      ctrl.abort();
-    } catch (_e) {
-      /* AbortController not available; the _loggedOut flag handles it */
-    }
-  });
+  _invalidateAuth();
+  const generation = authGeneration();
   fetch("/v1/api/auth/logout", { method: "POST" }).then(function () {
-    sessionStorage.removeItem("turnstone_permissions");
+    if (generation !== authGeneration()) return;
     if (_authChannel) _authChannel.postMessage("logout");
-    if (typeof window.onLogout === "function") window.onLogout();
     showLogin();
   });
 }
@@ -862,5 +935,8 @@ Object.assign(window, {
   initLogin,
   noteVersionMismatch,
   hasPermission,
+  hasScope,
+  authGeneration,
+  onAuthChange,
   whenPermissionsReady,
 });

--- a/turnstone/shared_static/cards.css
+++ b/turnstone/shared_static/cards.css
@@ -289,13 +289,12 @@
    near-zero --row-alt vanishes on a long list) and full-opacity muted text
    (AA-legible colours, no opacity hacks).  Idle-dimming is avoided at the
    source — renderSessionRow only sets data-state for `error`. */
-/* Saved rows are always interactive — resume on click, or toggle a checkbox
-   in delete mode — so they own the pointer cursor here rather than relying on
-   each app's `.dash-row` convention.  The server sets `cursor: pointer` on
-   every `.dash-row`; the console scopes it to `.dash-row.has-link` (a class
-   the shared row builder doesn't set), so without this the console's saved
-   rows fell back to the base `cursor: default`. */
+/* Metadata remains readable when the caller cannot resume or delete. */
 .saved-row {
+  cursor: default;
+}
+.saved-row[role="button"],
+.saved-row.ws-delete-mode {
   cursor: pointer;
 }
 .saved-row .dash-row-main {

--- a/turnstone/shared_static/cards.js
+++ b/turnstone/shared_static/cards.js
@@ -138,7 +138,9 @@ export var SavedColumns = {
       width: "120px",
       hideBelow: true,
       cell: function (s) {
-        return _projectName(s.project_id) || "—";
+        return (
+          _projectName(s.project_id) || (s.project_id ? "Unavailable" : "—")
+        );
       },
       sort: function (s) {
         return (_projectName(s.project_id) || "").toLowerCase();
@@ -234,13 +236,16 @@ export function renderSessionRow(sess, opts) {
   row.className = "dash-row saved-row" + (opts.busy ? " is-busy" : "");
   row.dataset.wsId = sess.ws_id;
   if (sess.state === "error") row.dataset.state = "error";
-  row.setAttribute("role", "button");
-  row.setAttribute("tabindex", "0");
+  var canActivate = opts.canActivate !== false;
+  row.setAttribute("role", canActivate ? "button" : "group");
+  if (canActivate) row.setAttribute("tabindex", "0");
   row.setAttribute(
     "aria-label",
-    typeof opts.ariaLabel === "function"
-      ? opts.ariaLabel(sess)
-      : "Resume: " + (sess.alias || sess.title || sess.name || sess.ws_id),
+    !canActivate
+      ? sess.alias || sess.title || sess.name || sess.ws_id
+      : typeof opts.ariaLabel === "function"
+        ? opts.ariaLabel(sess)
+        : "Resume: " + (sess.alias || sess.title || sess.name || sess.ws_id),
   );
   var main = document.createElement("div");
   main.className = "dash-row-main";
@@ -255,6 +260,7 @@ export function renderSessionRow(sess, opts) {
   });
   row.appendChild(main);
   var activate = function () {
+    if (!canActivate) return;
     if (row.classList.contains("is-busy")) return;
     if (typeof opts.onActivate === "function") opts.onActivate(sess, row);
   };
@@ -284,6 +290,8 @@ export function renderSessionRow(sess, opts) {
      columns           — array from SavedColumns
      noun              — "workstream" / "coordinator"
      onActivate        — sess => void (resume); gated by delete mode
+     canActivate       — optional sess => boolean (default true)
+     canDelete         — optional sess => boolean (default true)
      activateLabel     — optional sess => string (aria when not deleting)
      emptyText         — empty-state copy
      delete            — {idPrefix, buttonId, buildDeleteRequest, onClose}
@@ -312,6 +320,7 @@ export function createSavedTable(opts) {
         return "Resume: " + (s.alias || s.title || s.name || s.ws_id);
       },
     buildDeleteRequest: opts.delete.buildDeleteRequest,
+    canDelete: opts.canDelete,
     render: function () {
       render();
     },
@@ -543,6 +552,14 @@ export function createSavedTable(opts) {
     var start = state.page * pageSize;
     var rows = all.slice(start, start + pageSize);
     controller.setItems(rows);
+    var deleteButton = document.getElementById(opts.delete.buttonId);
+    if (deleteButton) {
+      deleteButton.style.display = state.items.some(function (s) {
+        return !opts.canDelete || opts.canDelete(s);
+      })
+        ? ""
+        : "none";
+    }
     /* One grid write per render: rows read it from the inherited CSS var. */
     if (opts.bodyEl) {
       opts.bodyEl.style.setProperty("--saved-grid", gridTemplate(cols));
@@ -564,9 +581,11 @@ export function createSavedTable(opts) {
       rows.forEach(function (sess) {
         var row = renderSessionRow(sess, {
           columns: cols,
+          canActivate: !opts.canActivate || opts.canActivate(sess),
           ariaLabel: controller.ariaLabel,
           onActivate: function (s, el) {
             if (controller.blockActivate()) return;
+            if (opts.canActivate && !opts.canActivate(s)) return;
             if (typeof opts.onActivate === "function") opts.onActivate(s, el);
           },
         });
@@ -609,6 +628,13 @@ export function createSavedTable(opts) {
   }
 
   return {
+    reset: function () {
+      state.items = [];
+      state.filter = "";
+      state.page = 0;
+      if (opts.filterEl) opts.filterEl.value = "";
+      controller.reset();
+    },
     setItems: function (items) {
       state.items = items || [];
       render();
@@ -660,6 +686,11 @@ export function createSavedTable(opts) {
 */
 export function createSavedCardsController(opts) {
   var state = { mode: false, selected: {}, items: [] };
+  var generation = 0;
+
+  function canDelete(sess) {
+    return !opts.canDelete || opts.canDelete(sess);
+  }
 
   function $(id) {
     return document.getElementById(opts.idPrefix + "-" + id);
@@ -679,13 +710,13 @@ export function createSavedCardsController(opts) {
   }
 
   function setItems(items) {
-    state.items = items;
+    state.items = items.filter(canDelete);
     /* Drop any selections whose ws_id is no longer on the visible page —
        SSE-driven re-renders or pagination jumps shouldn't leave ghost
        entries inflating the count and 404-ing on confirm. */
     if (state.mode) {
       var byId = {};
-      items.forEach(function (s) {
+      state.items.forEach(function (s) {
         byId[s.ws_id] = true;
       });
       Object.keys(state.selected).forEach(function (id) {
@@ -718,7 +749,7 @@ export function createSavedCardsController(opts) {
      event overrides used in delete mode.  Idempotent guard: only acts
      when the controller is active. */
   function decorateCard(card, sess) {
-    if (!state.mode) return;
+    if (!state.mode || !canDelete(sess)) return;
     card.classList.add("ws-delete-mode");
     card.removeAttribute("role");
     var chk = document.createElement("input");
@@ -899,6 +930,7 @@ export function createSavedCardsController(opts) {
   }
 
   function confirm() {
+    var currentGeneration = generation;
     var selected = Object.keys(state.selected);
     if (!selected.length) return;
     var byId = _byId();
@@ -968,6 +1000,7 @@ export function createSavedCardsController(opts) {
     });
 
     Promise.all(promises).then(function () {
+      if (currentGeneration !== generation) return;
       window.TurnstoneHatch.setBusy(dlg, false);
       if (listEl) {
         listEl.replaceChildren();
@@ -1022,6 +1055,20 @@ export function createSavedCardsController(opts) {
   }
 
   return {
+    reset: function () {
+      generation++;
+      state.resultsShown = false;
+      var dlg = $("dialog");
+      if (dlg && dlg.open) {
+        window.TurnstoneHatch.setBusy(dlg, false);
+        dlg.close();
+      }
+      ["list", "count", "meta", "error"].forEach(function (id) {
+        var element = $(id);
+        if (element) element.textContent = "";
+      });
+      cancel();
+    },
     setItems: setItems,
     inMode: inMode,
     blockActivate: blockActivate,

--- a/turnstone/shared_static/list_cache.js
+++ b/turnstone/shared_static/list_cache.js
@@ -52,7 +52,8 @@ import { authFetch } from "./auth.js";
  * in flight it chains ONE trailing refetch after it and awaits that, instead of
  * coalescing onto the in-flight response that may predate the change.
  * @returns {{refresh:Function, get:Function, getByKey:Function,
- *            loaded:Function, error:Function, extra:Function, onChange:Function}}
+ *            loaded:Function, error:Function, extra:Function, onChange:Function,
+ *            reset:Function}}
  */
 export function makeListCache(opts) {
   const url = opts.url;
@@ -81,6 +82,7 @@ export function makeListCache(opts) {
   let _fingerprint = null; // last fired signature, for change-detection
   let _extra = extraDefaults ? Object.assign({}, extraDefaults) : {};
   const _subs = []; // () => void, fired after each CHANGED refresh
+  let _generation = 0;
 
   function _fp() {
     // Cheap signature of what subscribers render, so a refresh returning
@@ -116,6 +118,7 @@ export function makeListCache(opts) {
   }
 
   function refresh(callOpts) {
+    const generation = _generation;
     // Coalesce concurrent callers (startup warm + a picker open can both fire
     // this) onto one in-flight request — they share the promise and _setCache
     // runs once.
@@ -139,6 +142,7 @@ export function makeListCache(opts) {
         _pending =
           _pending ||
           _inflight.then(function () {
+            if (generation !== _generation) return _cache;
             _pending = null;
             return refresh();
           });
@@ -148,6 +152,7 @@ export function makeListCache(opts) {
     }
     _inflight = authFetch(url)
       .then(function (r) {
+        if (generation !== _generation) return null;
         if (r.ok) return r.json();
         // A non-OK status (403 when a grant is missing, a 5xx, ...) is NOT "you
         // have zero rows": keep the prior cache rather than blanking it and
@@ -162,6 +167,7 @@ export function makeListCache(opts) {
         return null;
       })
       .then(function (data) {
+        if (generation !== _generation) return _cache;
         if (data) {
           _lastError = null;
           if (captureExtra) _extra = captureExtra(data);
@@ -170,6 +176,7 @@ export function makeListCache(opts) {
         return _cache;
       })
       .catch(function (e) {
+        if (generation !== _generation) return _cache;
         // Network drop or a non-JSON body — same policy as a non-OK status:
         // preserve the last-known cache, never reject (callers chain a bare
         // .then), surface the failure, fail-open the extra (when configured).
@@ -181,6 +188,7 @@ export function makeListCache(opts) {
         return _cache;
       })
       .finally(function () {
+        if (generation !== _generation) return;
         // One attempt has completed (ok or not) — lets a reader tell "still
         // loading" from "loaded, genuinely empty" / "load failed".
         _loaded = true;
@@ -191,6 +199,16 @@ export function makeListCache(opts) {
 
   return {
     refresh: refresh,
+    /** Forget the prior principal's rows and discard its pending responses. */
+    reset: function () {
+      _generation++;
+      _inflight = _pending = null;
+      _lastError = null;
+      _extra = extraDefaults ? Object.assign({}, extraDefaults) : {};
+      _setCache([]);
+      _loaded = false;
+      _fingerprint = null;
+    },
     /** Cached rows (empty array until the first refresh resolves). */
     get: function () {
       return _cache;

--- a/turnstone/shared_static/projects.js
+++ b/turnstone/shared_static/projects.js
@@ -17,7 +17,7 @@
  * app.js bundles.  All fetches ride the shared cookie-auth `authFetch`.
  */
 
-import { authFetch } from "./auth.js";
+import { authFetch, hasScope, onAuthChange } from "./auth.js";
 import { makeListCache } from "./list_cache.js";
 
 // The require_project advisory rides the same /v1/api/projects response as an
@@ -44,6 +44,11 @@ const _core = makeListCache({
   // a stale-true value hide options.  (Default, but explicit for the contrast
   // with models.js, whose cosmetic extra opts out of the reset.)
   resetExtraOnError: true,
+});
+
+onAuthChange(function () {
+  _core.reset();
+  if (hasScope("read")) _core.refresh();
 });
 
 /**

--- a/turnstone/ui/static/app.js
+++ b/turnstone/ui/static/app.js
@@ -1055,6 +1055,7 @@ function _setSavedWsMessage(text) {
 }
 
 function loadDashboard() {
+  const generation = authGeneration();
   const tableEl = document.getElementById("dash-ws-table");
   tableEl.replaceChildren(makeEmptyState("Loading\u2026"));
   _setSavedWsMessage("Loading\u2026");
@@ -1062,6 +1063,7 @@ function loadDashboard() {
     return r.json();
   });
   const sessP = authFetch("/v1/api/workstreams/saved").then(function (r) {
+    if (!r.ok) throw new Error("Saved sessions unavailable");
     return r.json();
   });
   // Refresh the projects cache alongside the table so the per-row project pills
@@ -1076,6 +1078,7 @@ function loadDashboard() {
     : Promise.resolve();
   Promise.all([dashP, sessP, projP, persP])
     .then(function (res) {
+      if (generation !== authGeneration()) return;
       const dashData = res[0];
       const wsList = dashData.workstreams || [];
       const agg = dashData.aggregate || {};
@@ -1090,6 +1093,7 @@ function loadDashboard() {
       _wsTable.setItems(savedList);
     })
     .catch(function () {
+      if (generation !== authGeneration()) return;
       tableEl.replaceChildren(makeEmptyState("Failed to load"));
       _setSavedWsMessage("Failed to load");
     });
@@ -1294,6 +1298,12 @@ function _initSavedWsTable() {
     columns: WS_COLUMNS,
     noun: "workstream",
     emptyText: "No saved workstreams",
+    canActivate: function () {
+      return hasScope("write");
+    },
+    canDelete: function () {
+      return hasScope("write");
+    },
     activateLabel: function (s) {
       return "Resume: " + (s.alias || s.title || s.ws_id);
     },
@@ -1326,6 +1336,10 @@ function _initSavedWsTable() {
       if (_wsTable) _wsTable.render();
     });
   }
+  onAuthChange(function () {
+    _wsTable.reset();
+    if (hasScope("read")) loadDashboard();
+  });
 }
 
 // HTML inline-onclick wrappers — keep the global names the existing markup

--- a/turnstone/ui/static/index.html
+++ b/turnstone/ui/static/index.html
@@ -669,7 +669,8 @@
     <script type="module" src="/shared/composer_attachments.js"></script>
     <script type="module" src="/shared/composer_queue.js"></script>
     <script type="module" src="/shared/status_bar.js"></script>
-    <script type="module" src="/shared/auth.js"></script>
+    <!-- cards/shell import auth.js. A separate versioned script URL would
+         create a second auth instance with independent login state. -->
     <script type="module" src="/shared/hatch.js"></script>
     <script type="module" src="/shared/kb.js"></script>
     <script src="/shared/katex-0.18.4/katex.min.js"></script>


### PR DESCRIPTION
Operators assigned to a project receive a 403 for the entire console saved-session list because
it is gated by `admin.coordinator`. Admit each workstream kind separately so operators can find
and reopen their own and related interactive history. Coordinator rows retain their named
permission gate, and every admitted row still passes project visibility checks.

Enforce coordinator authorization on the node's generic delete path using the same workstream
snapshot that fences deletion. Require write scope when detail GET would reopen a cold session;
loaded metadata and history/export remain readable. Saved queries use request-scoped storage
and report failures as 503 responses.

The browser uses effective transport scopes for resume/delete controls and clears saved rows,
selection, and project caches when identity or authority changes. Guard delayed responses and
ensure both dashboard pages initialize one shared auth module instance. Initial whoami rejection
uses the shared refresh/login path, so cached credentials cannot strand the login dialog when
startup responses arrive out of order. Update the API contracts and security documentation.

Validation:

- Full pytest before the final frontend repairs: **13,685 passed, 52 skipped**. The final targeted
  auth/history, shell, and static-serving run passed **133 tests**, including new module-graph and
  auth/history race coverage with failing negative controls.
- Ruff check/format and mypy pass. CSS specificity findings match the baseline.
- Verified in Chrome on the rebuilt PostgreSQL dev cluster with all ten nodes: operator own and
  related project history, require-project on/off, reopen/close/reload, standalone UI, and denied
  private-history/coordinator-delete access.
- Verified read-only controls and backend denials, administrator coordinator lifecycle/deletion,
  operator interactive deletion, three consecutive delayed-response/cross-tab login checks, and
  503/Retry recovery. Reviewed light/dark renders. Fixtures and settings were restored afterward.
- Rebuilt and verified the final startup repair in Chrome: actual rejected-cookie responses,
  operator re-login and history restoration, successful server refresh, delayed administrator
  responses during cross-tab switching, and the standalone operator page. No page errors.
- Independent whole-diff review and bounded follow-up reviews have no outstanding findings. The
  fresh reviewer passed 880 focused tests before the startup repair and 120 after it, and confirmed
  the repaired full-page browser reproduction. Full CI reruns on this update.

Session mint and renewal hardening follows in the second PR.
