### PR TITLE
fix(console): align pane selection and tab controls

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -397,14 +397,18 @@ The rail is fed by the cluster SSE snapshot and shows:
 
 Coordinator and interactive conversations open as tabs inside the same shell. Interactive panes use
 the owning node's console proxy, so users do not need direct network access to compute-node ports.
-Split-right and split-down actions can display several panes at once. Each visible pane has a dismiss
-button at the left of its tab: `−` hides a regular split pane while keeping its tab open; `×` closes a
-single pane or a preview. Hovering or focusing the button draws a dashed outline around the affected
-pane, distinct from the active pane's solid accent. The Dashboard can be hidden from a split but cannot
-be closed. Closing a pane removes only that tab; use the pane menu's explicit close or delete action to
-change the workstream lifecycle. When tabs overflow, their strip scrolls horizontally; activating a
-tab or moving keyboard focus to it reveals its label and dismiss control together. When the strip or
-tab widths change, the tab with keyboard focus stays visible; otherwise, the active tab stays visible.
+Split-right and split-down actions can display several panes at once. The active tab's accent
+underline matches its pane's solid accent border; other visible tabs have a neutral frame. Each tab
+has a leading dismiss button: `−` hides a regular split pane while keeping its tab open; `×` closes a
+background tab, single pane, or preview. Hiding a pane immediately changes its tab's button to `×`.
+Hovering or focusing the button outlines its visible pane with a dashed line, distinct from the active
+pane's solid accent. The Dashboard can be hidden from a split but cannot be closed. A trailing chevron
+button opens the pane's action menu; Enter, Space, or ArrowDown opens it from the keyboard. The tab
+label also supports right-click and Shift+F10. Closing a pane removes only that tab; use the menu's
+explicit close or delete action to change the workstream lifecycle. When tabs overflow, their strip
+scrolls horizontally; activating a tab or moving keyboard focus to one of its controls reveals the
+complete tab. When the strip or tab widths change, the tab with keyboard focus stays visible;
+otherwise, the active tab stays visible.
 
 ### Dashboard pane
 

--- a/tests/test_pane_js.py
+++ b/tests/test_pane_js.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from tests._js_harness_helpers import FAKE_DOM, node_skip, run_node_source
 
 _PANE_JS = Path(__file__).resolve().parent.parent / "turnstone/shared_static/pane.js"
@@ -38,9 +40,11 @@ FakeElement.prototype.insertBefore = function (child, anchor) {
 FakeElement.prototype.removeChild = function (child) { child.remove(); };
 let keyboardFocus = true;
 const emit = (target, type, props = {}, bubbles = true) => {
-  const event = {target, type, preventDefault() {}, ...props};
+  let stopped = false;
+  const event = {target, type, preventDefault() {}, stopPropagation() { stopped = true; }, ...props};
   for (let node = target; node; node = bubbles ? node.parentNode : null) {
     for (const {fn} of node._listeners.get(type) || []) fn(event);
+    if (stopped) break;
   }
 };
 FakeElement.prototype.matches = function (selector) {
@@ -113,7 +117,7 @@ const overflowTabs = () => {
 @node_skip
 def test_tab_dismiss_hides_without_activating_or_destroying_the_pane() -> None:
     _run_panes(r"""
-assert(dismiss(a).hidden && !dismiss(b).hidden, "only visible panes offer dismissal");
+assert(!dismiss(a).hidden && !dismiss(b).hidden, "closable tabs always offer dismissal");
 assert(dismiss(dashboard).hidden, "background Dashboard cannot be dismissed");
 assert(pm.splitFocused("right", a.id).ok, "split must succeed");
 assert(dismiss(a).textContent === "−" && dismiss(b).textContent === "−", "split hides cells");
@@ -126,19 +130,55 @@ dismiss(b).focus();
 dismiss(b).click();
 assert(b.el.hidden && b.el.isConnected && b.tabEl.isConnected, "hide must retain pane and tab");
 assert(!closed.length && activated.length === previousActivations, "hide must not activate target");
-assert(dismiss(b).hidden && dismiss(a).textContent === "✕", "survivor must enter close mode");
-assert(document.activeElement === b.tabEl, "hidden control must return focus to its tab");
+assert(!dismiss(b).hidden && dismiss(a).textContent === "✕", "background and survivor offer close");
+assert(document.activeElement === b.tabEl, "hiding must return focus to its tab");
 assert(b.tabEl.parentElement === group, "hiding must preserve the tab group");
 pm.activate(b.id);
-assert(!dismiss(b).hidden && dismiss(a).hidden, "tab switching must refresh availability");
+assert(!dismiss(b).hidden && !dismiss(a).hidden, "tab switching retains both close controls");
 pm.setTabTitle(b.id, "Renamed pane");
 assert(dismiss(b).getAttribute("aria-label").includes("Renamed pane"), "label follows title");
 pm._restoreLayout({type: "split", dir: "row", ratio: 0.5,
   children: [{type: "leaf", paneId: a.id}, {type: "leaf", paneId: b.id}]});
 assert(!dismiss(a).hidden && dismiss(b).textContent === "−", "restore refreshes dismiss modes");
 pm.unsplit();
-assert(dismiss(a).hidden && dismiss(b).textContent === "✕", "unsplit refreshes dismiss modes");
+assert(dismiss(a).textContent === "✕" && dismiss(b).textContent === "✕", "unsplit offers close on both tabs");
 """)
+
+
+@node_skip
+@pytest.mark.parametrize("split_remains", [False, True])
+@pytest.mark.parametrize("hide_active", [False, True])
+def test_hidden_tab_can_close_without_reactivation(split_remains: bool, hide_active: bool) -> None:
+    _run_panes(
+        f"const splitRemains = {json.dumps(split_remains)}, hideActive = {json.dumps(hide_active)};\n"
+        + r"""
+assert(pm.splitFocused("right", a.id).ok, "split must succeed");
+if (splitRemains)
+  assert(pm.splitFocused("down", dashboard.id).ok, "third cell must fit");
+pm.activate(hideActive ? b.id : a.id);
+assert(dismiss(b).textContent === "−", "visible split pane offers hide");
+dismiss(b).focus();
+dismiss(b).click();
+assert(b.el.hidden && b.tabEl.isConnected && !closed.length, "hide retains the background tab");
+assert(pm.isSplit() === splitRemains, "hiding changes only the intended split cell");
+assert(!dismiss(b).hidden, "hidden tab must immediately offer dismissal");
+assert(dismiss(b).textContent === "✕", "hidden tab must switch from hide to close");
+assert(dismiss(b).classList.contains("tab-dismiss--close"), "hidden tab uses destructive styling");
+assert(dismiss(b).title === "Close pane", "tooltip must describe close");
+assert(dismiss(b).getAttribute("aria-label") === "Close pane: b", "accessible name must describe close");
+const activeBeforeClose = pm.getActive().type;
+const activationsBeforeClose = activated.length;
+dismiss(b).focus();
+assert(!b.el.classList.contains("tab-dismiss-target"), "hidden tab must not highlight a pane");
+dismiss(b).click();
+assert(closed.join() === "b", "the second dismiss destroys only the hidden pane");
+assert(!b.el.isConnected && !b.tabEl.isConnected, "close removes the hidden pane and its tab");
+assert(pm.getActive().type === activeBeforeClose && activated.length === activationsBeforeClose,
+  "closing a hidden tab must not reactivate it or disturb the active pane");
+assert(!a.el.hidden && a.el.isConnected, "surviving pane content stays connected and visible");
+assert(document.activeElement === a.tabEl, "close returns keyboard focus to the active tab");
+"""
+    )
 
 
 @node_skip
@@ -146,6 +186,9 @@ def test_tab_dismiss_closes_preview_and_respects_dashboard() -> None:
     _run_panes(r"""
 const preview = pm.openPaneBeside("preview");
 assert(dismiss(preview).textContent === "✕", "split preview must advertise close");
+assert(dismiss(preview).classList.contains("tab-dismiss--close"), "preview has destructive styling");
+assert(dismiss(preview).title === "Close pane", "preview tooltip describes close");
+assert(dismiss(preview).getAttribute("aria-label") === "Close pane: preview", "preview has close name");
 const group = preview.tabEl.parentElement;
 dismiss(preview).focus();
 dismiss(preview).click();
@@ -159,6 +202,67 @@ dismiss(dashboard).click();
 assert(dashboard.el.isConnected && dashboard.el.hidden, "Dashboard hide must retain its tab");
 pm.activate(dashboard.id);
 assert(dismiss(dashboard).hidden, "single Dashboard must not offer close");
+""")
+
+
+@node_skip
+def test_tab_menu_button_is_separate_and_preserves_selection_and_focus() -> None:
+    _run_panes(r"""
+document.body = document.documentElement;
+document._listeners = new Map();
+document.addEventListener = FakeElement.prototype.addEventListener;
+document.removeEventListener = FakeElement.prototype.removeEventListener;
+FakeElement.prototype.getBoundingClientRect = () => ({left: 20, right: 60, top: 0, bottom: 28,
+  width: 40, height: 28});
+window.innerWidth = 1400;
+window.innerHeight = 900;
+let invoked = false;
+pm.registerType("menu", () => {
+  const pane = new ShellPane({type: "menu", title: "Menu pane"});
+  pane.tabMenu = () => [{label: "Inspect", action: () => { invoked = true; }},
+    {label: "Second", action: () => {}}];
+  return pane;
+});
+const pane = pm.openPane("menu");
+pm.activate(a.id);
+const button = pane._tabGroup.querySelector(".tab-caret");
+assert(button.tagName === "BUTTON" && button.type === "button", "menu has a real button");
+assert(button.parentElement === pane.tabEl.parentElement && !pane.tabEl.contains(button),
+  "menu and selection controls are siblings");
+assert(button.getAttribute("aria-haspopup") === "menu", "menu button announces its popup");
+assert(!button.hasAttribute("aria-hidden"), "menu button must be exposed to assistive technology");
+assert(!tabs.querySelector('[role="tablist"]').contains(button), "menu stays outside the tablist");
+pm.setTabTitle(pane.id, "Renamed menu");
+assert(button.getAttribute("aria-label") === "Pane actions: Renamed menu", "menu name follows title");
+const activationsBefore = activated.length;
+button.focus();
+emit(button, "click");
+assert(button.getAttribute("aria-expanded") === "true", "click opens the menu");
+assert(document.body.querySelector('[role="menu"]').getAttribute("aria-label") ===
+  "Renamed menu actions", "menu belongs to the requested background tab");
+button.focus();
+emit(button, "click");
+assert(button.getAttribute("aria-expanded") === "false", "second click closes the menu");
+pressKey("ArrowDown");
+assert(document.activeElement === document.body.querySelector('.tab-menu-item'),
+  "ArrowDown opens at the first menu item");
+emit(document, "keydown", {key: "Escape"});
+assert(document.activeElement === button && !document.body.querySelector('[role="menu"]'),
+  "Escape returns focus to the menu button");
+pane.tabEl.focus();
+emit(pane.tabEl, "keydown", {key: "F10", shiftKey: true});
+emit(document, "keydown", {key: "Escape"});
+assert(document.activeElement === pane.tabEl, "Shift+F10 returns focus to the tab label");
+emit(pane.tabEl, "contextmenu");
+document.body.querySelector('.tab-menu-item').click();
+assert(invoked && document.activeElement === pane.tabEl, "menu action returns focus to its opener");
+button.focus();
+emit(button, "click");
+await new Promise(resolve => setTimeout(resolve, 0));
+emit(document, "mousedown", {target: a.tabEl});
+assert(button.getAttribute("aria-expanded") === "false", "outside click clears menu state");
+assert(pm.getActive().type === "a" && activated.length === activationsBefore,
+  "menu interactions must not activate the background pane");
 """)
 
 

--- a/tests/test_preview_js.py
+++ b/tests/test_preview_js.py
@@ -295,15 +295,6 @@ class TestEphemeralDismiss:
             "the skipped (ephemeral / single-pane) case must land on close()"
         )
 
-    def test_tab_dismiss_signals_destruction_for_ephemeral(self) -> None:
-        """The glyph/label must not lie: an ephemeral pane's dismiss button reads
-        as a destructive close (✕ + danger hover + 'Close pane'), never the
-        reversible '− / Hide from split'."""
-        body = _read(_PANE_JS)
-        assert "const destroys = !multi || pane.ephemeral;" in body, (
-            "dismiss mode must treat ephemeral panes as destructive even in a split"
-        )
-
     def test_unsplit_closes_ephemeral_non_survivors(self) -> None:
         """Collapsing the split from the OTHER pane must not orphan the preview
         either — unsplit closes ephemeral panes it isn't keeping."""

--- a/tests/test_shell_js.py
+++ b/tests/test_shell_js.py
@@ -843,9 +843,9 @@ def test_step5d_rail_open_marker_tracks_active_pane() -> None:
 def test_step7_tab_dropdown_mechanism() -> None:
     """Step 7: PaneManager owns the GENERIC tab-action dropdown — a caret on any
     pane that exposes ``tabMenu()`` (the Dashboard home exposes none, so no
-    caret), opening a keyboard-navigable ``.tab-menu``.  The caret is a <span>,
-    NOT a nested <button> inside the tab <button> (invalid markup); the menu is
-    reachable by keyboard via ContextMenu / Shift+F10, and a single menu is open
+    caret), opening a keyboard-navigable ``.tab-menu``. The menu button is a sibling
+    of the selection button. The menu is also reachable through ContextMenu / Shift+F10,
+    and a single menu is open
     at a time (Escape / outside-click close it)."""
     body = _PANE_JS.read_text(encoding="utf-8")
     assert "_openTabMenu(" in body and "_closeTabMenu(" in body, (
@@ -1146,7 +1146,6 @@ def test_pane_manager_split_engine() -> None:
     # mode-DISTINCT glyphs (designer P1: identical signifier + locus with a
     # reversible/destructive divergence is a mode-error trap) — a click that
     # cannot be a reversible cell-hide shows ✕, else −.
-    assert "const destroys = !multi || pane.ephemeral;" in pane
     assert 'b.textContent = destroys ? "✕" : "−"' in pane
     assert '"tab-dismiss--close"' in pane
     # open-beside: the coordinator child-link placement (split right of the

--- a/turnstone/shared_static/pane.js
+++ b/turnstone/shared_static/pane.js
@@ -356,7 +356,7 @@ export class PaneManager {
     if (!pane || text == null || text === "") return;
     pane.title = text;
     if (pane._titleNode) pane._titleNode.textContent = text;
-    if (pane.tabEl) this._refreshTabDismiss(pane);
+    if (pane.tabEl) this._refreshTab(pane.tabEl, pane);
   }
 
   /** Open panes whose tab shows live Tier-1 state — `{id, rawId}[]` (the shell
@@ -1195,25 +1195,23 @@ export class PaneManager {
     titleNode.textContent = pane.title;
     tab.append(titleNode);
     pane._titleNode = titleNode; // setTabTitle repaints this from Tier-1
-    // Tab-action menu (step 7): a pane that exposes `tabMenu()` gets a caret to
-    // the right of its label that opens the action dropdown (the three-verb close
-    // + per-persona verbs).  The Dashboard home tab exposes none, so it gets no
-    // caret.  The caret is a <span>, NOT a nested <button> (invalid inside the
-    // tab <button>); a click is routed to the menu vs activation by its target.
+    // Pane actions have their own trailing button, beside the selection button.
+    // The Dashboard exposes no menu. Keep all three controls as siblings so
+    // opening the menu cannot activate the pane or nest interactive elements.
     if (typeof pane.tabMenu === "function") {
-      const caret = document.createElement("span");
+      const caret = document.createElement("button");
+      caret.type = "button";
       caret.className = "tab-caret";
-      caret.setAttribute("aria-hidden", "true");
-      caret.textContent = "▾"; // down-caret menu affordance
-      tab.append(caret);
-      tab.setAttribute("aria-haspopup", "menu");
-      tab.setAttribute("aria-expanded", "false");
+      caret.title = "Pane actions";
+      caret.setAttribute("aria-haspopup", "menu");
+      caret.setAttribute("aria-expanded", "false");
+      caret.addEventListener("click", () => {
+        if (caret.getAttribute("aria-expanded") === "true") this._closeTabMenu();
+        else this._openTabMenu(caret, pane);
+      });
+      pane._menuBtn = caret;
     }
-    tab.addEventListener("click", (e) => {
-      if (typeof pane.tabMenu === "function" && e.target.closest(".tab-caret"))
-        this._openTabMenu(tab, pane);
-      else this.activate(pane.id);
-    });
+    tab.addEventListener("click", () => this.activate(pane.id));
     // Right-click / long-press parity with the caret.
     tab.addEventListener("contextmenu", (e) => {
       if (typeof pane.tabMenu !== "function") return;
@@ -1221,6 +1219,7 @@ export class PaneManager {
       this._openTabMenu(tab, pane);
     });
     group.append(dismiss, tab);
+    if (pane._menuBtn) group.append(pane._menuBtn);
     this._tabResizeObserver.observe(group);
     pane.tabEl = tab;
     return tab;
@@ -1237,19 +1236,19 @@ export class PaneManager {
     tab.setAttribute("aria-selected", active ? "true" : "false");
     tab.tabIndex = active ? 0 : -1;
     this._refreshTabDismiss(pane);
+    if (pane._menuBtn)
+      pane._menuBtn.setAttribute("aria-label", "Pane actions: " + pane.title);
   }
 
-  /** Only visible panes offer dismissal: − hides a regular split cell while
-   *  ✕ closes a single or ephemeral pane.  The leading slot stays reserved
-   *  when unavailable, so hiding a cell cannot move another tab under the pointer. */
+  /** A visible regular split pane offers −; background, single, and ephemeral
+   *  panes offer ✕. Only an unclosable pane outside the split has no action;
+   *  its leading slot stays reserved so other tabs cannot shift under the pointer. */
   _refreshTabDismiss(pane) {
-    const multi = !!this._layout && this._leaves().length > 1;
-    const want =
-      !pane.el.hidden && (multi ? !!this._leafFor(pane.id) : pane.closable !== false);
+    const destroys = !this._leafFor(pane.id) || pane.ephemeral;
+    const want = !destroys || pane.closable !== false;
     const b = pane._dismissBtn;
     b.hidden = !want;
-    if (!want) pane.el.classList.remove("tab-dismiss-target");
-    const destroys = !multi || pane.ephemeral;
+    if (!want || pane.el.hidden) pane.el.classList.remove("tab-dismiss-target");
     b.textContent = destroys ? "✕" : "−";
     b.classList.toggle("tab-dismiss--close", destroys);
     const label = destroys
@@ -1267,13 +1266,18 @@ export class PaneManager {
     const group = document.activeElement.closest(".tab");
     const i = tabs.indexOf(group && group.querySelector('[role="tab"]'));
     if (i < 0) return;
-    // ContextMenu key / Shift+F10 opens the focused tab's action menu — keyboard
-    // parity with the caret click (the caret itself is a decorative span).
-    if (e.key === "ContextMenu" || (e.shiftKey && e.key === "F10")) {
-      const pane = this._panes.get(tabs[i].dataset.paneId);
+    const pane = this._panes.get(tabs[i].dataset.paneId);
+    const onMenu = pane && document.activeElement === pane._menuBtn;
+    // The menu button accepts ArrowDown; tab labels retain ContextMenu / Shift+F10.
+    if (
+      e.key === "ContextMenu" ||
+      (e.shiftKey && e.key === "F10") ||
+      (onMenu && e.key === "ArrowDown")
+    ) {
       if (pane && typeof pane.tabMenu === "function") {
         e.preventDefault();
-        this._openTabMenu(tabs[i], pane);
+        e.stopPropagation(); // the new menu must not consume its opening ArrowDown
+        this._openTabMenu(onMenu ? pane._menuBtn : tabs[i], pane);
       }
       return;
     }
@@ -1296,7 +1300,7 @@ export class PaneManager {
    *  chrome + keyboard + positioning live in the shared openPopupMenu helper.
    *  Singleton menu — opening one closes any other.  Items are
    *  `{label, key?, cls?, separator?, action}`. */
-  _openTabMenu(tab, pane) {
+  _openTabMenu(trigger, pane) {
     this._closeTabMenu();
     let items;
     try {
@@ -1307,13 +1311,13 @@ export class PaneManager {
     }
     if (!items.length) return;
     const handle = openPopupMenu(
-      tab.querySelector(".tab-caret") || tab,
+      pane._menuBtn || trigger,
       items,
       {
         label: (pane.title || "Pane") + " actions",
-        expandEl: tab,
-        returnFocusEl: tab,
-        ignoreEl: tab, // a click elsewhere on the tab is menu-adjacent, not "outside"
+        expandEl: pane._menuBtn || trigger,
+        returnFocusEl: trigger,
+        ignoreEl: pane._menuBtn || trigger,
         onClose: () => {
           if (this._openMenu && this._openMenu.handle === handle)
             this._openMenu = null;

--- a/turnstone/shared_static/shell.css
+++ b/turnstone/shared_static/shell.css
@@ -561,32 +561,42 @@
 .tab.active .glyph {
   color: var(--ink-2);
 }
-/* Tab-action caret — opens the pane's action dropdown (step 7).  A decorative
-   span inside the tab <button> (a nested <button> is invalid markup); the menu
-   it triggers is keyboard-reachable via ContextMenu / Shift+F10 on the focused
-   tab.  Dim by default, brightening on tab hover / active / open. */
+/* A divider and chevron identify the pane menu without another boxed control.
+   The trailing button keeps a 28px target beside the label and leading dismiss. */
 .tab-caret {
-  margin-left: 6px;
-  margin-right: -3px;
-  padding: 2px 3px;
-  color: var(--ink-4);
-  font-size: 10px;
-  line-height: 1;
-  border-radius: var(--r-sm);
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-right: 1px;
+  padding: 0;
+  border: 0;
+  border-left: 1px solid var(--hair-2);
+  border-radius: 0;
+  background: none;
+  color: var(--ink-3);
+  font: inherit;
+  cursor: pointer;
+  opacity: 0.85;
   transition:
     color 0.1s,
     background 0.1s;
 }
-.tab:hover .tab-caret,
-.tab.active .tab-caret {
-  color: var(--ink-2);
+.tab-caret::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-2px) rotate(45deg);
 }
 .tab-caret:hover,
-.tab-select[aria-expanded="true"] .tab-caret {
+.tab-caret[aria-expanded="true"] {
+  opacity: 1;
   color: var(--ink);
-}
-.tab-caret:hover {
-  background: var(--hair-2);
+  background: var(--panel-2);
 }
 /* Split controls in the tab-bar tail (they replaced the redundant [+] — the
    permanent Dashboard tab IS the launcher).  One ◫ glyph for both directions;
@@ -862,12 +872,9 @@
   z-index: 13; /* above the ring overlay — a clean bar, not bar-plus-ring-line */
   pointer-events: none;
 }
-/* Leading tab dismiss button — available for every visible pane.  Split mode:
-   "−" hides this cell (the TAB stays — closeCell), but an ephemeral pane (the
-   preview) shows "✕" and closes outright; single-pane: "✕" closes the pane
-   (withheld from the unclosable Dashboard).  The destructive "✕" modes wear
-   .tab-dismiss--close.  The fixed slot keeps tab positions stable when a pane
-   is hidden or the Dashboard cannot be dismissed. */
+/* Leading tab dismiss button: "−" hides a regular split cell (the tab stays);
+   "✕" closes a background tab, single pane, or preview. An unclosable Dashboard
+   outside the split has no action. The fixed slot keeps other tabs in place. */
 .tab-dismiss {
   flex: none;
   margin: 0 1px;
@@ -904,7 +911,8 @@
   border-color: var(--err);
 }
 .tab-select:focus-visible,
-.tab-dismiss:focus-visible {
+.tab-dismiss:focus-visible,
+.tab-caret:focus-visible {
   opacity: 1;
   outline: 2px solid var(--accent);
   outline-offset: -2px;
@@ -914,7 +922,8 @@
 }
 /* light resting glyph at .85 sat right at the 3:1 floor with --ink-3 — one
    ink step restores headroom (~4.5:1) without making the chip shout */
-[data-theme="light"] .tab-dismiss {
+[data-theme="light"] .tab-dismiss,
+[data-theme="light"] .tab-caret {
   color: var(--ink-2);
 }
 /* separator — a 7px hit area straddling the cell boundary with a 1px visual
@@ -973,15 +982,14 @@
   top: 2px;
   height: 3px;
 }
-/* a visible-but-unfocused pane's tab — the three tab states must each read:
-   rest (bare) → shown (accent UNDERLINE — a shape, not a fill delta; rhymes
-   with the focused cell's TOP bar) → active (panel fill).  Designer-measured:
-   a border/fill-only delta between shown and active was ≤1.1:1. */
+/* Visible panes keep a neutral tab frame. Only the active tab gets the accent
+   underline, matching its pane's solid accent border and top bar. A fill-only
+   difference is too subtle to distinguish selection from the other visible tabs. */
 .tab.shown:not(.active) {
   border-color: var(--hair-2);
   color: var(--ink-2);
 }
-.tab.shown:not(.active)::after {
+.tab.active::after {
   content: "";
   position: absolute;
   pointer-events: none;


### PR DESCRIPTION
Split views could underline a different tab from the active pane, and hiding a pane removed its
close control until reactivation. The pane menu also needed a clearer target beside the quick
hide/close control.

- Put the accent underline on the active tab so rail, preview, and tab selection agree visually.
- Immediately show a close button on hidden closable tabs; closing one preserves the active pane.
- Give pane actions a separate 28px chevron button with a divider, muted resting color, keyboard
  activation, and focus restoration.
- Add behavioral regression coverage and update the console documentation.

Validation:

- Full local SQLite suite: 13,761 passed, 52 skipped.
- Ruff checks, formatting, and mypy passed; CSS specificity has no new findings versus main.
- Dev browser verification covered selection, hiding and closing tabs, pointer and keyboard menus,
  and narrow layouts in both themes. The final color adjustment was checked separately in both
  themes. Assets came from the deployed image; workstream and preview data were browser fixtures.
- Admin and operator browser login and reload passed. The deployed assets match this change, and
  all ten nodes report healthy with no version drift.

