### PR TITLE
Fix MCP OAuth refresh client loop ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ frozen.
   with Python 3.13 or newer before upgrading. CI tests Python 3.13 and 3.14, and Docker images
   already include Python 3.14.
 
+### Fixed
+
+- **Per-user MCP OAuth refresh.** Discovery and refresh requests now use the MCP loop's HTTP
+  client, preventing cross-loop failures after browser sign-in.
+
 ## [1.8.3]
 
 Turnstone 1.8.3 makes scheduled work easier to launch, keeps conversations and node placement intact

--- a/scripts/obo-e2e/README.md
+++ b/scripts/obo-e2e/README.md
@@ -96,7 +96,7 @@ registration), runs the harness, then tears down. The harness drives the REAL
 console OAuth surface — `handle_mcp_oauth_authorize` →
 `handle_mcp_oauth_callback` → `get_user_access_token_classified` →
 `handle_mcp_oauth_revoke_connection`, mounted on the console's own routes with
-the client `initialize_mcp_oauth_state` installs — so RFC 9728
+the browser client `initialize_mcp_oauth_state` installs — so RFC 9728
 protected-resource metadata, RFC 8414 authorization-server metadata for a
 path-bearing realm issuer, the PKCE code exchange, the refresh grant and RFC
 7009 revocation all happen on the wire. The "MCP server" is a local stub that
@@ -107,9 +107,25 @@ itself. Ports: Keycloak 8092, resource-server stubs 8093 (path-specific) and
 8094 (origin-level only), redirect base 8095 (8090 = the dev console, 8091 =
 the obo harness).
 
+Token lookups run on a real `MCPClientManager` loop with its own HTTP client.
+C6/C7 warm both clients on their owner loops before refreshing against Keycloak,
+then require the token POST to use the MCP client. D5 clears the metadata cache
+and requires both discovery and refresh to use that client. Request hooks also
+record each client's calling loop (L1), so wrong ownership remains detectable
+if a keepalive connection expires. The manager is shut down and its thread
+joined before closing the browser clients and token store.
+
 ```bash
 ./scripts/obo-e2e/oauth_user_e2e.sh
 ```
+
+Results — RUN 2026-09-10, 17 VERIFIED / 0 FAILED (exit 0) with the #963 refresh-client fix:
+C6/C7 refresh on the MCP loop; D5 covers uncached discovery; L1 checks client loop ownership.
+Restoring the original refresh helper in an isolated process reproduces
+`RuntimeError: ... is bound to a different event loop` at C6's token POST. A second control,
+leaving only discovery on the browser client, passes C6/C7 with cached metadata and reproduces
+the same error at D5's discovery GET. Both controls exit 1; each run removes its ephemeral
+container.
 
 Results — RUN 2026-09-06, 15 VERIFIED / 0 FAILED (exit 0) after the #1081 and #1082 fixes:
 D4 verifies that the second row persists its issuer when AS metadata is already cached. N2's callback

--- a/scripts/obo-e2e/oauth_user_e2e.py
+++ b/scripts/obo-e2e/oauth_user_e2e.py
@@ -12,8 +12,10 @@ console's four OAuth routes mounted on a small Starlette app the way
 product installs (``initialize_mcp_oauth_state``) talking to a live realm.
 ``handle_mcp_oauth_authorize`` → headless login → ``handle_mcp_oauth_callback``
 → ``get_user_access_token_classified`` → ``handle_mcp_oauth_revoke_connection``.
-The "MCP server" is a local stub that serves only RFC 9728 protected-resource
-metadata; it never speaks MCP, because nothing under test does either.
+Browser routes run on the host loop; token lookups run on a real MCP manager's
+loop with its own HTTP client. The "MCP server" is a local stub that serves only
+RFC 9728 protected-resource metadata; it never speaks MCP, because nothing under
+test does either.
 
 Checks:
   D1 discovery: PRM read at the RFC 9728 path-specific location (origin never
@@ -27,9 +29,10 @@ Checks:
      request (the code exchange — issuer and metadata already cached)
   C4 cache hit: ZERO requests
   C5 callback replay refused (state is single-use), ZERO requests
-  C6 refresh after a real clock expiry: one token POST, no re-discovery,
+  C6 refresh on the MCP loop when the clock enters the refresh window:
+     warmed browser and MCP clients, one MCP-client token POST, no re-discovery,
      refresh-token rotation written back, the new token live
-  C7 force_refresh → one more token POST
+  C7 force_refresh on the MCP loop → one more token POST
   C8 connections list carries the row without secret material
   C9 revoke: 204, row gone, lookup → missing, RFC 7009 POST to the realm,
      and the refresh token is dead AT KEYCLOAK afterwards
@@ -41,6 +44,9 @@ Checks:
   D3 dynamic client registration (registration_mode=dcr) followed by consent
   D4 the resolved issuer is persisted on a row whose authorization server the
      in-process metadata cache already holds
+  D5 refresh with an empty metadata cache: real discovery and the token POST
+     both use the MCP client, while the warmed browser client stays idle
+  L1 browser and MCP clients stay on their separate owner loops
 
 Env (set by oauth_user_e2e.sh):
   KC_ISSUER, KC_CLIENT_ID, KC_NOAUD_CLIENT_ID, KC_USER, KC_PASSWORD,
@@ -72,7 +78,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import Mount, Route
 
 from turnstone.core.auth import AuthResult
-from turnstone.core.mcp_client import _validate_oauth_user_url
+from turnstone.core.mcp_client import MCPClientManager, _validate_oauth_user_url
 from turnstone.core.mcp_crypto import (
     MCPTokenCipher,
     MCPTokenCipherConfig,
@@ -92,6 +98,8 @@ from turnstone.core.oidc import OIDCConfig
 from turnstone.core.storage._sqlite import SQLiteBackend
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
     from starlette.requests import Request
     from starlette.responses import Response
 
@@ -178,16 +186,33 @@ class _PRMStub:
 class _Wire:
     """Every request the product's OAuth client sends, via httpx's request hook."""
 
-    def __init__(self, client: httpx.AsyncClient) -> None:
+    def __init__(
+        self, client: httpx.AsyncClient, *, loop: asyncio.AbstractEventLoop | None = None
+    ) -> None:
         self.calls: list[tuple[str, str]] = []
+        self.off_loop_calls: list[tuple[str, str]] = []
+        self.loop = loop if loop is not None else asyncio.get_running_loop()
         client.event_hooks["request"].append(self._seen)
 
     async def _seen(self, request: httpx.Request) -> None:
-        self.calls.append((request.method, str(request.url)))
+        call = (request.method, str(request.url))
+        self.calls.append(call)
+        if asyncio.get_running_loop() is not self.loop:
+            # Observe without raising: a negative control can still reproduce
+            # the real HTTP transport error, rather than failing in this hook.
+            self.off_loop_calls.append(call)
 
     def drain(self) -> list[tuple[str, str]]:
         calls, self.calls = self.calls, []
         return calls
+
+
+async def _on_mcp_loop[T](manager: MCPClientManager, coroutine: Coroutine[Any, Any, T]) -> T:
+    loop = manager._loop
+    assert loop is not None
+    return await asyncio.wait_for(
+        asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coroutine, loop)), timeout=40.0
+    )
 
 
 class _Browser:
@@ -359,6 +384,12 @@ async def _run(cfg: dict[str, str]) -> None:
     wire = _Wire(app.state.mcp_oauth_http_client)
     console = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url=redirect_base)
     kc = httpx.AsyncClient(timeout=20.0)
+    manager = MCPClientManager({})
+    # Drive lookups explicitly so a timer cannot consume the grant under test.
+    manager._user_token_sweep_s = 0
+    manager._static_health_check_s = 0
+    manager.set_storage(storage)
+    manager.set_app_state(app.state)
 
     async def userinfo(token: str) -> str | None:
         resp = await kc.get(
@@ -367,6 +398,20 @@ async def _run(cfg: dict[str, str]) -> None:
         return str(resp.json().get("preferred_username")) if resp.status_code == 200 else None
 
     try:
+        await asyncio.to_thread(manager.start)
+        assert manager._loop is not None
+        mint_client = app.state.obo_http_client
+        refresh_wire = _Wire(mint_client, loop=manager._loop)
+        want_document = issuer + "/.well-known/openid-configuration"
+
+        async def warm_clients() -> None:
+            # Keep actual Keycloak connections warm on BOTH loops immediately
+            # before refresh. These GETs do not fill the product metadata cache.
+            (await app.state.mcp_oauth_http_client.get(want_document)).raise_for_status()
+            (await _on_mcp_loop(manager, mint_client.get(want_document))).raise_for_status()
+            wire.drain()
+            refresh_wire.drain()
+
         # The row is admitted the way the console admits it: the https gate
         # (loopback exempt) and strict canonicalization at the write boundary.
         _validate_oauth_user_url(resource)
@@ -381,7 +426,6 @@ async def _run(cfg: dict[str, str]) -> None:
             record("FAILED", f"D1 authorize: HTTP {start.status_code} {start.text[:200]}")
             return
         row = storage.get_mcp_server_by_name("kc-mcp") or {}
-        want_document = issuer + "/.well-known/openid-configuration"
         as_probes = [url for url in gets if url.startswith(issuer.rsplit("/realms/", 1)[0])]
         d1_ok = (
             prm_hits == [f"{PRM}/mcp"]
@@ -463,10 +507,13 @@ async def _run(cfg: dict[str, str]) -> None:
         )
 
         # C4 — cache hit.
-        r4 = await get_user_access_token_classified(
-            app_state=app.state, user_id=USER, server_name="kc-mcp"
+        r4 = await _on_mcp_loop(
+            manager,
+            get_user_access_token_classified(
+                app_state=app.state, user_id=USER, server_name="kc-mcp"
+            ),
         )
-        calls = wire.drain()
+        calls = wire.drain() + refresh_wire.drain()
         record(
             "VERIFIED" if r4.kind == "token" and r4.token == access and not calls else "FAILED",
             f"C4 cache hit: kind={r4.kind} same_token={r4.token == access} requests={len(calls)} (want 0)",
@@ -487,7 +534,7 @@ async def _run(cfg: dict[str, str]) -> None:
             f"requests={len(calls)} (want 0) row_untouched={untouched}",
         )
 
-        # C6 — refresh after the token really expires. The realm issues
+        # C6 — refresh when the token enters the refresh window. The realm issues
         # short-lived tokens so the clock, not a forged row, crosses the
         # product's refresh-ahead window.
         from turnstone.core.mcp_oauth import _ACCESS_TOKEN_REFRESH_SKEW_SECONDS
@@ -498,10 +545,16 @@ async def _run(cfg: dict[str, str]) -> None:
         ).total_seconds()
         print(f"  waiting {max(wait, 0):.0f}s for the access token to enter the refresh window...")
         await asyncio.sleep(max(wait, 0))
-        r6 = await get_user_access_token_classified(
-            app_state=app.state, user_id=USER, server_name="kc-mcp"
+        await warm_clients()
+        print("  C6 refreshing on the MCP loop with warmed browser and MCP clients...")
+        r6 = await _on_mcp_loop(
+            manager,
+            get_user_access_token_classified(
+                app_state=app.state, user_id=USER, server_name="kc-mcp"
+            ),
         )
-        calls = wire.drain()
+        calls = refresh_wire.drain()
+        browser_calls = wire.drain()
         plain6 = store.get_user_token(USER, "kc-mcp")
         rotated = plain6 is not None and plain6["refresh_token"] not in (None, refresh)
         who6 = await userinfo(r6.token) if r6.token else None
@@ -510,13 +563,14 @@ async def _run(cfg: dict[str, str]) -> None:
             if r6.kind == "token"
             and r6.token != access
             and calls == [("POST", token_endpoint)]
+            and not browser_calls
             and rotated
             and plain6 is not None
             and plain6["last_refreshed"]
             and who6 == cfg["KC_USER"]
             else "FAILED",
-            f"C6 refresh after expiry: kind={r6.kind} new_token={r6.token != access} "
-            f"wire={calls} (want one token POST, no re-discovery) rotated={rotated} "
+            f"C6 MCP-loop refresh when due: kind={r6.kind} new_token={r6.token != access} "
+            f"mcp_wire={calls} (want one token POST) browser_wire={browser_calls} rotated={rotated} "
             f"last_refreshed={plain6['last_refreshed'] if plain6 else None} userinfo={who6!r}",
         )
 
@@ -525,15 +579,60 @@ async def _run(cfg: dict[str, str]) -> None:
         # token by design (second-precision last_refreshed is the contention
         # tiebreak), so the check first lets the second turn.
         await asyncio.sleep(1.05 - datetime.now(UTC).microsecond / 1_000_000)
-        r7 = await get_user_access_token_classified(
-            app_state=app.state, user_id=USER, server_name="kc-mcp", force_refresh=True
+        await warm_clients()
+        r7 = await _on_mcp_loop(
+            manager,
+            get_user_access_token_classified(
+                app_state=app.state, user_id=USER, server_name="kc-mcp", force_refresh=True
+            ),
         )
-        calls = wire.drain()
+        calls = refresh_wire.drain()
+        browser_calls = wire.drain()
         record(
             "VERIFIED"
-            if r7.kind == "token" and r7.token != r6.token and calls == [("POST", token_endpoint)]
+            if r7.kind == "token"
+            and r7.token != r6.token
+            and calls == [("POST", token_endpoint)]
+            and not browser_calls
             else "FAILED",
-            f"C7 force_refresh: kind={r7.kind} new_token={r7.token != r6.token} wire={calls}",
+            f"C7 MCP-loop force_refresh: kind={r7.kind} new_token={r7.token != r6.token} "
+            f"mcp_wire={calls} browser_wire={browser_calls}",
+        )
+
+        # D5 — a warm metadata cache can hide a discovery-only cross-loop bug.
+        # Force real Keycloak discovery while both clients have warm transports.
+        await asyncio.sleep(1.05 - datetime.now(UTC).microsecond / 1_000_000)
+        await warm_clients()
+        app.state.mcp_oauth_metadata_cache.clear()
+        before_discovery_refresh = store.get_user_token(USER, "kc-mcp")
+        stub.drain()
+        print("  D5 refreshing on the MCP loop with an empty metadata cache...")
+        r5 = await _on_mcp_loop(
+            manager,
+            get_user_access_token_classified(
+                app_state=app.state, user_id=USER, server_name="kc-mcp", force_refresh=True
+            ),
+        )
+        calls = refresh_wire.drain()
+        browser_calls = wire.drain()
+        plain5 = store.get_user_token(USER, "kc-mcp")
+        who5 = await userinfo(r5.token) if r5.token else None
+        record(
+            "VERIFIED"
+            if r5.kind == "token"
+            and r5.token != r7.token
+            and calls == [("GET", url) for url in as_probes] + [("POST", token_endpoint)]
+            and not browser_calls
+            and not stub.drain()
+            and issuer in app.state.mcp_oauth_metadata_cache
+            and plain5 is not None
+            and before_discovery_refresh is not None
+            and plain5["refresh_token"] not in (None, before_discovery_refresh["refresh_token"])
+            and plain5["access_token"] == r5.token
+            and who5 == cfg["KC_USER"]
+            else "FAILED",
+            f"D5 MCP-loop refresh rediscovery: kind={r5.kind} mcp_wire={calls} "
+            f"browser_wire={browser_calls} userinfo={who5!r}",
         )
 
         # C8 — the settings-page projection.
@@ -561,8 +660,11 @@ async def _run(cfg: dict[str, str]) -> None:
         await asyncio.gather(*_revoke_upstream_tasks)
         calls = wire.drain()
         gone = storage.get_mcp_user_token(USER, "kc-mcp") is None
-        r9 = await get_user_access_token_classified(
-            app_state=app.state, user_id=USER, server_name="kc-mcp"
+        r9 = await _on_mcp_loop(
+            manager,
+            get_user_access_token_classified(
+                app_state=app.state, user_id=USER, server_name="kc-mcp"
+            ),
         )
         dead = await kc.post(
             token_endpoint,
@@ -695,12 +797,27 @@ async def _run(cfg: dict[str, str]) -> None:
                 f"registration_wire={[(m, u) for m, u in calls if m == 'POST']} "
                 f"consent={done3.headers.get('location')} aud={aud3}",
             )
+        record(
+            "VERIFIED"
+            if wire.loop is not refresh_wire.loop
+            and app.state.mcp_oauth_http_client is not mint_client
+            and not wire.off_loop_calls
+            and not refresh_wire.off_loop_calls
+            else "FAILED",
+            f"L1 separate HTTP-client owner loops: browser_off_loop={wire.off_loop_calls} "
+            f"mcp_off_loop={refresh_wire.off_loop_calls}",
+        )
     finally:
+        thread = manager._thread
+        await asyncio.to_thread(manager.shutdown)
         await console.aclose()
         await kc.aclose()
         await close_mcp_oauth_state(app.state)
         stub.close()
         legacy.close()
+        storage.close()
+        if thread is not None and thread.is_alive():
+            raise RuntimeError("MCP harness loop thread survived shutdown")
 
 
 def main() -> int:

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -6,28 +6,72 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from turnstone.core.storage._sqlite import SQLiteBackend
 
 
-def test_cli_starts_with_fresh_database(tmp_path: Path) -> None:
+@pytest.mark.parametrize("oauth_pool", [False, True], ids=["empty", "web-user-pool"])
+def test_cli_starts_with_fresh_database(
+    tmp_path: Path, sqlite_backend_factory: Callable[[str], SQLiteBackend], oauth_pool: bool
+) -> None:
     """A fresh CLI session must reach the prompt and shut down cleanly."""
     config_path = tmp_path / "config.toml"
     config_path.write_text("", encoding="utf-8")
     config_path.chmod(0o600)
+
+    db_path = tmp_path / "turnstone.db"
+    if oauth_pool:
+        storage = sqlite_backend_factory(str(db_path))
+        storage.create_mcp_server(
+            server_id="web-oauth",
+            name="web-oauth",
+            transport="streamable-http",
+            url="https://mcp.example.com/mcp",
+            auth_type="oauth_user",
+            oauth_client_id="client-abc",
+        )
+        storage.close()
+
+    entrypoint = ["-m", "turnstone.cli"]
+    if oauth_pool:
+        entrypoint = [
+            "-c",
+            """
+from turnstone.core.mcp_client import MCPClientManager
+from turnstone.cli import main
+
+original_start = MCPClientManager.start
+
+def check_start(manager):
+    original_start(manager)
+    assert manager._user_token_sweep_s == 0
+    assert manager._user_token_sweep_task is None
+    print("CLI token sweep disabled")
+
+MCPClientManager.start = check_start
+main()
+""",
+        ]
 
     env = {key: value for key, value in os.environ.items() if not key.startswith("TURNSTONE_")}
     env.update(
         {
             "OPENAI_API_KEY": "dummy",
             "TURNSTONE_DB_BACKEND": "sqlite",
-            "TURNSTONE_DB_PATH": str(tmp_path / "turnstone.db"),
+            "TURNSTONE_DB_PATH": str(db_path),
         }
     )
 
     result = subprocess.run(
         [
             sys.executable,
-            "-m",
-            "turnstone.cli",
+            *entrypoint,
             "--config",
             str(config_path),
             "--model",
@@ -49,3 +93,5 @@ def test_cli_starts_with_fresh_database(tmp_path: Path) -> None:
     assert result.returncode == 0, output
     assert "Type /help for commands" in result.stdout
     assert "Goodbye." in result.stdout
+    if oauth_pool:
+        assert "CLI token sweep disabled" in result.stdout

--- a/tests/test_mcp_oauth_discovery.py
+++ b/tests/test_mcp_oauth_discovery.py
@@ -2141,7 +2141,7 @@ class TestPrivateNetworkOptIn:
         store = MagicMock()
         store.get.return_value = True
         state = SimpleNamespace(
-            mcp_oauth_http_client=MagicMock(spec=httpx.AsyncClient),
+            obo_http_client=MagicMock(spec=httpx.AsyncClient),
             mcp_oauth_metadata_cache=None,
             config_store=store,
         )

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -24,16 +24,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import sqlalchemy as sa
+from aiohttp import web
 
-from tests.conftest import make_mcp_token_cipher
+from tests.conftest import _run_on_loop, make_mcp_token_cipher
+from turnstone.core.mcp_client import MCPClientManager
 from turnstone.core.mcp_crypto import MCPTokenStore
 from turnstone.core.mcp_oauth import (
     discover_authorization_server,
     get_user_access_token,
     get_user_access_token_classified,
+    json_http_client,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from turnstone.core.storage._sqlite import SQLiteBackend
 
 # Generous CI ceiling — cancel/drain is sub-millisecond on a healthy loop.
@@ -100,7 +106,7 @@ def _make_app_state(storage: SQLiteBackend, *, http_client: httpx.AsyncClient) -
     state = SimpleNamespace(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
-        mcp_oauth_http_client=http_client,
+        obo_http_client=http_client,
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )
@@ -174,8 +180,190 @@ def _mk_response(status_code: int = 200, json_body: Any = None) -> MagicMock:
     return resp
 
 
-def _public_addr_patch():
+def _public_addr_patch() -> contextlib.AbstractContextManager[Any]:
     return patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))])
+
+
+@pytest.fixture
+def mint_manager() -> Iterator[MCPClientManager]:
+    manager = MCPClientManager({})
+    manager._user_token_sweep_s = 0
+    manager._static_health_check_s = 0
+    try:
+        manager.start()
+        yield manager
+    finally:
+        manager.shutdown()
+
+
+@pytest.mark.parametrize("injected_client", [True, False], ids=["manager", "transient"])
+def test_refresh_discovery_and_post_stay_off_the_browser_loop(
+    storage: SQLiteBackend, mint_manager: MCPClientManager, injected_client: bool
+) -> None:
+    """Warm real connections on both live loops; discover with an empty metadata cache."""
+    _seed_server(storage)
+
+    async def _run() -> None:
+        requests: list[tuple[str, httpx.AsyncClient, asyncio.AbstractEventLoop]] = []
+
+        def observe_client(client: httpx.AsyncClient) -> httpx.AsyncClient:
+            async def on_request(request: httpx.Request) -> None:
+                requests.append((request.url.path, client, asyncio.get_running_loop()))
+
+            client.event_hooks["request"].append(on_request)
+            return client
+
+        def transient_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            return observe_client(json_http_client(*args, **kwargs))
+
+        async def handle(request: web.Request) -> web.Response:
+            if request.path == "/.well-known/oauth-authorization-server":
+                metadata = _good_as_metadata_doc()
+                metadata.update(
+                    issuer=origin,
+                    authorization_endpoint=f"{origin}/authorize",
+                    token_endpoint=f"{origin}/token",
+                    jwks_uri=f"{origin}/jwks",
+                )
+                return web.json_response(metadata)
+            if request.path == "/token":
+                assert request.headers["Accept"] == "application/json"
+                assert (await request.post())["grant_type"] == "refresh_token"
+                return web.json_response(
+                    {
+                        "access_token": "fresh-bbb",
+                        "refresh_token": "refresh-rotated",
+                        "expires_in": 3600,
+                    }
+                )
+            assert request.path == "/warm"
+            return web.json_response({})
+
+        app = web.Application()
+        app.router.add_route("*", "/{path:.*}", handle)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            await web.TCPSite(runner, "127.0.0.1", 0).start()
+            origin = f"http://127.0.0.1:{runner.addresses[0][1]}"
+            storage.update_mcp_server("srv-id", oauth_as_issuer_cached=origin)
+            async with httpx.AsyncClient() as browser_client:
+                observe_client(browser_client)
+                state = _make_app_state(storage, http_client=browser_client)
+                state.mcp_oauth_http_client = browser_client
+                _seed_token(state, expires_in_seconds=-1000)
+                mint_manager.set_app_state(state)
+                manager_client = observe_client(state.obo_http_client)
+                loop = mint_manager._loop
+                assert loop is not None
+                await browser_client.get(f"{origin}/warm")
+                await asyncio.wrap_future(
+                    asyncio.run_coroutine_threadsafe(
+                        state.obo_http_client.get(f"{origin}/warm"), loop
+                    )
+                )
+                if not injected_client:
+                    del state.obo_http_client
+                assert state.mcp_oauth_metadata_cache == {}
+                with patch("turnstone.core.mcp_oauth.json_http_client", transient_client):
+                    result = await asyncio.wait_for(
+                        asyncio.wrap_future(
+                            asyncio.run_coroutine_threadsafe(
+                                get_user_access_token_classified(
+                                    app_state=state, user_id="user-1", server_name="srv-oauth"
+                                ),
+                                loop,
+                            ),
+                        ),
+                        timeout=10,
+                    )
+
+                assert result.kind == "token", result
+                assert result.token == "fresh-bbb"
+                assert [path for path, _, _ in requests] == [
+                    "/warm",
+                    "/warm",
+                    "/.well-known/oauth-authorization-server",
+                    "/token",
+                ]
+                # Client identity survives keepalive expiry between requests.
+                discovery_client, token_client = (client for _, client, _ in requests[2:])
+                assert discovery_client is token_client
+                assert token_client is not browser_client
+                assert (token_client is manager_client) == injected_client
+                assert all(owner_loop is loop for _, _, owner_loop in requests[1:])
+                token = state.mcp_token_store.get_user_token("user-1", "srv-oauth")
+                assert token is not None
+                assert token["refresh_token"] == "refresh-rotated"
+                # The browser's own client remains usable on its original loop.
+                assert (await browser_client.get(f"{origin}/warm")).status_code == 200
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize("keepalive", [False, True], ids=["expiry", "keepalive"])
+@pytest.mark.parametrize(
+    "failure", [None, "invalid_grant", "temporarily_unavailable", "provider_error"]
+)
+def test_sweep_refreshes_with_no_browser_client(
+    storage: SQLiteBackend, mint_manager: MCPClientManager, keepalive: bool, failure: str | None
+) -> None:
+    """A real sweep needs no browser client and only observes failed grants."""
+    _seed_server(storage)
+    state = SimpleNamespace(
+        auth_storage=storage,
+        mcp_token_store=MCPTokenStore(storage, make_mcp_token_cipher(), node_id="test"),
+        mcp_oauth_refresh_locks={},
+        mcp_oauth_refresh_backoff={},
+    )
+    # Age the stored creation timestamp without aging the access-token expiry.
+    _seed_token(state, expires_in_seconds=3600 if keepalive else -1000)
+    with storage._engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "UPDATE mcp_user_tokens SET created = :created "
+                "WHERE user_id = :uid AND server_name = :sn"
+            ),
+            {
+                "created": (datetime.now(UTC) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S"),
+                "uid": "user-1",
+                "sn": "srv-oauth",
+            },
+        )
+    mint_manager.set_storage(storage)
+    mint_manager.set_app_state(state)
+    mint_manager._oauth_user_server_names = {"srv-oauth"}
+    mint_manager._user_token_refresh_keepalive_s = 3600 if keepalive else 0
+    requests: list[str] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        if request.method == "GET":
+            return httpx.Response(200, json=_good_as_metadata_doc())
+        assert request.method == "POST"
+        if failure:
+            # A 400 reaches the error-code classifier even for the transient code.
+            return httpx.Response(400, json={"error": failure})
+        return httpx.Response(200, json={"access_token": "fresh-bbb", "expires_in": 3600})
+
+    async def _tick() -> None:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            state.obo_http_client = client
+            with _public_addr_patch():
+                await mint_manager._sweep_user_token_freshness()
+
+    loop = mint_manager._loop
+    assert loop is not None
+    _run_on_loop(loop, _tick())
+    assert requests == ["GET", "POST"]
+    token = state.mcp_token_store.get_user_token("user-1", "srv-oauth")
+    assert token is not None
+    assert token["access_token"] == ("access-aaa" if failure else "fresh-bbb")
+    assert token["refresh_token"] == "refresh-rrr"
+    assert state.mcp_oauth_refresh_backoff == {}
+    assert bool(mint_manager._token_sweep_warned) == (failure == "invalid_grant")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_pending_consent_dispatch.py
+++ b/tests/test_mcp_pending_consent_dispatch.py
@@ -141,7 +141,7 @@ def _wire_mgr(mgr: MCPClientManager, backend: Any) -> None:
     app_state = SimpleNamespace(
         auth_storage=backend,
         mcp_token_store=MCPTokenStore(backend, cipher, node_id="test"),
-        mcp_oauth_http_client=MagicMock(),
+        obo_http_client=MagicMock(),
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )

--- a/tests/test_mcp_pool_auth_integration.py
+++ b/tests/test_mcp_pool_auth_integration.py
@@ -293,7 +293,7 @@ def _make_app_state(storage: SQLiteBackend, *, cipher: Any) -> SimpleNamespace:
     return SimpleNamespace(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
-        mcp_oauth_http_client=MagicMock(),
+        obo_http_client=MagicMock(),
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )

--- a/tests/test_mcp_pool_auth_introspection.py
+++ b/tests/test_mcp_pool_auth_introspection.py
@@ -104,7 +104,7 @@ def _make_app_state(storage: SQLiteBackend, *, cipher: Any) -> SimpleNamespace:
     return SimpleNamespace(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
-        mcp_oauth_http_client=MagicMock(),
+        obo_http_client=MagicMock(),
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )

--- a/tests/test_mcp_pool_auth_prompt_integration.py
+++ b/tests/test_mcp_pool_auth_prompt_integration.py
@@ -230,7 +230,7 @@ def _make_app_state(storage: SQLiteBackend, *, cipher: Any) -> SimpleNamespace:
     return SimpleNamespace(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
-        mcp_oauth_http_client=MagicMock(),
+        obo_http_client=MagicMock(),
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )

--- a/tests/test_mcp_pool_auth_resource_integration.py
+++ b/tests/test_mcp_pool_auth_resource_integration.py
@@ -239,7 +239,7 @@ def _make_app_state(storage: SQLiteBackend, *, cipher: Any) -> SimpleNamespace:
     return SimpleNamespace(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
-        mcp_oauth_http_client=MagicMock(),
+        obo_http_client=MagicMock(),
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )

--- a/tests/test_mcp_user_pool.py
+++ b/tests/test_mcp_user_pool.py
@@ -99,7 +99,7 @@ def _make_app_state(storage: SQLiteBackend, *, cipher: Any) -> SimpleNamespace:
     return SimpleNamespace(
         auth_storage=storage,
         mcp_token_store=MCPTokenStore(storage, cipher, node_id="test"),
-        mcp_oauth_http_client=MagicMock(),
+        obo_http_client=MagicMock(),
         mcp_oauth_refresh_locks={},
         mcp_oauth_metadata_cache={},
     )

--- a/turnstone/cli.py
+++ b/turnstone/cli.py
@@ -1316,6 +1316,9 @@ def main() -> None:
         getattr(args, "mcp_config", None),
         storage=_get_storage(),
         required=registry.has_dynamic_auth(),
+        # Nodes maintain web users' grants; CLI sessions must not become a
+        # second background refresher against a shared SQLite database.
+        user_token_sweep=False,
     )
     if mcp_client is not None:
         cli_auth_storage = _get_storage()

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -925,9 +925,9 @@ class MCPClientManager:
         # asserts non-None when it actually runs, so static-only callers
         # never hit it.
         self._app_state: Any = None
-        # Long-lived HTTP client created and closed on the mcp-loop. Model-token
-        # mints run on that loop and must not borrow the lifespan-loop OAuth
-        # client or pay a DNS/TLS setup on every turn.
+        # Long-lived HTTP client created and closed on the mcp-loop. Token mints
+        # and per-user refreshes (including discovery) reuse its connections.
+        # The browser OAuth client belongs to the lifespan loop.
         self._model_auth_http_client: httpx.AsyncClient | None = None
 
         # In-memory cache of server names whose ``auth_type='oauth_user'``.
@@ -1049,11 +1049,12 @@ class MCPClientManager:
     def set_app_state(self, app_state: Any) -> None:
         """Wire the OAuth ``app.state`` into the manager.
 
-        Called from the lifespan after ``initialize_mcp_crypto_state`` and
-        ``initialize_mcp_oauth_state`` have populated the token store,
-        OAuth HTTP client, metadata cache, and refresh-lock map. Required
-        before any ``auth_type='oauth_user'`` dispatch; static-only
-        deployments may leave it unset.
+        Hosts supply the token store, OAuth configuration, metadata cache,
+        and refresh-lock state needed by their auth paths. The manager injects
+        its loop-owned ``obo_http_client`` for mints and per-user refreshes;
+        browser clients are not used on this loop. Required before any
+        ``auth_type='oauth_user'`` dispatch; static-only deployments may leave
+        it unset.
         """
         self._app_state = app_state
         if self._model_auth_http_client is not None:
@@ -9543,6 +9544,7 @@ def create_mcp_client(
     *,
     storage: Any = None,
     required: bool = False,
+    user_token_sweep: bool = True,
 ) -> MCPClientManager | None:
     """Create and start an MCP client manager.
 
@@ -9557,6 +9559,10 @@ def create_mcp_client(
     installs left the host managerless after every restart — no pools,
     no MCP — until the next admin MCP write or reload fan-out happened
     to lazy-construct one.)
+
+    Set ``user_token_sweep=False`` for hosts such as the CLI that must not
+    maintain web users' grants in the background. This disables the sweep
+    before the manager starts, without changing the configured node cadence.
     """
     # Check DB first to know which servers are DB-managed
     db_names: set[str] = set()
@@ -9583,5 +9589,7 @@ def create_mcp_client(
     mgr._db_managed = {name for name in servers if name in db_names}
     mgr._oauth_user_server_names = oauth_user_names
     mgr._obo_server_names = obo_names
+    if not user_token_sweep:
+        mgr._user_token_sweep_s = 0.0
     mgr.start()
     return mgr

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -3297,11 +3297,10 @@ async def get_obo_access_token_classified(
         # client object and a pooled connection is bound to the loop that
         # created it, so sharing the login client here collides routinely —
         # the login exchange and the first mint hit the same IdP origin
-        # seconds apart by design. No long-lived mint client is kept: a fresh
-        # one is opened per mint below (mints are ~hourly per (user, server),
-        # not hot-path). ``obo_http_client`` is the loop-owned client the node
-        # installs at connect time and the injection seam for the e2e
-        # harnesses; when unset a per-mint client is created.
+        # seconds apart by design. ``obo_http_client`` is the long-lived,
+        # loop-owned client the manager installs at connect time and the
+        # injection seam for the e2e harnesses; when unset a transient client
+        # is created on the current loop.
         # One client for the whole mint: the rfc8693 leg makes TWO POSTs to the
         # same token endpoint, so a per-request transient would pay two TLS
         # handshakes. ``_enter_mint_client`` yields the installed client or a
@@ -3702,7 +3701,8 @@ async def _enter_mint_client(app_state: Any) -> Any:
 
     The node installs its loop-owned client at connect time and the e2e
     harnesses inject theirs; anything else gets a per-mint client from the
-    same factory, so every mint carries the module's JSON-preferring posture.
+    same factory, so every mint or per-user refresh carries the module's
+    JSON-preferring posture.
     """
     injected_client: httpx.AsyncClient | None = getattr(app_state, "obo_http_client", None)
     if injected_client is not None:
@@ -4414,10 +4414,6 @@ async def _refresh_and_persist(
     Returns ``(access_token, refresh_token_or_none, expires_at_or_none)``.
     Raises :class:`MCPOAuthRefreshFailed` on failure.
     """
-    http_client: httpx.AsyncClient | None = getattr(app_state, "mcp_oauth_http_client", None)
-    if http_client is None:
-        raise MCPOAuthRefreshFailed("mcp_oauth_http_client is not configured")
-
     server_id = str(server_row["server_id"])
     override_url = server_row.get("oauth_authorization_server_url") or None
     cached_issuer = server_row.get("oauth_as_issuer_cached") or None
@@ -4425,48 +4421,53 @@ async def _refresh_and_persist(
     if not isinstance(client_id, str) or not client_id:
         raise MCPOAuthRefreshFailed("server has no oauth_client_id")
     metadata_cache = getattr(app_state, "mcp_oauth_metadata_cache", None)
-    try:
-        server_url = _canonical_server_url(server_row)
-        as_metadata = await discover_authorization_server(
-            server_name=server_name,
-            server_url=server_url,
-            override_url=override_url if isinstance(override_url, str) else None,
-            cached_issuer=cached_issuer if isinstance(cached_issuer, str) else None,
-            http_client=http_client,
-            storage=storage,
-            server_id=server_id,
-            trusted_hosts=frozenset(),
-            metadata_cache=metadata_cache,
-            allow_private_network=oauth_allow_private_network(app_state),
-        )
-    except MCPOAuthDiscoveryError as exc:
-        raise MCPOAuthRefreshFailed(f"discovery failed during refresh: {exc}") from exc
-
-    client_secret: str | None = None
-    if token_store is not None:
+    # Refresh runs on the MCP loop, while browser handlers own the ASGI client.
+    # Discovery and the token POST must share the mint client's loop ownership.
+    async with _enter_mint_client(app_state) as http_client:
         try:
-            client_secret = await asyncio.to_thread(token_store.get_oauth_client_secret, server_id)
-        except Exception:
-            log.warning(
-                "mcp_server.oauth.client_secret_decrypt_failed",
+            server_url = _canonical_server_url(server_row)
+            as_metadata = await discover_authorization_server(
                 server_name=server_name,
-                exc_info=True,
+                server_url=server_url,
+                override_url=override_url if isinstance(override_url, str) else None,
+                cached_issuer=cached_issuer if isinstance(cached_issuer, str) else None,
+                http_client=http_client,
+                storage=storage,
+                server_id=server_id,
+                trusted_hosts=frozenset(),
+                metadata_cache=metadata_cache,
+                allow_private_network=oauth_allow_private_network(app_state),
             )
-            client_secret = None
+        except MCPOAuthDiscoveryError as exc:
+            raise MCPOAuthRefreshFailed(f"discovery failed during refresh: {exc}") from exc
 
-    # RFC 8707 ``resource=`` parameter is the canonical MCP server URL,
-    # not the audience. Audience (Auth0-style ``audience=``) is a
-    # separate concept — the authorize URL passes both, but the
-    # token-grant uses ``resource=`` only.
-    tokens = await refresh_token(
-        as_metadata=as_metadata,
-        refresh_token_value=refresh_value,
-        client_id=client_id,
-        client_secret=client_secret,
-        mcp_server_canonical_url=server_url,
-        scopes=existing_scopes,
-        http_client=http_client,
-    )
+        client_secret: str | None = None
+        if token_store is not None:
+            try:
+                client_secret = await asyncio.to_thread(
+                    token_store.get_oauth_client_secret, server_id
+                )
+            except Exception:
+                log.warning(
+                    "mcp_server.oauth.client_secret_decrypt_failed",
+                    server_name=server_name,
+                    exc_info=True,
+                )
+                client_secret = None
+
+        # RFC 8707 ``resource=`` parameter is the canonical MCP server URL,
+        # not the audience. Audience (Auth0-style ``audience=``) is a
+        # separate concept — the authorize URL passes both, but the
+        # token-grant uses ``resource=`` only.
+        tokens = await refresh_token(
+            as_metadata=as_metadata,
+            refresh_token_value=refresh_value,
+            client_id=client_id,
+            client_secret=client_secret,
+            mcp_server_canonical_url=server_url,
+            scopes=existing_scopes,
+            http_client=http_client,
+        )
 
     new_access = tokens.get("access_token")
     if not isinstance(new_access, str) or not new_access:


### PR DESCRIPTION
After browser OAuth sign-in warms an HTTP connection, per-user MCP refresh can reuse that
client from the manager loop and raise `RuntimeError: ... is bound to a different event loop`.
Route both authorization-server discovery and the refresh POST through the existing loop-owned
mint client, including its transient fallback.

Disable the CLI's all-user token sweep before manager startup so this fix does not introduce a
second refresher for web users' grants on shared SQLite. Update the affected fixtures and client
ownership documentation, and extend the live Keycloak harness to exercise separate browser and
MCP loops with both cached and uncached discovery.

Validation:

- Full offline SQLite suite: 13,926 passed, 28 skipped, 17 deselected.
- Ruff lint/format and mypy passed across the package and updated harness.
- Live Keycloak per-user harness: all 17 checks passed.
- Isolated live controls reproduce the cross-loop error at the token POST with the original
  helper, and at discovery with a POST-only fix. All 10 new offline refresh/sweep cases also
  fail with the original helper.

Fixes #1080.

Prerequisite for #963. The existing possibility of client closure during in-flight shutdown
remains part of that issue's runtime lifecycle work.
