### PR TITLE
test: reduce fixture setup and teardown overhead

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import shutil
 import socket
 import subprocess
 import sys
@@ -139,6 +140,7 @@ def resolve_when_pending(ui: Any, *args: Any, **kwargs: Any) -> _PendingResolver
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from pathlib import Path
 
     from turnstone.core.mcp_client import MCPClientManager, StaticServerState
     from turnstone.core.mcp_crypto import MCPTokenCipher
@@ -405,13 +407,39 @@ def fresh_pg_url(request: pytest.FixtureRequest) -> Iterator[Any]:
         admin.dispose()
 
 
+@pytest.fixture(scope="session")
+def sqlite_schema_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Prepare an empty schema once; tests copy it into their own temporary paths."""
+    from turnstone.core.storage._sqlite import SQLiteBackend
+
+    path = tmp_path_factory.mktemp("sqlite-schema") / "template.db"
+    # Closing the last connection checkpoints WAL before any file is copied.
+    with contextlib.closing(SQLiteBackend(str(path))):
+        pass
+    return path
+
+
+@pytest.fixture(scope="session")
+def sqlite_migrated_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Prepare migration seed data without changing the storage singleton."""
+    from turnstone.core.storage._migrate import run_migrations
+    from turnstone.core.storage._sqlite import SQLiteBackend
+
+    path = tmp_path_factory.mktemp("sqlite-migrated") / "template.db"
+    with contextlib.closing(SQLiteBackend(str(path), create_tables=False)) as storage:
+        run_migrations(storage, "sqlite")
+    return path
+
+
 @pytest.fixture
-def tmp_db(tmp_path):
+def tmp_db(tmp_path, sqlite_schema_template):
     """Provide a temporary SQLite storage backend (singleton registry)."""
     from turnstone.core.storage import init_storage, reset_storage
 
     db_path = str(tmp_path / "test.db")
     reset_storage()
+    if not os.path.exists(db_path):
+        shutil.copyfile(sqlite_schema_template, db_path)
     init_storage("sqlite", path=db_path, run_migrations=False)
     yield db_path
     reset_storage()
@@ -456,6 +484,8 @@ def storage_backend(request, tmp_path):
             reset_storage()
     else:
         db_path = str(tmp_path / "test.db")
+        if not os.path.exists(db_path):
+            shutil.copyfile(request.getfixturevalue("sqlite_schema_template"), db_path)
         backend = init_storage("sqlite", path=db_path, run_migrations=False)
         yield backend
         reset_storage()

--- a/tests/test_interactive_history_rbac.py
+++ b/tests/test_interactive_history_rbac.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import queue
+import shutil
 import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import bcrypt
 import httpx
 import pytest
 
@@ -14,7 +16,7 @@ from tests.test_server_authz import _FakeSession, _FakeUI
 from turnstone.console.collector import ClusterCollector
 from turnstone.console.server import create_app as create_console
 from turnstone.core.adapters.interactive_adapter import InteractiveAdapter
-from turnstone.core.auth import JWT_AUD_CONSOLE, JWT_AUD_SERVER, create_jwt, hash_password
+from turnstone.core.auth import JWT_AUD_CONSOLE, JWT_AUD_SERVER, create_jwt
 from turnstone.core.config_store import ConfigStore
 from turnstone.core.session_manager import SessionManager
 from turnstone.core.storage import init_storage, reset_storage
@@ -25,11 +27,15 @@ _SECRET = "history-rbac-test-secret-at-least-32-characters"
 
 
 @pytest.fixture
-async def history_apps(tmp_path):
+async def history_apps(tmp_path, sqlite_migrated_template):
     reset_storage()
-    storage = init_storage("sqlite", path=str(tmp_path / "history.db"))
+    db_path = tmp_path / "history.db"
+    shutil.copyfile(sqlite_migrated_template, db_path)
+    storage = init_storage("sqlite", path=str(db_path))
     password = "history-test-password"
-    password_hash = hash_password(password)
+    # Exercise real password verification without paying production hashing cost
+    # in every auth-policy case. Hashing policy has its own test_auth_identity coverage.
+    password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=4)).decode()
     for user, role in (("operator", "operator"), ("admin", "admin"), ("viewer", "viewer")):
         storage.create_user(user, user, user, password_hash)
         storage.assign_role(user, "builtin-" + role)

--- a/tests/test_output_guard_judge.py
+++ b/tests/test_output_guard_judge.py
@@ -44,7 +44,11 @@ class _VersionedConfigStore:
 
 
 def _make_provider(
-    content: str = "", *, delay: float = 0.0, raises: Exception | None = None
+    content: str = "",
+    *,
+    release: threading.Event | None = None,
+    started: threading.Event | None = None,
+    raises: Exception | None = None,
 ) -> Any:
     """Build a mock LLMProvider whose create_streaming returns the given content."""
     provider = MagicMock()
@@ -57,8 +61,11 @@ def _make_provider(
     provider.get_capabilities = MagicMock(return_value=ModelCapabilities(context_window=200_000))
 
     def _create_streaming(**_kwargs: Any) -> Any:
-        if delay:
-            time.sleep(delay)
+        if started is not None:
+            started.set()
+        if release is not None:
+            # Only a failure backstop: healthy tests release their worker in finally.
+            release.wait(5.0)
         if raises is not None:
             raise raises
         return as_stream(_mock_result(content))
@@ -101,7 +108,8 @@ def _make_judge(
     *,
     content: str = "",
     timeout: float = 5.0,
-    delay: float = 0.0,
+    release: threading.Event | None = None,
+    started: threading.Event | None = None,
     raises: Exception | None = None,
 ) -> OutputGuardJudge:
     """Construct an OutputGuardJudge wired to a mock provider.
@@ -109,7 +117,7 @@ def _make_judge(
     Patches ``_create_client`` on the instance so the lazy-init path
     returns the in-memory mock without hitting the real client factory.
     """
-    provider = _make_provider(content, delay=delay, raises=raises)
+    provider = _make_provider(content, release=release, started=started, raises=raises)
     config = JudgeConfig(output_guard_llm=True, output_guard_llm_timeout=timeout)
     client = MagicMock()
     client.base_url = "http://test"
@@ -317,41 +325,44 @@ class TestEvaluateFailurePaths:
         assert v.error.startswith("provider_error:")
 
     def test_timeout_returns_within_budget(self) -> None:
-        # Provider sleeps 5s but timeout is 1s.  Verify the function
-        # actually returns within ~1s wall-clock — the previous
-        # `with ThreadPoolExecutor` exit blocked until the worker
-        # drained, so this test would have hung waiting for the 5s
-        # sleep before the executor's shutdown(wait=True) on exit.
+        # Keep the provider blocked until after the early-return assertion. The
+        # old executor shutdown(wait=True) would wait for the 5s failure backstop.
+        release = threading.Event()
+        started = threading.Event()
         judge = _make_judge(
             content='{"risk_level":"medium","flags":[],"reasoning":""}',
             timeout=1.0,
-            delay=5.0,
+            release=release,
+            started=started,
         )
-        start = time.monotonic()
-        v = judge.evaluate("payload", call_id="c1")
-        elapsed = time.monotonic() - start
-        assert not v.succeeded
-        assert v.error == "timeout"
-        # Allow generous slack — 2x the configured timeout is plenty.
-        assert elapsed < 2.5, f"timeout returned in {elapsed:.2f}s, expected < 2.5s"
+        try:
+            start = time.monotonic()
+            v = judge.evaluate("payload", call_id="c1")
+            elapsed = time.monotonic() - start
+            assert started.is_set()
+            assert not v.succeeded
+            assert v.error == "timeout"
+            assert elapsed < 2.5, f"timeout returned in {elapsed:.2f}s, expected < 2.5s"
+        finally:
+            release.set()
 
     def test_cancel_event(self) -> None:
-        judge = _make_judge(content='{"risk_level":"medium"}', delay=5.0, timeout=10.0)
+        release = threading.Event()
         cancel = threading.Event()
-        # Fire the cancel from a side thread shortly after evaluate starts.
-
-        def _trigger() -> None:
-            time.sleep(0.2)
-            cancel.set()
-
-        threading.Thread(target=_trigger, daemon=True).start()
-        start = time.monotonic()
-        v = judge.evaluate("payload", call_id="c1", cancel_event=cancel)
-        elapsed = time.monotonic() - start
-        assert not v.succeeded
-        assert v.error == "cancelled"
-        # Cancel should return promptly, well below the 10s timeout.
-        assert elapsed < 2.0, f"cancel returned in {elapsed:.2f}s, expected < 2.0s"
+        # Signal cancellation only once the provider is actually running.
+        judge = _make_judge(
+            content='{"risk_level":"medium"}', timeout=10.0, release=release, started=cancel
+        )
+        try:
+            start = time.monotonic()
+            v = judge.evaluate("payload", call_id="c1", cancel_event=cancel)
+            elapsed = time.monotonic() - start
+            assert cancel.is_set()
+            assert not v.succeeded
+            assert v.error == "cancelled"
+            assert elapsed < 2.0, f"cancel returned in {elapsed:.2f}s, expected < 2.0s"
+        finally:
+            release.set()
 
     def test_pre_set_cancel_skips_client_auth_and_provider(self) -> None:
         """An already-abandoned evaluation spends no connection or credential work."""
@@ -380,19 +391,25 @@ class TestEvaluateFailurePaths:
         # The old ThreadPoolExecutor worker was non-daemon and got joined by
         # concurrent.futures' atexit hook, hanging the whole test run at
         # shutdown.  See turnstone/core/deadline.py.
+        release = threading.Event()
+        started = threading.Event()
         judge = _make_judge(
             content='{"risk_level":"medium","flags":[],"reasoning":""}',
             timeout=1.0,
-            delay=5.0,
+            release=release,
+            started=started,
         )
-        v = judge.evaluate("payload", call_id="c1")
-        assert v.error == "timeout"
-        stragglers = [
-            t
-            for t in threading.enumerate()
-            if t.name.startswith("output-guard-judge") and not t.daemon
-        ]
-        assert stragglers == [], f"non-daemon worker survived evaluate(): {stragglers}"
+        try:
+            v = judge.evaluate("payload", call_id="c1")
+            assert started.is_set()
+            assert v.error == "timeout"
+            workers = [t for t in threading.enumerate() if t.name.startswith("output-guard-judge")]
+            assert workers, "provider worker must still be blocked when its daemon flag is checked"
+            assert all(t.daemon for t in workers), (
+                f"non-daemon worker survived evaluate(): {workers}"
+            )
+        finally:
+            release.set()
 
 
 class TestOversizeGuard:

--- a/tests/test_session_attachments.py
+++ b/tests/test_session_attachments.py
@@ -40,6 +40,8 @@ def _make_session(mock_client, user_id: str = "u1") -> ChatSession:
         user_id=user_id,
     )
     register_workstream(s._ws_id)
+    # Message-shape tests do not exercise the background title request.
+    s._title_generated = True
     # Short-circuit the response loop: patch out the methods send() will call
     # after appending the user message so the test can focus on message shape.
     s._refresh_model_from_registry = lambda: None  # type: ignore[method-assign]

--- a/tests/test_storage_fixtures.py
+++ b/tests/test_storage_fixtures.py
@@ -1,0 +1,51 @@
+"""Shared database fixtures retain isolation, seed policy, and full-text indexing."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+
+import pytest
+
+from turnstone.core.storage import get_storage
+from turnstone.core.storage._sqlite import SQLiteBackend
+
+
+@pytest.mark.parametrize("fixture_name", ["tmp_db", "storage_backend"])
+@pytest.mark.parametrize("iteration", range(2))
+def test_storage_fixtures_start_empty_and_index_new_rows(request, fixture_name, iteration):
+    # Reusing the same keys in separate invocations catches a shared writable DB.
+    request.getfixturevalue(fixture_name)
+    storage = get_storage()
+    assert storage.get_user("fixture-user") is None
+    assert storage.get_role("builtin-admin") is None
+    storage.create_user("fixture-user", "fixture-user", "Fixture User", "")
+    assert storage.get_user("fixture-user") is not None
+    storage.register_workstream("fixture-ws")
+    storage.save_message("fixture-ws", "user", "fixturetoken")
+    assert storage.search_history("fixturetoken")
+
+    if isinstance(storage, SQLiteBackend):
+        with contextlib.closing(sqlite3.connect(storage._path)) as connection:
+            fts5 = connection.execute("SELECT sqlite_compileoption_used('ENABLE_FTS5')").fetchone()
+            if fts5[0]:
+                # A copied schema opened with create_tables=False would leave the
+                # backend's FTS flag disabled and silently use fallback search.
+                assert storage._fts5_available
+                rows = connection.execute(
+                    "SELECT rowid FROM conversations_fts WHERE conversations_fts MATCH ?",
+                    ("fixturetoken",),
+                ).fetchall()
+                assert len(rows) == 1
+
+
+@pytest.mark.parametrize(
+    "first,second", [("tmp_db", "storage_backend"), ("storage_backend", "tmp_db")]
+)
+def test_sqlite_fixtures_preserve_rows_when_reopening_the_same_path(request, first, second):
+    if request.config.getoption("--storage-backend") != "sqlite":
+        pytest.skip("the two fixtures only share a path in the SQLite lane")
+    request.getfixturevalue(first)
+    get_storage().create_user("fixture-user", "fixture-user", "Fixture User", "")
+    request.getfixturevalue(second)
+    assert get_storage().get_user("fixture-user") is not None


### PR DESCRIPTION
Repeated database setup and background worker cleanup consume a substantial part of the test
suite's CI budget. Prepare closed SQLite schema and migration templates once per pytest run,
then copy them into each test's private database while retaining normal initialization and FTS
checks. Templates regenerate from the current schema and migrations automatically.

Use inexpensive bcrypt credentials in the history auth fixture, suppress unrelated title
generation in attachment tests, and release blocked judge fakes after their timeout/cancellation
assertions. Each test retains independent database/app state, real password verification, and
the existing timeout and thread-leak checks. Add six fixture cases covering isolation, seed
policy, FTS indexing, and reopening an existing database.

The CI timeout is unchanged.

### Timing

One complete local before/after comparison using Python 3.13.11, identical test dependency
versions, and coverage enabled: **886.69s → 698.51s (21.2% faster)**. GitHub runner savings
remain to be measured.

| Phase | Before | After |
| --- | ---: | ---: |
| Setup | 367.80s | 213.97s |
| Test calls | 362.91s | 353.42s |
| Teardown | 84.39s | 46.60s |

### Validation

- Full SQLite CI selection with coverage: **13,878 passed, 28 skipped, 17 deselected**.
  All 13,900 original selected test IDs and outcomes are retained, with six added cases.
- Targeted PostgreSQL 18 storage/schema checks: **92 passed, 2 skipped**.
- Runtime negative controls still fail for blocking worker cleanup and non-daemon workers.
- CI-pinned Ruff check/format and mypy passed.
- Independent correctness and code-quality reviews found no actionable issues; each reviewer
  also passed all 130 tests in the affected test modules.
