### PR TITLE
fix(auth): enforce session mint and renewal authority

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -79,7 +79,7 @@ JWTs are the recommended credential for browser sessions. API tokens are suitabl
 
 ### `POST /v1/api/auth/login`
 
-Authenticate with credentials and receive a JWT. Accepts two credential formats:
+Authenticate with a password or raw stored API token and receive a JWT. JWT input is refused.
 
 **Username + password:**
 
@@ -100,6 +100,7 @@ Authenticate with credentials and receive a JWT. Accepts two credential formats:
   "status": "ok",
   "role": "full",
   "scopes": "approve,read,write",
+  "can_refresh": true,
   "jwt": "eyJhbGciOiJIUzI1NiIs...",
   "user_id": "u_abc123"
 }
@@ -113,6 +114,29 @@ The response also sets a surface-scoped HttpOnly cookie containing the JWT
 ```json
 {"error": "Invalid credentials"}
 ```
+
+Password login requires at least one effective role permission. An empty set returns 403;
+permission-store failure returns 503 without minting a JWT. Raw API tokens retain their explicit
+scopes and return `can_refresh: false`.
+
+---
+
+### `POST /v1/api/auth/refresh`
+
+Renew a currently valid, non-service password/OIDC session using current role permissions. The
+success response includes the login fields, `can_refresh: true`, and `exp` in epoch seconds, and
+sets a fresh session cookie. An empty permission set or an ineligible credential source returns
+403. Permission-store failure returns 503 without replacing or clearing the existing cookie.
+
+API-derived JWTs have a fixed lifetime and cannot renew here; exchange a still-valid raw API token
+through login instead. Proxy, coordinator, service, and other JWT sources cannot use this endpoint.
+Ordinary use of existing JWTs continues until their original expiry.
+
+### `GET /v1/api/auth/whoami`
+
+Return the authenticated identity, named `permissions`, effective `scopes`, and `can_refresh`.
+Renewal eligibility uses the same credential source/scope rule as the refresh endpoint. Cookie
+sessions also include their `exp` when available.
 
 ---
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,7 +30,7 @@ docker compose exec caddy cat /data/caddy/pki/authorities/local/root.crt
 Create your first admin user (any node works — they share one database):
 
 ```bash
-docker compose exec node-1 turnstone-admin create-user --username admin --name "Admin"
+docker compose exec node-1 turnstone-admin create-admin --username admin --name "Admin"
 ```
 
 ### Bring your own LLM

--- a/docs/security.md
+++ b/docs/security.md
@@ -50,6 +50,24 @@ console cannot be used to authenticate against a server node, and vice versa.
 Tokens without an `aud` claim are accepted during the rollout window when
 `audience` validation is not specified.
 
+Password and OIDC sessions require at least one current effective role permission. Login and
+renewal refuse an empty permission set with 403; a permission-store outage returns 503 without
+issuing a JWT or changing the existing cookie. Nonempty granular permissions retain the read
+transport floor, and write/approve keep their scope hierarchy.
+
+`POST /v1/api/auth/login` accepts a password or a raw stored `ts_` API token. It rejects JWT input.
+`POST /v1/api/auth/refresh` renews only non-service password/OIDC sessions, resolving their roles
+again. API-derived sessions keep their explicit token scopes and fixed expiry; exchange a
+still-valid raw API token to obtain another session. Proxy, coordinator, service, and other JWT
+sources use their existing credential managers instead of human-session renewal.
+
+Login, setup, refresh, and whoami expose `can_refresh`, derived from the same source/scope rule.
+The browser uses it to gate renewal. A temporary 503 preserves current authority and permits a
+retry before the original expiry; a refused renewal does not schedule that retry. Existing JWTs
+remain usable for their original lifetime. Removing roles does not revoke an explicit raw API
+token or a delegated credential. OIDC retains its explicit default-viewer provisioning, including
+for returning identities whose roles were all removed.
+
 ---
 
 ## Scope Model
@@ -100,10 +118,9 @@ enforcement, the governance layer adds named permissions checked
 per-endpoint by `require_permission()`. Permissions are bundled into
 roles; users are assigned roles via the `user_roles` join table.
 
-At login, `_load_user_permissions()` aggregates all permissions from
-the user's assigned roles. `_permissions_to_scopes()` derives legacy
-scopes for backward compatibility (e.g., any `admin.*` permission
-implies the `approve` scope). The JWT carries both `scopes` and
+At human login and renewal, current permissions are resolved strictly from the user's assigned
+roles. `_permissions_to_scopes()` derives transport scopes (for example, an `admin.*` permission
+implies `approve`). An empty permission set grants no scopes. The JWT carries both `scopes` and
 `permissions` claims.
 
 Three built-in roles are seeded by migration 008:
@@ -374,16 +391,19 @@ All admin endpoints require `approve` scope.
 The `turnstone-admin` command provides offline user and token management:
 
 ```
-turnstone-admin create-user --username admin --name "Admin" [--password] [--token]
+turnstone-admin create-admin --username admin --name "Admin" [--password]
+turnstone-admin create-user --username reader --name "Reader" [--password] [--token]
 turnstone-admin create-token --user <user_id> --scopes read,write --name "CI bot"
 turnstone-admin list-users
 turnstone-admin list-tokens
 turnstone-admin revoke-token <token_id>
 ```
 
-When `--password` is omitted, the CLI prompts interactively. When
-`--token` is passed to `create-user`, an API token is created alongside
-the user and printed to stdout.
+When `--password` is omitted, the CLI prompts interactively. `create-user` explicitly assigns the
+viewer role before reporting success or issuing an optional API token; failed role provisioning
+rolls back the new user. Historical accounts without roles receive no automatic grant and require
+an administrator to assign one. `create-admin` can create or promote an account. When `--token` is
+passed to `create-user`, the API token is printed to stdout.
 
 ---
 

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -318,7 +318,7 @@
     },
     "/v1/api/auth/login": {
       "post": {
-        "summary": "Authenticate with a token",
+        "summary": "Authenticate with a password or raw stored API token",
         "operationId": "v1_api_auth_login_post",
         "tags": [
           "Auth"
@@ -344,8 +344,48 @@
               }
             }
           },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Error 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Error 429",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
             "content": {
               "application/json": {
                 "schema": {
@@ -504,6 +544,57 @@
         "responses": {
           "302": {
             "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/api/auth/refresh": {
+      "post": {
+        "summary": "Renew a password/OIDC session from current role permissions",
+        "operationId": "v1_api_auth_refresh_post",
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthRefreshResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -7908,7 +7999,7 @@
           },
           "token": {
             "default": "",
-            "description": "Legacy: bearer token to authenticate",
+            "description": "Raw stored ts_ API token; JWT exchange is refused",
             "title": "Token",
             "type": "string"
           }
@@ -7953,12 +8044,82 @@
             "description": "JWT session token (if JWT auth is configured)",
             "title": "Jwt",
             "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
           }
         },
         "required": [
           "role"
         ],
         "title": "AuthLoginResponse",
+        "type": "object"
+      },
+      "AuthRefreshResponse": {
+        "description": "POST /v1/api/auth/refresh success response.",
+        "properties": {
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "user_id": {
+            "default": "",
+            "description": "Authenticated user ID",
+            "title": "User Id",
+            "type": "string"
+          },
+          "role": {
+            "description": "Legacy role",
+            "examples": [
+              "full",
+              "read"
+            ],
+            "title": "Role",
+            "type": "string"
+          },
+          "scopes": {
+            "default": "",
+            "description": "Comma-separated scopes",
+            "examples": [
+              "read,write,approve"
+            ],
+            "title": "Scopes",
+            "type": "string"
+          },
+          "jwt": {
+            "default": "",
+            "description": "JWT session token (if JWT auth is configured)",
+            "title": "Jwt",
+            "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
+          },
+          "exp": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Session expiry in epoch seconds",
+            "title": "Exp"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "AuthRefreshResponse",
         "type": "object"
       },
       "AuthSetupRequest": {
@@ -8019,6 +8180,12 @@
             "description": "JWT session token",
             "title": "Jwt",
             "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
           }
         },
         "required": [
@@ -15657,6 +15824,12 @@
             "description": "Comma-separated effective transport scopes",
             "title": "Scopes",
             "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
           }
         },
         "required": [

--- a/sdk/typescript/openapi-server.json
+++ b/sdk/typescript/openapi-server.json
@@ -1687,7 +1687,7 @@
     },
     "/v1/api/auth/login": {
       "post": {
-        "summary": "Authenticate with a token",
+        "summary": "Authenticate with a password or raw stored API token",
         "operationId": "v1_api_auth_login_post",
         "tags": [
           "Auth"
@@ -1713,8 +1713,48 @@
               }
             }
           },
+          "400": {
+            "description": "Error 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Error 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Error 429",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
             "content": {
               "application/json": {
                 "schema": {
@@ -1873,6 +1913,57 @@
         "responses": {
           "302": {
             "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/api/auth/refresh": {
+      "post": {
+        "summary": "Renew a password/OIDC session from current role permissions",
+        "operationId": "v1_api_auth_refresh_post",
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthRefreshResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error 503",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -2497,7 +2588,7 @@
           },
           "token": {
             "default": "",
-            "description": "Legacy: bearer token to authenticate",
+            "description": "Raw stored ts_ API token; JWT exchange is refused",
             "title": "Token",
             "type": "string"
           }
@@ -2542,12 +2633,82 @@
             "description": "JWT session token (if JWT auth is configured)",
             "title": "Jwt",
             "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
           }
         },
         "required": [
           "role"
         ],
         "title": "AuthLoginResponse",
+        "type": "object"
+      },
+      "AuthRefreshResponse": {
+        "description": "POST /v1/api/auth/refresh success response.",
+        "properties": {
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "user_id": {
+            "default": "",
+            "description": "Authenticated user ID",
+            "title": "User Id",
+            "type": "string"
+          },
+          "role": {
+            "description": "Legacy role",
+            "examples": [
+              "full",
+              "read"
+            ],
+            "title": "Role",
+            "type": "string"
+          },
+          "scopes": {
+            "default": "",
+            "description": "Comma-separated scopes",
+            "examples": [
+              "read,write,approve"
+            ],
+            "title": "Scopes",
+            "type": "string"
+          },
+          "jwt": {
+            "default": "",
+            "description": "JWT session token (if JWT auth is configured)",
+            "title": "Jwt",
+            "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
+          },
+          "exp": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Session expiry in epoch seconds",
+            "title": "Exp"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "AuthRefreshResponse",
         "type": "object"
       },
       "AuthSetupRequest": {
@@ -2608,6 +2769,12 @@
             "description": "JWT session token",
             "title": "Jwt",
             "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
           }
         },
         "required": [
@@ -4652,6 +4819,12 @@
             "description": "Comma-separated effective transport scopes",
             "title": "Scopes",
             "type": "string"
+          },
+          "can_refresh": {
+            "default": false,
+            "description": "Eligible for human-session renewal",
+            "title": "Can Refresh",
+            "type": "boolean"
           }
         },
         "required": [

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -28,6 +28,7 @@ export interface AuthLoginRequest {
 }
 
 export interface AuthLoginResponse {
+  can_refresh?: boolean;
   status: string;
   role: string;
   scopes?: string;
@@ -42,6 +43,7 @@ export interface AuthStatusResponse {
 }
 
 export interface AuthSetupResponse {
+  can_refresh?: boolean;
   status: string;
   user_id: string;
   username: string;

--- a/tests/test_admin_create_admin.py
+++ b/tests/test_admin_create_admin.py
@@ -1,11 +1,8 @@
 """Tests for ``turnstone-admin create-admin`` (issue #824).
 
-``create-user`` creates a role-less user; the web UI derives a login's scopes
-purely from assigned roles, so that account logs in read-only and hits
-"Forbidden: token lacks 'approve' scope" on any admin action.  ``create-admin``
-assigns the built-in admin role — mirroring the web setup wizard
-(``POST /api/auth/setup``) — and promotes an existing role-less user, which is
-the recovery path for anyone already stuck.
+``create-user`` assigns the viewer role for read access. ``create-admin`` assigns the built-in
+admin role, mirroring the web setup wizard, and can promote either a viewer or a historical
+account without roles. Accounts without any effective permissions cannot log in with a password.
 
 Each test drives the real ``_cmd_create_admin`` handler against a real,
 fully-migrated SQLite DB: the ``builtin-admin`` role is seeded by migration
@@ -104,11 +101,11 @@ def test_create_admin_defaults_display_name_to_username(tmp_path: Path) -> None:
 def test_create_admin_promotes_existing_read_only_user(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Issue #824 recovery path: a role-less create-user account, then create-admin."""
+    """Issue #824 recovery path: a read-only create-user account, then create-admin."""
     db_path = str(tmp_path / "admin.db")
     storage = _migrated_storage(db_path)
 
-    # Reproduce the locked-out account exactly (role-less create-user).
+    # A viewer cannot administer the installation until explicitly promoted.
     _cmd_create_user(_db_args(db_path, username="admin", name="Admin", password="hunter2!pw"))
     user = storage.get_user_by_username("admin")
     assert user is not None
@@ -168,3 +165,50 @@ def test_create_admin_invalid_username_rejected(
 
     assert exc_info.value.code == 1
     assert "invalid username" in capsys.readouterr().err
+
+
+def test_create_user_assigns_explicit_viewer(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "viewer.db")
+    storage = _migrated_storage(db_path)
+    _cmd_create_user(_db_args(db_path, username="reader", password="reader-password"))
+    user = storage.get_user_by_username("reader")
+    assert user is not None
+    assert [r["role_id"] for r in storage.list_user_roles(user["user_id"])] == ["builtin-viewer"]
+    assert storage.get_user_permissions(user["user_id"]) == {"read"}
+
+
+@pytest.mark.parametrize("failure", ["assignment", "empty_permissions"])
+def test_create_user_rolls_back_incomplete_viewer_provisioning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    failure: str,
+) -> None:
+    db_path = str(tmp_path / "viewer.db")
+    storage = _migrated_storage(db_path)
+    if failure == "assignment":
+        monkeypatch.setattr("turnstone.admin._get_storage", lambda _args: storage)
+
+        def unavailable(*_args: Any) -> None:
+            raise RuntimeError("storage unavailable")
+
+        monkeypatch.setattr(storage, "assign_role", unavailable)
+    else:
+        storage.set_role_overrides("builtin-viewer", set(), {"read"})
+    with pytest.raises(SystemExit) as exc:
+        _cmd_create_user(
+            _db_args(db_path, username="reader", password="reader-password", token=True)
+        )
+    assert exc.value.code == 1
+    assert storage.get_user_by_username("reader") is None
+    assert "Created user" not in capsys.readouterr().out
+
+
+def test_create_admin_can_recover_historical_roleless_user(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "historical.db")
+    storage = _migrated_storage(db_path)
+    storage.create_user("historical", "historical", "Historical", "unused-password-hash")
+    assert storage.get_user_permissions("historical") == set()
+    assert _login_scopes(storage, "historical") == frozenset()
+    _cmd_create_admin(_db_args(db_path, username="historical"))
+    assert _has_admin_role(storage, "historical")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1266,6 +1266,7 @@ class TestServerLogin:
             if uid == "uid_test"
             else None
         )
+        mock_storage.get_user_permissions.return_value = {"read", "write", "approve"}
         mock_storage.list_user_roles.return_value = [
             {"role_id": "builtin-admin", "scopes": "read,write,approve"}
         ]
@@ -1432,15 +1433,8 @@ class TestServerLogin:
         resp = self.test_client.post("/v1/api/auth/refresh")
         assert resp.status_code == 401
 
-    def test_refresh_storage_failure_falls_back(self):
-        """Transient storage error → fall back to in-token claims, not 403.
-
-        The earlier implementation called _load_user_permissions() which
-        swallows exceptions and returns set(); that path was
-        indistinguishable from a deleted user (legitimate 403).  The
-        handler now calls storage.get_user_permissions() directly so
-        DB hiccups fall through to in-token perms.
-        """
+    def test_refresh_storage_failure_does_not_renew(self):
+        """Permission lookup failure refuses renewal without clearing valid credentials."""
         # Re-arm the storage so login works first
         self.test_client.app.state.auth_storage.get_user_permissions.return_value = {
             "read",
@@ -1459,10 +1453,10 @@ class TestServerLogin:
         )
         try:
             resp = self.test_client.post("/v1/api/auth/refresh")
-            assert resp.status_code == 200, resp.text
-            body = resp.json()
-            # Permissions should still be present (fell back to in-token claims)
-            assert body.get("permissions"), body
+            assert resp.status_code == 503, resp.text
+            assert "jwt" not in resp.json()
+            assert "set-cookie" not in resp.headers
+            assert self.test_client.get("/v1/api/workstreams").status_code == 200
         finally:
             # Restore for any subsequent tests
             self.test_client.app.state.auth_storage.get_user_permissions.side_effect = None
@@ -1542,6 +1536,7 @@ class TestConsoleLogin:
             if uid == "uid_test"
             else None
         )
+        mock_storage.get_user_permissions.return_value = {"read", "write", "approve"}
         mock_storage.list_user_roles.return_value = [
             {"role_id": "builtin-admin", "scopes": "read,write,approve"}
         ]

--- a/tests/test_history_authority_js.py
+++ b/tests/test_history_authority_js.py
@@ -45,8 +45,8 @@ const drain = async () => { for (let i = 0; i < 5; i++) await new Promise(setImm
 function reply(request, data, status = 200) {
   request.resolve(new Response(JSON.stringify(data), {status}));
 }
-const operator = {user_id:'operator', scopes:'read,write', permissions:'read,write'};
-const reader = {user_id:'admin', scopes:'read', permissions:'admin.coordinator'};
+const operator = {can_refresh:true, user_id:'operator', scopes:'read,write', permissions:'read,write'};
+const reader = {can_refresh:true, user_id:'admin', scopes:'read', permissions:'admin.coordinator'};
 function element(id) {
   const el = new FakeElement('div'); elements.set(id, el); return el;
 }
@@ -161,6 +161,7 @@ def test_startup_whoami_401_recovers_pending_requests(cached_identity, refresh_o
         f"const cachedIdentity = {str(cached_identity).lower()};\n"
         f"const refreshOK = {str(refresh_ok).lower()};\n"
         + r"""
+sessionStorage.setItem('turnstone_can_refresh', 'true');
 if (cachedIdentity) {
   sessionStorage.setItem('ts.user_id', operator.user_id);
   sessionStorage.setItem('turnstone_scopes', operator.scopes);

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -85,6 +85,9 @@ def storage(tmp_path: Any) -> SQLiteBackend:
     """Fresh SQLite backend with a seeded admin user."""
     backend = SQLiteBackend(str(tmp_path / "test.db"))
     backend.create_user("test-admin", "testadmin", "Test Admin", "hash")
+    for role, permissions in (("admin", "read,write,approve"), ("viewer", "read")):
+        backend.create_role("builtin-" + role, role, role, permissions, True)
+    backend.assign_role("test-admin", "builtin-admin")
     return backend
 
 
@@ -1239,3 +1242,51 @@ class TestAdminOIDCIdentities:
         # Missing both
         resp = admin_client.delete("/v1/api/admin/oidc-identities")
         assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("failure", [None, "empty", "unavailable"])
+def test_oidc_session_requires_current_permissions_after_explicit_provisioning(
+    authorize_client: TestClient,
+    storage: SQLiteBackend,
+    oidc_config: OIDCConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str | None,
+) -> None:
+    if failure == "empty":
+        storage.set_role_overrides("builtin-viewer", set(), {"read"})
+    elif failure == "unavailable":
+
+        def unavailable(_user: str) -> set[str]:
+            raise RuntimeError("private permission database diagnostic")
+
+        monkeypatch.setattr(storage, "get_user_permissions", unavailable)
+    claims = {"sub": "session-authority-user", "email": "oidc@example.com", "name": "OIDC Reader"}
+    storage.create_oidc_pending_state("authority-state", "nonce", "verifier", "test-audience")
+    with (
+        patch(
+            "turnstone.core.auth.exchange_code", new=AsyncMock(return_value={"id_token": "test"})
+        ),
+        patch("turnstone.core.auth.validate_id_token", return_value=claims),
+    ):
+        response = authorize_client.get(
+            "/v1/api/auth/oidc/callback?code=test&state=authority-state", follow_redirects=False
+        )
+        if failure:
+            assert response.status_code == (403 if failure == "empty" else 503)
+            assert "set-cookie" not in response.headers
+            assert "private permission" not in response.text
+            return
+        assert response.status_code == 302
+        assert "oidc_success=1" in response.headers["location"]
+        identity = storage.get_oidc_identity(oidc_config.issuer, claims["sub"])
+        assert identity is not None
+        user_id = identity["user_id"]
+        assert storage.get_user_permissions(user_id) == {"read"}
+        # Existing OIDC policy explicitly re-provisions viewer when all roles are removed.
+        storage.unassign_role(user_id, "builtin-viewer")
+        storage.create_oidc_pending_state("return-state", "nonce", "verifier", "test-audience")
+        returning = authorize_client.get(
+            "/v1/api/auth/oidc/callback?code=test&state=return-state", follow_redirects=False
+        )
+        assert returning.status_code == 302
+        assert storage.get_user_permissions(user_id) == {"read"}

--- a/tests/test_session_authority.py
+++ b/tests/test_session_authority.py
@@ -1,0 +1,188 @@
+"""Session mint and renewal boundaries with real storage, middleware, and proxies."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tests.test_interactive_history_rbac import _SECRET
+from tests.test_interactive_history_rbac import history_apps as history_apps
+from turnstone.core.auth import (
+    JWT_AUD_CONSOLE,
+    JWT_AUD_SERVER,
+    create_jwt,
+    generate_token,
+    hash_token,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _surface(apps, name):
+    if name == "node":
+        return apps.node, "/v1/api", JWT_AUD_SERVER
+    return apps.console, ("/node/missing" if name == "proxy" else "") + "/v1/api", JWT_AUD_CONSOLE
+
+
+async def _login(client, prefix, user="viewer"):
+    response = await client.post(
+        prefix + "/auth/login", json={"username": user, "password": "history-test-password"}
+    )
+    assert response.status_code == 200, response.text
+    return response
+
+
+@pytest.mark.parametrize("surface", ["node", "console", "proxy"])
+@pytest.mark.parametrize("revoke", [False, True])
+async def test_empty_roles_cannot_mint_through_login_refresh_or_jwt_exchange(
+    history_apps, surface, revoke
+):
+    apps = history_apps
+    client, prefix, _ = _surface(apps, surface)
+    original = await _login(client, prefix)
+    assert original.json()["can_refresh"] is True
+    if revoke:
+        apps.storage.set_role_overrides("builtin-viewer", set(), {"read"})
+    else:
+        apps.storage.unassign_role("viewer", "builtin-viewer")
+    for endpoint, body, status in (
+        ("login", {"username": "viewer", "password": "history-test-password"}, 403),
+        ("refresh", {}, 403),
+        ("login", {"token": original.json()["jwt"]}, 401),
+    ):
+        response = await client.post(prefix + "/auth/" + endpoint, json=body)
+        assert response.status_code == status, response.text
+        assert "jwt" not in response.json()
+        assert "set-cookie" not in response.headers
+    # Existing JWT claims retain their remaining lifetime; refusal does not mint or revoke one.
+    assert (await client.get(prefix + "/auth/whoami")).status_code == 200
+
+
+@pytest.mark.parametrize("surface", ["node", "console", "proxy"])
+async def test_role_store_outage_refuses_mint_and_preserves_existing_cookie(
+    history_apps, surface, monkeypatch
+):
+    client, prefix, _ = _surface(history_apps, surface)
+    await _login(client, prefix)
+    cookies = dict(client.cookies)
+
+    def unavailable(_user):
+        raise RuntimeError("private database diagnostic")
+
+    monkeypatch.setattr(history_apps.storage, "get_user_permissions", unavailable)
+    for endpoint, body in (
+        ("login", {"username": "viewer", "password": "history-test-password"}),
+        ("refresh", {}),
+    ):
+        response = await client.post(prefix + "/auth/" + endpoint, json=body)
+        assert response.status_code == 503
+        assert "private" not in response.text
+        assert "set-cookie" not in response.headers
+        assert "jwt" not in response.json()
+    assert dict(client.cookies) == cookies
+    assert (await client.get(prefix + "/auth/whoami")).status_code == 200
+
+
+@pytest.mark.parametrize("surface", ["node", "console", "proxy"])
+@pytest.mark.parametrize(
+    ("source", "service", "eligible"),
+    [
+        ("password", False, True),
+        ("oidc", False, True),
+        ("password", True, False),
+        ("oidc", True, False),
+        ("database", False, False),
+        ("console-proxy", False, False),
+        ("coordinator", False, False),
+        ("console", True, False),
+        ("unknown", False, False),
+        ("", False, False),
+        ("tls-acme-enrollment", True, False),
+    ],
+)
+async def test_renewal_source_matrix_and_whoami_agree(
+    history_apps, surface, source, service, eligible
+):
+    client, prefix, audience = _surface(history_apps, surface)
+    token = create_jwt(
+        user_id="viewer",
+        scopes=frozenset({"service" if service else "read"}),
+        source=source,
+        secret=_SECRET,
+        audience=audience,
+        permissions=frozenset({"read"}),
+    )
+    headers = {"Authorization": "Bearer " + token}
+    whoami = await client.get(prefix + "/auth/whoami", headers=headers)
+    if source == "tls-acme-enrollment":
+        assert whoami.status_code == 403
+    else:
+        assert whoami.status_code == 200
+        assert whoami.json()["can_refresh"] is eligible
+    refresh = await client.post(prefix + "/auth/refresh", headers=headers)
+    assert refresh.status_code == (200 if eligible else 403), refresh.text
+    if eligible:
+        assert refresh.json()["can_refresh"] is True
+        assert refresh.json()["scopes"] == "read"
+    else:
+        assert "set-cookie" not in refresh.headers
+    exchange = await client.post(prefix + "/auth/login", json={"token": token})
+    assert exchange.status_code == 401
+    assert "set-cookie" not in exchange.headers
+
+
+@pytest.mark.parametrize("surface", ["node", "console", "proxy"])
+@pytest.mark.parametrize("roleless", [False, True])
+async def test_raw_api_tokens_keep_explicit_scope_and_fixed_session_lifetime(
+    history_apps, surface, roleless
+):
+    client, prefix, _ = _surface(history_apps, surface)
+    storage = history_apps.storage
+    if roleless:
+        storage.unassign_role("admin", "builtin-admin")
+    raw = generate_token()
+    storage.create_api_token("narrow", hash_token(raw), raw[:8], "admin", "Narrow", "read")
+    response = await client.post(prefix + "/auth/login", json={"token": raw})
+    assert response.status_code == 200
+    assert response.json()["scopes"] == "read"
+    assert response.json()["can_refresh"] is False
+    derived = response.json()["jwt"]
+    for token in (raw, derived):
+        headers = {"Authorization": "Bearer " + token}
+        assert (await client.get(prefix + "/auth/whoami", headers=headers)).json()[
+            "can_refresh"
+        ] is False
+        refused = await client.post(prefix + "/auth/refresh", headers=headers)
+        assert refused.status_code == 403
+        assert "set-cookie" not in refused.headers
+    storage.delete_api_token("narrow")
+    assert (await client.post(prefix + "/auth/login", json={"token": raw})).status_code == 401
+    assert (await client.get(prefix + "/auth/whoami")).json()["scopes"] == "read"
+    expired = generate_token()
+    storage.create_api_token(
+        "expired",
+        hash_token(expired),
+        expired[:8],
+        "admin",
+        "Expired",
+        "read",
+        expires=(datetime.now(UTC) - timedelta(seconds=1)).isoformat(),
+    )
+    assert (await client.post(prefix + "/auth/login", json={"token": expired})).status_code == 401
+
+
+@pytest.mark.parametrize(
+    ("permissions", "scopes"),
+    [("project.read", "read"), ("write", "read,write"), ("approve", "approve,read,write")],
+)
+async def test_nonempty_permission_floor_and_scope_hierarchy_are_preserved(
+    history_apps, permissions, scopes
+):
+    storage = history_apps.storage
+    storage.unassign_role("viewer", "builtin-viewer")
+    storage.create_role("custom", "custom", "Custom", permissions, False)
+    storage.assign_role("viewer", "custom")
+    login = await _login(history_apps.node, "/v1/api")
+    assert login.json()["scopes"] == scopes
+    refresh = await history_apps.node.post("/v1/api/auth/refresh")
+    assert refresh.status_code == 200
+    assert refresh.json()["scopes"] == scopes

--- a/tests/test_session_authority_js.py
+++ b/tests/test_session_authority_js.py
@@ -1,0 +1,100 @@
+"""Execute refresh eligibility and availability behavior in the shared auth client."""
+
+from tests._js_harness_helpers import node_skip
+from tests.test_history_authority_js import _run
+
+pytestmark = node_skip
+
+
+def test_api_session_does_not_schedule_or_attempt_refresh():
+    _run(r"""
+const timers = [];
+globalThis.setTimeout = (fn, delay) => { timers.push({fn, delay}); return timers.length; };
+const fixed = {...reader, can_refresh:false, exp:Date.now()/1000+3600};
+reply(requests.shift(), fixed); await drain();
+assert.equal(timers.length, 0);
+assert.equal(await _tryRefresh(), false); assert.equal(requests.length, 0);
+// A sibling refresh notification rechecks whoami but cannot make this session renewable.
+_scheduleRefreshFromWhoami(); reply(requests.shift(), fixed); await drain();
+assert.equal(timers.length, 0);
+const overlay = element('login-overlay'); overlay.style.display = 'none';
+const request = authFetch('/saved').catch(e=>e.message);
+reply(requests.shift(), {error:'expired'}, 401); await drain();
+assert.equal(await request, 'auth');
+assert.equal(overlay.style.display, 'flex');
+assert.deepEqual(requests.map(r=>r.url), ['/v1/api/auth/status']);
+""")
+
+
+def test_unknown_session_can_still_open_login_without_refresh():
+    _run(r"""
+const overlay = element('login-overlay'); overlay.style.display = 'none';
+reply(requests.shift(), {error:'expired'}, 401); await drain();
+assert.equal(overlay.style.display, 'flex');
+assert.deepEqual(requests.map(r=>r.url), ['/v1/api/auth/status']);
+""")
+
+
+def test_refresh_503_keeps_authority_and_retries_before_original_expiry():
+    _run(r"""
+let now = 2000000000000, serial = 0; const timers = new Map();
+Date.now = () => now;
+globalThis.setTimeout = (fn, delay) => { timers.set(++serial, {fn, delay}); return serial; };
+globalThis.clearTimeout = id => timers.delete(id);
+const expiry = now/1000+600;
+reply(requests.shift(), {...operator, exp:expiry}); await drain();
+const overlay = element('login-overlay'); overlay.style.display = 'none';
+const generation = authGeneration();
+const api = authFetch('/saved').catch(e=>e.message);
+reply(requests.shift(), {error:'expired'}, 401); await drain();
+assert.equal(requests[0].url, '/v1/api/auth/refresh');
+reply(requests.shift(), {error:'Permission storage unavailable'}, 503); await drain();
+assert.match(await api, /temporarily unavailable/);
+assert.equal(authGeneration(), generation);
+assert.equal(sessionStorage.getItem('ts.user_id'), 'operator');
+assert.equal(hasScope('write'), true); assert.equal(overlay.style.display, 'none');
+assert.equal(timers.size, 1);
+const [id, timer] = [...timers][0];
+assert.equal(timer.delay, 30000);
+timers.delete(id); now += timer.delay; timer.fn();
+assert.equal(requests.length, 1);
+reply(requests.shift(), {...operator, scopes:'read', permissions:'read', exp:expiry+600});
+await drain(); assert.equal(hasScope('write'), false); assert.equal(hasScope('read'), true);
+assert.equal(overlay.style.display, 'none');
+""")
+
+
+def test_delayed_retry_stops_at_expiry_and_logout_cancels_it():
+    _run(r"""
+let now = 2000000000000, serial = 0; const timers = new Map();
+Date.now = () => now;
+globalThis.setTimeout = (fn, delay) => { timers.set(++serial, {fn, delay}); return serial; };
+globalThis.clearTimeout = id => timers.delete(id);
+const expiry = now/1000+600;
+reply(requests.shift(), {...operator, exp:expiry}); await drain();
+const renewal = _tryRefresh(); reply(requests.shift(), {}, 503);
+assert.equal(await renewal, null);
+const [id, timer] = [...timers][0]; timers.delete(id);
+now = expiry*1000+1; timer.fn();
+assert.equal(requests.length, 0);
+_scheduleRefreshAt(expiry+600);
+const pending = _tryRefresh(), old = requests.shift();
+_invalidateAuth(); reply(old, {}, 503);
+assert.equal(await pending, false);
+assert.equal(timers.size, 0);
+assert.equal(sessionStorage.getItem('turnstone_can_refresh'), null);
+""")
+
+
+def test_authoritative_refresh_refusal_does_not_schedule_a_retry():
+    _run(r"""
+reply(requests.shift(), operator); await drain();
+const overlay = element('login-overlay'); overlay.style.display = 'none';
+const timers = [];
+globalThis.setTimeout = (fn, delay) => { timers.push({fn, delay}); return 1; };
+const renewal = _tryRefresh(); reply(requests.shift(), {error:'No active permissions'}, 403);
+assert.equal(await renewal, false);
+assert.equal(timers.length, 0);
+// The existing cookie retains its original lifetime; a later rejected API request opens login.
+assert.equal(overlay.style.display, 'none'); assert.equal(hasScope('read'), true);
+""")

--- a/turnstone/admin.py
+++ b/turnstone/admin.py
@@ -73,9 +73,23 @@ def _cmd_create_user(args: argparse.Namespace) -> None:
 
     pw_hash = hash_password(password)
     storage.create_user(user_id, args.username, args.name, pw_hash)
+    try:
+        storage.assign_role(user_id, "builtin-viewer", "")
+        if not storage.get_user_permissions(user_id):
+            raise RuntimeError("Viewer role has no active permissions")
+    except Exception:
+        try:
+            storage.delete_user(user_id)
+        except Exception:
+            print(f"Error: failed to roll back incomplete user {user_id}.", file=sys.stderr)
+        print(
+            "Error: failed to provision viewer access; check database migrations.", file=sys.stderr
+        )
+        sys.exit(1)
     print(f"Created user: {user_id}")
     print(f"  Username: {args.username}")
     print(f"  Name: {args.name}")
+    print("  Role: viewer (read access)")
 
     if args.token:
         from turnstone.core.auth import reject_unassignable_scopes
@@ -104,11 +118,9 @@ def _cmd_create_user(args: argparse.Namespace) -> None:
 def _cmd_create_admin(args: argparse.Namespace) -> None:
     """Create an admin user (or promote an existing one) with full access.
 
-    Unlike ``create-user`` — which creates a role-less user that logs into the
-    web UI read-only — this assigns the built-in admin role, mirroring the web
-    first-run setup wizard (``POST /api/auth/setup``).  Use it for headless
-    installs, or to unstick a ``create-user`` account that logs in only to hit
-    "Forbidden: token lacks 'approve' scope".
+    While ``create-user`` assigns viewer access, this assigns the built-in admin role, mirroring
+    the web first-run setup wizard (``POST /api/auth/setup``). Use it for headless installs or to
+    promote a reader who needs administrator access.
     """
     import getpass
 
@@ -129,7 +141,7 @@ def _cmd_create_admin(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    # Promote an existing user (recovery path: create-user assigns no role).
+    # Promote an existing viewer or historical account without assigned roles.
     existing = storage.get_user_by_username(args.username)
     if existing is not None:
         user_id = existing["user_id"]

--- a/turnstone/api/console_spec.py
+++ b/turnstone/api/console_spec.py
@@ -124,6 +124,7 @@ from turnstone.api.openapi import EndpointSpec, QueryParam, build_openapi
 from turnstone.api.schemas import (
     AuthLoginRequest,
     AuthLoginResponse,
+    AuthRefreshResponse,
     AuthSetupRequest,
     AuthSetupResponse,
     AuthStatusResponse,
@@ -246,10 +247,10 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         "/v1/api/auth/login",
         "POST",
-        "Authenticate with a token",
+        "Authenticate with a password or raw stored API token",
         request_model=AuthLoginRequest,
         response_model=AuthLoginResponse,
-        error_codes=[401],
+        error_codes=[400, 401, 403, 429, 503],
         tags=["Auth"],
     ),
     EndpointSpec(
@@ -288,6 +289,14 @@ CONSOLE_ENDPOINTS: list[EndpointSpec] = [
         "GET",
         "OIDC callback — validates code, provisions user, sets JWT cookie, redirects to app",
         response_code=302,
+        tags=["Auth"],
+    ),
+    EndpointSpec(
+        "/v1/api/auth/refresh",
+        "POST",
+        "Renew a password/OIDC session from current role permissions",
+        response_model=AuthRefreshResponse,
+        error_codes=[401, 403, 503],
         tags=["Auth"],
     ),
     EndpointSpec(
@@ -1799,6 +1808,7 @@ _ALL_MODELS: list[type[BaseModel]] = [
     DeleteSettingResponse,
     AuthLoginRequest,
     AuthLoginResponse,
+    AuthRefreshResponse,
     AuthSetupRequest,
     AuthSetupResponse,
     AuthStatusResponse,

--- a/turnstone/api/schemas.py
+++ b/turnstone/api/schemas.py
@@ -51,7 +51,7 @@ class AuthLoginRequest(BaseModel):
 
     username: str = Field(default="", description="Login username")
     password: str = Field(default="", description="Login password")
-    token: str = Field(default="", description="Legacy: bearer token to authenticate")
+    token: str = Field(default="", description="Raw stored ts_ API token; JWT exchange is refused")
 
 
 class AuthLoginResponse(BaseModel):
@@ -64,6 +64,13 @@ class AuthLoginResponse(BaseModel):
         default="", description="Comma-separated scopes", examples=["read,write,approve"]
     )
     jwt: str = Field(default="", description="JWT session token (if JWT auth is configured)")
+    can_refresh: bool = Field(default=False, description="Eligible for human-session renewal")
+
+
+class AuthRefreshResponse(AuthLoginResponse):
+    """POST /v1/api/auth/refresh success response."""
+
+    exp: int | None = Field(default=None, description="Session expiry in epoch seconds")
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +163,7 @@ class AuthSetupResponse(BaseModel):
     role: str = Field(default="full")
     scopes: str = Field(default="approve,read,write")
     jwt: str = Field(default="", description="JWT session token")
+    can_refresh: bool = Field(default=False, description="Eligible for human-session renewal")
 
 
 class AuthStatusResponse(BaseModel):
@@ -175,6 +183,7 @@ class AuthWhoamiResponse(BaseModel):
     user_id: str
     permissions: str = ""
     scopes: str = Field(default="", description="Comma-separated effective transport scopes")
+    can_refresh: bool = Field(default=False, description="Eligible for human-session renewal")
 
 
 # ---------------------------------------------------------------------------

--- a/turnstone/api/server_spec.py
+++ b/turnstone/api/server_spec.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 from turnstone.api.schemas import (
     AuthLoginRequest,
     AuthLoginResponse,
+    AuthRefreshResponse,
     AuthSetupRequest,
     AuthSetupResponse,
     AuthStatusResponse,
@@ -446,10 +447,10 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         "/v1/api/auth/login",
         "POST",
-        "Authenticate with a token",
+        "Authenticate with a password or raw stored API token",
         request_model=AuthLoginRequest,
         response_model=AuthLoginResponse,
-        error_codes=[401],
+        error_codes=[400, 401, 403, 429, 503],
         tags=["Auth"],
     ),
     EndpointSpec(
@@ -488,6 +489,14 @@ SERVER_ENDPOINTS: list[EndpointSpec] = [
         "GET",
         "OIDC callback — validates code, provisions user, sets JWT cookie, redirects to app",
         response_code=302,
+        tags=["Auth"],
+    ),
+    EndpointSpec(
+        "/v1/api/auth/refresh",
+        "POST",
+        "Renew a password/OIDC session from current role permissions",
+        response_model=AuthRefreshResponse,
+        error_codes=[401, 403, 503],
         tags=["Auth"],
     ),
     EndpointSpec(
@@ -605,6 +614,7 @@ _ALL_MODELS: list[type[BaseModel]] = [
     StatusResponse,
     AuthLoginRequest,
     AuthLoginResponse,
+    AuthRefreshResponse,
     AuthSetupRequest,
     AuthSetupResponse,
     AuthStatusResponse,

--- a/turnstone/core/auth.py
+++ b/turnstone/core/auth.py
@@ -153,6 +153,25 @@ def _load_user_permissions(storage: Any, user_id: str) -> set[str]:
         return set()
 
 
+def _session_permissions(storage: Any, user_id: str) -> set[str] | JSONResponse:
+    """Resolve current role authority before issuing or renewing a human session."""
+    from starlette.responses import JSONResponse
+
+    try:
+        permissions = set(storage.get_user_permissions(user_id))
+    except Exception:
+        log.warning("Session permission storage unavailable for user %s", user_id, exc_info=True)
+        return JSONResponse({"error": "Permission storage unavailable"}, status_code=503)
+    if not permissions:
+        return JSONResponse({"error": "User has no active permissions"}, status_code=403)
+    return permissions
+
+
+def _can_refresh_session(source: str, scopes: frozenset[str]) -> bool:
+    """Only human role-derived credentials use the public session renewal path."""
+    return source in {"password", "oidc"} and "service" not in scopes
+
+
 def user_has_permission(user_id: str, permission: str, *, storage: Any = None) -> bool:
     """Return True if *user_id* holds *permission*.
 
@@ -615,8 +634,7 @@ def _permissions_to_scopes(permissions: set[str]) -> frozenset[str]:
     """Derive legacy scopes from a granular permission set."""
     scopes: set[str] = set()
     if not permissions:
-        scopes.add("read")
-        return frozenset(scopes)
+        return frozenset()
     for perm in permissions:
         if perm in VALID_SCOPES and perm != "service":
             scopes.update(SCOPE_HIERARCHY.get(perm, {perm}))
@@ -1671,7 +1689,7 @@ class AuthMiddleware:
 async def handle_auth_login(request: Request, audience: str, cookie_name: str) -> Response:
     """Shared ``POST /api/auth/login`` handler.
 
-    Authenticates via username:password or legacy token exchange, returning
+    Authenticates via username:password or a raw stored API token, returning
     a JWT and setting the auth cookie.  *audience* selects the JWT ``aud``
     claim (``JWT_AUD_SERVER`` or ``JWT_AUD_CONSOLE``).
     """
@@ -1721,7 +1739,9 @@ async def handle_auth_login(request: Request, audience: str, cookie_name: str) -
         user = storage.get_user_by_username(username)
         if user and verify_password(password, user["password_hash"]):
             # Derive scopes and permissions from assigned roles
-            perms = _load_user_permissions(storage, user["user_id"])
+            perms = _session_permissions(storage, user["user_id"])
+            if isinstance(perms, JSONResponse):
+                return perms
             scopes = _permissions_to_scopes(perms)
             result = AuthResult(
                 user_id=user["user_id"],
@@ -1730,17 +1750,10 @@ async def handle_auth_login(request: Request, audience: str, cookie_name: str) -
                 permissions=frozenset(perms),
             )
     elif body.get("token"):
-        result = _authenticate_token(
-            body["token"],
-            jwt_secret=jwt_secret,
-            jwt_audience=audience,
-            storage=storage,
-        )
-        # Enrollment JWTs are capabilities for the protected ACME responder,
-        # not general service credentials.  In particular, never let the
-        # legacy token-exchange path extend one into a fresh 24-hour session.
-        if result is not None and result.token_source == TLS_ACME_TOKEN_SOURCE:
-            result = None
+        # JWT exchange would bypass live-role renewal checks and reset expiry.
+        token = body["token"]
+        if isinstance(token, str) and token.startswith(TOKEN_PREFIX) and storage is not None:
+            result = _authenticate_api_token(token, storage)
 
     if result is None:
         # Record failed attempt for rate limiting
@@ -1764,7 +1777,12 @@ async def handle_auth_login(request: Request, audience: str, cookie_name: str) -
 
     role = "full" if result.has_scope("write") else "read"
     scopes_str = ",".join(sorted(result.scopes))
-    resp_body: dict[str, str] = {"status": "ok", "role": role, "scopes": scopes_str}
+    resp_body: dict[str, Any] = {
+        "status": "ok",
+        "role": role,
+        "scopes": scopes_str,
+        "can_refresh": _can_refresh_session(result.token_source, result.scopes),
+    }
     if result.permissions:
         resp_body["permissions"] = ",".join(sorted(result.permissions))
     if jwt_token:
@@ -1879,8 +1897,8 @@ async def handle_auth_setup(request: Request, audience: str, cookie_name: str) -
         )
 
     # Derive permissions from roles
-    perms = _load_user_permissions(storage, user_id)
-    if not perms:
+    perms = _session_permissions(storage, user_id)
+    if isinstance(perms, JSONResponse):
         log.error(
             "First user %s has no permissions after role assignment — aborting setup", user_id
         )
@@ -1905,12 +1923,13 @@ async def handle_auth_setup(request: Request, audience: str, cookie_name: str) -
             version=jwt_version_slot(),
         )
 
-    resp_body: dict[str, str] = {
+    resp_body: dict[str, Any] = {
         "status": "ok",
         "user_id": user_id,
         "username": username,
         "role": "full",
         "scopes": ",".join(sorted(scopes)),
+        "can_refresh": _can_refresh_session("password", scopes),
     }
     if perms:
         resp_body["permissions"] = ",".join(sorted(perms))
@@ -1941,6 +1960,7 @@ async def handle_auth_whoami(request: Request, cookie_name: str) -> Response:
     resp: dict[str, Any] = {
         "user_id": auth_result.user_id,
         "scopes": ",".join(sorted(auth_result.scopes)),
+        "can_refresh": _can_refresh_session(auth_result.token_source, auth_result.scopes),
     }
     # Surface the human username / display name for the UI — ``user_id`` is an
     # opaque uuid, not something to show in the footer.  Best-effort: a storage
@@ -1978,7 +1998,7 @@ async def handle_auth_whoami(request: Request, cookie_name: str) -> Response:
 async def handle_auth_refresh(request: Request, audience: str, cookie_name: str) -> Response:
     """Shared ``POST /api/auth/refresh`` handler — re-mint the auth cookie.
 
-    Requires a currently-valid auth cookie (auth middleware enforces).
+    Requires a currently-valid, non-service password/OIDC session.
     Re-resolves the user's permissions from storage so a role change
     propagates within one refresh cycle (rather than persisting until
     the original token's natural expiry).  Returns the same JSON shape
@@ -1997,37 +2017,20 @@ async def handle_auth_refresh(request: Request, audience: str, cookie_name: str)
     auth_result: AuthResult | None = getattr(request.state, "auth_result", None)
     if not auth_result or not auth_result.user_id:
         return JSONResponse({"error": "Not authenticated"}, status_code=401)
+    if not _can_refresh_session(auth_result.token_source, auth_result.scopes):
+        return JSONResponse({"error": "Credential cannot renew a human session"}, status_code=403)
 
     jwt_secret = getattr(request.app.state, "jwt_secret", "")
     storage = getattr(request.app.state, "auth_storage", None)
 
-    # Re-resolve permissions so revoked / promoted users see the change
-    # within one refresh cycle.  Call storage.get_user_permissions
-    # directly (not _load_user_permissions) so we can distinguish a
-    # genuine empty result (user deleted / role-stripped → 403) from a
-    # transient storage failure (fall back to in-token claims, better
-    # than logging the session out mid-flight).
+    # An outage must not extend stale claims. The existing cookie remains valid
+    # until expiry, so the browser can retry a 503 without treating it as logout.
     user_id = auth_result.user_id
-    perms: frozenset[str] = auth_result.permissions
-    scopes: frozenset[str] = auth_result.scopes
-    if storage is not None:
-        try:
-            fresh_perms = storage.get_user_permissions(user_id)
-        except Exception:
-            log.warning(
-                "Refresh: storage unavailable for permission re-resolve; "
-                "falling back to in-token claims for %s",
-                user_id,
-                exc_info=True,
-            )
-        else:
-            if not fresh_perms and not auth_result.has_scope("service"):
-                return JSONResponse(
-                    {"error": "User has no active permissions"},
-                    status_code=403,
-                )
-            perms = frozenset(fresh_perms)
-            scopes = _permissions_to_scopes(set(perms))
+    resolved = _session_permissions(storage, user_id)
+    if isinstance(resolved, JSONResponse):
+        return resolved
+    perms = frozenset(resolved)
+    scopes = _permissions_to_scopes(resolved)
 
     if not jwt_secret:
         return JSONResponse({"error": "JWT signing not configured"}, status_code=503)
@@ -2035,7 +2038,7 @@ async def handle_auth_refresh(request: Request, audience: str, cookie_name: str)
     new_token = create_jwt(
         user_id=user_id,
         scopes=scopes,
-        source=auth_result.token_source or "refresh",
+        source=auth_result.token_source,
         secret=jwt_secret,
         audience=audience,
         permissions=perms,
@@ -2049,6 +2052,7 @@ async def handle_auth_refresh(request: Request, audience: str, cookie_name: str)
         "scopes": ",".join(sorted(scopes)),
         "user_id": user_id,
         "jwt": new_token,
+        "can_refresh": _can_refresh_session(auth_result.token_source, scopes),
     }
     if perms:
         resp_body["permissions"] = ",".join(sorted(perms))
@@ -2317,6 +2321,10 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
         _record_oidc_failure()
         return RedirectResponse("/?oidc_error=Authentication+failed", status_code=302)
 
+    perms = await asyncio.to_thread(_session_permissions, storage, user["user_id"])
+    if isinstance(perms, JSONResponse):
+        return perms
+
     # Capture the IdP refresh token as the user's single OBO credential
     # (issue #551).  Best-effort: capture failure must not block login —
     # the mint path surfaces a missing credential on the reconnect rail.
@@ -2363,8 +2371,7 @@ async def handle_oidc_callback(request: Request, audience: str, cookie_name: str
                     context="oidc-capture",
                 )
 
-    # Load permissions and issue Turnstone JWT
-    perms = await asyncio.to_thread(_load_user_permissions, storage, user["user_id"])
+    # Issue the role-derived Turnstone JWT.
     scopes = _permissions_to_scopes(perms)
     jwt_token = ""
     if jwt_secret:

--- a/turnstone/shared_static/auth.js
+++ b/turnstone/shared_static/auth.js
@@ -104,11 +104,14 @@ async function _recoverUnauthorized(r, isCurrent, allowRefresh = true) {
   if (!isCurrent()) throw new Error("auth changed");
   // Reactive refresh covers expired cookies when the proactive timer missed.
   const generation = authGeneration();
-  if (allowRefresh && (await _tryRefresh())) return;
+  const refreshed = allowRefresh ? await _tryRefresh() : false;
+  if (refreshed === true) return;
   // A concurrent whoami may supersede refresh for the same identity.
   // Its newly confirmed authority must survive this older request.
   if (!isCurrent() || generation !== authGeneration())
     throw new Error("auth changed");
+  if (refreshed === null)
+    throw new Error("Authentication temporarily unavailable. Try again.");
   showLogin();
   throw new Error("auth");
 }
@@ -128,6 +131,7 @@ const _REFRESH_AT_FRACTION = 0.9;
 const _REFRESH_MIN_DELAY_MS = 30 * 1000;
 const _REFRESH_MAX_DELAY_MS = 24 * 60 * 60 * 1000;
 let _refreshTimer = null;
+let _refreshExpiry = 0;
 let _refreshInFlight = null;
 // Logout race guard: a refresh (or whoami) in flight when the user
 // clicks Logout can land AFTER /logout and re-populate state, silently
@@ -169,6 +173,7 @@ function _invalidateAuth() {
   _authEpoch++;
   _loggedOut = true;
   _cancelRefreshTimer();
+  _refreshExpiry = 0;
   _refreshSequence++;
   _whoamiSequence++;
   [_refreshAbort, _whoamiAbort].forEach(function (ctrl) {
@@ -241,7 +246,7 @@ export function whenPermissionsReady(cb) {
 
 async function _tryRefresh() {
   // Don't start a refresh if logout already won the race.
-  if (_loggedOut) return false;
+  if (_loggedOut || !_canRefresh()) return false;
   // De-dupe concurrent callers — many parallel authFetch'es hitting
   // 401 at once should still only fire one /refresh request.
   if (_refreshInFlight) {
@@ -263,6 +268,11 @@ async function _tryRefresh() {
         credentials: "same-origin",
         signal: _refreshAbort ? _refreshAbort.signal : undefined,
       });
+      if (_loggedOut || generation !== authGeneration()) return false;
+      if (r.status === 503) {
+        _scheduleRefreshRetry();
+        return null; // Unavailable, not an authoritative authentication refusal.
+      }
       if (!r.ok) return false;
       let data = null;
       try {
@@ -299,7 +309,9 @@ async function _tryRefresh() {
       if (_authChannel) _authChannel.postMessage("refresh");
       return true;
     } catch (_e) {
-      return false;
+      if (_loggedOut || generation !== authGeneration()) return false;
+      _scheduleRefreshRetry();
+      return null;
     } finally {
       if (sequence === _refreshSequence) {
         _refreshInFlight = null;
@@ -310,12 +322,33 @@ async function _tryRefresh() {
   return await _refreshInFlight;
 }
 
+function _canRefresh() {
+  return sessionStorage.getItem("turnstone_can_refresh") === "true";
+}
+
+function _scheduleRefreshRetry() {
+  const deadline = _refreshExpiry * 1000;
+  if (!_canRefresh() || deadline - Date.now() <= _REFRESH_MIN_DELAY_MS) return;
+  _cancelRefreshTimer();
+  _refreshTimer = setTimeout(function () {
+    _refreshTimer = null;
+    // A suspended tab must not keep retrying beyond the original session's life.
+    if (Date.now() < deadline) _tryRefresh();
+  }, _REFRESH_MIN_DELAY_MS);
+}
+
 function _scheduleRefreshAt(epochSeconds) {
   if (_refreshTimer) {
     clearTimeout(_refreshTimer);
     _refreshTimer = null;
   }
-  if (typeof epochSeconds !== "number" || !isFinite(epochSeconds)) return;
+  if (
+    !_canRefresh() ||
+    typeof epochSeconds !== "number" ||
+    !isFinite(epochSeconds)
+  )
+    return;
+  _refreshExpiry = epochSeconds;
   const nowMs = Date.now();
   const expMs = epochSeconds * 1000;
   const remaining = expMs - nowMs;
@@ -841,6 +874,7 @@ function _storePermissions(data) {
     "ts.user_id",
     "turnstone_permissions",
     "turnstone_scopes",
+    "turnstone_can_refresh",
   ].map(function (key) {
     return sessionStorage.getItem(key);
   });
@@ -853,6 +887,13 @@ function _storePermissions(data) {
     sessionStorage.setItem("turnstone_scopes", data.scopes);
   } else {
     sessionStorage.removeItem("turnstone_scopes");
+  }
+  if (data && data.can_refresh === true) {
+    sessionStorage.setItem("turnstone_can_refresh", "true");
+  } else {
+    sessionStorage.removeItem("turnstone_can_refresh");
+    _cancelRefreshTimer();
+    _refreshExpiry = 0;
   }
   // Surface the authenticated identity for the rail footer's user chip.  whoami
   // returns the human `username` (display name) alongside the opaque user_id;
@@ -873,11 +914,14 @@ function _storePermissions(data) {
   } else {
     sessionStorage.removeItem("ts.user_id");
   }
-  const after = ["ts.user_id", "turnstone_permissions", "turnstone_scopes"].map(
-    function (key) {
-      return sessionStorage.getItem(key);
-    },
-  );
+  const after = [
+    "ts.user_id",
+    "turnstone_permissions",
+    "turnstone_scopes",
+    "turnstone_can_refresh",
+  ].map(function (key) {
+    return sessionStorage.getItem(key);
+  });
   if (before[0] && before[0] !== after[0]) _authEpoch++;
   if (JSON.stringify(before) !== JSON.stringify(after)) _publishAuthChange();
 }


### PR DESCRIPTION
Password login could issue a read-scoped session to a user with no effective permissions. JWT
exchange could bypass a refused renewal, and renewing an API-token session could expand its
explicit scopes to its owner's current roles.

Resolve password/OIDC permissions strictly at mint and renewal: empty authority returns 403 and
permission-store outages return 503 without replacing the existing cookie. Public token login
accepts raw stored API tokens; their derived sessions keep a fixed lifetime. Only non-service
password/OIDC sessions can renew. The browser consumes the same `can_refresh` eligibility and
retains current authority during a temporary refresh failure, with bounded retry before expiry.

CLI `create-user` now explicitly provisions viewer authority and rolls back failed provisioning.
Existing JWTs retain their remaining lifetime, explicit API token grants remain valid, and OIDC
keeps its existing default-viewer provisioning. API documentation and SDK schemas/types describe
these boundaries.

Validation:

- Independent whole-diff review: 177 focused tests passed. Fixed its one finding, the missing
  TypeScript setup eligibility field.
- Full Python suite: 13,757 passed, 52 skipped; Ruff check/format and mypy passed. TypeScript
  typecheck and all 85 SDK tests passed.
- Mounted node/console/proxy tests cover role removal, empty effective permissions, storage
  failures, source/scope eligibility, JWT exchange, and API-token deletion/expiry. The three
  storage-outage tests fail against the preceding implementation, confirming the regression guard.
- Real Chrome on the rebuilt PostgreSQL dev cluster verifies admin/operator login and console/node
  history, read-only API-token sessions, JWT/refresh refusal, raw-token revocation, and role removal.
  An injected browser 503 preserves identity and retries successfully against the real server.
  Temporary users/tokens are cleaned up. External OIDC exchange is mocked in callback tests.
- Repeated the expired-cookie startup, refresh recovery, and cross-tab stale-response checks on
  this build; all passed with no page errors and one shared auth module.

The negative-login checks exposed an existing Compose proxy configuration issue: Uvicorn's default
forwarded-header trust excludes Caddy's Docker IP, so browser clients share one login-rate bucket.
An isolated middleware/limiter reproduction confirms it; the exact-Caddy trust control separates
the clients. The login cooldown expired and both provided accounts and the reporting user could
sign in again. This change does not alter proxy trust or login-rate-limit policy.
