### PR TITLE
chore: modernize Python typing and enable Ruff checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "TCH"]
-# Keep assignment-based aliases, shared TypeVars, and explicit generator type arguments.
-ignore = ["E501", "UP040", "UP043", "UP047"]
+ignore = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/sdk/typescript/openapi-console.json
+++ b/sdk/typescript/openapi-console.json
@@ -12443,12 +12443,8 @@
             "type": "integer"
           },
           "max_concurrency": {
-            "default": 0,
-            "description": "Maximum concurrent model generations for this alias in one process; zero means unlimited.",
-            "maximum": 2147483647,
-            "minimum": 0,
-            "title": "Max Concurrency",
-            "type": "integer"
+            "$ref": "#/components/schemas/ModelMaxConcurrency",
+            "default": 0
           },
           "capabilities": {
             "default": "{}",
@@ -12550,6 +12546,12 @@
         "title": "ModelDefinitionInfo",
         "type": "object"
       },
+      "ModelMaxConcurrency": {
+        "description": "Maximum concurrent model generations for this alias in one process; zero means unlimited.",
+        "maximum": 2147483647,
+        "minimum": 0,
+        "type": "integer"
+      },
       "ModelDefinitionWriteResponse": {
         "description": "Create/update response: the stored row plus an optional caveat.\n\n``registry_warning`` is present only when the DB write succeeded but\nTHIS console's live coordinator registry refused to adopt it (keyless\nhost with dynamic-auth rows): the row is saved, yet running sessions\nkeep the previous config until the deployment fault is remedied.\nClients should surface it as a warning beside the success, never as a\nfailure. Absent on a clean save (SkipJsonSchema: the server omits the\nkey rather than sending null).",
         "properties": {
@@ -12586,12 +12588,8 @@
             "type": "integer"
           },
           "max_concurrency": {
-            "default": 0,
-            "description": "Maximum concurrent model generations for this alias in one process; zero means unlimited.",
-            "maximum": 2147483647,
-            "minimum": 0,
-            "title": "Max Concurrency",
-            "type": "integer"
+            "$ref": "#/components/schemas/ModelMaxConcurrency",
+            "default": 0
           },
           "capabilities": {
             "default": "{}",
@@ -12730,12 +12728,8 @@
             "type": "integer"
           },
           "max_concurrency": {
-            "default": 0,
-            "description": "Maximum concurrent model generations for this alias in one process; zero means unlimited.",
-            "maximum": 2147483647,
-            "minimum": 0,
-            "title": "Max Concurrency",
-            "type": "integer"
+            "$ref": "#/components/schemas/ModelMaxConcurrency",
+            "default": 0
           },
           "capabilities": {
             "additionalProperties": true,
@@ -12891,11 +12885,8 @@
             "title": "Context Window"
           },
           "max_concurrency": {
-            "description": "Maximum concurrent model generations for this alias in one process; zero means unlimited.",
-            "maximum": 2147483647,
-            "minimum": 0,
-            "title": "Max Concurrency",
-            "type": "integer"
+            "$ref": "#/components/schemas/ModelMaxConcurrency",
+            "title": "Max Concurrency"
           },
           "capabilities": {
             "additionalProperties": true,

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -421,18 +421,21 @@ def test_model_max_concurrency_schema_is_strict_non_nullable_integer() -> None:
     from turnstone.api.console_spec import build_console_spec
 
     schemas = build_console_spec()["components"]["schemas"]
+    concurrency_schema = schemas["ModelMaxConcurrency"]
+    assert concurrency_schema["type"] == "integer"
+    assert concurrency_schema["minimum"] == 0
+    assert concurrency_schema["maximum"] == 2_147_483_647
+    assert "anyOf" not in concurrency_schema
+    assert "default" not in concurrency_schema
+
     for name in ("ModelDefinitionInfo", "CreateModelDefinitionRequest"):
         prop = schemas[name]["properties"]["max_concurrency"]
-        assert prop["type"] == "integer"
+        assert prop["$ref"] == "#/components/schemas/ModelMaxConcurrency"
         assert prop["default"] == 0
-        assert prop["minimum"] == 0
-        assert prop["maximum"] == 2_147_483_647
         assert "anyOf" not in prop
 
     update_prop = schemas["UpdateModelDefinitionRequest"]["properties"]["max_concurrency"]
-    assert update_prop["type"] == "integer"
-    assert update_prop["minimum"] == 0
-    assert update_prop["maximum"] == 2_147_483_647
+    assert update_prop["$ref"] == "#/components/schemas/ModelMaxConcurrency"
     assert "anyOf" not in update_prop
     assert "default" not in update_prop
 

--- a/turnstone/api/console_schemas.py
+++ b/turnstone/api/console_schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -1048,7 +1048,7 @@ class RegistryInstallRequest(BaseModel):
 # Admin: Model Definitions
 # ---------------------------------------------------------------------------
 
-ModelMaxConcurrency: TypeAlias = Annotated[
+type ModelMaxConcurrency = Annotated[
     int,
     Field(
         strict=True,

--- a/turnstone/channels/_routing.py
+++ b/turnstone/channels/_routing.py
@@ -11,15 +11,13 @@ import asyncio
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal
 
 from turnstone.channels._config import CREATE_LOCK_CAP
 from turnstone.core.log import get_logger
 from turnstone.sdk._types import TurnstoneAPIError
 from turnstone.sdk.console import AsyncTurnstoneConsole
 from turnstone.sdk.server import AsyncTurnstoneServer
-
-_V = TypeVar("_V")
 
 
 @dataclass
@@ -73,11 +71,11 @@ _STARTUP_PROBE_TIMEOUT = 10.0
 # ---------------------------------------------------------------------------
 
 
-def get_cycle_entry(
-    entries: Mapping[tuple[str, str], _V],
+def get_cycle_entry[V](
+    entries: Mapping[tuple[str, str], V],
     ws_id: str,
     cycle_id: str,
-) -> _V | None:
+) -> V | None:
     """Exact ``(ws_id, cycle_id)`` lookup with the pre-multi-cycle fallback.
 
     An empty *cycle_id* falls back to the workstream's single tracked
@@ -90,11 +88,11 @@ def get_cycle_entry(
     return entry
 
 
-def pop_cycle_entry(
-    entries: MutableMapping[tuple[str, str], _V],
+def pop_cycle_entry[V](
+    entries: MutableMapping[tuple[str, str], V],
     ws_id: str,
     cycle_id: str,
-) -> _V | None:
+) -> V | None:
     """Like :func:`get_cycle_entry`, but removes the matched entry."""
     entry = entries.pop((ws_id, cycle_id), None)
     if entry is None and not cycle_id:
@@ -104,7 +102,7 @@ def pop_cycle_entry(
     return entry
 
 
-def pop_ws_entries(entries: MutableMapping[tuple[str, str], _V], ws_id: str) -> None:
+def pop_ws_entries[V](entries: MutableMapping[tuple[str, str], V], ws_id: str) -> None:
     """Drop every entry tracked under *ws_id* (all cycles)."""
     for key in [k for k in entries if k[0] == ws_id]:
         entries.pop(key, None)

--- a/turnstone/console/coordinator_idle_observer.py
+++ b/turnstone/console/coordinator_idle_observer.py
@@ -116,7 +116,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from turnstone.console.coordinator_client import TASK_OPEN_STATUSES, load_task_envelope
 from turnstone.core.log import get_logger
@@ -252,10 +252,7 @@ class _StorageReadError(Exception):
         self.read = read
 
 
-_ReadResultT = TypeVar("_ReadResultT")
-
-
-def _event_read(ws_id: str, read: str, fn: Callable[[], _ReadResultT]) -> _ReadResultT:
+def _event_read[ReadResultT](ws_id: str, read: str, fn: Callable[[], ReadResultT]) -> ReadResultT:
     """Run one storage-backed gate read under the event's fail-closed
     rule: a raise becomes :class:`_StorageReadError`, which ``_on_idle``
     turns into "neither nudge fires, neither cap is charged".

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -1454,7 +1454,7 @@ async def cluster_events_sse(request: Request) -> Response:
     # Per-connection private-project tenancy — see _ClusterTenancyFilter.
     tenancy = _ClusterTenancyFilter(WorkstreamProjectVisibility.for_request(request))
 
-    async def event_generator() -> AsyncGenerator[dict[str, str], None]:
+    async def event_generator() -> AsyncGenerator[dict[str, str]]:
         loop = asyncio.get_running_loop()
         try:
             # Atomic snapshot+register — no event gap possible.
@@ -3565,7 +3565,7 @@ async def _proxy_sse(
     if last_event_id_hdr is not None:
         upstream_headers["Last-Event-ID"] = last_event_id_hdr
 
-    async def raw_stream() -> AsyncGenerator[bytes, None]:
+    async def raw_stream() -> AsyncGenerator[bytes]:
         try:
             async with sse_client.stream(
                 "GET",
@@ -5774,7 +5774,7 @@ def _teardown_partial_coord_subsystem(app: Any) -> None:
 
 
 @asynccontextmanager
-async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
+async def _lifespan(app: Starlette) -> AsyncGenerator[None]:
     # Create async HTTP clients for proxy routes.  Auth headers are NOT baked
     # in — _proxy_auth_headers() injects a fresh token per-request so JWTs
     # auto-rotate via ServiceTokenManager instead of expiring after 1 hour.

--- a/turnstone/core/deadline.py
+++ b/turnstone/core/deadline.py
@@ -22,12 +22,10 @@ import contextlib
 import queue
 import threading
 import time
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-_T = TypeVar("_T")
 
 
 class DeadlineExceededError(Exception):
@@ -173,14 +171,14 @@ class StreamAbortRef(list[Any]):
         return self._aborted or bool(self._cancel_event is not None and self._cancel_event.is_set())
 
 
-def run_abortable_with_deadline(
-    fn: Callable[[StreamAbortRef], _T],
+def run_abortable_with_deadline[T](
+    fn: Callable[[StreamAbortRef], T],
     *,
     timeout: float,
     cancel_event: threading.Event | None = None,
     poll: float = 1.0,
     thread_name: str = "deadline-worker",
-) -> _T:
+) -> T:
     """:func:`run_with_deadline` with the stream-abort wiring built in.
 
     Mints a :class:`StreamAbortRef`, hands it to *fn* (thread it into the
@@ -205,8 +203,8 @@ def run_abortable_with_deadline(
     )
 
 
-def run_with_deadline(
-    fn: Callable[[], _T],
+def run_with_deadline[T](
+    fn: Callable[[], T],
     *,
     timeout: float,
     cancel_event: threading.Event | None = None,
@@ -214,7 +212,7 @@ def run_with_deadline(
     thread_name: str = "deadline-worker",
     on_abandon: Callable[[], None] | None = None,
     deadline_credit: Callable[[], float] | None = None,
-) -> _T:
+) -> T:
     """Run ``fn()`` on a daemon thread, bounded by ``timeout``/``cancel_event``.
 
     Returns ``fn()``'s result, or re-raises whatever ``fn`` raised.  Raises
@@ -266,7 +264,7 @@ def run_with_deadline(
             pass
         else:
             if ok:
-                return payload  # type: ignore[return-value]  # ok=True ⇒ payload is _T
+                return payload  # type: ignore[return-value]  # ok=True ⇒ payload is T
             raise payload  # type: ignore[misc]  # ok=False ⇒ payload is the raised exc
 
         if cancel_event is not None and cancel_event.is_set():

--- a/turnstone/core/ip_classify.py
+++ b/turnstone/core/ip_classify.py
@@ -43,9 +43,8 @@ from __future__ import annotations
 import enum
 import ipaddress
 import socket
-from typing import TypeAlias
 
-IPAddress: TypeAlias = ipaddress.IPv4Address | ipaddress.IPv6Address
+type IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
 
 
 class AddressLane(enum.IntEnum):

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -33,7 +33,7 @@ import time
 import urllib.parse
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import httpx
 
@@ -3428,10 +3428,9 @@ _MODEL_OBO_MISSING_CRED_WARNED: set[tuple[str, str]] = set()
 _WARN_DEDUP_CAP = 512
 
 
-_DedupKey = TypeVar("_DedupKey", str, tuple[str, str])
-
-
-def _warn_dedup_once(warned: set[_DedupKey], key: _DedupKey, event: str, **fields: Any) -> None:
+def _warn_dedup_once[DedupKey: (str, tuple[str, str])](
+    warned: set[DedupKey], key: DedupKey, event: str, **fields: Any
+) -> None:
     """Emit ``log.warning(event, **fields)`` once per ``key`` in ``warned``.
 
     The shared mechanics of the module's once-per-key warn namespaces, in

--- a/turnstone/core/session_routes.py
+++ b/turnstone/core/session_routes.py
@@ -36,7 +36,7 @@ import functools
 import re
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from starlette.responses import JSONResponse
 from starlette.routing import Route
@@ -4163,7 +4163,7 @@ def _resume_cursor_and_trim(
 # ``load_failed`` is True when the durable load or the canonical public
 # decoration/projection pipeline raised — never for a legitimately empty
 # workstream; see ``_reconstruct`` inside :func:`make_history_handler`.
-_HistoryFlightResult: TypeAlias = tuple[list[dict[str, Any]], int | None, bool, str | None, bool]
+type _HistoryFlightResult = tuple[list[dict[str, Any]], int | None, bool, str | None, bool]
 """``(messages, cursor, load_failed, handoff_token, storage_fallback)``.
 
 ``storage_fallback`` marks the cold storage-only read — the workstream is

--- a/turnstone/core/tls.py
+++ b/turnstone/core/tls.py
@@ -111,9 +111,7 @@ class ACMEHTTPAuth(httpx2.Auth):
         self._bases = tuple(bases)
         self._token_provider = token_provider
 
-    def auth_flow(
-        self, request: httpx2.Request
-    ) -> Generator[httpx2.Request, httpx2.Response, None]:
+    def auth_flow(self, request: httpx2.Request) -> Generator[httpx2.Request, httpx2.Response]:
         if request.url.userinfo or request.url.query or request.url.fragment:
             raise RuntimeError(f"Refusing non-canonical ACME request URL: {request.url}")
         raw_path = request.url.raw_path

--- a/turnstone/sdk/_sync.py
+++ b/turnstone/sdk/_sync.py
@@ -9,17 +9,15 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Coroutine, Iterator
 
-T = TypeVar("T")
-
 _STOP = object()
 
 
-async def _safe_anext(agen: AsyncIterator[T]) -> T | object:
+async def _safe_anext[T](agen: AsyncIterator[T]) -> T | object:
     """Advance *agen* without raising StopAsyncIteration across a thread boundary."""
     try:
         return await agen.__anext__()
@@ -43,13 +41,13 @@ class _SyncRunner:
                 self._thread.start()
             return self._loop
 
-    def run(self, coro: Coroutine[Any, Any, T]) -> T:
+    def run[T](self, coro: Coroutine[Any, Any, T]) -> T:
         """Submit *coro* to the background loop and block for the result."""
         loop = self._ensure_loop()
         future = asyncio.run_coroutine_threadsafe(coro, loop)
         return future.result()
 
-    def run_iter(self, async_gen: AsyncIterator[T]) -> Iterator[T]:
+    def run_iter[T](self, async_gen: AsyncIterator[T]) -> Iterator[T]:
         """Synchronously iterate over an async generator."""
         loop = self._ensure_loop()
         while True:

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -1241,7 +1241,7 @@ async def global_events_sse(request: Request) -> Response:
             if client_queue in listeners:
                 listeners.remove(client_queue)
 
-    async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
+    async def event_generator() -> AsyncGenerator[dict[str, Any]]:
         _metrics.record_sse_connect()
 
         def _format_event(event: dict[str, Any]) -> dict[str, str]:
@@ -1743,7 +1743,7 @@ async def speech_to_text_stream(request: Request) -> Response:
     # the upstream connection, handing deltas to the loop via a queue.  A client
     # disconnect sets ``stop`` so the thread releases the connection promptly
     # instead of being pinned mid-``next()`` (which can't be cancelled).
-    async def _body() -> AsyncGenerator[bytes, None]:
+    async def _body() -> AsyncGenerator[bytes]:
         loop = asyncio.get_running_loop()
         queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         stop = threading.Event()
@@ -5254,7 +5254,7 @@ def _global_fanout_thread(
 
 
 @asynccontextmanager
-async def _lifespan(app: Starlette) -> AsyncGenerator[None, None]:
+async def _lifespan(app: Starlette) -> AsyncGenerator[None]:
     """Start background threads and handle shutdown."""
     # Dedicated executor for SSE queue polling so it doesn't compete
     # with the default asyncio executor (which caps at ~32 workers).


### PR DESCRIPTION
Enable Ruff's `UP040`, `UP043`, and `UP047` checks by fixing all 18 violations and removing
their global exclusions. Use modern type aliases and function type parameters, remove obsolete
`TypeVar` declarations, and omit default generator type arguments. Future violations will fail
normal Ruff and CI checks.

Refresh the console OpenAPI artifact to represent `ModelMaxConcurrency` as a shared schema
component. Existing tests cover its integer bounds, defaults, and null handling.

Validation:

- Ruff 0.15.6: lint and formatting passed across all 723 Python files.
- Locked mypy 2.3.1: passed across all 261 package source files.
- Python 3.13.11: 1,003 focused tests passed in 37.22 seconds.
- Python 3.14.4: the same 1,003 focused tests passed in 37.46 seconds.

Both test runs retain one existing Starlette/AnyIO deprecation warning. An extra check with the
older pre-commit mypy pin (1.19.1) reports three errors in unchanged `session.py` code; its
diagnostics are identical on the `origin/dev` base, `1b4ba2b5`.
