### PR TITLE
fix: preserve reading position during conversation updates

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -410,6 +410,11 @@ scrolls horizontally; activating a tab or moving keyboard focus to one of its co
 complete tab. When the strip or tab widths change, the tab with keyboard focus stays visible;
 otherwise, the active tab stays visible.
 
+Both conversation views follow new output while you are at the bottom. Scrolling up pauses
+autoscroll, including during tool updates and when a response finishes. Scroll down to within 48
+pixels of the bottom, or select **Jump to latest**, to resume following. Sending or queuing a message
+also brings your new message into view. Each pane keeps its own follow state when you switch tabs.
+
 ### Dashboard pane
 
 The home view is coordinator-first. It contains the persistent workstream

--- a/tests/test_conversation_scroll_js.py
+++ b/tests/test_conversation_scroll_js.py
@@ -1,0 +1,509 @@
+"""Behavioral guards for conversation autoscroll and the shared pane wiring."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests._js_harness_helpers import FAKE_DOM, extract_braced, node_skip, run_node_source
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SHARED = _ROOT / "turnstone/shared_static"
+_INTERACTIVE = _SHARED / "interactive.js"
+_COORDINATOR = _ROOT / "turnstone/console/static/coordinator/coordinator.js"
+
+_HARNESS = (
+    FAKE_DOM
+    + f"""
+const {{ mountConversationScroll }} = await import(
+  {json.dumps((_SHARED / "conversation_scroll.js").as_uri())}
+);
+const presentation = await import(
+  {json.dumps((_SHARED / "transcript_presentation.js").as_uri())}
+);
+"""
+    + """
+const assert = (ok, message) => { if (!ok) throw new Error(message); };
+// Keep window listeners independently removable across multiple panes.
+const windowEvents = new FakeElement('window');
+window.addEventListener = windowEvents.addEventListener.bind(windowEvents);
+window.removeEventListener = windowEvents.removeEventListener.bind(windowEvents);
+function input(target, type, event = {}) {
+  for (const { fn } of target._listeners.get(type) || []) fn({ target, ...event });
+}
+FakeElement.prototype.after = function (sibling) {
+  const parent = this.parentNode;
+  parent.children.splice(parent.children.indexOf(this) + 1, 0, sibling);
+  sibling.parentNode = parent;
+  sibling._setConnected(parent.isConnected);
+};
+let nextFrame = 0;
+const frames = new Map();
+globalThis.requestAnimationFrame = (fn) => { frames.set(++nextFrame, fn); return nextFrame; };
+globalThis.cancelAnimationFrame = (id) => frames.delete(id);
+function paint() {
+  const pending = [...frames.values()];
+  frames.clear();
+  pending.forEach((fn) => fn());
+}
+function view() {
+  const parent = document.createElement('div');
+  const scroller = document.createElement('div');
+  scroller.scrollHeight = 1000;
+  scroller.clientHeight = 200;
+  let top = 800;
+  let writes = 0;
+  Object.defineProperty(scroller, 'scrollTop', {
+    get: () => top,
+    set: (value) => {
+      writes++;
+      top = Math.max(0, Math.min(value, scroller.scrollHeight - scroller.clientHeight));
+    },
+  });
+  html.appendChild(parent);
+  parent.appendChild(scroller);
+  const follow = mountConversationScroll(scroller);
+  const button = parent.querySelector('.conv-scroll-latest');
+  const scroll = (value) => {
+    input(scroller, 'wheel', { deltaY: value - scroller.scrollTop });
+    scroller.scrollTop = value;
+    scroller.dispatch('scroll');
+  };
+  return { parent, scroller, follow, button, scroll, writes: () => writes };
+}
+"""
+)
+
+
+def _run(body: str) -> None:
+    proc = run_node_source(_HARNESS + body)
+    assert proc.returncode == 0, proc.stderr
+
+
+@node_skip
+def test_streaming_yields_to_small_upward_scroll_and_resumes_near_bottom() -> None:
+    _run("""
+const { scroller, follow, button, scroll, writes } = view();
+scroller.scrollHeight += 500;
+follow.schedule();
+follow.schedule();
+assert(frames.size === 1, 'streaming must coalesce pins');
+paint();
+assert(scroller.scrollTop === 1300 && writes() === 1, 'tall output lost the bottom pin');
+// Content can arrive before the event from our own previous write.
+scroller.scrollHeight += 200;
+scroller.dispatch('scroll');
+follow.schedule();
+paint();
+assert(scroller.scrollTop === 1500, 'delayed programmatic scroll event stopped following');
+
+follow.schedule();
+scroll(1496);
+paint();
+assert(scroller.scrollTop === 1496, 'a pending pin swallowed a small upward gesture');
+assert(!follow.isFollowing() && !button.hidden, 'scrolling up must offer Jump to latest');
+for (let i = 0; i < 5; i++) {
+  scroller.scrollHeight += 400;
+  follow.schedule();
+  paint();
+}
+assert(scroller.scrollTop === 1496, 'continued streaming pulled the reader down');
+scroll(3400);
+assert(!follow.isFollowing(), 'following resumed too far from the bottom');
+scroll(3452);
+assert(follow.isFollowing() && button.hidden, 'downward scroll into the 48px band did not resume');
+scroller.scrollHeight += 700;
+follow.schedule();
+paint();
+assert(scroller.scrollTop === 4200, 'resumed following failed on a large append');
+""")
+
+
+@node_skip
+def test_scroll_runs_after_markdown_render_even_when_a_new_shell_schedules_first() -> None:
+    _run("""
+const { scroller, follow } = view();
+follow.schedule();
+requestAnimationFrame(() => { scroller.scrollHeight += 600; });
+follow.schedule();
+paint();
+assert(scroller.scrollTop === 1400, 'pin ran before the newly queued markdown render');
+""")
+
+
+@node_skip
+def test_content_reflow_does_not_disengage_follow_before_the_next_pin() -> None:
+    _run("""
+const { scroller, follow, button } = view();
+// Finishing a reasoning row can clamp the viewport upward. An info message
+// arriving before its scroll event then leaves a gap below that position.
+scroller.scrollTop -= 17;
+scroller.scrollHeight += 81;
+follow.schedule();
+scroller.dispatch('scroll');
+paint();
+assert(follow.isFollowing() && button.hidden, 'content reflow was mistaken for reading up');
+assert(scroller.scrollTop === 881, 'info message stranded the bottom pin');
+// A tool result inserted above the viewport can anchor it downward while
+// more output below it grows the gap. That is not a request to pause either.
+scroller.scrollHeight += 500;
+scroller.scrollTop += 300;
+follow.schedule();
+scroller.dispatch('scroll');
+paint();
+assert(follow.isFollowing() && scroller.scrollTop === 1381, 'tool growth stopped following');
+""")
+
+
+@node_skip
+def test_scroll_anchoring_does_not_resume_a_paused_reader_near_the_bottom() -> None:
+    _run("""
+const { scroller, follow, button, scroll } = view();
+scroll(796);
+// Native anchoring preserves the visible text as an earlier tool row grows.
+scroller.scrollHeight += 300;
+scroller.scrollTop += 300;
+scroller.dispatch('scroll');
+assert(!follow.isFollowing() && !button.hidden, 'anchoring resumed a paused reader');
+scroller.scrollHeight += 300;
+follow.schedule();
+paint();
+assert(scroller.scrollTop === 1096, 'later output pulled the reader to the bottom');
+scroll(1352);
+assert(follow.isFollowing(), 'deliberate downward scrolling did not resume');
+""")
+
+
+@node_skip
+def test_user_input_still_pauses_during_content_reflow() -> None:
+    _run("""
+for (const gesture of ['wheel', 'keyboard', 'touch', 'scrollbar']) {
+  const { scroller, follow, button } = view();
+  scroller.scrollHeight += 400;
+  follow.schedule();
+  if (gesture === 'wheel') input(scroller, 'wheel', { deltaY: -4 });
+  if (gesture === 'keyboard') input(scroller, 'keydown', { key: 'ArrowUp' });
+  if (gesture === 'touch') {
+    input(scroller, 'touchstart', { touches: [{ clientY: 100 }] });
+    input(scroller, 'touchmove', { touches: [{ clientY: 104 }] });
+  }
+  if (gesture === 'scrollbar') input(scroller, 'pointerdown');
+  scroller.scrollTop -= 4;
+  scroller.dispatch('scroll');
+  input(windowEvents, 'pointerup');
+  paint();
+  assert(!follow.isFollowing() && !button.hidden, gesture + ' lost to reflow');
+  assert(scroller.scrollTop === 796, gesture + ' lost to the pending pin');
+  follow.destroy();
+}
+assert([...windowEvents._listeners.values()].every(rows => rows.length === 0), 'window listener leak');
+""")
+
+
+@node_skip
+def test_jump_focus_newer_user_scroll_and_destroy() -> None:
+    _run("""
+const { scroller, follow, button, scroll, parent } = view();
+scroll(200);
+button.focus();
+button.click();
+paint();
+assert(scroller.scrollTop === 800 && button.hidden, 'Jump to latest failed');
+assert(document.activeElement === scroller, 'jump left focus on the hidden button');
+assert(scroller.getAttribute('tabindex') === '-1', 'log did not receive temporary focus');
+scroller.dispatch('blur');
+assert(!scroller.hasAttribute('tabindex'), 'temporary focus target leaked');
+
+scroll(200);
+follow.jumpToLatest();
+scroll(190);
+paint();
+assert(scroller.scrollTop === 190 && !follow.isFollowing(), 'newer scroll lost to explicit jump');
+follow.jumpToLatest();
+follow.destroy();
+paint();
+assert(scroller.scrollTop === 190, 'destroyed pane retained a pending pin');
+assert(parent.children.length === 1, 'destroy leaked the jump control');
+assert(scroller._listeners.get('scroll').length === 0, 'destroy leaked the scroll listener');
+assert(resizeObservers.every((o) => o.disconnected), 'destroy leaked its observer');
+follow.schedule();
+follow.jumpToLatest();
+assert(frames.size === 0, 'destroyed pane rearmed scrolling');
+""")
+
+
+@node_skip
+def test_hidden_panes_and_resizing_keep_independent_follow_choices() -> None:
+    _run("""
+const a = view();
+const b = view();
+b.scroll(200);
+for (const v of [a, b]) {
+  v.scroller.clientHeight = 0;
+  v.scroller._visible = false;
+  v.scroller.scrollHeight = 1600;
+  triggerResize(v.scroller);
+  v.scroller.dispatch('scroll');
+  v.follow.schedule();
+}
+paint();
+assert(a.scroller.scrollTop === 800 && b.scroller.scrollTop === 200, 'hidden pane was scrolled');
+assert(a.follow.isFollowing() && !b.follow.isFollowing(), 'hidden geometry replaced user intent');
+for (const v of [a, b]) {
+  v.scroller.clientHeight = 300;
+  v.scroller._visible = true;
+  triggerResize(v.scroller);
+}
+paint();
+assert(a.scroller.scrollTop === 1300, 'following pane did not catch up on reveal');
+assert(b.scroller.scrollTop === 200 && !b.button.hidden, 'reading pane moved on reveal');
+a.scroller.clientHeight = 100;
+triggerResize(a.scroller);
+paint();
+assert(a.scroller.scrollTop === 1500, 'shrinking the pane lost the bottom pin');
+""")
+
+
+@node_skip
+def test_compact_transcript_reflows_respect_a_paused_follow_inside_threshold() -> None:
+    _run("""
+const v = view();
+presentation.registerTranscriptScroller(v.scroller, {
+  isFollowing: v.follow.isFollowing, scrollToBottom: v.follow.schedule,
+});
+v.scroll(796);
+presentation.preserveTranscriptBottomPin(v.scroller, () => { v.scroller.scrollHeight += 400; });
+presentation.setTranscriptPresentation('compact');
+paint();
+assert(v.scroller.scrollTop === 796, 'presentation reflow overrode a small upward scroll');
+assert(!v.follow.isFollowing(), 'presentation silently resumed following');
+v.follow.jumpToLatest();
+paint();
+presentation.preserveTranscriptBottomPin(v.scroller, () => { v.scroller.scrollHeight += 400; });
+v.scroll(1190);
+paint();
+assert(v.scroller.scrollTop === 1190, 'late presentation restore defeated a newer scroll');
+""")
+
+
+@node_skip
+def test_presentation_restores_share_the_panes_programmatic_scroll_tracking() -> None:
+    _run("""
+const v = view();
+presentation.registerTranscriptScroller(v.scroller, {
+  isFollowing: v.follow.isFollowing, scrollToBottom: v.follow.schedule,
+});
+presentation.preserveTranscriptBottomPin(v.scroller, () => { v.scroller.scrollHeight += 400; });
+paint();
+paint();
+assert(v.scroller.scrollTop === 1200, 'presentation restore did not pin the bottom');
+v.scroller.scrollHeight += 400;
+v.scroller.dispatch('scroll');
+v.follow.schedule();
+paint();
+assert(v.scroller.scrollTop === 1600, 'presentation scroll event disengaged streaming follow');
+""")
+
+
+@node_skip
+def test_interactive_stream_end_and_system_updates_use_the_shared_follow_state() -> None:
+    body = _INTERACTIVE.read_text()
+    methods = "\n".join(
+        extract_braced(body, marker)
+        for marker in (
+            "  scrollToBottom(force) {",
+            "  handleEvent(evt) {",
+            "  addSystemContext(content, source, meta) {",
+        )
+    )
+    _run(
+        """
+const v = view();
+const resetCompactionHolder = () => {};
+const streamingRenderFinalize = () => { v.scroller.scrollHeight += 600; };
+const buildCompactionCard = () => document.createElement('div');
+const buildWatchResultCard = buildCompactionCard;
+const _buildGuardFindingBubble = buildCompactionCard;
+const operatorSourceLabel = (source) => source;
+const pane = {
+  _scrollFollow: v.follow, messagesEl: v.scroller,
+  _reasoningActivity: { finish() {} }, _compaction: {},
+  removeEmptyState() {},
+"""
+        + methods.replace("\n  }", "\n  },")
+        + """
+};
+v.scroll(200);
+pane.currentAssistantBodyEl = document.createElement('div');
+pane.contentBuffer = 'finished answer';
+pane.handleEvent({ type: 'stream_end' });
+for (const source of ['compaction', 'watch_triggered', 'output_guard', 'user_interjection']) {
+  pane.addSystemContext('update', source, { message: 'queued elsewhere' });
+}
+paint();
+assert(v.scroller.scrollTop === 200, 'background completion/system output forced a jump');
+pane.scrollToBottom(true);
+paint();
+assert(v.scroller.scrollTop === 1400, 'explicit local send did not resume following');
+"""
+    )
+
+
+@node_skip
+@pytest.mark.parametrize("surface", ["interactive", "coordinator"])
+def test_edit_resend_resumes_following_even_if_history_refetch_fails(surface: str) -> None:
+    common = """
+const v = view();
+const posts = [];
+const STALE_RETRY_BASE_MS = 2000, STALE_RETRY_JITTER_MS = 0;
+const mintClientSendId = () => 'edit-send-id';
+const parsePriority = text => ({ displayText: text, priority: 'notice' });
+const authFetch = (url, init) => {
+  posts.push({ url, body: JSON.parse(init.body) });
+  return Promise.resolve({ ok: true });
+};
+const postAndSettleSend = () => {};
+const append = v.scroller.appendChild.bind(v.scroller);
+v.scroller.appendChild = el => { v.scroller.scrollHeight += 200; return append(el); };
+v.scroll(200);
+"""
+    if surface == "interactive":
+        body = _INTERACTIVE.read_text()
+        methods = "\n".join(
+            extract_braced(body, marker)
+            for marker in (
+                "  scrollToBottom(force) {",
+                "  addUserMessage(text, attachments, opts) {",
+                "  handleEvent(evt) {",
+            )
+        )
+        source = "class Pane {\n" + methods + "\n}\n" + common
+        source += """
+const pane = new Pane();
+Object.assign(pane, {
+  wsId: 'ws', _base: '', _historyLoadToken: 1, _pendingEditSend: 'edited local message',
+  _scrollFollow: v.follow, messagesEl: v.scroller,
+  _beginReplayQuiesce() {},
+  // A failed refetch resolves and retains the old transcript; the committed edit still sends.
+  _refetchHistory() { return Promise.resolve(); },
+  removeEmptyState() {}, _addUserMsgActions() {},
+  setBusy(value, source) { this.busy = value; this.busySource = source; },
+  addErrorMessage(message) { throw Error(message); },
+});
+pane.handleEvent({ type: 'clear_ui' });
+await Promise.resolve(); await Promise.resolve();
+clearTimeout(pane._staleRetryTimer);
+"""
+    else:
+        body = _COORDINATOR.read_text()
+        source = common + "\n".join(
+            extract_braced(body, marker)
+            for marker in (
+                "  function handleEvent(ev) {",
+                "  function appendUserMessageWithAttachments(text, attachments, opts) {",
+                "  function appendMsg(role, html, opts) {",
+                "  function appendText(role, text, opts) {",
+                "  function _scheduleScroll() {",
+            )
+        )
+        source += """
+const wsId = 'ws', queue = {}, composer = { value: '' };
+const scrollFollow = v.follow, messagesEl = v.scroller;
+const _MSG_VARIANTS = { user: 'user' }, esc = text => text;
+const setSafeHtml = (el, html) => { el.textContent = html; };
+const _addUserMsgActions = () => {};
+const refetchHistory = () => Promise.resolve();
+let historyStale = false, staleRetryTimer = null, visHandler = () => {};
+let _pendingEditSend = 'edited local message', busy = false, busySource = '';
+function setBusy(value, source) { busy = value; busySource = source; }
+handleEvent({ type: 'clear_ui' });
+await Promise.resolve(); await Promise.resolve();
+clearTimeout(staleRetryTimer);
+"""
+    _run(
+        source
+        + """
+paint();
+assert(posts.length === 1 && posts[0].body.message === 'edited local message', 'edit did not send');
+assert(v.follow.isFollowing() && v.button.hidden, 'local resend left following paused');
+assert(v.scroller.scrollTop === 1000, 'local edited message was left out of view');
+"""
+    )
+
+
+@node_skip
+def test_coordinator_only_folds_live_results_outside_the_reading_viewport() -> None:
+    append = extract_braced(
+        _COORDINATOR.read_text(),
+        "  function appendToolResult(name, callId, output, isError, opts) {",
+    )
+    _run(
+        f"""
+const {{ markConvRowResultSettled }} = await import(
+  {json.dumps((_SHARED / "conversation.js").as_uri())}
+);
+"""
+        + """
+const { canAutoFoldTranscriptBatch, getTranscriptPresentation } = presentation;
+const toolRows = new Map();
+const toolResultNodes = new Map();
+let messagesEl, scrollFollow;
+function _appendResultToRow(row, output) {
+  const result = document.createElement('div');
+  result.className = 'conv-row-result';
+  result.textContent = output;
+  row.appendChild(result);
+  return result;
+}
+function _unsetBatchRunningIfAllResults() {}
+function _announcePolite() {}
+function convBatchSummaryText() { return 'finished'; }
+function _scheduleScroll() { scrollFollow.schedule(); }
+"""
+        + append
+        + """
+presentation.setTranscriptPresentation('compact');
+for (const [paused, belowViewport, shouldFold] of [
+  [true, false, false], [true, true, true], [false, false, true],
+]) {
+  const v = view();
+  messagesEl = v.scroller;
+  scrollFollow = v.follow;
+  presentation.registerTranscriptScroller(messagesEl, {
+    isFollowing: scrollFollow.isFollowing, scrollToBottom: scrollFollow.schedule,
+  });
+  messagesEl.getBoundingClientRect = () => ({ top: 0, bottom: 200 });
+  const batch = document.createElement('div');
+  batch.className = 'conv-batch conv-batch--auto';
+  batch.getBoundingClientRect = () => ({ top: belowViewport ? 250 : 50, bottom: 350 });
+  const row = document.createElement('div');
+  row.className = 'conv-row';
+  row.dataset.effectStatus = 'committed';
+  batch.appendChild(row);
+  messagesEl.appendChild(batch);
+  toolRows.set('call', { batch, row });
+  if (paused) v.scroll(700);
+  appendToolResult('bash', 'call', 'Finished output', false, { accepted: true });
+  assert(row.dataset.resultSettled === 'true', 'accepted result was not settled');
+  assert((batch.dataset.compactFolded === 'true') === shouldFold,
+    'coordinator folded a result being read, or lost safe automatic folding');
+}
+"""
+    )
+
+
+def test_both_panes_route_queue_and_lifecycle_through_the_shared_controller() -> None:
+    interactive = _INTERACTIVE.read_text()
+    coordinator = _COORDINATOR.read_text()
+    assert 'from "./conversation_scroll.js"' in interactive
+    assert 'from "/shared/conversation_scroll.js"' in coordinator
+    assert "scroll: () => this.scrollToBottom()" in interactive
+    assert "scroll: () => _scheduleScroll()" in coordinator
+    assert "pane._scrollFollow.destroy()" in interactive
+    assert "scrollFollow.destroy()" in coordinator
+    schedule = extract_braced(coordinator, "  function _scheduleScroll() {")
+    assert "scrollFollow.schedule()" in schedule
+    queue = (_SHARED / "composer_queue.js").read_text()
+    assert "scrollTop =" not in queue

--- a/tests/test_coordinator_page.py
+++ b/tests/test_coordinator_page.py
@@ -1251,7 +1251,7 @@ def test_compact_presentation_coordinator_wiring_and_ordering():
     """Coordinator retains its own result lifecycle but shares presentation.
 
     The running-state cleanup must precede settlement, which must precede the
-    coordinator's existing forced scroll. Replay stages the same fold without
+    coordinator's scheduled follow. Replay stages the same fold without
     a completion announcement, and only the rail-less page mounts a control.
     """
     from pathlib import Path
@@ -1288,7 +1288,7 @@ def test_compact_presentation_coordinator_wiring_and_ordering():
     assert 'querySelector("#coord-status-bar")' in create
     status_mount = create.index('querySelector("#coord-status-bar")')
     assert mount < status_mount, "the presentation control must not enter the live status region"
-    assert "registerTranscriptScroller(messagesEl)" in create
+    assert "registerTranscriptScroller(messagesEl," in create
 
     live = _extract_braced(
         body,
@@ -1297,8 +1297,8 @@ def test_compact_presentation_coordinator_wiring_and_ordering():
     append = live.index("_appendResultToRow(")
     running_cleanup = live.index("_unsetBatchRunningIfAllResults(", append)
     settlement = live.index("markConvRowResultSettled(", running_cleanup)
-    forced_scroll = live.index("_scheduleScroll()", settlement)
-    assert append < running_cleanup < settlement < forced_scroll
+    scheduled_scroll = live.index("_scheduleScroll()", settlement)
+    assert append < running_cleanup < settlement < scheduled_scroll
     assert "settlement.autoFolded" in live
     assert 'getTranscriptPresentation() === "compact"' in live
     assert '_announcePolite("Completed: "' in live

--- a/tests/test_history_handoff_js.py
+++ b/tests/test_history_handoff_js.py
@@ -617,6 +617,7 @@ function getTranscriptPresentation() { return "default"; }
 function convBatchSummaryText() { return "tool batch"; }
 
 const toolRows = new Map();
+const scrollFollow = { isFollowing: () => true };
 const latestToolRowElements = new Map();
 const toolResultNodes = new Map();
 const renderedToolEventIds = new Set();

--- a/tests/test_interactive_pane_js.py
+++ b/tests/test_interactive_pane_js.py
@@ -620,14 +620,11 @@ def test_per_token_hot_path_avoids_container_scans() -> None:
     )
     assert "this._reasoningActivity" in body
     near = body.index("isNearBottom() {")
-    assert "return this._nearBottom;" in body[near : near + 700]
-    assert "passive: true" in body
-    # The rAF pin re-checks the flag AT FIRE TIME (a user scroll landing in
-    # the schedule→rAF window must win over a stale pin), with force
-    # requests latched across the coalescing window; resizes re-derive the
-    # flag via ResizeObserver since they move the bottom without a scroll.
-    assert "this._scrollPinForce = false;" in body
-    assert "ResizeObserver" in body
+    assert "return this._scrollFollow.isFollowing();" in body[near : near + 700]
+    scroll = (_ROOT / "turnstone/shared_static/conversation_scroll.js").read_text()
+    assert "passive: true" in scroll
+    assert "requestAnimationFrame" in scroll
+    assert "ResizeObserver" in scroll
     for helper in ("_toolRow(callId) {", "_streamEl(callId) {"):
         assert helper in body, f"missing lookup-cache helper: {helper!r}"
 
@@ -888,8 +885,7 @@ def test_truncated_resync_is_full_fresh_connect_with_churn_limit() -> None:
     assert "if (this.wsId !== wsId) this._truncatedFromCursor = null;" in load_seg, (
         "a ws switch must drop the old ws's truncation record"
     )
-    replay_fn = body.index("replayHistory(messages) {")
-    replay_head = body[replay_fn : replay_fn + 1200]
+    replay_head = _extract_braced(body, "replayHistory(messages) {")
     assert "this._truncatedFromCursor = null;" in replay_head, (
         "a successful full-history render must clear the truncation record"
     )

--- a/turnstone/console/static/coordinator/coordinator.js
+++ b/turnstone/console/static/coordinator/coordinator.js
@@ -54,12 +54,14 @@ import {
   setToolOutputReviewState,
 } from "/shared/conversation.js";
 import {
+  canAutoFoldTranscriptBatch,
   getTranscriptPresentation,
   mountTranscriptPresentationToggle,
   preserveTranscriptBottomPin,
   registerTranscriptScroller,
 } from "/shared/transcript_presentation.js";
 import { redactCredentials } from "/shared/redact_credentials.js";
+import { mountConversationScroll } from "/shared/conversation_scroll.js";
 import { tryParseMcpError, buildMcpErrorEmbed } from "/shared/mcp_error.js";
 import {
   acceptUserTurnEvent,
@@ -474,7 +476,11 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   const messagesEl = root.querySelector("#coord-messages");
-  const unregisterTranscriptScroller = registerTranscriptScroller(messagesEl);
+  const scrollFollow = mountConversationScroll(messagesEl);
+  const unregisterTranscriptScroller = registerTranscriptScroller(messagesEl, {
+    isFollowing: scrollFollow.isFollowing,
+    scrollToBottom: scrollFollow.schedule,
+  });
   const coordMain = root.querySelector("#coord-main");
   const composerMount = root.querySelector("#coord-composer-mount");
   const composer = new Composer(composerMount, {
@@ -512,6 +518,7 @@ function createCoordinatorPane(root, wsId, opts) {
   });
   const queue = createQueueController({
     messagesEl: messagesEl,
+    scroll: () => _scheduleScroll(),
     getWsId: function () {
       return wsId;
     },
@@ -1083,19 +1090,8 @@ function createCoordinatorPane(root, wsId, opts) {
   // Message append helpers
   // ------------------------------------------------------------------
 
-  // Coalesce scrollTop writes through requestAnimationFrame so the
-  // bulk history-replay loop doesn't fire one synchronous reflow per
-  // appended message — for histories with hundreds of turns the
-  // un-coalesced version visibly stalls the page.  Live SSE streaming
-  // also benefits: token-rate scrolls collapse into one paint.
-  let _scrollPending = false;
   function _scheduleScroll() {
-    if (_scrollPending) return;
-    _scrollPending = true;
-    requestAnimationFrame(() => {
-      _scrollPending = false;
-      messagesEl.scrollTop = messagesEl.scrollHeight;
-    });
+    scrollFollow.schedule();
   }
 
   // Map raw role → .msg variant (DS primitives/message.css).  "error"
@@ -1662,6 +1658,7 @@ function createCoordinatorPane(root, wsId, opts) {
   }
 
   function appendToolResult(name, callId, output, isError, opts) {
+    const atBottom = scrollFollow.isFollowing();
     if (callId && toolRows.has(callId)) {
       const entry = toolRows.get(callId);
       const prior = toolResultNodes.get(callId);
@@ -1677,9 +1674,12 @@ function createCoordinatorPane(root, wsId, opts) {
       // state.  Per-row check (not a counter) keeps the logic
       // resilient to out-of-order replay + late SSE deliveries.
       _unsetBatchRunningIfAllResults(entry.batch);
+      const allowAutoFold =
+        getTranscriptPresentation() !== "compact" ||
+        canAutoFoldTranscriptBatch(messagesEl, entry.batch, { atBottom });
       const settlement =
         opts && opts.accepted
-          ? markConvRowResultSettled(entry.row, { autoFold: true })
+          ? markConvRowResultSettled(entry.row, { autoFold: allowAutoFold })
           : null;
       if (
         getTranscriptPresentation() === "compact" &&
@@ -2690,6 +2690,7 @@ function createCoordinatorPane(root, wsId, opts) {
     // Move the retry affordance onto the just-completed last assistant turn
     // (#549). No-op when the turn ended tool-only (see _refreshRetryButton).
     _refreshRetryButton();
+    _scheduleScroll();
   }
 
   // ------------------------------------------------------------------
@@ -2902,6 +2903,7 @@ function createCoordinatorPane(root, wsId, opts) {
         },
       );
     }
+    scrollFollow.jumpToLatest();
     composer.clear();
 
     // Bound the send POST with an AbortController + ~15s timeout (mirrors
@@ -4502,6 +4504,7 @@ function createCoordinatorPane(root, wsId, opts) {
               label: "you",
               clientSendId: editClientSendId,
             });
+            scrollFollow.jumpToLatest();
             postAndSettleSend(
               queue,
               authFetch(
@@ -6832,6 +6835,7 @@ function createCoordinatorPane(root, wsId, opts) {
         evtSource.readyState !== EventSource.OPEN)
     )
       return;
+    const scrollTop = messagesEl.scrollTop;
     messagesEl.replaceChildren();
     _syncApprovalChip();
     // A full committed-history render repairs any recorded truncation gap —
@@ -7245,6 +7249,8 @@ function createCoordinatorPane(root, wsId, opts) {
           ? hist.handoff_token
           : null;
     }
+    messagesEl.scrollTop = scrollTop;
+    _scheduleScroll();
     // The outcome tells the repair settle whether a TOKENLESS response was a
     // completed render (the server's deliberate cold storage-only read —
     // downgrade to the tokenless bootstrap) or a failure (fail closed).
@@ -7311,6 +7317,7 @@ function createCoordinatorPane(root, wsId, opts) {
     if (_childObserver && _childObserver.disconnect)
       _childObserver.disconnect();
     unregisterTranscriptScroller();
+    scrollFollow.destroy();
     if (unmountTranscriptPresentation) {
       unmountTranscriptPresentation();
       unmountTranscriptPresentation = null;

--- a/turnstone/shared_static/composer_queue.js
+++ b/turnstone/shared_static/composer_queue.js
@@ -28,6 +28,8 @@
  *
  * Caller options:
  *   messagesEl: HTMLElement — chat log container.
+ *   scroll:     optional () => void — called after appending a queued bubble;
+ *               the caller owns whether to follow output or retain the reading position.
  *   getWsId:    () => string — current ws id (function so the
  *               interactive pane can swap tabs without re-instantiating).
  *   getBase:    optional () => string — node-proxy URL prefix ("" local,
@@ -144,7 +146,7 @@ export function createQueueController(opts) {
   }
 
   function _scrollIntoView() {
-    messagesEl.scrollTop = messagesEl.scrollHeight;
+    if (opts.scroll) opts.scroll();
   }
 
   function _deleteRequest(msgId) {

--- a/turnstone/shared_static/conversation.css
+++ b/turnstone/shared_static/conversation.css
@@ -31,6 +31,46 @@
    element and let the caller append + scroll (pane- and transport-agnostic).
    ========================================================================== */
 
+/* A zero-height sibling anchors the control above the bottom of each log. */
+.conv-scroll-control {
+  position: relative;
+  flex: 0 0 0;
+  height: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+.conv-scroll-latest {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+  max-width: calc(100% - 24px);
+  padding: 6px 12px;
+  border: 1px solid var(--hair);
+  border-radius: 18px;
+  background: var(--panel-2);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  pointer-events: auto;
+}
+.conv-scroll-latest[hidden] {
+  display: none;
+}
+.conv-scroll-latest:hover {
+  border-color: var(--ink-3);
+}
+.conv-scroll-latest:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* ==========================================================================
    Card shell — pairs tool calls with their verdicts + results and embeds
    the approval gate.  One construct per dispatch turn:

--- a/turnstone/shared_static/conversation_scroll.js
+++ b/turnstone/shared_static/conversation_scroll.js
@@ -1,0 +1,178 @@
+/* Per-pane follow state shared by coordinator and interactive conversations. */
+
+import { focusTemporarily } from "./conversation.js";
+
+const BOTTOM_THRESHOLD_PX = 48;
+
+export function mountConversationScroll(scroller) {
+  const control = document.createElement("div");
+  control.className = "conv-scroll-control";
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "conv-scroll-latest";
+  button.hidden = true;
+  button.title = "Jump to latest and resume autoscroll";
+  const arrow = document.createElement("span");
+  arrow.setAttribute("aria-hidden", "true");
+  arrow.textContent = "\u2193";
+  const label = document.createElement("span");
+  label.textContent = "Jump to latest";
+  button.append(arrow, label);
+  control.appendChild(button);
+  scroller.after(control);
+
+  let following = true;
+  let lastTop = scroller.scrollTop;
+  let lastExtent = scroller.scrollHeight - scroller.clientHeight;
+  let pointerActive = false;
+  let touchY = null;
+  let frame = null;
+  let destroyed = false;
+
+  function visible() {
+    return scroller.isConnected && scroller.clientHeight > 0;
+  }
+
+  function distanceFromBottom() {
+    return scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop;
+  }
+
+  function setFollowing(value) {
+    following = value;
+    // Do not leave keyboard focus on a control that is about to disappear.
+    if (following && document.activeElement === button) {
+      focusTemporarily(scroller);
+    }
+    button.hidden = following;
+  }
+
+  function onScroll() {
+    if (!visible()) return;
+    const top = Math.max(0, scroller.scrollTop);
+    const extent = scroller.scrollHeight - scroller.clientHeight;
+    const distance = extent - top;
+    // Reflow can clamp or anchor the viewport before our next pin. Only
+    // interpret that movement as user scrolling when geometry is stable or
+    // a pointer is dragging. Wheel, touch, and keyboard intent also pause
+    // directly so an upward gesture still wins during simultaneous output.
+    // Ignore our own unchanged scroll position if more content has arrived
+    // before the browser delivers the event from the previous bottom pin.
+    if (
+      top < lastTop &&
+      distance > 1 &&
+      (pointerActive || extent === lastExtent)
+    ) {
+      setFollowing(false);
+    } else if (
+      distance <= 1 ||
+      (top > lastTop && distance <= BOTTOM_THRESHOLD_PX &&
+        (pointerActive || extent === lastExtent))
+    ) {
+      setFollowing(true);
+    }
+    lastTop = top;
+    lastExtent = extent;
+  }
+
+  function noteInput(direction) {
+    if (!visible()) return;
+    // Output may have grown without scrolling a paused pane. Start measuring
+    // this gesture from the geometry the user is actually looking at now.
+    lastTop = scroller.scrollTop;
+    lastExtent = scroller.scrollHeight - scroller.clientHeight;
+    if (direction < 0 && lastTop > 0) setFollowing(false);
+    else if (direction > 0 && lastExtent - lastTop <= BOTTOM_THRESHOLD_PX) {
+      setFollowing(true);
+    }
+  }
+
+  function onKeyDown(event) {
+    if (
+      event.defaultPrevented ||
+      event.target.closest("input, textarea, select, button, [contenteditable]")
+    ) {
+      return;
+    }
+    if (
+      ["ArrowUp", "PageUp", "Home"].includes(event.key) ||
+      (event.key === " " && event.shiftKey)
+    ) {
+      noteInput(-1);
+    } else if (["ArrowDown", "PageDown", "End", " "].includes(event.key)) {
+      noteInput(1);
+    }
+  }
+
+  function schedule() {
+    if (destroyed || !following) return;
+    // Keep the pin after the latest render callback. A new message shell
+    // can request a scroll before streamingRender queues its markdown paint.
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      // A newer user scroll wins, including one after Jump to latest or Send.
+      // Hidden panes retain their choice; ResizeObserver follows on reveal.
+      if (destroyed || !following || !visible()) return;
+      scroller.scrollTop = scroller.scrollHeight;
+      lastTop = scroller.scrollTop;
+      lastExtent = scroller.scrollHeight - scroller.clientHeight;
+    });
+  }
+
+  function jumpToLatest() {
+    if (destroyed) return;
+    setFollowing(true);
+    schedule();
+  }
+
+  const listeners = [];
+  function listen(target, type, handler) {
+    target.addEventListener(type, handler, { passive: true });
+    listeners.push([target, type, handler]);
+  }
+  listen(scroller, "scroll", onScroll);
+  listen(scroller, "wheel", (event) => {
+    if (event.deltaY && !event.ctrlKey) noteInput(event.deltaY);
+  });
+  listen(scroller, "keydown", onKeyDown);
+  listen(scroller, "pointerdown", () => {
+    pointerActive = true;
+    noteInput(0);
+  });
+  const releasePointer = () => {
+    pointerActive = false;
+  };
+  listen(window, "pointerup", releasePointer);
+  listen(window, "pointercancel", releasePointer);
+  listen(scroller, "touchstart", (event) => {
+    touchY = event.touches.length === 1 ? event.touches[0].clientY : null;
+    noteInput(0);
+  });
+  listen(scroller, "touchmove", (event) => {
+    const y = event.touches.length === 1 ? event.touches[0].clientY : null;
+    if (touchY !== null && y !== null && y !== touchY) noteInput(touchY - y);
+    touchY = y;
+  });
+  listen(button, "click", jumpToLatest);
+  const observer = new ResizeObserver(() => {
+    if (!visible()) return;
+    if (distanceFromBottom() <= 1) setFollowing(true);
+    schedule();
+  });
+  observer.observe(scroller);
+
+  return {
+    isFollowing: () => following,
+    schedule,
+    jumpToLatest,
+    destroy() {
+      destroyed = true;
+      if (frame !== null) cancelAnimationFrame(frame);
+      observer.disconnect();
+      for (const [target, type, handler] of listeners) {
+        target.removeEventListener(type, handler);
+      }
+      control.remove();
+    },
+  };
+}

--- a/turnstone/shared_static/interactive.js
+++ b/turnstone/shared_static/interactive.js
@@ -76,6 +76,7 @@ import {
   viewerUserId,
 } from "./composer_queue.js";
 import { StatusBar } from "./status_bar.js";
+import { mountConversationScroll } from "./conversation_scroll.js";
 import { streamingRender, streamingRenderFinalize } from "./renderer.js";
 import {
   buildMsgCopyButton,
@@ -313,7 +314,7 @@ class Pane {
       },
       placePrompt: (prompt) => {
         this.messagesEl.appendChild(prompt);
-        this.scrollToBottom(true);
+        this.scrollToBottom();
       },
     });
     // Monotonic STREAM-generation counter (#900), bumped only in
@@ -390,12 +391,8 @@ class Pane {
     // block.
     this._staleRetryTimer = null;
     // Hot-path caches — all invalidated by _clearAgentTracking/replayHistory.
-    // _nearBottom mirrors the scroller position via a passive scroll listener
-    // (no per-token geometry reads); the two Maps make per-event row/stream
-    // lookups O(1) instead of whole-transcript attribute-selector scans.
-    this._nearBottom = true;
-    this._scrollPinPending = false;
-    this._scrollPinForce = false;
+    // The Maps make per-event row/stream lookups O(1) instead of
+    // whole-transcript attribute-selector scans.
     this._reasoningActivity = createReasoningActivity();
     // Compaction lifecycle holder for the shared reducer
     // (conversation.applyCompactionEvent); `card` is the in-progress card
@@ -425,7 +422,6 @@ class Pane {
     // compaction progress. Parallel task agents compact independently, so one
     // foreground holder cannot represent them.
     this._agentCompactions = new Map();
-    this._resizeObs = null;
     // Set when replay_truncated arrives mid-stream (refetching then would
     // detach the live bubble); consumed on the next idle edge.  Cleared by
     // _loadHistoryThenConnect at load start AND by replayHistory's
@@ -718,19 +714,19 @@ class Pane {
     if (source === "compaction") {
       const card = buildCompactionCard(meta, content || "");
       this.messagesEl.appendChild(card);
-      this.scrollToBottom(true);
+      this.scrollToBottom();
       return card;
     }
     if (source === "watch_triggered" && meta && typeof meta === "object") {
       const card = buildWatchResultCard(meta, content || "");
       this.messagesEl.appendChild(card);
-      this.scrollToBottom(true);
+      this.scrollToBottom();
       return card;
     }
     if (source === "output_guard" && meta && typeof meta === "object") {
       const card = _buildGuardFindingBubble(meta);
       this.messagesEl.appendChild(card);
-      this.scrollToBottom(true);
+      this.scrollToBottom();
       return card;
     }
     // user_interjection renders as a "queued message" bubble showing the user's
@@ -759,7 +755,7 @@ class Pane {
     body.appendChild(textEl);
     el.appendChild(body);
     this.messagesEl.appendChild(el);
-    this.scrollToBottom(true);
+    this.scrollToBottom();
     return el;
   }
 
@@ -779,7 +775,7 @@ class Pane {
       container: this.messagesEl,
       renderedIds: this._renderedSystemEventIds,
       onNotice: (msg) => this.addInfoMessage(msg),
-      scroll: (force) => this.scrollToBottom(force),
+      scroll: () => this.scrollToBottom(),
     });
     // Manual compaction's busy state can start reasoning before this card.
     if (this._compaction.card) this._reasoningActivity.finish();
@@ -856,7 +852,7 @@ class Pane {
     }
     this._addUserMsgActions(el, text);
     this.messagesEl.appendChild(el);
-    this.scrollToBottom(true);
+    this.scrollToBottom();
     // Returned so the send flow can retro-convert the optimistic bubble
     // into a queued chip when the server answers queued+deferred.
     return el;
@@ -975,10 +971,6 @@ class Pane {
     if (!chunk) return;
     const stripped = stripAnsi(chunk);
     if (!stripped) return;
-    // Capture pin before the chunk grows the stream block — see
-    // announceToolBlock.
-    const stick = this.isNearBottom();
-
     let el = this._streamEl(callId);
     if (!el) {
       let target = this._toolRow(callId);
@@ -1023,7 +1015,7 @@ class Pane {
         el.scrollTop = el.scrollHeight;
       });
     }
-    this.scrollToBottom(stick);
+    this.scrollToBottom();
   }
 
   showOutputWarning(evt) {
@@ -1192,40 +1184,12 @@ class Pane {
   }
 
   isNearBottom() {
-    // Cached from the passive scroll listener (_createDOM) instead of read
-    // from geometry: the old scrollHeight/scrollTop/clientHeight triplet
-    // forced a synchronous layout of the whole transcript, and this runs on
-    // every streamed token and every tool chunk.  Content growth without a
-    // scroll leaves the cache untouched — which is the DESIRED semantics:
-    // "pinned" is a statement about where the user last scrolled to, not
-    // about the current pixel distance (the old post-append measurement is
-    // exactly what used to silently disengage auto-follow at tool time).
-    return this._nearBottom;
+    return this._scrollFollow.isFollowing();
   }
 
   scrollToBottom(force) {
-    if (force) this._scrollPinForce = true;
-    else if (!this._nearBottom) return;
-    // rAF-coalesced pin: at most one scrollHeight read + scrollTop write per
-    // frame no matter how many deltas arrived.  The pin re-checks
-    // _nearBottom AT FIRE TIME: a user wheel-scroll can land between the
-    // schedule (when the cached flag was still true) and the rAF — pinning
-    // anyway would yank them back to the bottom, and the programmatic
-    // scroll's own event would re-mark the flag true, trapping them there
-    // for the rest of the stream.  Scroll events fire before rAF callbacks
-    // within a frame, so the re-check sees the user's disengage.  Force
-    // requests latch across the coalescing window (a forced pin must win
-    // even if a non-forced schedule got there first).
-    if (this._scrollPinPending) return;
-    this._scrollPinPending = true;
-    requestAnimationFrame(() => {
-      this._scrollPinPending = false;
-      const forced = this._scrollPinForce;
-      this._scrollPinForce = false;
-      if (forced || this._nearBottom) {
-        this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
-      }
-    });
+    if (force) this._scrollFollow.jumpToLatest();
+    else this._scrollFollow.schedule();
   }
 
   _createDOM() {
@@ -1356,39 +1320,15 @@ class Pane {
     this.messagesEl.setAttribute("role", "log");
     this.messagesEl.setAttribute("aria-live", "polite");
     this.messagesEl.setAttribute("aria-label", "Chat messages");
+    this.el.appendChild(this.messagesEl);
+    this._scrollFollow = mountConversationScroll(this.messagesEl);
     this._unregisterTranscriptScroller = registerTranscriptScroller(
       this.messagesEl,
-    );
-    // Track "pinned to bottom" from actual scrolls (user or programmatic)
-    // instead of reading scroller geometry per event — see isNearBottom().
-    // Passive: never blocks the compositor thread.
-    this.messagesEl.addEventListener(
-      "scroll",
-      () => {
-        this._nearBottom =
-          this.messagesEl.scrollHeight -
-            this.messagesEl.scrollTop -
-            this.messagesEl.clientHeight <
-          80;
+      {
+        isFollowing: () => this.isNearBottom(),
+        scrollToBottom: () => this.scrollToBottom(),
       },
-      { passive: true },
     );
-    // Layout changes that move the bottom WITHOUT a scroll event (window
-    // resize, split-drag, orientation change) would leave the cached flag
-    // stale — a user visually back at the bottom after growing the pane
-    // stayed disengaged until they nudged the scroller.  Resizes are rare,
-    // so the geometry read here is off the hot path by construction.
-    if (typeof ResizeObserver === "function") {
-      this._resizeObs = new ResizeObserver(() => {
-        this._nearBottom =
-          this.messagesEl.scrollHeight -
-            this.messagesEl.scrollTop -
-            this.messagesEl.clientHeight <
-          80;
-      });
-      this._resizeObs.observe(this.messagesEl);
-    }
-    this.el.appendChild(this.messagesEl);
 
     // Per-workstream status bar (above input)
     this.statusBarEl = document.createElement("div");
@@ -1478,6 +1418,7 @@ class Pane {
     });
     this.queue = createQueueController({
       messagesEl: this.messagesEl,
+      scroll: () => this.scrollToBottom(),
       getWsId: () => {
         return this.wsId;
       },
@@ -2455,7 +2396,7 @@ class Pane {
             doneBodyEl.textContent = doneBuffer;
           }
         }
-        this.scrollToBottom(true);
+        this.scrollToBottom();
         break;
       }
 
@@ -2815,7 +2756,7 @@ class Pane {
         this.stopBtn.disabled = true;
         this.stopBtn.textContent = "Cancelling\u2026";
         this.stopBtn.setAttribute("aria-label", "Cancelling generation");
-        this.scrollToBottom(true);
+        this.scrollToBottom();
         // After 2s, offer "Force Stop" for a harder cancel that abandons
         // the stuck worker thread.  Safety timeout at 10s auto-recovers
         // if state_change never arrives (connection drop).
@@ -2990,6 +2931,7 @@ class Pane {
             const editEl = this.addUserMessage(editText, null, {
               clientSendId: editClientSendId,
             });
+            this.scrollToBottom(true);
             postAndSettleSend(
               this.queue,
               authFetch(
@@ -3759,6 +3701,7 @@ class Pane {
   }
 
   replayHistory(messages) {
+    const scrollTop = this.messagesEl.scrollTop;
     this.messagesEl.replaceChildren();
     // A full committed-history render repairs any recorded truncation
     // gap — from the resync itself or an unrelated clear_ui rebuild — so
@@ -4136,6 +4079,7 @@ class Pane {
       }
     }
     this._attachRetryToLastAssistant();
+    this.messagesEl.scrollTop = scrollTop;
     this.scrollToBottom();
     // Focus the input so keyboard users land on the next-action target
     // after replay finishes — but only when this is the focused pane,
@@ -4221,13 +4165,6 @@ class Pane {
   announceToolBlock(items) {
     const list = (items || []).filter(Boolean);
     if (!list.length) return;
-    // Re-pin to the bottom only if we were already there — captured BEFORE the
-    // block grows scrollHeight.  A tool batch is a tall one-shot append; if
-    // isNearBottom() were measured after appendChild (as scrollToBottom does on
-    // its own) the freshly-added height would read >80px from the new bottom,
-    // so auto-follow would silently disengage at exactly tool-call time.  Token
-    // streaming stays pinned without this because each append is sub-threshold.
-    const stick = this.isNearBottom();
     // Key the shell by its call_id set.  A re-announce of the SAME batch
     // replaces its own shell; shells of OTHER batches stay — parallel
     // task agents announce concurrently and must not discard each other.
@@ -4270,7 +4207,7 @@ class Pane {
     this.messagesEl.appendChild(block);
     this._indexToolRows(block);
     this._relinkAgentCards(list);
-    this.scrollToBottom(stick);
+    this.scrollToBottom();
     toolAnnounce(_toolAnnounceText(list));
   }
 
@@ -4297,9 +4234,6 @@ class Pane {
   }
 
   showInlineToolBlock(items, autoApproved, judgePending, cycleId) {
-    // Capture pin before _takeAnnouncedBlock/append change scrollHeight — see
-    // announceToolBlock for why post-append measurement breaks here.
-    const stick = this.isNearBottom();
     // Reuse the early-paint announce shell if it's for this batch (upgrade in
     // place); else build fresh.
     const announced = this._takeAnnouncedBlock(items);
@@ -4413,7 +4347,7 @@ class Pane {
       }
     }
     this._relinkAgentCards(items);
-    this.scrollToBottom(stick);
+    this.scrollToBottom();
   }
 
   resolveApproval(approved, always, feedback, skipPost, cycleId) {
@@ -4425,10 +4359,6 @@ class Pane {
     const entry = this.approvalCycles.get(id);
     if (!entry) return; // already resolved (peer tab / server race) — idempotent
     this.approvalCycles.delete(id);
-
-    // Capture pin before the status badge reflows the block — see
-    // announceToolBlock.
-    const stick = this.isNearBottom();
 
     entry.blockEls.forEach((el) => {
       const actions = el.querySelector(".conv-actions");
@@ -4478,7 +4408,7 @@ class Pane {
       });
     }
 
-    this.scrollToBottom(stick);
+    this.scrollToBottom();
   }
 
   // --- Task-agent card: nest a sub-agent's sub-tool steps under its row -----
@@ -4587,7 +4517,7 @@ class Pane {
         }
         notice.textContent = stripAnsi(message);
       },
-      scroll: (force) => this.scrollToBottom(force),
+      scroll: () => this.scrollToBottom(),
     });
   }
 
@@ -4628,7 +4558,6 @@ class Pane {
       const toggle = card.wrap.querySelector(".conv-agent-toggle");
       if (toggle) toggle.setAttribute("aria-expanded", "true");
     }
-    const stick = this.isNearBottom();
     const approveRows = [];
     items.forEach((item) => {
       if (!item || !item.parent_call_id) return;
@@ -4692,7 +4621,7 @@ class Pane {
       this._registerApprovalCycle(cycleId, approveRows, items);
     }
     this._updateAgentLabel(card);
-    this.scrollToBottom(stick);
+    this.scrollToBottom();
     return true;
   }
 
@@ -4997,9 +4926,8 @@ class Pane {
 
   appendToolOutput(callId, name, output, isError, preview, opts = {}) {
     const accepted = opts.accepted === true;
-    // Capture pin before the streamEl removal + result insertion change
-    // scrollHeight — see announceToolBlock.  The result block is the other
-    // tall one-shot append in the tool flow (up to 10 lines before collapse).
+    // Folding uses the pre-mutation follow state; the deferred scroll also
+    // checks for a newer user scroll before it moves the viewport.
     const stick = this.isNearBottom();
     // A task_agent's OWN result completing flips its card running -> done/error
     // (child sub-tool results carry namespaced ids, never keys of _agentCards).
@@ -5195,7 +5123,7 @@ class Pane {
       }
     }
     if (resultNodes.length || (settlement && settlement.autoFolded)) {
-      this.scrollToBottom(stick);
+      this.scrollToBottom();
     }
     return true;
   }
@@ -5340,6 +5268,7 @@ class Pane {
         clientSendId,
       });
     }
+    this.scrollToBottom(true);
     this.composer.clear();
 
     // Bound the send POST with an AbortController + ~15s timeout (mirrors
@@ -6209,10 +6138,7 @@ function createInteractivePane(root, wsId, opts) {
       // card maps, and stop observing the detached scroller.
       pane._clearAgentTracking();
       pane._replayQueue = null;
-      if (pane._resizeObs) {
-        pane._resizeObs.disconnect();
-        pane._resizeObs = null;
-      }
+      pane._scrollFollow.destroy();
       if (pane._unregisterTranscriptScroller) {
         pane._unregisterTranscriptScroller();
         pane._unregisterTranscriptScroller = null;

--- a/turnstone/shared_static/transcript_presentation.js
+++ b/turnstone/shared_static/transcript_presentation.js
@@ -65,6 +65,20 @@ function scrollerIsAtBottom(scroller) {
   return distance <= BOTTOM_THRESHOLD_PX;
 }
 
+function scrollerIsFollowing(state) {
+  return state.isFollowing
+    ? state.isFollowing()
+    : scrollerIsAtBottom(state.scroller);
+}
+
+function restoreScrollerBottom(state) {
+  // Let the pane account for its own scroll writes, including the browser's
+  // delayed scroll event after more streamed content has arrived.
+  if (state.scrollToBottom) state.scrollToBottom();
+  else state.scroller.scrollTop = state.scroller.scrollHeight;
+  state.atBottom = true;
+}
+
 function releaseScroller(scroller, state, removeMarker) {
   if (scrollers.get(scroller) !== state) return;
   scrollers.delete(scroller);
@@ -80,14 +94,13 @@ function refreshScrollerFollowState(state) {
     const restoreRevision = state.pendingBottomRestoreRevision;
     state.pendingBottomRestoreRevision = null;
     if (restoreRevision !== state.scrollRevision) {
-      state.atBottom = scrollerIsAtBottom(scroller);
+      state.atBottom = scrollerIsFollowing(state);
       return;
     }
-    scroller.scrollTop = scroller.scrollHeight;
-    state.atBottom = true;
+    restoreScrollerBottom(state);
     return;
   }
-  state.atBottom = scrollerIsAtBottom(scroller);
+  state.atBottom = scrollerIsFollowing(state);
 }
 
 function isPlaying(media) {
@@ -154,7 +167,7 @@ function captureScrollers() {
       continue;
     }
     if (isVisibleScroller(scroller)) {
-      state.atBottom = scrollerIsAtBottom(scroller);
+      state.atBottom = scrollerIsFollowing(state);
     }
     snapshots.push({
       scroller,
@@ -186,8 +199,7 @@ function restoreBottomPins(snapshots) {
         continue;
       }
       snapshot.state.pendingBottomRestoreRevision = null;
-      snapshot.scroller.scrollTop = snapshot.scroller.scrollHeight;
-      snapshot.state.atBottom = true;
+      restoreScrollerBottom(snapshot.state);
     }
   });
 }
@@ -282,16 +294,16 @@ export function mountTranscriptPresentationToggle(container, options) {
 
 // Preserve follow state across a synchronous transcript reflow (for example,
 // reopening a folded batch when a late exceptional verdict lands). The
-// registered scroller owns the cached hidden-pane state; visible panes are
-// remeasured immediately before mutation so users who scrolled away are never
-// pulled back. Restoration is deferred until layout reflects the mutation.
+// registered scroller uses the pane's follow choice when supplied, otherwise
+// visible geometry and cached hidden-pane state. Restoration is deferred until
+// layout reflects the mutation and yields to newer user scrolling.
 export function preserveTranscriptBottomPin(element, mutate) {
   if (typeof mutate !== "function") return undefined;
   const state = scrollers.get(element);
   let snapshot = null;
   if (state && element.isConnected) {
     if (isVisibleScroller(element)) {
-      state.atBottom = scrollerIsAtBottom(element);
+      state.atBottom = scrollerIsFollowing(state);
     }
     snapshot = {
       scroller: element,
@@ -307,16 +319,18 @@ export function preserveTranscriptBottomPin(element, mutate) {
   }
 }
 
-export function registerTranscriptScroller(element) {
+export function registerTranscriptScroller(element, options = {}) {
   if (!element) return () => {};
   const prior = scrollers.get(element);
   if (prior) releaseScroller(element, prior, false);
   element.setAttribute(TRANSCRIPT_ROOT_ATTRIBUTE, "");
   const state = {
     scroller: element,
-    atBottom: isVisibleScroller(element)
-      ? scrollerIsAtBottom(element)
-      : true,
+    isFollowing: options.isFollowing,
+    scrollToBottom: options.scrollToBottom,
+    atBottom: options.isFollowing
+      ? options.isFollowing()
+      : !isVisibleScroller(element) || scrollerIsAtBottom(element),
     pendingBottomRestoreRevision: null,
     scrollRevision: 0,
     onScroll: null,
@@ -326,7 +340,7 @@ export function registerTranscriptScroller(element) {
     state.scrollRevision += 1;
     state.pendingBottomRestoreRevision = null;
     if (isVisibleScroller(element)) {
-      state.atBottom = scrollerIsAtBottom(element);
+      state.atBottom = scrollerIsFollowing(state);
     }
   };
   element.addEventListener("scroll", state.onScroll, { passive: true });


### PR DESCRIPTION
Coordinator and interactive conversations now pause autoscroll when the reader scrolls up. Resume
near the bottom, with Jump to latest, or on a local send, including queued and edited messages.

Share per-pane follow state across streaming, tool and info updates, history rebuilds, hidden tabs,
and compact transcript folding. Distinguish browser reflow from user input to avoid mistaken
pauses and resumes when content changes height.

Closes #1129.

Validation:

- Frontend suite: 723 passed; focused suites after the final changes: 120 passed.
- Chrome checks for desktop/mobile, default/compact views, small upward gestures, native scroll
  anchoring, info/result reflow, history rebuilds, and local sends/edit-and-resend.
- `scripts/livepass.py --perf`: 300 and 3,000 messages, no page errors.
- `scripts/recovery_e2e.py --scenario all`: all 25 scenarios passed in an isolated run. An initial
  attempt hit the harness's thread-start/join race.
- Ruff, formatting, mypy, and diff checks passed.

