### PR TITLE
refactor: give shared OAuth token storage neutral names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,19 @@ frozen.
 
 ## [Unreleased]
 
+> **Before upgrading:** migration 077 renames `mcp_user_tokens` to `oauth_tokens` and its
+> `server_name` column to `token_key`, preserving existing keys and encrypted data. Processes
+> running older code cannot use this OAuth storage until their code is upgraded; OAuth operations
+> on those processes can fail between migration and replacement. MCP API fields and token-keyring
+> configuration names are unchanged. See [Shared OAuth storage](docs/oauth-storage.md).
+
 ### Changed
 
 - **Shared delegated-auth modules.** OAuth/OIDC protocol code, generic encrypted token storage,
   and model-provider mint orchestration now have separate homes from MCP consent and transport.
+- **Shared OAuth token storage.** MCP grants and model mint caches now use consumer-neutral
+  storage names, and model lifecycle purges delete only their token rows. Shared operator
+  guidance covers the deployment keyring, rotation, and credential lifecycle.
 - **Python 3.13 minimum for Turnstone 1.9.** Python 3.11 and 3.12 are no longer supported; 1.8 is
   the last series that accepts them. Native installations must recreate their virtual environment
   with Python 3.13 or newer before upgrading. CI tests Python 3.13 and 3.14, and Docker images

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ UML diagrams in [`docs/diagrams/`](docs/diagrams/):
 | [Channels](docs/diagrams/png/16-channel-architecture.png) | Discord / Slack adapters + routing |
 | [Judge](docs/diagrams/png/22-judge-architecture.png) | Intent validation pipeline |
 | [OIDC](docs/diagrams/png/25-oidc-architecture.png) | SSO authorization code flow |
+| [OAuth Storage](docs/diagrams/png/28-oauth-storage-architecture.png) | Shared token store, captured credentials, and MCP state |
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1944,6 +1944,33 @@ Turnstone supports three authentication mechanisms, unified behind an
    successful credential validation. Contain `sub` (user_id), `scopes`, and
    `src` (origin) in claims.
 
+### Shared OAuth Token Storage
+
+Outbound MCP and model authentication share `core/token_store/`. `TokenStore`
+encrypts access/refresh tokens and captured OIDC credentials; `crypto.py`
+supplies the cipher and deployment keyring loader. `core/oauth/` owns grant, HTTP, OIDC protocol,
+cache, and coordination primitives. Model mint policy stays in `model_oauth.py`,
+while MCP consent, server-secret integration, and audit presentation stay in
+`mcp_oauth.py` / `mcp_crypto.py`.
+
+`oauth_tokens` has a composite `(user_id, token_key)` primary key. The key is an
+opaque identity: MCP uses server names; models use reserved synthetic keys based
+on the owning alias. Audience/scopes remain freshness checks, independent of
+identity. `oidc_user_credentials` holds the shared per-user, per-issuer refresh
+credential. Both SQLite and PostgreSQL expose the same ciphertext-only storage
+API; metadata list queries omit the token columns at the SQL boundary.
+
+Model lifecycle uses token-only deletion by key. MCP's composed purge deletes
+tokens and `mcp_oauth_pending` browser authorization states in one transaction,
+leaving `mcp_pending_consent` untouched. The connections handler projects
+internal `token_key` back to the public `server_name` field and filters mint
+caches from the user's revocable connections.
+
+See [Shared OAuth storage](oauth-storage.md) for operator configuration and
+[OAuth storage diagram](diagrams/png/28-oauth-storage-architecture.png) for the
+consumer/storage boundary. Migration 077 renames the existing table and column
+without rewriting ciphertext or changing token identities.
+
 ### Scope Model
 
 Three hierarchical scopes control endpoint access:

--- a/docs/diagrams/02-package-structure.puml
+++ b/docs/diagrams/02-package-structure.puml
@@ -34,6 +34,9 @@ package "turnstone/core/" <<Rectangle>> {
     component [lowering.py\nprovider-wire lowering] as lowering <<core>>
     component [state_writer.py\nordered durable state tail] as statewriter <<core>>
     component [model_backend_auth.py\nper-call backend credentials] as modelauth <<core>>
+    component [model_oauth.py\nModel mint orchestration] as modeloauth <<core>>
+    component [oauth/\nShared grants, HTTP, OIDC, coordination] as oauth <<core>>
+    component [token_store/\nEncrypted tokens + captured credentials] as tokenstore <<core>>
     component [providers/\nLLMProvider, OpenAI, Anthropic, Google] as providers <<core>>
     component [workstream.py\nWorkstream types + state] as workstream <<core>>
     component [tools.py\nTool loader] as tools <<core>>
@@ -48,6 +51,7 @@ package "turnstone/core/" <<Rectangle>> {
     component [healthcheck.py\nBackendHealthMonitor] as healthcheck <<core>>
     component [ratelimit.py\nRateLimiter] as ratelimit <<core>>
     component [mcp_client.py\nMCPClientManager\n(push + manual refresh)] as mcp <<core>>
+    component [mcp_oauth.py + mcp_crypto.py\nMCP consent, secrets, audit policy] as mcpauth <<core>>
     component [tool_search.py\nToolSearchManager, BM25] as toolsearch <<core>>
     component [model_registry.py\nModelRegistry] as registry <<core>>
 }
@@ -156,6 +160,14 @@ registry --> providers
 modelturn --> registry : coherent snapshot
 healthcheck --> metrics
 mcp --> config
+mcp --> mcpauth
+mcp --> modeloauth : mint bridge
+mcpauth --> oauth
+mcpauth --> tokenstore
+modeloauth --> oauth
+modeloauth --> tokenstore
+oauth --> tokenstore
+tokenstore --> storage
 registry --> config
 tools --> schemas
 

--- a/docs/diagrams/28-oauth-storage-architecture.puml
+++ b/docs/diagrams/28-oauth-storage-architecture.puml
@@ -1,0 +1,51 @@
+@startuml
+!theme plain
+title Turnstone — Shared OAuth Storage
+
+top to bottom direction
+skinparam componentStyle rectangle
+
+component "MCP authorization\nand lifecycle" as MCP #C8E6C9
+component "Model authentication\nand lifecycle" as Model #B3E5FC
+component "OIDC login\ncredential capture" as Login #FFE0B2
+component "core/oauth/\nGrants, HTTP, OIDC protocol, coordination" as OAuth #E8EAF6
+component "core/token_store/\nTokenStore + TokenCipher\nShared reserved key namespace" as Store #FFF9C4
+component "StorageBackend\nSQLite / PostgreSQL" as Storage #F3E5F5
+
+database "oauth_tokens" as Tokens {
+    card "PK (user_id, token_key)\naccess_token_ct / refresh_token_ct\naudience / scopes / issuer\nexpiry / created / last_refreshed" as TokenRow
+}
+database "oidc_user_credentials" as Credentials {
+    card "PK (user_id, issuer)\nrefresh_token_ct\ncreated / last_refreshed" as CredentialRow
+}
+database "MCP-specific state" as MCPState {
+    card "mcp_oauth_pending\nBrowser authorization state (10-minute TTL)" as Pending
+    card "mcp_pending_consent\nNon-interactive consent reminders" as Consent
+    card "mcp_servers.oauth_client_secret_ct\nEncrypted with the shared cipher" as Secrets
+}
+
+MCP --> OAuth
+Model --> OAuth
+Login --> OAuth
+OAuth --> Store : cache persistence
+MCP --> Store
+Model --> Store
+Login --> Store : captured credential
+Store --> Storage : ciphertext + metadata
+Storage --> Tokens
+Storage --> Credentials
+MCP --> MCPState : MCP-only APIs
+
+note bottom of Tokens
+  token_key is opaque; audience is a separate field.
+  MCP keys: server names.
+  Model keys: ~_~_model~_obo~_~_: / ~_~_model~_app~_~_: + alias.
+  App-identity rows belong to user ~_~_app~_~_.
+end note
+
+note bottom of MCPState
+  MCP purge: tokens + pending browser authorization
+  state in one transaction; pending consent is untouched.
+  Model purge: token rows only.
+end note
+@enduml

--- a/docs/diagrams/png/02-package-structure.png
+++ b/docs/diagrams/png/02-package-structure.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66847ccdf10ef2bd04e93bc0d3924a56ce28462ec9e76a383b53aee4500755e8
-size 631799
+oid sha256:dc986b29ceaeaa1b2ad35efa852a4adc580f7540667bf57cdfe5aeb520e263f2
+size 599679

--- a/docs/diagrams/png/28-oauth-storage-architecture.png
+++ b/docs/diagrams/png/28-oauth-storage-architecture.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aaae9d1f77a81ae88d0fd159c52531eb49e7c630a4275e80063569cdfe6ba876
+size 105574

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -34,7 +34,7 @@ Switching `auth_type` away from `oauth_user` / `oauth_obo` **deletes** that serv
 
 ## Prerequisites for `auth_type=oauth_user`
 
-1. **Encryption key**. Tokens are stored encrypted with Fernet. Set `[security] mcp_token_encryption_key` in `config.toml` (Turnstone won't start with an `oauth_user` row configured but no key installed). Rotate via `MultiFernet` — add the new key first, then later remove the old one once all rows have been re-encrypted.
+1. **Encryption key**. Tokens are stored encrypted with Fernet. Set `[security] mcp_token_encryption_key` in `config.toml` (Turnstone won't start with an `oauth_user` row configured but no key installed). Follow the [shared keyring and rotation procedure](oauth-storage.md#key-rotation) for every console and node that uses the database.
 
 2. **MCP server publishes RFC 9728 PRM and RFC 8414 AS metadata** *or* you configure the AS URL override on the server row. PKCE S256 is mandatory; Turnstone refuses to connect to authorization servers that don't advertise `code_challenge_methods_supported: ["S256"]`.
 
@@ -193,24 +193,11 @@ reachable.
 
 ### Encryption key
 
-```toml
-[security]
-mcp_token_encryption_key = "base64-fernet-key"
-# For rotation, list the keys in priority order — first is used for new
-# writes, all are tried for reads.
-# mcp_token_encryption_keys = ["new-key", "old-key"]
-```
-
-This key is accepted only from `config.toml`, not environment variables or
-DB-backed runtime settings. Use the same keyring on the console and all nodes
-sharing the database, and retain a private backup. Losing it makes stored
-tokens and client secrets undecryptable.
-
-File-backed storage avoids putting the key in inherited process environments.
-It does not isolate the key from a shell running as the same OS user: that
-shell can read the file too. A read-only Docker mount prevents changes, not
-reads. Keep the file outside the mounted workspace and use process/filesystem
-isolation when tools must not be able to access service credentials.
+MCP tokens and client secrets use the deployment keyring shared with model
+authentication. See [Shared OAuth storage](oauth-storage.md) for configuration,
+backup, rotation, and credential lifecycle. The existing
+`[security] mcp_token_encryption_key` / `mcp_token_encryption_keys` names remain
+unchanged and are read only from `config.toml`.
 
 ---
 
@@ -279,7 +266,7 @@ The captured credential is a single per-user secret that can mint for every `oau
 
 1. **First tool call** for a user against an `oauth_user` MCP server: pool dispatch finds no stored token, returns `mcp_consent_required` to the agent. Dashboard renders an inline "Connect" action card.
 
-2. **User clicks Connect**: opens `/v1/api/mcp/oauth/start?server=<name>` in a popup. Browser redirects through the AS authorize endpoint, user grants consent, AS redirects back to `/v1/api/mcp/oauth/callback`. Turnstone exchanges code → tokens via PKCE, validates audience, encrypts, persists in `mcp_user_tokens`, redirects user back to the originating URL.
+2. **User clicks Connect**: opens `/v1/api/mcp/oauth/start?server=<name>` in a popup. Browser redirects through the AS authorize endpoint, user grants consent, AS redirects back to `/v1/api/mcp/oauth/callback`. Turnstone exchanges code → tokens via PKCE, validates audience, encrypts, persists in `oauth_tokens`, redirects user back to the originating URL.
 
 3. **Subsequent tool calls** by the same user against the same server reuse the persisted token via the per-(user, server) session pool. Tokens auto-refresh via the refresh-token grant when expired; failed refresh emits `mcp_consent_required` to drive re-consent.
 
@@ -307,7 +294,7 @@ Additional indicators (circuit-breaker state, encryption-key mismatch) are expos
 | From | To | What happens |
 |---|---|---|
 | `none` / `static` → `oauth_user` | — | New code path activates for this server. Existing static headers (if any) are no longer sent. Users must authorize on first use. |
-| `oauth_user` → `none` / `static` | — | Existing `mcp_user_tokens` rows are **deleted**: the tokens are bound to the auth model + URL active at consent time, and rows left behind could silently rebind if a row with the old name/URL reappears. Switching back to `oauth_user` later starts clean — users re-consent on next use. This is **not reversible**; the AS-side grants are untouched (revoke upstream via the AS if needed). |
+| `oauth_user` → `none` / `static` | — | Existing `oauth_tokens` rows are **deleted**: the tokens are bound to the auth model + URL active at consent time, and rows left behind could silently rebind if a row with the old name/URL reappears. Switching back to `oauth_user` later starts clean — users re-consent on next use. This is **not reversible**; the AS-side grants are untouched (revoke upstream via the AS if needed). |
 | OAuth `client_id` or `client_secret` rotated | — | Existing tokens may stop refreshing if the AS treats them as bound to the previous client. Bulk-revoke after rotation. |
 | `oauth_user` ↔ `oauth_obo` | — | The per-user rows are **deleted** on the flip (they mean different things: per-server AS refresh tokens vs. minted cache). `oauth_audience` and `oauth_scopes` mean different things in each model (a resource indicator vs. an IdP app identifier; AS-consent scopes vs. an rfc8693 exchange scope), so on a flip they **never carry** — each is taken from the request for the target model or set NULL. The admin console clears these fields when you change the auth type, so re-enter the correct values for the new mode; via the API, supply them explicitly (a flip into `oauth_obo` with no `oauth_audience` is rejected, and a non-empty `oauth_scopes` under the `entra` profile is rejected since that leg pins `<audience>/.default`). |
 | `oauth_obo` → `none` / `static` | — | Minted cache rows are deleted. |
@@ -324,7 +311,7 @@ Every transition that changes what a stored row *means* deletes the rows outrigh
 | `MCP OAuth is not configured on this node.` / encryption-key configuration hint | Console or node did not load the shared TOML file | Check the read-only mount, `TURNSTONE_CONFIG`, file ownership, and the same key on every consumer; restart after TOML edits or recreate after changing Compose mounts/environment. |
 | OAuth start says the redirect base is not configured | Missing or invalid `[oidc] redirect_base` | Set the public HTTPS origin, with no path/query/fragment, even for local-auth installs; restart the console and nodes. |
 | `mcp_consent_required` even after consenting | Token persistence failed, or refresh-token rejected by AS | Check audit log for `mcp_server.oauth.persist_failed` or `mcp_server.oauth.token_revoked`. Re-consent via settings modal. |
-| `mcp_token_undecryptable_key_unknown` | Encryption key rotated without keeping the previous key in the keyring | Add the previous key back to `mcp_token_encryption_keys` until all rows have been re-encrypted, then drop. |
+| `mcp_token_undecryptable_key_unknown` | Encryption key rotated without keeping the previous key in the keyring | Restore the previous key in `mcp_token_encryption_keys` and follow the [key retirement guidance](oauth-storage.md#key-rotation). Reads do not re-encrypt old rows. |
 | `mcp_oauth_url_insecure` | MCP server URL is `http://` (not `https://`) on a non-loopback host | Use `https://`. Per-user bearers must not transit cleartext. |
 | `PRM resource identifier does not match the server URL` | The server's protected-resource metadata declares a different resource than the row's canonical Server URL (or, at the origin-level location, its origin) | Compare the Server URL path and spelling with what the server publishes at `/.well-known/oauth-protected-resource<path>`. |
 | `AS metadata returned HTTP 404` for an issuer with a path | None of the metadata locations answered | Set the Authorization Server URL override to the issuer exactly as the AS publishes it. A query string or fragment in the issuer is refused with its own message. |

--- a/docs/oauth-storage.md
+++ b/docs/oauth-storage.md
@@ -1,0 +1,116 @@
+# Shared OAuth storage
+
+MCP authorization and dynamic model authentication use the same encrypted token
+store and deployment keyring. Configure the keyring on every process that reads
+or writes the shared database, including the console and all server nodes.
+Provider setup remains in the [MCP OAuth](mcp-oauth.md) and [OIDC](oidc.md) guides.
+
+## Deployment keyring
+
+Generate a Fernet key in an environment with Turnstone's dependencies installed:
+
+```sh
+python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+```
+
+Store it in the shared bootstrap `config.toml`:
+
+```toml
+[security]
+mcp_token_encryption_key = "base64-fernet-key"
+# For rotation, use an ordered list instead:
+# mcp_token_encryption_keys = ["new-key", "old-key"]
+```
+
+These configuration names remain unchanged even when only model authentication
+uses the store. They are accepted only from `config.toml`, not environment
+variables or database-backed runtime settings. A nonempty plural list takes
+precedence over the singular key. The first key encrypts new writes; all keys
+are tried when reading existing ciphertext. Rows carry no key identifier.
+Restart each process after changing its bootstrap file.
+
+Credential capture and user-scoped MCP servers require the key at startup.
+Dynamic model authentication requires it too: a node without the required key
+refuses to start, while a console whose model registry needs it withholds the
+coordinator subsystem and reports the configuration error.
+
+Retain a private backup of the keyring separately from database backups. Losing
+the necessary key makes stored tokens, captured credentials, and MCP client
+secrets unreadable. A decryption failure preserves the row so restoring the
+correct keyring can recover access.
+
+Keep the file outside the mounted workspace when tools should not read service
+credentials. File-based configuration avoids inherited environment variables,
+but a shell running as the same OS user can still read the file. A read-only
+container mount prevents changes, not reads; use filesystem/process isolation
+where that boundary matters. See [Docker bootstrap config](docker.md#shared-bootstrap-config).
+
+## Key rotation
+
+1. Distribute `["old-key", "new-key"]` to every reader and writer, and restart
+   them. Writes still use the old key while every process learns the new one.
+2. Once all processes have both keys, promote the new key with
+   `["new-key", "old-key"]` and restart them. During this rollout every process
+   can read ciphertext written with either key.
+3. Keep the old key until every ciphertext that must remain readable has been
+   replaced or removed. This includes rarely used refresh credentials, cached
+   tokens, and stored MCP client secrets. Retained database backups may also
+   need the old key.
+
+Loading a new keyring or reading a row does **not** re-encrypt it. New captures,
+token writes, and client-secret updates use the first key, but there is no
+automatic full-store re-encryption pass. The storage rename in migration 077
+does not rewrite ciphertext either. Do not retire the old key merely because
+all processes have restarted successfully.
+
+## Stored credentials and token identities
+
+| Storage | Contents and identity |
+| --- | --- |
+| `oauth_tokens` | Encrypted access tokens and optional refresh tokens, keyed by `(user_id, token_key)`. MCP uses the server name as the key. Model caches use reserved `__model_obo__:` and `__model_app__:` keys derived from the owning model alias. `token_key` is an opaque identity; audience and scopes are separate fields. |
+| `oidc_user_credentials` | One encrypted captured IdP refresh credential per `(user_id, issuer)`, shared by delegated MCP and model mints. |
+| `mcp_servers.oauth_client_secret_ct` | An MCP server's optional encrypted OAuth client secret, using the same keyring. |
+| `mcp_oauth_pending` | Short-lived MCP browser authorization state with a ten-minute TTL. This is separate from `mcp_pending_consent`, which records consent needed by non-interactive work. |
+
+An `oauth_user` token row holds a user's per-server grant. An `oauth_obo` or
+dynamic model row is a mint cache; deleting it permits a later mint from the
+surviving credential. App-identity model rows belong to the shared `__app__`
+pseudo-user. Legacy synthetic keys retain their existing values through the
+rename. Access-token expiry and refresh behavior are unchanged; the rename
+does not add a cache-cleanup sweep.
+
+## Credential lifecycle
+
+- **Login capture:** enabling `[oidc] capture_user_credential` requests an offline
+  credential during sign-in and stores it encrypted. Disabling capture stops
+  new captures; it does not revoke stored credentials. Delegated MCP and model
+  mints share the captured credential and persist refresh-token rotation.
+- **MCP disconnect:** the user's connections page deletes the local `oauth_user`
+  grant and attempts upstream revocation. Sign-in passthrough and model mint
+  caches are excluded from that page. MCP admin purges delete token rows and
+  pending browser authorization states in one transaction; that purge does not
+  delete pending-consent rows or captured OIDC credentials.
+- **Model edits and deletion:** changes to alias, audience, scopes, or auth mode
+  purge the affected alias's delegated and app token caches. Model purges delete
+  only token rows; they leave MCP authorization states and captured credentials
+  alone. Other aliases' tokens survive.
+- **Identity unlink:** unlinking an OIDC identity deletes its captured credential,
+  purges the user's delegated MCP/model token caches, and requests model-memo
+  eviction on the console and registered nodes. Independent `oauth_user` grants
+  and shared app-identity caches survive. Existing upstream access tokens may
+  remain valid until expiry; the identity provider governs downstream access.
+- **User deletion:** deletes that user's database token rows and captured
+  credentials. App-identity rows under `__app__` belong to the application and
+  survive another user's deletion.
+
+## Migration 077
+
+Migration 077 renames `mcp_user_tokens` to `oauth_tokens` and its `server_name`
+column to `token_key`. It preserves keys, ciphertext, expiry, and timestamps on
+SQLite and PostgreSQL, with matching downgrade support. The MCP HTTP API still
+uses `server_name` in its connections responses and routes.
+
+Processes running older code cannot query the renamed table until their code
+is upgraded. During an upgrade, OAuth operations on those processes can fail
+between migration and process replacement. See the [changelog](../CHANGELOG.md)
+for the release migration notice.

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -207,8 +207,9 @@ edit of a row saved before the pairing rule keeps working — and at runtime a
 mismatched legacy row refuses to mint with `cause=grant_profile_mismatch` and
 no IdP traffic. RFC 8693 client-credentials is not implemented.
 
-The delegated modes need the MCP encryption key, a credential captured for the
-driving user, and delegated/admin-consented permission to the audience.
+The delegated modes need the [shared token encryption key](oauth-storage.md),
+a credential captured for the driving user, and delegated/admin-consented
+permission to the audience.
 `rfc8693_obo` additionally carries `obo_scopes`, the space-separated scope
 list its exchange leg requests: exchange-capable IdPs that gate audiences
 behind optional scopes refuse the exchange without it ("Requested audience not
@@ -238,13 +239,10 @@ degrades loudly, with the reason visible mid-incident even after the
 once-per-process line has rotated out of retained logs, rather than silently
 swapping per-user attribution for the shared static key.
 
-The `[security]` token encryption key is deployment-wide, not per-host: rows are
-encrypted with `MultiFernet` and carry no key id, so every host that reads them
-needs the same keyring. That includes the console, which mints for
-coordinator-hosted sessions. A node that needs the key and lacks it refuses to
-start; the console starts but withholds its coordinator subsystem and shows
-the key requirement as the remediation error instead of failing silently at
-call time.
+The token keyring is shared by the console and every node that reads the
+database. See [Shared OAuth storage](oauth-storage.md) for bootstrap settings,
+startup requirements, key rotation, and the effect of identity unlink on
+delegated credentials and app-identity caches.
 
 ---
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -175,7 +175,7 @@ mint failures may use it by default; set `model.auth_fail_closed = true` to
 prohibit even that fallback. A refusal is not routed through the model
 fallback chain.
 
-Dynamic token caches are encrypted in `mcp_user_tokens`, shared across nodes,
+Dynamic token caches are encrypted in `oauth_tokens`, shared across nodes,
 and memoized on each host. Unlinking a user's OIDC identity purges their
 delegated-mode rows and memo entries. `entra_app` rows belong to the shared
 `__app__` identity and are not user-deprovisioned; after client-credential

--- a/scripts/obo-e2e/README.md
+++ b/scripts/obo-e2e/README.md
@@ -290,7 +290,7 @@ Findings that feed the design:
 1. **One per-user credential -> N audience tokens: VERIFIED on a second IdP.**
    The substrate is portable; only the grant leg differs per IdP.
 2. **Exchanged tokens are cache-shaped** (short TTL, no RT) — per-server
-   `mcp_user_tokens` rows as short-lived mint cache is the right model.
+   `oauth_tokens` rows as short-lived mint cache is the right model.
 3. **RT rotation happens here too** — newest-RT write-back on every redemption
    is a correctness requirement of the capture layer, not an Entra quirk.
 4. **The IdP-side "delegated grant" has a per-IdP shape**: Entra = API

--- a/scripts/obo-e2e/entra_e2e.py
+++ b/scripts/obo-e2e/entra_e2e.py
@@ -174,7 +174,7 @@ async def _run(cfg: dict[str, str], refresh_token: str) -> None:
         )
         if r.kind == "token" and r.token:
             ok, aud = aud_matches(r.token, aud_a)
-            row = storage.get_mcp_user_token(USER, "e2e-a")
+            row = storage.get_oauth_token(USER, "e2e-a")
             cache_ok = (
                 row is not None and row["refresh_token_ct"] is None and bool(row["expires_at"])
             )

--- a/scripts/obo-e2e/keycloak_e2e.py
+++ b/scripts/obo-e2e/keycloak_e2e.py
@@ -178,7 +178,7 @@ async def _run(cfg: dict[str, str], refresh_token: str) -> None:
         )
         if r.kind == "token" and r.token:
             ok, aud = aud_carries(r.token, cfg["AUD_A"])
-            row = storage.get_mcp_user_token(USER, "kc-a")
+            row = storage.get_oauth_token(USER, "kc-a")
             cache_ok = row is not None and row["refresh_token_ct"] is None
             record(
                 "VERIFIED" if ok and cache_ok else "FAILED",
@@ -299,7 +299,7 @@ async def _run(cfg: dict[str, str], refresh_token: str) -> None:
             scopes=cfg.get("SCOPE_A", ""),
             grant_leg="rfc8693",
         )
-        cache_row = storage.get_mcp_user_token(USER, model_obo_cache_server("model-a"))
+        cache_row = storage.get_oauth_token(USER, model_obo_cache_server("model-a"))
         if m1:
             record(
                 "VERIFIED"

--- a/scripts/obo-e2e/oauth_user_e2e.py
+++ b/scripts/obo-e2e/oauth_user_e2e.py
@@ -462,7 +462,7 @@ async def _run(cfg: dict[str, str]) -> None:
         state_ok = _query(callback_location).get("state") == authz.get("state")
         done = await console.get(callback_location)
         exchange = wire.drain()
-        ct_row = storage.get_mcp_user_token(USER, "kc-mcp")
+        ct_row = storage.get_oauth_token(USER, "kc-mcp")
         plain = store.get_user_token(USER, "kc-mcp")
         if done.status_code != 302 or plain is None or ct_row is None:
             record(
@@ -656,7 +656,7 @@ async def _run(cfg: dict[str, str]) -> None:
         revoked = await console.delete(f"{CONNECTIONS}/kc-mcp")
         await asyncio.gather(*_revoke_upstream_tasks)
         calls = wire.drain()
-        gone = storage.get_mcp_user_token(USER, "kc-mcp") is None
+        gone = storage.get_oauth_token(USER, "kc-mcp") is None
         r9 = await _on_mcp_loop(
             manager,
             get_user_access_token_classified(
@@ -718,7 +718,7 @@ async def _run(cfg: dict[str, str]) -> None:
                 await browser2.consent(start2.headers["location"], callback_url)
             )
             calls = wire.drain()
-            persisted = storage.get_mcp_user_token(USER, "kc-noaud") is not None
+            persisted = storage.get_oauth_token(USER, "kc-noaud") is not None
             record(
                 "VERIFIED"
                 if done2.status_code == 302

--- a/tests/test_admin_model_registry_refresh.py
+++ b/tests/test_admin_model_registry_refresh.py
@@ -2027,11 +2027,11 @@ def test_over_cap_residue_capped_rewrite_is_auth_gated(
 
     assert resp.status_code == 200, resp.text
     assert storage.get_model_definition("m1")["obo_scopes"] == capped
-    assert storage.get_mcp_user_token("alice", own_key) is None
+    assert storage.get_oauth_token("alice", own_key) is None
 
 
 def _seed_mint_cache_row(storage: SQLiteBackend, user: str, key: str) -> None:
-    storage.create_mcp_user_token(
+    storage.create_oauth_token(
         user,
         key,
         access_token_ct=b"ct",
@@ -2081,9 +2081,9 @@ def test_scopes_change_purges_the_alias_rows_never_a_siblings(
     )
 
     assert resp.status_code == 200, resp.text
-    assert storage.get_mcp_user_token("alice", own_obo) is None
-    assert storage.get_mcp_user_token("alice", own_app) is None
-    assert storage.get_mcp_user_token("alice", sibling) is not None
+    assert storage.get_oauth_token("alice", own_obo) is None
+    assert storage.get_oauth_token("alice", own_app) is None
+    assert storage.get_oauth_token("alice", sibling) is not None
 
 
 def test_alias_rename_purges_the_old_alias_rows(
@@ -2116,7 +2116,7 @@ def test_alias_rename_purges_the_old_alias_rows(
     resp = client.put("/v1/api/admin/model-definitions/m1", json={"alias": "renamed"})
 
     assert resp.status_code == 200, resp.text
-    assert storage.get_mcp_user_token("alice", old_key) is None
+    assert storage.get_oauth_token("alice", old_key) is None
 
 
 def test_delete_purges_mint_cache_rows(
@@ -2146,9 +2146,9 @@ def test_delete_purges_mint_cache_rows(
     resp = client.delete("/v1/api/admin/model-definitions/m1")
 
     assert resp.status_code == 200, resp.text
-    assert storage.get_mcp_user_token("alice", own_obo) is None
-    assert storage.get_mcp_user_token("alice", own_app) is None
-    assert storage.get_mcp_user_token("alice", sibling) is not None
+    assert storage.get_oauth_token("alice", own_obo) is None
+    assert storage.get_oauth_token("alice", own_app) is None
+    assert storage.get_oauth_token("alice", sibling) is not None
 
 
 def test_purge_partial_failure_still_purges_the_other_prefix(
@@ -2166,19 +2166,19 @@ def test_purge_partial_failure_still_purges_the_other_prefix(
     app_key = model_app_cache_server("local")
     for key in (obo_key, app_key):
         _seed_mint_cache_row(storage, "alice", key)
-    real_delete = storage.delete_mcp_oauth_rows_by_server_name
+    real_delete = storage.delete_oauth_tokens_by_key
 
     def flaky(server_name: str) -> int:
         if server_name == obo_key:
             raise RuntimeError("transient storage error")
         return real_delete(server_name)
 
-    monkeypatch.setattr(storage, "delete_mcp_oauth_rows_by_server_name", flaky)
+    monkeypatch.setattr(storage, "delete_oauth_tokens_by_key", flaky)
 
     _purge_model_mint_cache(storage, "m1", "local")
 
-    assert storage.get_mcp_user_token("alice", obo_key) is not None
-    assert storage.get_mcp_user_token("alice", app_key) is None
+    assert storage.get_oauth_token("alice", obo_key) is not None
+    assert storage.get_oauth_token("alice", app_key) is None
 
 
 def test_mode_flip_away_keeps_unchanged_scopes_residue(

--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -681,7 +681,7 @@ class TestUpdateMcpServer:
         """
         import sqlalchemy as sa
 
-        from turnstone.core.storage._schema import mcp_user_tokens
+        from turnstone.core.storage._schema import oauth_tokens
 
         # Seed an oauth_user row at URL_A.
         r = client.post(
@@ -699,10 +699,10 @@ class TestUpdateMcpServer:
         # Plant a per-user token row keyed on the server name.
         with storage._engine.connect() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens),
+                sa.insert(oauth_tokens),
                 {
                     "user_id": "u1",
-                    "server_name": "url-change-purge",
+                    "token_key": "url-change-purge",
                     "access_token_ct": b"\x00ciphertext-a",
                     "refresh_token_ct": b"\x00ciphertext-r",
                     "expires_at": "2026-12-31T00:00:00",
@@ -716,8 +716,8 @@ class TestUpdateMcpServer:
             conn.commit()
             count_before = conn.execute(
                 sa.select(sa.func.count())
-                .select_from(mcp_user_tokens)
-                .where(mcp_user_tokens.c.server_name == "url-change-purge")
+                .select_from(oauth_tokens)
+                .where(oauth_tokens.c.token_key == "url-change-purge")
             ).scalar()
         assert count_before == 1
 
@@ -736,8 +736,8 @@ class TestUpdateMcpServer:
         with storage._engine.connect() as conn:
             count_after = conn.execute(
                 sa.select(sa.func.count())
-                .select_from(mcp_user_tokens)
-                .where(mcp_user_tokens.c.server_name == "url-change-purge")
+                .select_from(oauth_tokens)
+                .where(oauth_tokens.c.token_key == "url-change-purge")
             ).scalar()
         assert count_after == 0, "URL change must purge per-user tokens"
 
@@ -1010,7 +1010,7 @@ class TestUpdateMcpServer:
         the mint cache invariant forbids)."""
         import sqlalchemy as sa
 
-        from turnstone.core.storage._schema import mcp_user_tokens
+        from turnstone.core.storage._schema import oauth_tokens
 
         r = client.post(
             "/v1/api/admin/mcp-servers",
@@ -1028,10 +1028,10 @@ class TestUpdateMcpServer:
 
         with storage._engine.connect() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens),
+                sa.insert(oauth_tokens),
                 {
                     "user_id": "u1",
-                    "server_name": "flip-to-obo",
+                    "token_key": "flip-to-obo",
                     "access_token_ct": b"\x00ct-a",
                     "refresh_token_ct": b"\x00ct-r",
                     "expires_at": "2026-12-31T00:00:00",
@@ -1058,8 +1058,8 @@ class TestUpdateMcpServer:
         with storage._engine.connect() as conn:
             remaining = conn.execute(
                 sa.select(sa.func.count())
-                .select_from(mcp_user_tokens)
-                .where(mcp_user_tokens.c.server_name == "flip-to-obo")
+                .select_from(oauth_tokens)
+                .where(oauth_tokens.c.token_key == "flip-to-obo")
             ).scalar()
         assert remaining == 0, "oauth_user→oauth_obo flip must purge stale per-user rows"
 
@@ -1195,7 +1195,7 @@ class TestUpdateMcpServer:
             oauth_audience="api://mcp-a",
         )
         for i in range(2):
-            storage.create_mcp_user_token(
+            storage.create_oauth_token(
                 f"u{i}",
                 "obo-count",
                 access_token_ct=b"\x00ct",
@@ -1219,7 +1219,7 @@ class TestUpdateMcpServer:
         tokens minted for the OLD audience (they are audience-bound)."""
         import sqlalchemy as sa
 
-        from turnstone.core.storage._schema import mcp_user_tokens
+        from turnstone.core.storage._schema import oauth_tokens
 
         r = client.post(
             "/v1/api/admin/mcp-servers",
@@ -1234,10 +1234,10 @@ class TestUpdateMcpServer:
         sid = r.json()["server_id"]
         with storage._engine.connect() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens),
+                sa.insert(oauth_tokens),
                 {
                     "user_id": "u1",
-                    "server_name": "aud-change",
+                    "token_key": "aud-change",
                     "access_token_ct": b"\x00ct",
                     "refresh_token_ct": None,
                     "expires_at": "2026-12-31T00:00:00",
@@ -1258,15 +1258,15 @@ class TestUpdateMcpServer:
         with storage._engine.connect() as conn:
             remaining = conn.execute(
                 sa.select(sa.func.count())
-                .select_from(mcp_user_tokens)
-                .where(mcp_user_tokens.c.server_name == "aud-change")
+                .select_from(oauth_tokens)
+                .where(oauth_tokens.c.token_key == "aud-change")
             ).scalar()
         assert remaining == 0, "audience change must purge old-audience cache rows"
 
     def _seed_obo_row_with_cache(self, client, storage, *, name: str, scopes: str | None) -> str:
         import sqlalchemy as sa
 
-        from turnstone.core.storage._schema import mcp_user_tokens
+        from turnstone.core.storage._schema import oauth_tokens
 
         r = client.post(
             "/v1/api/admin/mcp-servers",
@@ -1282,10 +1282,10 @@ class TestUpdateMcpServer:
         sid: str = r.json()["server_id"]
         with storage._engine.connect() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens),
+                sa.insert(oauth_tokens),
                 {
                     "user_id": "u1",
-                    "server_name": name,
+                    "token_key": name,
                     "access_token_ct": b"\x00ct",
                     "refresh_token_ct": None,
                     "expires_at": "2026-12-31T00:00:00",
@@ -1302,13 +1302,13 @@ class TestUpdateMcpServer:
     def _count_cache_rows(self, storage, name: str) -> int:
         import sqlalchemy as sa
 
-        from turnstone.core.storage._schema import mcp_user_tokens
+        from turnstone.core.storage._schema import oauth_tokens
 
         with storage._engine.connect() as conn:
             count = conn.execute(
                 sa.select(sa.func.count())
-                .select_from(mcp_user_tokens)
-                .where(mcp_user_tokens.c.server_name == name)
+                .select_from(oauth_tokens)
+                .where(oauth_tokens.c.token_key == name)
             ).scalar()
         return int(count or 0)
 

--- a/tests/test_mcp_admin_bulk_revoke.py
+++ b/tests/test_mcp_admin_bulk_revoke.py
@@ -12,7 +12,7 @@ Coverage:
 - 200 + ``rows_deleted`` + ``consented_users_before`` on success.
 - Audit row written with
   ``upstream_revoke_outcome="bulk_admin_no_upstream"``.
-- Token rows are gone from ``mcp_user_tokens`` post-call.
+- Token rows are gone from ``oauth_tokens`` post-call.
 """
 
 from __future__ import annotations
@@ -116,7 +116,7 @@ def _seed_static_server(
 
 def _seed_user_tokens(backend: SQLiteBackend, server_name: str, users: int) -> None:
     for i in range(users):
-        backend.create_mcp_user_token(
+        backend.create_oauth_token(
             f"user-{i}",
             server_name,
             access_token_ct=b"ct",
@@ -159,7 +159,7 @@ def test_400_on_invalid_server_name(storage: SQLiteBackend) -> None:
 
 
 def test_200_on_oauth_obo_server(storage: SQLiteBackend) -> None:
-    """#551: bulk-revoke serves oauth_obo too (it populates mcp_user_tokens with
+    """#551: bulk-revoke serves oauth_obo too (it populates oauth_tokens with
     minted cache rows) — the documented remediation for stale rows after an
     oauth_user→oauth_obo flip."""
     storage.create_mcp_server(

--- a/tests/test_mcp_oauth_connections.py
+++ b/tests/test_mcp_oauth_connections.py
@@ -166,6 +166,56 @@ def _seed_user_token(
     )
 
 
+def test_connections_storage_projection_on_selected_backend(
+    backend: Any, http_client_mock: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise the real response on both CI backends, independent of SQLite fixtures."""
+    _seed_oauth_user_server(backend)
+    backend.create_mcp_server(
+        server_id="obo-id",
+        name="obo-server",
+        transport="streamable-http",
+        url="https://mcp.example.com/obo",
+        auth_type="oauth_obo",
+    )
+    store = _make_token_store(backend)
+    for user, key in (
+        ("user-1", "srv-oauth"),
+        ("user-2", "srv-oauth"),
+        ("user-1", "obo-server"),
+        ("user-1", "__model_obo__:gateway"),
+        ("user-1", "__model_app__:gateway"),
+        ("user-1", "__model_obo__:api://legacy"),
+    ):
+        _seed_user_token(store, user_id=user, server_name=key, refresh_token=None)
+    row = backend.get_oauth_token("user-1", "srv-oauth")
+    assert row is not None
+    assert row["token_key"] == "srv-oauth" and "server_name" not in row
+
+    def unexpected_decrypt(ciphertext: bytes) -> bytes:
+        pytest.fail("connections metadata decrypted a token")
+
+    monkeypatch.setattr(store.cipher, "decrypt", unexpected_decrypt)
+    app = _build_app(storage=backend, http_client=http_client_mock, token_store=store)
+    with TestClient(app) as client:
+        response = client.get("/v1/api/mcp/oauth/connections")
+    assert response.status_code == 200
+    assert response.json() == {
+        "connections": [
+            {
+                "user_id": "user-1",
+                "server_name": "srv-oauth",
+                "expires_at": "2099-12-31T00:00:00",
+                "scopes": "openid profile",
+                "as_issuer": "https://as.example.com",
+                "audience": "https://mcp.example.com",
+                "created": row["created"],
+                "last_refreshed": None,
+            }
+        ]
+    }
+
+
 def _good_as_metadata_doc(
     *, revocation_endpoint: str | None = "https://as.example.com/revoke"
 ) -> dict[str, Any]:

--- a/tests/test_mcp_oauth_pending_storage.py
+++ b/tests/test_mcp_oauth_pending_storage.py
@@ -1,25 +1,20 @@
-"""Smoke tests for the new OAuth-MCP storage tables.
-
-Phase 2 only adds the schema — token CRUD lands in Phase 3 and pending-
-state CRUD in Phase 4.  These tests verify the tables exist after
-``init_storage`` and accept the documented row shape via raw SQL.
-"""
+"""Schema checks for shared OAuth tokens and MCP browser authorization state."""
 
 from __future__ import annotations
 
 import sqlalchemy as sa
 
-from turnstone.core.storage._schema import mcp_oauth_pending, mcp_user_tokens
+from turnstone.core.storage._schema import mcp_oauth_pending, oauth_tokens
 
 
-class TestMcpUserTokensTable:
+class TestOAuthTokensTable:
     def test_table_exists_and_accepts_row(self, backend) -> None:
         with backend._engine.connect() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens),
+                sa.insert(oauth_tokens),
                 {
                     "user_id": "u1",
-                    "server_name": "srv-a",
+                    "token_key": "srv-a",
                     "access_token_ct": b"\x00ciphertext-a",
                     "refresh_token_ct": b"\x00ciphertext-r",
                     "expires_at": "2026-05-04T12:00:00",
@@ -32,8 +27,8 @@ class TestMcpUserTokensTable:
             )
             conn.commit()
             row = conn.execute(
-                sa.select(mcp_user_tokens).where(
-                    (mcp_user_tokens.c.user_id == "u1") & (mcp_user_tokens.c.server_name == "srv-a")
+                sa.select(oauth_tokens).where(
+                    (oauth_tokens.c.user_id == "u1") & (oauth_tokens.c.token_key == "srv-a")
                 )
             ).one()
         assert row.access_token_ct == b"\x00ciphertext-a"
@@ -41,15 +36,15 @@ class TestMcpUserTokensTable:
         assert row.scopes == "openid profile"
         assert row.audience == "https://mcp.example.com"
 
-    def test_composite_pk_distinguishes_user_server(self, backend) -> None:
+    def test_composite_pk_distinguishes_user_token_key(self, backend) -> None:
         """Same user, different server => two rows; same (user, server) => conflict."""
         with backend._engine.connect() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens),
+                sa.insert(oauth_tokens),
                 [
                     {
                         "user_id": "u1",
-                        "server_name": "srv-a",
+                        "token_key": "srv-a",
                         "access_token_ct": b"a",
                         "refresh_token_ct": None,
                         "expires_at": None,
@@ -61,7 +56,7 @@ class TestMcpUserTokensTable:
                     },
                     {
                         "user_id": "u1",
-                        "server_name": "srv-b",
+                        "token_key": "srv-b",
                         "access_token_ct": b"b",
                         "refresh_token_ct": None,
                         "expires_at": None,
@@ -74,7 +69,7 @@ class TestMcpUserTokensTable:
                 ],
             )
             conn.commit()
-            count = conn.execute(sa.select(sa.func.count()).select_from(mcp_user_tokens)).scalar()
+            count = conn.execute(sa.select(sa.func.count()).select_from(oauth_tokens)).scalar()
         assert count == 2
 
 

--- a/tests/test_mcp_oauth_refresh.py
+++ b/tests/test_mcp_oauth_refresh.py
@@ -323,8 +323,8 @@ def test_sweep_refreshes_with_no_browser_client(
     with storage._engine.begin() as conn:
         conn.execute(
             sa.text(
-                "UPDATE mcp_user_tokens SET created = :created "
-                "WHERE user_id = :uid AND server_name = :sn"
+                "UPDATE oauth_tokens SET created = :created "
+                "WHERE user_id = :uid AND token_key = :sn"
             ),
             {
                 "created": (datetime.now(UTC) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S"),

--- a/tests/test_mcp_oauth_storage.py
+++ b/tests/test_mcp_oauth_storage.py
@@ -129,7 +129,7 @@ def _create_user_token_row(
     backend,
     *,
     user_id: str,
-    server_name: str,
+    token_key: str,
     created: str,
 ) -> None:
     """Insert a token row + backdate ``created`` so ordering is deterministic.
@@ -138,9 +138,9 @@ def _create_user_token_row(
     multi-row ordering tests we backdate via raw SQL so the inserts stay
     independent of clock resolution.
     """
-    backend.create_mcp_user_token(
+    backend.create_oauth_token(
         user_id,
-        server_name,
+        token_key,
         access_token_ct=b"ct-access",
         refresh_token_ct=b"ct-refresh",
         expires_at="2026-05-04T12:00:00",
@@ -151,26 +151,26 @@ def _create_user_token_row(
     with backend._engine.connect() as conn:
         conn.execute(
             sa.text(
-                "UPDATE mcp_user_tokens SET created = :created "
-                "WHERE user_id = :uid AND server_name = :sn"
+                "UPDATE oauth_tokens SET created = :created "
+                "WHERE user_id = :uid AND token_key = :sn"
             ),
-            {"created": created, "uid": user_id, "sn": server_name},
+            {"created": created, "uid": user_id, "sn": token_key},
         )
         conn.commit()
 
 
-class TestListMCPUserTokenMetadataByUser:
-    def test_list_mcp_user_token_metadata_by_user_empty(self, backend) -> None:
-        assert backend.list_mcp_user_token_metadata_by_user("nobody") == []
+class TestListOAuthTokenMetadataByUser:
+    def test_list_oauth_token_metadata_by_user_empty(self, backend) -> None:
+        assert backend.list_oauth_token_metadata_by_user("nobody") == []
 
-    def test_list_mcp_user_token_metadata_by_user_single_server(self, backend) -> None:
+    def test_list_oauth_token_metadata_by_user_single_server(self, backend) -> None:
         _create_user_token_row(
-            backend, user_id="u1", server_name="srv-a", created="2026-05-01T00:00:00"
+            backend, user_id="u1", token_key="srv-a", created="2026-05-01T00:00:00"
         )
-        rows = backend.list_mcp_user_token_metadata_by_user("u1")
+        rows = backend.list_oauth_token_metadata_by_user("u1")
         assert len(rows) == 1
         assert rows[0]["user_id"] == "u1"
-        assert rows[0]["server_name"] == "srv-a"
+        assert rows[0]["token_key"] == "srv-a"
         assert rows[0]["as_issuer"] == "https://auth.example.com"
         assert rows[0]["audience"] == "https://mcp.example.com"
         assert rows[0]["scopes"] == "openid"
@@ -179,34 +179,34 @@ class TestListMCPUserTokenMetadataByUser:
         assert "access_token_ct" not in rows[0]
         assert "refresh_token_ct" not in rows[0]
 
-    def test_list_mcp_user_token_metadata_by_user_multiple_servers(self, backend) -> None:
+    def test_list_oauth_token_metadata_by_user_multiple_servers(self, backend) -> None:
         _create_user_token_row(
-            backend, user_id="u1", server_name="srv-c", created="2026-05-03T00:00:00"
+            backend, user_id="u1", token_key="srv-c", created="2026-05-03T00:00:00"
         )
         _create_user_token_row(
-            backend, user_id="u1", server_name="srv-a", created="2026-05-01T00:00:00"
+            backend, user_id="u1", token_key="srv-a", created="2026-05-01T00:00:00"
         )
         _create_user_token_row(
-            backend, user_id="u1", server_name="srv-b", created="2026-05-02T00:00:00"
+            backend, user_id="u1", token_key="srv-b", created="2026-05-02T00:00:00"
         )
-        rows = backend.list_mcp_user_token_metadata_by_user("u1")
-        assert [r["server_name"] for r in rows] == ["srv-a", "srv-b", "srv-c"]
+        rows = backend.list_oauth_token_metadata_by_user("u1")
+        assert [r["token_key"] for r in rows] == ["srv-a", "srv-b", "srv-c"]
 
-    def test_list_mcp_user_token_metadata_by_user_isolates_by_user(self, backend) -> None:
+    def test_list_oauth_token_metadata_by_user_isolates_by_user(self, backend) -> None:
         _create_user_token_row(
-            backend, user_id="user-a", server_name="srv-a", created="2026-05-01T00:00:00"
+            backend, user_id="user-a", token_key="srv-a", created="2026-05-01T00:00:00"
         )
         _create_user_token_row(
-            backend, user_id="user-a", server_name="srv-b", created="2026-05-02T00:00:00"
+            backend, user_id="user-a", token_key="srv-b", created="2026-05-02T00:00:00"
         )
         _create_user_token_row(
-            backend, user_id="user-b", server_name="srv-a", created="2026-05-03T00:00:00"
+            backend, user_id="user-b", token_key="srv-a", created="2026-05-03T00:00:00"
         )
-        rows_a = backend.list_mcp_user_token_metadata_by_user("user-a")
-        assert {r["server_name"] for r in rows_a} == {"srv-a", "srv-b"}
+        rows_a = backend.list_oauth_token_metadata_by_user("user-a")
+        assert {r["token_key"] for r in rows_a} == {"srv-a", "srv-b"}
         assert all(r["user_id"] == "user-a" for r in rows_a)
 
-        rows_b = backend.list_mcp_user_token_metadata_by_user("user-b")
+        rows_b = backend.list_oauth_token_metadata_by_user("user-b")
         assert len(rows_b) == 1
         assert rows_b[0]["user_id"] == "user-b"
-        assert rows_b[0]["server_name"] == "srv-a"
+        assert rows_b[0]["token_key"] == "srv-a"

--- a/tests/test_mcp_obo_mint.py
+++ b/tests/test_mcp_obo_mint.py
@@ -17,7 +17,7 @@ call-counting):
 
 Semantics pinned here:
 
-- minted tokens cache in ``mcp_user_tokens`` with ``refresh_token_ct``
+- minted tokens cache in ``oauth_tokens`` with ``refresh_token_ct``
   NULL (cache, not custody);
 - rotation write-back persists the newest IdP refresh token on the
   shared credential;
@@ -147,16 +147,14 @@ def _seed_cache_row(
         # path need a row that is unambiguously from the past.
         import sqlalchemy as sa
 
-        from turnstone.core.storage._schema import mcp_user_tokens
+        from turnstone.core.storage._schema import oauth_tokens
 
         backdated = (datetime.now(UTC) - timedelta(seconds=created_seconds_ago)).strftime(_ISO)
         storage = state.auth_storage
         with storage._engine.connect() as conn:
             conn.execute(
-                sa.update(mcp_user_tokens)
-                .where(
-                    (mcp_user_tokens.c.user_id == USER) & (mcp_user_tokens.c.server_name == SERVER)
-                )
+                sa.update(oauth_tokens)
+                .where((oauth_tokens.c.user_id == USER) & (oauth_tokens.c.token_key == SERVER))
                 .values(created=backdated)
             )
             conn.commit()
@@ -193,7 +191,7 @@ def _mint(state: SimpleNamespace) -> Any:
 class TestEntraLeg:
     def test_happy_path_mints_with_default_scope_and_caches(self, storage: SQLiteBackend) -> None:
         """Case 1: one POST with the exact spike-verified Entra body; the mint
-        caches as a refresh-less ``mcp_user_tokens`` row with ``as_issuer`` /
+        caches as a refresh-less ``oauth_tokens`` row with ``as_issuer`` /
         ``audience`` populated and ``expires_at`` derived from ``expires_in``."""
         _seed_obo_server(storage)  # empty oauth_scopes → scope falls back to /.default
         client = MagicMock(spec=httpx.AsyncClient)
@@ -221,7 +219,7 @@ class TestEntraLeg:
             "scope": f"{AUDIENCE}/.default",
         }
         # Cache row: refresh-less (cache, not custody), issuer/audience stamped.
-        raw = storage.get_mcp_user_token(USER, SERVER)
+        raw = storage.get_oauth_token(USER, SERVER)
         assert raw is not None
         assert raw["refresh_token_ct"] is None
         assert raw["as_issuer"] == ISSUER
@@ -281,7 +279,7 @@ class TestEntraLeg:
         result = _mint(state)
         assert result.kind == "token"
         # The row records the effective (empty) scope, not "custom.scope".
-        row = storage.get_mcp_user_token(USER, SERVER)
+        row = storage.get_oauth_token(USER, SERVER)
         assert row is not None
         assert (row["scopes"] or "") == ""
 
@@ -315,7 +313,7 @@ class TestEntraLeg:
         assert cred is not None
         assert cred["refresh_token"] == "rt-2"
         # The rotated RT stays on the credential — the cache row is refresh-less.
-        raw = storage.get_mcp_user_token(USER, SERVER)
+        raw = storage.get_oauth_token(USER, SERVER)
         assert raw is not None
         assert raw["refresh_token_ct"] is None
 
@@ -513,7 +511,7 @@ class TestRfc8693Leg:
         result = _mint(state)
 
         assert result.kind == "token"
-        row = storage.get_mcp_user_token(USER, SERVER)
+        row = storage.get_oauth_token(USER, SERVER)
         assert row is not None
         # Not NULL — a bounded expiry within the default TTL window was stamped.
         assert row["expires_at"] is not None
@@ -568,7 +566,7 @@ class TestCacheAndCredentialLookup:
     def test_fresh_cache_row_returns_token_with_zero_http_calls(
         self, storage: SQLiteBackend
     ) -> None:
-        """Case 4: a fresh ``mcp_user_tokens`` row is served straight from the
+        """Case 4: a fresh ``oauth_tokens`` row is served straight from the
         cache — no IdP round-trip."""
         _seed_obo_server(storage)
         client = MagicMock(spec=httpx.AsyncClient)
@@ -622,7 +620,7 @@ class TestCacheAndCredentialLookup:
 
             res = asyncio.run(_go())
             # Clear the cache row so the next run mints again (independent count).
-            storage.delete_mcp_user_token(USER, SERVER)
+            storage.delete_oauth_token(USER, SERVER)
             return res, reads["n"]
 
         result_hint, reads_hint = _run_with_hint(True)
@@ -659,7 +657,7 @@ class TestCacheAndCredentialLookup:
         assert result.token == "reminted-at"
         assert client.post.call_count == 1
         # The cache row is now for the current audience.
-        row = storage.get_mcp_user_token(USER, SERVER)
+        row = storage.get_oauth_token(USER, SERVER)
         assert row is not None and row["audience"] == AUDIENCE
 
     def test_stale_scopes_cache_row_is_not_served_and_remints(self, storage: SQLiteBackend) -> None:
@@ -700,7 +698,7 @@ class TestCacheAndCredentialLookup:
         assert result.kind == "token"
         assert result.token == "reminted-narrow"
         assert client.post.call_count == 2
-        row = storage.get_mcp_user_token(USER, SERVER)
+        row = storage.get_oauth_token(USER, SERVER)
         assert row is not None and (row["scopes"] or "") == "api.read"
 
     def test_missing_credential_returns_missing_with_zero_http_calls(
@@ -757,7 +755,7 @@ class TestFailureHandling:
 
         assert result.kind == "refresh_failed"
         # Cache row GONE...
-        assert storage.get_mcp_user_token(USER, SERVER) is None
+        assert storage.get_oauth_token(USER, SERVER) is None
         # ...but the credential STILL EXISTS — never auto-deleted here.
         assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
         # The revoke is audited through the shared choke point.
@@ -814,7 +812,7 @@ class TestFailureHandling:
         assert result.kind == "refresh_failed_transient"
         assert client.post.call_count == 1
         assert state.mcp_token_store.get_oidc_credential(USER, ISSUER) is not None
-        assert storage.get_mcp_user_token(USER, SERVER) is None  # nothing was cached
+        assert storage.get_oauth_token(USER, SERVER) is None  # nothing was cached
 
     def test_oversized_error_body_on_client_error_is_ambiguous_not_transient(
         self, storage: SQLiteBackend

--- a/tests/test_mcp_pending_consent_storage.py
+++ b/tests/test_mcp_pending_consent_storage.py
@@ -150,7 +150,7 @@ class TestCountConsentedUsersByServer:
     def test_counts_distinct_non_expired_users(self, backend) -> None:
         self._seed_server(backend)
         future = "2099-01-01T00:00:00"
-        backend.create_mcp_user_token(
+        backend.create_oauth_token(
             "alice",
             "srv-x",
             access_token_ct=b"ct",
@@ -160,7 +160,7 @@ class TestCountConsentedUsersByServer:
             as_issuer="https://as.example.com",
             audience="https://example.com/mcp",
         )
-        backend.create_mcp_user_token(
+        backend.create_oauth_token(
             "bob",
             "srv-x",
             access_token_ct=b"ct",
@@ -172,7 +172,7 @@ class TestCountConsentedUsersByServer:
         )
         # Different server — must not count.
         self._seed_server(backend, name="srv-y")
-        backend.create_mcp_user_token(
+        backend.create_oauth_token(
             "carol",
             "srv-y",
             access_token_ct=b"ct",
@@ -187,7 +187,7 @@ class TestCountConsentedUsersByServer:
 
     def test_excludes_expired(self, backend) -> None:
         self._seed_server(backend)
-        backend.create_mcp_user_token(
+        backend.create_oauth_token(
             "alice",
             "srv-x",
             access_token_ct=b"ct",

--- a/tests/test_mcp_token_store.py
+++ b/tests/test_mcp_token_store.py
@@ -64,7 +64,7 @@ class TestUserTokenCRUD:
         plain = store.get_user_token("u1", "srv-a")
         assert plain is not None
         assert plain["user_id"] == "u1"
-        assert plain["server_name"] == "srv-a"
+        assert plain["token_key"] == "srv-a"
         assert plain["access_token"] == "access-aaa"
         assert plain["refresh_token"] == "refresh-bbb"
         assert plain["scopes"] == "openid profile"
@@ -209,7 +209,7 @@ class TestDecryptFailureInvariant:
             as_issuer="https://auth.example.com",
             audience="https://mcp.example.com",
         )
-        raw_before = backend.get_mcp_user_token("u1", "srv-a")
+        raw_before = backend.get_oauth_token("u1", "srv-a")
         assert raw_before is not None
         ct_before = bytes(raw_before["access_token_ct"])
 
@@ -221,7 +221,7 @@ class TestDecryptFailureInvariant:
         assert exc_info.value.key_fingerprints_attempted == cipher_b.key_fingerprints
 
         # Row MUST still exist with ciphertext intact.
-        raw_after = backend.get_mcp_user_token("u1", "srv-a")
+        raw_after = backend.get_oauth_token("u1", "srv-a")
         assert raw_after is not None
         assert bytes(raw_after["access_token_ct"]) == ct_before
 

--- a/tests/test_mcp_token_store_metadata.py
+++ b/tests/test_mcp_token_store_metadata.py
@@ -31,13 +31,13 @@ def _seed_token(
     backend,
     *,
     user_id: str,
-    server_name: str,
+    token_key: str,
     created: str,
 ) -> None:
     """Create a token via the store and backdate ``created`` for ordering."""
     store.create_user_token(
         user_id,
-        server_name,
+        token_key,
         access_token="access-secret",
         refresh_token="refresh-secret",
         expires_at="2026-05-04T12:00:00",
@@ -48,10 +48,10 @@ def _seed_token(
     with backend._engine.connect() as conn:
         conn.execute(
             sa.text(
-                "UPDATE mcp_user_tokens SET created = :created "
-                "WHERE user_id = :uid AND server_name = :sn"
+                "UPDATE oauth_tokens SET created = :created "
+                "WHERE user_id = :uid AND token_key = :sn"
             ),
-            {"created": created, "uid": user_id, "sn": server_name},
+            {"created": created, "uid": user_id, "sn": token_key},
         )
         conn.commit()
 
@@ -59,9 +59,7 @@ def _seed_token(
 class TestListUserTokenMetadata:
     def test_list_user_token_metadata_returns_non_secret_fields_only(self, backend) -> None:
         store = _make_store(backend)
-        _seed_token(
-            store, backend, user_id="u1", server_name="srv-a", created="2026-05-01T00:00:00"
-        )
+        _seed_token(store, backend, user_id="u1", token_key="srv-a", created="2026-05-01T00:00:00")
         rows = store.list_user_token_metadata("u1")
         assert len(rows) == 1
         meta = rows[0]
@@ -72,7 +70,7 @@ class TestListUserTokenMetadata:
         assert "refresh_token_ct" not in meta
         # Non-secret columns surface verbatim.
         assert meta["user_id"] == "u1"
-        assert meta["server_name"] == "srv-a"
+        assert meta["token_key"] == "srv-a"
         assert meta["scopes"] == "openid profile"
         assert meta["as_issuer"] == "https://auth.example.com"
         assert meta["audience"] == "https://mcp.example.com"
@@ -86,17 +84,11 @@ class TestListUserTokenMetadata:
 
     def test_list_user_token_metadata_preserves_creation_order(self, backend) -> None:
         store = _make_store(backend)
-        _seed_token(
-            store, backend, user_id="u1", server_name="srv-c", created="2026-05-03T00:00:00"
-        )
-        _seed_token(
-            store, backend, user_id="u1", server_name="srv-a", created="2026-05-01T00:00:00"
-        )
-        _seed_token(
-            store, backend, user_id="u1", server_name="srv-b", created="2026-05-02T00:00:00"
-        )
+        _seed_token(store, backend, user_id="u1", token_key="srv-c", created="2026-05-03T00:00:00")
+        _seed_token(store, backend, user_id="u1", token_key="srv-a", created="2026-05-01T00:00:00")
+        _seed_token(store, backend, user_id="u1", token_key="srv-b", created="2026-05-02T00:00:00")
         rows = store.list_user_token_metadata("u1")
-        assert [r["server_name"] for r in rows] == ["srv-a", "srv-b", "srv-c"]
+        assert [r["token_key"] for r in rows] == ["srv-a", "srv-b", "srv-c"]
         assert [r["created"] for r in rows] == [
             "2026-05-01T00:00:00",
             "2026-05-02T00:00:00",

--- a/tests/test_migration_077.py
+++ b/tests/test_migration_077.py
@@ -1,0 +1,193 @@
+"""OAuth storage rename preserves populated databases in both directions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+from tests.conftest import make_mcp_token_cipher
+
+_MIGRATIONS = str(Path(__file__).resolve().parents[1] / "turnstone/core/storage/migrations")
+_ISSUER = "https://idp.example.com/tenant"
+_CREATED = "2026-01-02T03:04:05"
+
+
+def _rows(engine: sa.Engine, name: str) -> list[dict[str, Any]]:
+    table = sa.Table(name, sa.MetaData(), autoload_with=engine)
+    with engine.connect() as conn:
+        return [
+            dict(row)
+            for row in conn.execute(sa.select(table).order_by(*table.primary_key)).mappings()
+        ]
+
+
+def _assert_layout(engine: sa.Engine, *, renamed: bool) -> None:
+    table = "oauth_tokens" if renamed else "mcp_user_tokens"
+    key = "token_key" if renamed else "server_name"
+    index = "idx_oauth_tokens_key" if renamed else "idx_mcp_user_tokens_server"
+    absent_table = "mcp_user_tokens" if renamed else "oauth_tokens"
+    inspector = sa.inspect(engine)
+    assert table in inspector.get_table_names()
+    assert absent_table not in inspector.get_table_names()
+    assert {column["name"] for column in inspector.get_columns(table)} == {
+        "user_id",
+        key,
+        "access_token_ct",
+        "refresh_token_ct",
+        "expires_at",
+        "scopes",
+        "as_issuer",
+        "audience",
+        "created",
+        "last_refreshed",
+    }
+    pk = inspector.get_pk_constraint(table)
+    assert pk["constrained_columns"] == ["user_id", key]
+    assert pk["name"] == (f"{table}_pkey" if engine.dialect.name == "postgresql" else None)
+    secondary = [i for i in inspector.get_indexes(table) if not i.get("duplicates_constraint")]
+    assert [(i["name"], i["column_names"], bool(i["unique"])) for i in secondary] == [
+        (index, [key, "expires_at"], False)
+    ]
+    with engine.connect() as conn:
+        if engine.dialect.name == "postgresql":
+            names = set(
+                conn.execute(
+                    sa.text(
+                        "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema() "
+                        "AND tablename = :table"
+                    ),
+                    {"table": table},
+                ).scalars()
+            )
+            assert names == {f"{table}_pkey", index}
+        else:
+            names = {row[1] for row in conn.execute(sa.text(f'PRAGMA index_list("{table}")'))}
+            assert names == {f"sqlite_autoindex_{table}_1", index}
+
+
+def _roundtrip(url: sa.URL) -> None:
+    cfg = Config()
+    cfg.set_main_option("script_location", _MIGRATIONS)
+    cfg.set_main_option(
+        "sqlalchemy.url", url.render_as_string(hide_password=False).replace("%", "%%")
+    )
+    # Starting empty also exercises the complete historical migration chain.
+    command.upgrade(cfg, "076")
+    engine = sa.create_engine(url)
+    cipher = make_mcp_token_cipher()
+    identities = [
+        ("u1", "mcp-custodial"),
+        ("u2", "mcp-custodial"),
+        ("u1", "mcp-obo"),
+        ("u1", "__model_obo__:gateway"),
+        ("u2", "__model_obo__:gateway"),
+        ("__app__", "__model_app__:gateway"),
+        ("u1", "__model_obo__:api://legacy-audience"),
+        ("__app__", "__model_app__:api://legacy-audience"),
+        ("u1", "__model_obo__:legacy\x1fsha256:opaque"),
+    ]
+    expected = [
+        {
+            "user_id": user,
+            "server_name": key,
+            "access_token_ct": cipher.encrypt(f"access-{i}".encode()),
+            "refresh_token_ct": cipher.encrypt(f"refresh-{i}".encode()) if i < 2 else None,
+            "expires_at": None if i == 0 else "2026-02-03T04:05:06",
+            "scopes": None if i == 0 else ("" if i == 1 else "openid aud-gateway"),
+            "as_issuer": _ISSUER,
+            "audience": f"api://audience-{i}",
+            "created": _CREATED,
+            "last_refreshed": None if i % 2 else "2026-01-03T04:05:06",
+        }
+        for i, (user, key) in enumerate(identities)
+    ]
+    try:
+        tables = sa.MetaData()
+        tables.reflect(
+            engine,
+            only=[
+                "mcp_user_tokens",
+                "oidc_user_credentials",
+                "mcp_oauth_pending",
+                "mcp_pending_consent",
+            ],
+        )
+        with engine.begin() as conn:
+            conn.execute(tables.tables["mcp_user_tokens"].insert(), expected)
+            conn.execute(
+                tables.tables["oidc_user_credentials"].insert(),
+                [
+                    {
+                        "user_id": user,
+                        "issuer": _ISSUER,
+                        "refresh_token_ct": cipher.encrypt(f"credential-{user}".encode()),
+                        "created": _CREATED,
+                        "last_refreshed": "2026-01-03T04:05:06",
+                    }
+                    for user in ("u1", "u2")
+                ],
+            )
+            conn.execute(
+                tables.tables["mcp_oauth_pending"].insert(),
+                {
+                    "state": "auth-state",
+                    "user_id": "u1",
+                    "server_name": "mcp-custodial",
+                    "code_verifier": "verifier",
+                    "return_url": "/settings",
+                    "created_at": _CREATED,
+                },
+            )
+            conn.execute(
+                tables.tables["mcp_pending_consent"].insert(),
+                {
+                    "user_id": "u2",
+                    "server_name": "mcp-custodial",
+                    "error_code": "needs_auth",
+                    "scopes_required": "scope",
+                    "first_seen_at": _CREATED,
+                    "last_seen_at": _CREATED,
+                    "occurrence_count": 4,
+                },
+            )
+        expected = _rows(engine, "mcp_user_tokens")
+        untouched = {
+            name: _rows(engine, name)
+            for name in ("oidc_user_credentials", "mcp_oauth_pending", "mcp_pending_consent")
+        }
+        _assert_layout(engine, renamed=False)
+
+        # Round-trip twice: inverse names must leave the next upgrade usable.
+        for _ in range(2):
+            command.upgrade(cfg, "077")
+            _assert_layout(engine, renamed=True)
+            actual = _rows(engine, "oauth_tokens")
+            assert [
+                {
+                    ("server_name" if key == "token_key" else key): value
+                    for key, value in row.items()
+                }
+                for row in actual
+            ] == expected
+            for row in actual:
+                assert cipher.decrypt(row["access_token_ct"]).startswith(b"access-")
+            assert {name: _rows(engine, name) for name in untouched} == untouched
+
+            command.downgrade(cfg, "076")
+            _assert_layout(engine, renamed=False)
+            assert _rows(engine, "mcp_user_tokens") == expected
+            assert {name: _rows(engine, name) for name in untouched} == untouched
+    finally:
+        engine.dispose()
+
+
+def test_oauth_token_rename_sqlite(tmp_path: Path) -> None:
+    _roundtrip(sa.URL.create("sqlite", database=str(tmp_path / "oauth.db")))
+
+
+def test_oauth_token_rename_postgresql(fresh_pg_url: sa.URL) -> None:
+    _roundtrip(fresh_pg_url)

--- a/tests/test_model_provider_obo.py
+++ b/tests/test_model_provider_obo.py
@@ -498,7 +498,7 @@ class TestMintOboAccessToken:
         # Persisted as a "cache, not custody" row (refresh_token NULL),
         # decodable, identity-keyed on the owning alias.
         cache_server = f"__model_obo__:{MODEL_ALIAS}"
-        raw = storage.get_mcp_user_token(USER, cache_server)
+        raw = storage.get_oauth_token(USER, cache_server)
         assert raw is not None and raw["refresh_token_ct"] is None
         plain = node_a.mcp_token_store.get_user_token(USER, cache_server)
         assert plain is not None
@@ -773,7 +773,7 @@ class TestMintOboAccessToken:
         assert plain["scopes"] == "aud-gw openid"
         assert plain["audience"] == AUDIENCE
         # Identity keys: another alias holds no row — one owner per key.
-        assert storage.get_mcp_user_token(USER, model_obo_cache_server("other-model")) is None
+        assert storage.get_oauth_token(USER, model_obo_cache_server("other-model")) is None
 
         # Warm re-mint with the same scopes serves the cache, zero IdP calls.
         assert _mint(state, scopes="aud-gw openid", grant_leg="rfc8693") == "exchanged-at"
@@ -1148,7 +1148,7 @@ class TestMintAppAccessToken:
         assert _mint_app(state) == "app-at"
         assert client.post.call_count == 1
         cache_server = f"__model_app__:{APP_ALIAS}"
-        raw = storage.get_mcp_user_token("__app__", cache_server)
+        raw = storage.get_oauth_token("__app__", cache_server)
         assert raw is not None and raw["refresh_token_ct"] is None
 
     def test_works_with_zero_user_credentials(self, storage: SQLiteBackend) -> None:
@@ -1232,7 +1232,7 @@ class TestMintAppAccessToken:
         assert client.post.call_args.kwargs["data"]["scope"] == f"{AUDIENCE}/.default"
         # The cache row lives under the stripped identity key with the
         # stripped audience column.
-        raw = storage.get_mcp_user_token("__app__", model_app_cache_server("gw-app"))
+        raw = storage.get_oauth_token("__app__", model_app_cache_server("gw-app"))
         assert raw is not None
         plain = state.mcp_token_store.get_user_token("__app__", model_app_cache_server("gw-app"))
         assert plain is not None and plain["audience"] == AUDIENCE

--- a/tests/test_oauth_token_storage.py
+++ b/tests/test_oauth_token_storage.py
@@ -1,0 +1,155 @@
+"""Shared token lifecycle and MCP projections on the selected storage backend."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import sqlalchemy as sa
+
+from turnstone.core.model_oauth import model_app_cache_server, model_obo_cache_server
+from turnstone.core.token_store.store import MODEL_APP_MINT_PRINCIPAL
+
+if TYPE_CHECKING:
+    from turnstone.core.storage._protocol import StorageBackend
+
+
+def _seed_token(
+    storage: StorageBackend, user: str, key: str, *, expires: str | None = None
+) -> None:
+    storage.create_oauth_token(
+        user,
+        key,
+        access_token_ct=b"access",
+        refresh_token_ct=None,
+        expires_at=expires,
+        scopes="scope",
+        as_issuer="https://idp.example.com",
+        audience="api://resource",
+    )
+
+
+def _seed_auth_state(storage: StorageBackend, key: str) -> None:
+    storage.create_mcp_oauth_pending_state(f"state-{key}", "u1", key, "verifier", "/settings")
+    storage.upsert_mcp_pending_consent("u1", key, "needs_auth", None, "2026-01-01T00:00:00")
+
+
+def test_model_lifecycle_purge_only_deletes_the_alias_tokens(backend: StorageBackend) -> None:
+    from turnstone.console.server import _purge_model_mint_cache
+
+    obo_key = model_obo_cache_server("gateway")
+    app_key = model_app_cache_server("gateway")
+    sibling = model_obo_cache_server("sibling")
+    for key in (obo_key, app_key, sibling, "mcp-server"):
+        for user in ("u1", "u2", MODEL_APP_MINT_PRINCIPAL):
+            _seed_token(backend, user, key)
+        _seed_auth_state(backend, key)
+    backend.upsert_oidc_user_credential(
+        "u1", "https://idp.example.com", refresh_token_ct=b"credential"
+    )
+    credential = backend.get_oidc_user_credential("u1", "https://idp.example.com")
+    pending_consent = backend.list_mcp_pending_consent_by_user("u1")
+
+    _purge_model_mint_cache(backend, "definition-1", "gateway")
+
+    for user in ("u1", "u2", MODEL_APP_MINT_PRINCIPAL):
+        assert backend.get_oauth_token(user, obo_key) is None
+        assert backend.get_oauth_token(user, app_key) is None
+        assert backend.get_oauth_token(user, sibling) is not None
+        assert backend.get_oauth_token(user, "mcp-server") is not None
+    assert backend.get_oidc_user_credential("u1", "https://idp.example.com") == credential
+    assert backend.list_mcp_pending_consent_by_user("u1") == pending_consent
+    for key in (obo_key, app_key, sibling, "mcp-server"):
+        assert backend.pop_mcp_oauth_pending_state(f"state-{key}") is not None
+    assert backend.delete_oauth_tokens_by_key(obo_key) == 0
+    assert backend.delete_oauth_tokens_by_key(sibling) == 3
+
+
+def test_mcp_purge_rolls_back_both_deletes_and_preserves_pending_consent(backend: Any) -> None:
+    for key in ("mcp-server", "other-server"):
+        for user in ("u1", "u2"):
+            _seed_token(backend, user, key)
+        _seed_auth_state(backend, key)
+    backend.upsert_oidc_user_credential(
+        "u1", "https://idp.example.com", refresh_token_ct=b"credential"
+    )
+    pending_consent = backend.list_mcp_pending_consent_by_user("u1")
+    credential = backend.get_oidc_user_credential("u1", "https://idp.example.com")
+    rows = [backend.get_oauth_token(user, "mcp-server") for user in ("u1", "u2")]
+
+    def fail_pending_delete(
+        conn: Any, cursor: Any, statement: str, parameters: Any, context: Any, executemany: bool
+    ) -> None:
+        if statement.startswith("DELETE FROM mcp_oauth_pending"):
+            raise RuntimeError("controlled pending-state delete failure")
+
+    sa.event.listen(backend._engine, "before_cursor_execute", fail_pending_delete)
+    try:
+        with pytest.raises(RuntimeError, match="controlled pending-state delete failure"):
+            backend.delete_mcp_oauth_rows_by_server_name("mcp-server")
+    finally:
+        sa.event.remove(backend._engine, "before_cursor_execute", fail_pending_delete)
+    assert [backend.get_oauth_token(user, "mcp-server") for user in ("u1", "u2")] == rows
+
+    assert backend.delete_mcp_oauth_rows_by_server_name("mcp-server") == 3
+    assert backend.delete_mcp_oauth_rows_by_server_name("mcp-server") == 0
+    for user in ("u1", "u2"):
+        assert backend.get_oauth_token(user, "mcp-server") is None
+        assert backend.get_oauth_token(user, "other-server") is not None
+    assert backend.pop_mcp_oauth_pending_state("state-mcp-server") is None
+    assert backend.pop_mcp_oauth_pending_state("state-other-server") is not None
+    assert backend.list_mcp_pending_consent_by_user("u1") == pending_consent
+    assert backend.get_oidc_user_credential("u1", "https://idp.example.com") == credential
+
+
+def test_user_delete_removes_shared_tokens_and_credentials(backend: StorageBackend) -> None:
+    keys = (
+        "mcp-custodial",
+        "mcp-obo",
+        model_obo_cache_server("gateway"),
+        "__model_obo__:api://legacy",
+    )
+    for user in ("u1", "u2"):
+        backend.create_user(user, user, user, "hash")
+        for key in keys:
+            _seed_token(backend, user, key)
+        backend.upsert_oidc_user_credential(
+            user, "https://idp.example.com", refresh_token_ct=b"credential"
+        )
+    app_key = model_app_cache_server("gateway")
+    _seed_token(backend, MODEL_APP_MINT_PRINCIPAL, app_key)
+    other_rows = backend.list_oauth_token_metadata_by_user("u2")
+    app_row = backend.get_oauth_token(MODEL_APP_MINT_PRINCIPAL, app_key)
+
+    assert backend.delete_user("u1") is True
+
+    assert backend.list_oauth_token_metadata_by_user("u1") == []
+    assert backend.get_oidc_user_credential("u1", "https://idp.example.com") is None
+    assert backend.list_oauth_token_metadata_by_user("u2") == other_rows
+    assert backend.get_oidc_user_credential("u2", "https://idp.example.com") is not None
+    assert backend.get_oauth_token(MODEL_APP_MINT_PRINCIPAL, app_key) == app_row
+
+
+def test_mcp_counts_and_sweep_use_the_renamed_token_key(backend: StorageBackend) -> None:
+    for key, auth_type in (("mcp-custodial", "oauth_user"), ("mcp-obo", "oauth_obo")):
+        backend.create_mcp_server(
+            key, key, "streamable-http", url="https://mcp.example.com", auth_type=auth_type
+        )
+    _seed_token(backend, "no-expiry", "mcp-custodial")
+    _seed_token(backend, "fresh", "mcp-custodial", expires="2099-01-01T00:00:00")
+    _seed_token(backend, "expired", "mcp-custodial", expires="2000-01-01T00:00:00")
+    _seed_token(backend, "u1", "mcp-obo")
+    _seed_token(backend, "u1", model_obo_cache_server("gateway"))
+    _seed_token(backend, MODEL_APP_MINT_PRINCIPAL, model_app_cache_server("gateway"))
+
+    assert backend.count_mcp_consented_users_by_server("mcp-custodial") == 2
+    assert backend.count_mcp_consented_users_grouped_by_server()["mcp-custodial"] == 2
+    targets = backend.list_mcp_user_token_reconcile_targets()
+    assert {(user, key) for user, key, _ in targets} == {
+        ("no-expiry", "mcp-custodial"),
+        ("fresh", "mcp-custodial"),
+        ("expired", "mcp-custodial"),
+    }
+    for user, key, exercised in targets:
+        row = backend.get_oauth_token(user, key)
+        assert row is not None and exercised == row["created"]

--- a/tests/test_oidc_handlers.py
+++ b/tests/test_oidc_handlers.py
@@ -1210,9 +1210,9 @@ class TestAdminOIDCIdentities:
         assert body["obo_cache_rows_purged"] == 2
         # Credential gone → no future mints; cache row gone → no live cached bearer.
         assert store.get_oidc_credential("user-x", issuer) is None
-        assert storage.get_mcp_user_token("user-x", "obo-srv") is None
-        assert storage.get_mcp_user_token("user-x", "__model_obo__:api://model-a") is None
-        assert storage.get_mcp_user_token("__app__", "__model_app__:api://model-a") is not None
+        assert storage.get_oauth_token("user-x", "obo-srv") is None
+        assert storage.get_oauth_token("user-x", "__model_obo__:api://model-a") is None
+        assert storage.get_oauth_token("__app__", "__model_app__:api://model-a") is not None
         app.state.mcp_client.invalidate_model_mint_memo_sync.assert_called_once_with(
             user_id="user-x",
             server_prefix="__model_obo__:",

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -51,6 +51,29 @@ def _structured_memory_indexes(inspector: sa.Inspector) -> dict[str, tuple[str, 
     return indexes
 
 
+def _assert_oauth_token_schema(inspector: sa.Inspector) -> None:
+    """Pin names as well as columns: a table rename alone leaves old PG names."""
+    from turnstone.core.storage._schema import oauth_tokens
+
+    assert "mcp_user_tokens" not in inspector.get_table_names()
+    assert {
+        column["name"]: column["nullable"] for column in inspector.get_columns("oauth_tokens")
+    } == {column.name: column.nullable for column in oauth_tokens.columns}
+    pk = inspector.get_pk_constraint("oauth_tokens")
+    assert pk["constrained_columns"] == ["user_id", "token_key"]
+    assert pk["name"] == (
+        "oauth_tokens_pkey" if inspector.bind.dialect.name == "postgresql" else None
+    )
+    # PostgreSQL reflection includes the backing PK index; SQLite excludes its
+    # unnamed autoindex. Compare the secondary indexes on both dialects.
+    indexes = {
+        index["name"]: (tuple(index["column_names"]), bool(index["unique"]))
+        for index in inspector.get_indexes("oauth_tokens")
+        if not index.get("duplicates_constraint")
+    }
+    assert indexes == {"idx_oauth_tokens_key": (("token_key", "expires_at"), False)}
+
+
 @pytest.fixture
 def sqlite_inspectors(tmp_path: Path) -> Iterator[tuple[sa.Inspector, sa.Inspector]]:
     """Inspect both schema paths while owning their connection pools."""
@@ -93,8 +116,8 @@ def test_create_all_matches_migrations(
                 "only_create_all": sorted(ec - mc),
             }
         # Named CHECK constraints only — unnamed ones reflect as backend noise.
-        mck = {c["name"] for c in mig.get_check_constraints(t) if c.get("name")}
-        eck = {c["name"] for c in meta.get_check_constraints(t) if c.get("name")}
+        mck = {name for c in mig.get_check_constraints(t) if (name := c["name"])}
+        eck = {name for c in meta.get_check_constraints(t) if (name := c["name"])}
         if mck != eck:
             check_drift[t] = {
                 "only_migrations": sorted(mck - eck),
@@ -105,9 +128,11 @@ def test_create_all_matches_migrations(
     assert not check_drift, f"check-constraint drift: {check_drift}"
     assert _structured_memory_indexes(mig) == _STRUCTURED_MEMORY_INDEXES
     assert _structured_memory_indexes(meta) == _STRUCTURED_MEMORY_INDEXES
+    _assert_oauth_token_schema(mig)
+    _assert_oauth_token_schema(meta)
 
 
-def test_postgresql_structured_memory_indexes_match_both_paths(
+def test_postgresql_selected_indexes_match_both_paths(
     fresh_pg_url: sa.URL,
 ) -> None:
     from turnstone.core.storage._schema import metadata
@@ -120,12 +145,14 @@ def test_postgresql_structured_memory_indexes_match_both_paths(
     engine = sa.create_engine(fresh_pg_url)
     try:
         migrated_indexes = _structured_memory_indexes(sa.inspect(engine))
+        _assert_oauth_token_schema(sa.inspect(engine))
 
         # The database is fixture-owned and disposable. Rebuild it through the
         # second schema path so PostgreSQL reflection covers both definitions.
         metadata.drop_all(engine)
         metadata.create_all(engine)
         create_all_indexes = _structured_memory_indexes(sa.inspect(engine))
+        _assert_oauth_token_schema(sa.inspect(engine))
     finally:
         engine.dispose()
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -37,7 +37,7 @@ def test_generic_store_round_trip_and_decrypt_hook(
     credential = store.get_oidc_credential("u1", "https://idp.example.com")
     assert token is not None and token["access_token"] == "access"
     assert credential is not None and credential["refresh_token"] == "credential"
-    token_row = backend.get_mcp_user_token("u1", "generic-key")
+    token_row = backend.get_oauth_token("u1", "generic-key")
     credential_row = backend.get_oidc_user_credential("u1", "https://idp.example.com")
     assert token_row is not None and token_row["access_token_ct"] != b"access"
     assert credential_row is not None and credential_row["refresh_token_ct"] != b"credential"
@@ -57,5 +57,5 @@ def test_generic_store_round_trip_and_decrypt_hook(
         ("generic-key", wrong_cipher.key_fingerprints),
         ("oidc:https://idp.example.com", wrong_cipher.key_fingerprints),
     ]
-    assert backend.get_mcp_user_token("u1", "generic-key") == token_row
+    assert backend.get_oauth_token("u1", "generic-key") == token_row
     assert backend.get_oidc_user_credential("u1", "https://idp.example.com") == credential_row

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6665,17 +6665,17 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
                 exc_info=True,
             )
         for row in metadata:
-            server_name = str(row.get("server_name") or "")
-            if not server_name.startswith(MODEL_OBO_CACHE_PREFIX):
+            token_key = str(row.get("token_key") or "")
+            if not token_key.startswith(MODEL_OBO_CACHE_PREFIX):
                 continue
             try:
-                if token_store.delete_user_token(user_id, server_name):
+                if token_store.delete_user_token(user_id, token_key):
                     obo_cache_purged += 1
             except Exception:
                 log.warning(
                     "admin.oidc_identity.model_obo_cache_purge_failed user=%s server=%s",
                     user_id,
-                    server_name,
+                    token_key,
                     exc_info=True,
                 )
     # The console-hosted coordinator has its own manager/memo and is not in the
@@ -10634,7 +10634,7 @@ def _purge_model_mint_cache(storage: Any, definition_id: str, alias: str) -> Non
     # storage failure, each miss logged on its own.
     for server_key in (model_obo_cache_server(alias), model_app_cache_server(alias)):
         try:
-            storage.delete_mcp_oauth_rows_by_server_name(server_key)
+            storage.delete_oauth_tokens_by_key(server_key)
         except Exception:
             log.warning(
                 "admin.models.purge_mint_cache_failed definition_id=%s server=%s",
@@ -11169,7 +11169,7 @@ async def admin_list_mcp_servers(request: Request) -> JSONResponse:
     # entirely when no row is oauth_user so static-only installs
     # exercise zero new storage queries.
 
-    # Both pool-backed types populate mcp_user_tokens (oauth_user: consents;
+    # Both pool-backed types populate oauth_tokens (oauth_user: consents;
     # oauth_obo: minted cache), so run the count for either — it drives the
     # per-row pill: oauth_user's consented-users count and oauth_obo's
     # flush-cache action (gated on count>0 in the UI).
@@ -12295,7 +12295,7 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
 
     Authoritative local delete via
     :meth:`StorageBackend.delete_mcp_oauth_rows_by_server_name` —
-    purges both ``mcp_user_tokens`` and ``mcp_oauth_pending`` rows for
+    purges both ``oauth_tokens`` and ``mcp_oauth_pending`` rows for
     the named server.  Upstream RFC 7009 revoke is intentionally NOT
     attempted in bulk (would require per-row decrypt + N upstream HTTP
     calls); operators who need upstream cleanup should use the per-
@@ -12330,7 +12330,7 @@ async def admin_mcp_bulk_revoke(request: Request) -> JSONResponse:
     existing = storage.get_mcp_server_by_name(name)
     if existing is None:
         return JSONResponse({"error": "No such server"}, status_code=404)
-    # Both pool-backed types populate mcp_user_tokens, but the semantics differ
+    # Both pool-backed types populate oauth_tokens, but the semantics differ
     # and must be honest (issue #551): for oauth_user, deleting the rows is a
     # durable REVOCATION — users lose access until they re-consent. For
     # oauth_obo, the per-server rows are a mint CACHE; the shared per-user

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -3489,13 +3489,23 @@ async def _handle_mcp_oauth_list_connections_inner(request: Request) -> Response
             obo_names = await asyncio.to_thread(obo_server_names, storage)
         except Exception:
             obo_names = set()
+    # Keep the MCP API's server_name field at the boundary of the shared store.
     return JSONResponse(
         {
             "connections": [
-                r
+                {
+                    "user_id": r["user_id"],
+                    "server_name": r["token_key"],
+                    "expires_at": r["expires_at"],
+                    "scopes": r["scopes"],
+                    "as_issuer": r["as_issuer"],
+                    "audience": r["audience"],
+                    "created": r["created"],
+                    "last_refreshed": r["last_refreshed"],
+                }
                 for r in rows
-                if r["server_name"] not in obo_names
-                and not str(r["server_name"]).startswith(token_store_store.SYNTHETIC_TOKEN_PREFIXES)
+                if r["token_key"] not in obo_names
+                and not str(r["token_key"]).startswith(token_store_store.SYNTHETIC_TOKEN_PREFIXES)
             ]
         }
     )
@@ -3668,7 +3678,7 @@ async def _handle_mcp_oauth_revoke_connection_inner(request: Request) -> Respons
     # surfaces as 404 (with the same shape used for cross-user attempts
     # so existence is not leaked across tenants).
     if plain is None:
-        storage_row = await asyncio.to_thread(storage.get_mcp_user_token, user_id, server_name)
+        storage_row = await asyncio.to_thread(storage.get_oauth_token, user_id, server_name)
         if storage_row is None:
             return JSONResponse({"error": "No such connection"}, status_code=404)
 

--- a/turnstone/core/model_oauth.py
+++ b/turnstone/core/model_oauth.py
@@ -30,7 +30,7 @@ log = get_logger(__name__)
 # alias that points at it — not a per-server grant graph.  So this owns no
 # dead-grant classification or re-consent affordance.  It reuses the same mint
 # legs, credential store, RT-rotation CAS, cluster credential lock, AND the same
-# ``mcp_user_tokens`` mint-cache row the classified path uses (refresh_token=NULL,
+# ``oauth_tokens`` mint-cache row the classified path uses (refresh_token=NULL,
 # "cache, not custody") — keyed under a synthetic ``__model_obo__:<alias>``
 # server name. The DB row shares the token across workers; a loop-local memo
 # avoids a SQL read + decrypt on every warm model turn.
@@ -284,7 +284,7 @@ def _memoize_minted_token(
     now = datetime.now(UTC).replace(tzinfo=None).isoformat(timespec="seconds")
     _model_mint_memo(app_state)[(user_id, cache_server)] = {
         "user_id": user_id,
-        "server_name": cache_server,
+        "token_key": cache_server,
         "access_token": access_token,
         "refresh_token": None,
         "expires_at": expires_at,
@@ -308,7 +308,7 @@ def _memoize_minted_token(
 _SYNTHETIC_KEY_SEP = chr(0x1F)
 
 
-# Byte bound for the synthetic mint-cache keys: ``mcp_user_tokens.server_name``
+# Byte bound for the synthetic mint-cache keys: ``oauth_tokens.token_key``
 # is half the table's PRIMARY KEY and btree-indexed, and PostgreSQL's index
 # tuple limit is ~2704 bytes — a key at most 2600 UTF-8 bytes stays safely
 # under it. Console-written aliases are capped at 64 ASCII characters, so
@@ -372,7 +372,7 @@ def _normalized_mint_scopes(scopes: Any) -> str:
 
 
 def model_obo_cache_server(alias: str) -> str:
-    """Synthetic ``mcp_user_tokens`` server key for a model alias's mint-cache row.
+    """Synthetic ``oauth_tokens`` server key for a model alias's mint-cache row.
 
     Public: the session heartbeat and the e2e harness build the same key to
     read the per-alias refusal-cause record, which shares this key's
@@ -436,7 +436,7 @@ async def mint_obo_access_token(
     Redeems the user's captured refresh credential (``oidc_user_credentials``)
     for *audience* via the configured OBO grant profile, persists any rotated
     refresh token (value CAS, cluster-locked exactly like the MCP mint), and
-    caches the minted access token in an ``mcp_user_tokens`` mint-cache row
+    caches the minted access token in an ``oauth_tokens`` mint-cache row
     (``refresh_token=NULL``) keyed ``__model_obo__:<alias>`` — the same
     "cache, not custody" row the classified path uses — so the token is shared
     across worker nodes and inspectable, until shortly before expiry. The key
@@ -735,7 +735,7 @@ _APP_CACHE_USER = token_store_store.MODEL_APP_MINT_PRINCIPAL
 
 
 def model_app_cache_server(alias: str) -> str:
-    """Synthetic ``mcp_user_tokens`` key for an app-credential mint-cache row.
+    """Synthetic ``oauth_tokens`` key for an app-credential mint-cache row.
 
     App tokens carry no user, so they cache once per owning definition under
     the shared ``__app__`` pseudo-user; the ``__model_app__:`` prefix keeps
@@ -764,7 +764,7 @@ async def mint_app_access_token(
     Uses Turnstone's own SSO app registration (``[oidc]`` ``client_id`` +
     ``client_secret``) — no user, no captured refresh token, no rotation. One
     token per owning definition *alias*, shared by every caller and cached in
-    an ``mcp_user_tokens`` row under the synthetic ``__app__`` user until
+    an ``oauth_tokens`` row under the synthetic ``__app__`` user until
     shortly before expiry (identity-keyed like the OBO twin; the freshness
     gate compares the row's stored audience against the current one, so a
     re-aimed alias refuses its old row and overwrites it on the next mint).

--- a/turnstone/core/oauth/grants.py
+++ b/turnstone/core/oauth/grants.py
@@ -66,7 +66,7 @@ async def refresh_token(
 #              audience scopes)
 #
 # The minted token is cached in the existing per-(user, server)
-# mcp_user_tokens row with refresh_token_ct=NULL — cache, not custody.  A
+# oauth_tokens row with refresh_token_ct=NULL — cache, not custody.  A
 # permanent mint failure drops ONLY that cache row (re-consent UX for that
 # server); the shared credential is NEVER auto-deleted here — a missing
 # tenant grant for one server (AADSTS65001, verified) must not lock the user

--- a/turnstone/core/storage/_postgresql.py
+++ b/turnstone/core/storage/_postgresql.py
@@ -31,8 +31,8 @@ from turnstone.core.storage._protocol import (
     ForkCloneSnapshot,
     MCPOAuthPendingState,
     MCPPendingConsentRow,
-    MCPUserToken,
-    MCPUserTokenMetadataRow,
+    OAuthToken,
+    OAuthTokenMetadataRow,
     OIDCIdentity,
     OIDCPendingState,
     OIDCUserCredential,
@@ -48,10 +48,10 @@ from turnstone.core.storage._schema import (
     mcp_oauth_pending,
     mcp_pending_consent,
     mcp_servers,
-    mcp_user_tokens,
     memory_index_snapshots,
     metadata,
     model_definitions,
+    oauth_tokens,
     oidc_identities,
     oidc_pending_states,
     oidc_user_credentials,
@@ -2211,7 +2211,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
             conn.execute(
                 sa.delete(oidc_user_credentials).where(oidc_user_credentials.c.user_id == user_id)
             )
-            conn.execute(sa.delete(mcp_user_tokens).where(mcp_user_tokens.c.user_id == user_id))
+            conn.execute(sa.delete(oauth_tokens).where(oauth_tokens.c.user_id == user_id))
             conn.execute(sa.delete(mcp_oauth_pending).where(mcp_oauth_pending.c.user_id == user_id))
             result = conn.execute(sa.delete(users).where(users.c.user_id == user_id))
             conn.commit()
@@ -5793,10 +5793,10 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
             conn.commit()
             return result.rowcount > 0
 
-    def create_mcp_user_token(
+    def create_oauth_token(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token_ct: bytes,
         refresh_token_ct: bytes | None,
@@ -5805,16 +5805,16 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         as_issuer: str,
         audience: str,
     ) -> None:
-        """Insert a new per-(user, server) token row. No-op on conflict."""
+        """Insert a new per-(user, token key) token row. No-op on conflict."""
         from sqlalchemy.dialects import postgresql
 
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
             conn.execute(
-                postgresql.insert(mcp_user_tokens)
+                postgresql.insert(oauth_tokens)
                 .values(
                     user_id=user_id,
-                    server_name=server_name,
+                    token_key=token_key,
                     access_token_ct=access_token_ct,
                     refresh_token_ct=refresh_token_ct,
                     expires_at=expires_at,
@@ -5828,21 +5828,20 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
             )
             conn.commit()
 
-    def get_mcp_user_token(self, user_id: str, server_name: str) -> MCPUserToken | None:
-        """Return the per-(user, server) token row or None."""
+    def get_oauth_token(self, user_id: str, token_key: str) -> OAuthToken | None:
+        """Return the per-(user, token key) token row or None."""
         with self._conn() as conn:
             row = conn.execute(
-                sa.select(mcp_user_tokens).where(
-                    (mcp_user_tokens.c.user_id == user_id)
-                    & (mcp_user_tokens.c.server_name == server_name)
+                sa.select(oauth_tokens).where(
+                    (oauth_tokens.c.user_id == user_id) & (oauth_tokens.c.token_key == token_key)
                 )
             ).fetchone()
             if row is None:
                 return None
             m = row._mapping
-            return MCPUserToken(
+            return OAuthToken(
                 user_id=m["user_id"],
-                server_name=m["server_name"],
+                token_key=m["token_key"],
                 access_token_ct=bytes(m["access_token_ct"]),
                 refresh_token_ct=(
                     bytes(m["refresh_token_ct"]) if m["refresh_token_ct"] is not None else None
@@ -5855,10 +5854,10 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                 last_refreshed=m["last_refreshed"],
             )
 
-    def update_mcp_user_token_after_refresh(
+    def update_oauth_token_after_refresh(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token_ct: bytes,
         refresh_token_ct: bytes | None,
@@ -5873,10 +5872,9 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
             result = conn.execute(
-                sa.update(mcp_user_tokens)
+                sa.update(oauth_tokens)
                 .where(
-                    (mcp_user_tokens.c.user_id == user_id)
-                    & (mcp_user_tokens.c.server_name == server_name)
+                    (oauth_tokens.c.user_id == user_id) & (oauth_tokens.c.token_key == token_key)
                 )
                 .values(
                     access_token_ct=access_token_ct,
@@ -5888,19 +5886,18 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
             conn.commit()
             return result.rowcount > 0
 
-    def delete_mcp_user_token(self, user_id: str, server_name: str) -> bool:
-        """Delete the per-(user, server) token row. Returns True if existed."""
+    def delete_oauth_token(self, user_id: str, token_key: str) -> bool:
+        """Delete the per-(user, token key) token row. Returns True if existed."""
         with self._conn() as conn:
             result = conn.execute(
-                sa.delete(mcp_user_tokens).where(
-                    (mcp_user_tokens.c.user_id == user_id)
-                    & (mcp_user_tokens.c.server_name == server_name)
+                sa.delete(oauth_tokens).where(
+                    (oauth_tokens.c.user_id == user_id) & (oauth_tokens.c.token_key == token_key)
                 )
             )
             conn.commit()
             return result.rowcount > 0
 
-    def list_mcp_user_token_metadata_by_user(self, user_id: str) -> list[MCPUserTokenMetadataRow]:
+    def list_oauth_token_metadata_by_user(self, user_id: str) -> list[OAuthTokenMetadataRow]:
         """Return non-secret metadata rows for ``user_id``, ordered by ``created`` ASC.
 
         Projects metadata columns at the SQL boundary so ciphertext
@@ -5910,25 +5907,25 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         with self._conn() as conn:
             rows = conn.execute(
                 sa.select(
-                    mcp_user_tokens.c.user_id,
-                    mcp_user_tokens.c.server_name,
-                    mcp_user_tokens.c.expires_at,
-                    mcp_user_tokens.c.scopes,
-                    mcp_user_tokens.c.as_issuer,
-                    mcp_user_tokens.c.audience,
-                    mcp_user_tokens.c.created,
-                    mcp_user_tokens.c.last_refreshed,
+                    oauth_tokens.c.user_id,
+                    oauth_tokens.c.token_key,
+                    oauth_tokens.c.expires_at,
+                    oauth_tokens.c.scopes,
+                    oauth_tokens.c.as_issuer,
+                    oauth_tokens.c.audience,
+                    oauth_tokens.c.created,
+                    oauth_tokens.c.last_refreshed,
                 )
-                .where(mcp_user_tokens.c.user_id == user_id)
-                .order_by(mcp_user_tokens.c.created)
+                .where(oauth_tokens.c.user_id == user_id)
+                .order_by(oauth_tokens.c.created)
             ).fetchall()
-            out: list[MCPUserTokenMetadataRow] = []
+            out: list[OAuthTokenMetadataRow] = []
             for row in rows:
                 m = row._mapping
                 out.append(
-                    MCPUserTokenMetadataRow(
+                    OAuthTokenMetadataRow(
                         user_id=m["user_id"],
-                        server_name=m["server_name"],
+                        token_key=m["token_key"],
                         expires_at=m["expires_at"],
                         scopes=m["scopes"],
                         as_issuer=m["as_issuer"],
@@ -5938,6 +5935,15 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
                     )
                 )
             return out
+
+    def delete_oauth_tokens_by_key(self, token_key: str) -> int:
+        """Delete token rows for *token_key* without touching other auth state."""
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.delete(oauth_tokens).where(oauth_tokens.c.token_key == token_key)
+            )
+            conn.commit()
+            return int(result.rowcount or 0)
 
     def list_mcp_user_token_reconcile_targets(self) -> list[tuple[str, str, str | None]]:
         """Return ``(user_id, server_name, COALESCE(last_refreshed, created))`` per
@@ -5951,14 +5957,14 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         with self._conn() as conn:
             rows = conn.execute(
                 sa.select(
-                    mcp_user_tokens.c.user_id,
-                    mcp_user_tokens.c.server_name,
-                    sa.func.coalesce(mcp_user_tokens.c.last_refreshed, mcp_user_tokens.c.created),
+                    oauth_tokens.c.user_id,
+                    oauth_tokens.c.token_key,
+                    sa.func.coalesce(oauth_tokens.c.last_refreshed, oauth_tokens.c.created),
                 )
                 .select_from(
-                    mcp_user_tokens.join(
+                    oauth_tokens.join(
                         mcp_servers,
-                        mcp_servers.c.name == mcp_user_tokens.c.server_name,
+                        mcp_servers.c.name == oauth_tokens.c.token_key,
                     )
                 )
                 .where(mcp_servers.c.auth_type == "oauth_user")
@@ -5969,7 +5975,7 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         """Purge user tokens + pending OAuth state for *server_name*."""
         with self._conn() as conn:
             tokens_result = conn.execute(
-                sa.delete(mcp_user_tokens).where(mcp_user_tokens.c.server_name == server_name)
+                sa.delete(oauth_tokens).where(oauth_tokens.c.token_key == server_name)
             )
             pending_result = conn.execute(
                 sa.delete(mcp_oauth_pending).where(mcp_oauth_pending.c.server_name == server_name)
@@ -6139,16 +6145,16 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
     def count_mcp_consented_users_by_server(self, server_name: str) -> int:
         # ``expires_at IS NULL`` => non-expired (refresh-only tokens with no
         # advertised expiry).  Compare lexically against ISO-8601 strings,
-        # mirroring the convention in ``mcp_user_tokens.expires_at``.
+        # mirroring the convention in ``oauth_tokens.expires_at``.
         now_iso = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
             result = conn.execute(
-                sa.select(sa.func.count(sa.distinct(mcp_user_tokens.c.user_id)))
-                .where(mcp_user_tokens.c.server_name == server_name)
+                sa.select(sa.func.count(sa.distinct(oauth_tokens.c.user_id)))
+                .where(oauth_tokens.c.token_key == server_name)
                 .where(
                     sa.or_(
-                        mcp_user_tokens.c.expires_at.is_(None),
-                        mcp_user_tokens.c.expires_at > now_iso,
+                        oauth_tokens.c.expires_at.is_(None),
+                        oauth_tokens.c.expires_at > now_iso,
                     )
                 )
             ).scalar()
@@ -6159,16 +6165,16 @@ class PostgreSQLBackend(_KeyedAttachmentSaveWrappers):
         with self._conn() as conn:
             rows = conn.execute(
                 sa.select(
-                    mcp_user_tokens.c.server_name,
-                    sa.func.count(sa.distinct(mcp_user_tokens.c.user_id)),
+                    oauth_tokens.c.token_key,
+                    sa.func.count(sa.distinct(oauth_tokens.c.user_id)),
                 )
                 .where(
                     sa.or_(
-                        mcp_user_tokens.c.expires_at.is_(None),
-                        mcp_user_tokens.c.expires_at > now_iso,
+                        oauth_tokens.c.expires_at.is_(None),
+                        oauth_tokens.c.expires_at > now_iso,
                     )
                 )
-                .group_by(mcp_user_tokens.c.server_name)
+                .group_by(oauth_tokens.c.token_key)
             ).fetchall()
         return {row[0]: int(row[1] or 0) for row in rows}
 

--- a/turnstone/core/storage/_protocol.py
+++ b/turnstone/core/storage/_protocol.py
@@ -151,10 +151,9 @@ class OIDCUserCredential(TypedDict):
     """Row shape for the per-(user, issuer) captured IdP refresh token.
 
     ``refresh_token_ct`` is a Fernet ciphertext blob (same envelope as
-    ``mcp_user_tokens``); the storage layer returns it verbatim and
-    ``MCPTokenStore`` handles encrypt/decrypt.  One row per user per
-    issuer — the single credential that ``auth_type='oauth_obo'`` MCP
-    servers redeem on demand (issue #551).
+    ``oauth_tokens``); the storage layer returns it verbatim and
+    ``TokenStore`` handles encrypt/decrypt. One row per user per issuer —
+    the credential that delegated MCP and model consumers redeem on demand.
     """
 
     user_id: str
@@ -174,16 +173,17 @@ class OIDCPendingState(TypedDict):
     created_at: str
 
 
-class MCPUserToken(TypedDict):
-    """Row shape returned by per-(user, MCP server) OAuth token lookups.
+class OAuthToken(TypedDict):
+    """Row shape returned by per-(user, token key) OAuth token lookups.
 
     ``access_token_ct`` and ``refresh_token_ct`` are Fernet ciphertext
-    blobs; the storage layer returns them verbatim and ``MCPTokenStore``
-    handles encrypt/decrypt.
+    blobs; the storage layer returns them verbatim and ``TokenStore``
+    handles encrypt/decrypt. ``token_key`` is an opaque identity, separate
+    from the audience/resource URL, used by both MCP grants and mint caches.
     """
 
     user_id: str
-    server_name: str
+    token_key: str
     access_token_ct: bytes
     refresh_token_ct: bytes | None
     expires_at: str | None
@@ -194,17 +194,17 @@ class MCPUserToken(TypedDict):
     last_refreshed: str | None
 
 
-class MCPUserTokenMetadataRow(TypedDict):
-    """Non-secret projection of ``mcp_user_tokens`` for the settings UI.
+class OAuthTokenMetadataRow(TypedDict):
+    """Non-secret projection of ``oauth_tokens`` for metadata consumers.
 
     Excludes ``access_token_ct`` and ``refresh_token_ct`` so the
     storage layer never materialises ciphertext for list queries that
-    only need metadata. ``MCPTokenStore.list_user_token_metadata``
+    only need metadata. ``TokenStore.list_user_token_metadata``
     re-types these rows as ``UserTokenMetadata`` (same field shape).
     """
 
     user_id: str
-    server_name: str
+    token_key: str
     expires_at: str | None
     scopes: str | None
     as_issuer: str
@@ -2678,7 +2678,7 @@ class StorageBackend(Protocol):
         """Delete an MCP server definition. Returns True if existed."""
         ...
 
-    # -- MCP OAuth: client-secret + per-(user, server) tokens ------------------
+    # -- MCP OAuth client secret ---------------------------------------------
     #
     # ``oauth_client_secret_ct`` is intentionally absent from
     # ``MCP_SERVER_MUTABLE`` (see ``_utils.py``).  It has its own dedicated
@@ -2693,10 +2693,12 @@ class StorageBackend(Protocol):
         """
         ...
 
-    def create_mcp_user_token(
+    # -- Shared OAuth tokens -------------------------------------------------
+
+    def create_oauth_token(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token_ct: bytes,
         refresh_token_ct: bytes | None,
@@ -2705,17 +2707,17 @@ class StorageBackend(Protocol):
         as_issuer: str,
         audience: str,
     ) -> None:
-        """Insert a new per-(user, server) token row. No-op on conflict."""
+        """Insert a new per-(user, token key) token row. No-op on conflict."""
         ...
 
-    def get_mcp_user_token(self, user_id: str, server_name: str) -> MCPUserToken | None:
-        """Return the per-(user, server) token row or None."""
+    def get_oauth_token(self, user_id: str, token_key: str) -> OAuthToken | None:
+        """Return the per-(user, token key) token row or None."""
         ...
 
-    def update_mcp_user_token_after_refresh(
+    def update_oauth_token_after_refresh(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token_ct: bytes,
         refresh_token_ct: bytes | None,
@@ -2729,21 +2731,32 @@ class StorageBackend(Protocol):
         """
         ...
 
-    def delete_mcp_user_token(self, user_id: str, server_name: str) -> bool:
-        """Delete the per-(user, server) token row. Returns True if existed."""
+    def delete_oauth_token(self, user_id: str, token_key: str) -> bool:
+        """Delete the per-(user, token key) token row. Returns True if existed."""
         ...
 
-    def list_mcp_user_token_metadata_by_user(self, user_id: str) -> list[MCPUserTokenMetadataRow]:
+    def list_oauth_token_metadata_by_user(self, user_id: str) -> list[OAuthTokenMetadataRow]:
         """Return non-secret metadata for every token row owned by ``user_id``,
         ordered by ``created`` ASC.
 
         Empty list when the user has no rows. Ciphertext columns are
         intentionally NOT loaded — the projection runs at the SQL boundary
         so the LargeBinary blobs never cross the wire for the list-view
-        path. ``MCPTokenStore`` re-types the rows as
-        ``UserTokenMetadata`` (same field shape) for the settings UI.
+        path. ``TokenStore`` re-types the rows as
+        ``UserTokenMetadata`` (same field shape).
         """
         ...
+
+    def delete_oauth_tokens_by_key(self, token_key: str) -> int:
+        """Delete all users' token rows for an opaque key; return the row count.
+
+        Does not touch captured OIDC credentials, pending authorization
+        states, or pending consent. Model lifecycle purges use this helper;
+        MCP lifecycle uses its transactional composed purge below.
+        """
+        ...
+
+    # -- MCP-specific token queries and lifecycle ----------------------------
 
     def list_mcp_user_token_reconcile_targets(self) -> list[tuple[str, str, str | None]]:
         """Return ``(user_id, server_name, last_exercised_iso)`` for every MCP
@@ -2771,11 +2784,10 @@ class StorageBackend(Protocol):
         server with the same ``name``. Returns the total number of rows
         deleted across both tables.
 
-        Both ``mcp_user_tokens`` and ``mcp_oauth_pending`` are keyed on
-        the mutable ``server_name`` rather than the immutable
-        ``server_id``; until those tables migrate to a server_id FK with
-        ON DELETE CASCADE (a future schema migration), explicit purge on
-        rename/delete is the only safe path.
+        MCP uses the mutable server name as ``oauth_tokens.token_key``
+        and ``mcp_oauth_pending.server_name``, so rename/delete must purge
+        both in one transaction. The separate ``mcp_pending_consent``
+        table is untouched.
         """
         ...
 

--- a/turnstone/core/storage/_schema.py
+++ b/turnstone/core/storage/_schema.py
@@ -1043,16 +1043,17 @@ oidc_user_credentials = sa.Table(
 )
 
 # ---------------------------------------------------------------------------
-# MCP per-(user, server) OAuth tokens and pending authorization-flow state.
+# Shared per-(user, token key) OAuth tokens. Keys are opaque identities:
+# MCP uses server names; model consumers use reserved synthetic keys.
 # No FKs at the schema level (matches `oidc_*` tables; tests avoid orphan
 # rows via fixtures).
 # ---------------------------------------------------------------------------
 
-mcp_user_tokens = sa.Table(
-    "mcp_user_tokens",
+oauth_tokens = sa.Table(
+    "oauth_tokens",
     metadata,
     sa.Column("user_id", sa.Text, nullable=False),
-    sa.Column("server_name", sa.Text, nullable=False),
+    sa.Column("token_key", sa.Text, nullable=False),
     sa.Column("access_token_ct", sa.LargeBinary, nullable=False),
     sa.Column("refresh_token_ct", sa.LargeBinary, nullable=True),
     sa.Column("expires_at", sa.Text, nullable=True),
@@ -1061,18 +1062,19 @@ mcp_user_tokens = sa.Table(
     sa.Column("audience", sa.Text, nullable=False),
     sa.Column("created", sa.Text, nullable=False),
     sa.Column("last_refreshed", sa.Text, nullable=True),
-    sa.PrimaryKeyConstraint("user_id", "server_name"),
+    sa.PrimaryKeyConstraint("user_id", "token_key"),
 )
-# Phase 9: covers the ``WHERE server_name = ? AND (expires_at IS NULL
+# Phase 9: covers the ``WHERE token_key = ? AND (expires_at IS NULL
 # OR expires_at > now)`` shape used by ``count_mcp_consented_users_*``
 # for the admin status pill.  The composite PK can't satisfy filters
 # that don't lead with ``user_id``.
 sa.Index(
-    "idx_mcp_user_tokens_server",
-    mcp_user_tokens.c.server_name,
-    mcp_user_tokens.c.expires_at,
+    "idx_oauth_tokens_key",
+    oauth_tokens.c.token_key,
+    oauth_tokens.c.expires_at,
 )
 
+# MCP-specific pending authorization-flow state.
 mcp_oauth_pending = sa.Table(
     "mcp_oauth_pending",
     metadata,

--- a/turnstone/core/storage/_sqlite.py
+++ b/turnstone/core/storage/_sqlite.py
@@ -31,8 +31,8 @@ from turnstone.core.storage._protocol import (
     ForkCloneSnapshot,
     MCPOAuthPendingState,
     MCPPendingConsentRow,
-    MCPUserToken,
-    MCPUserTokenMetadataRow,
+    OAuthToken,
+    OAuthTokenMetadataRow,
     OIDCIdentity,
     OIDCPendingState,
     OIDCUserCredential,
@@ -48,10 +48,10 @@ from turnstone.core.storage._schema import (
     mcp_oauth_pending,
     mcp_pending_consent,
     mcp_servers,
-    mcp_user_tokens,
     memory_index_snapshots,
     metadata,
     model_definitions,
+    oauth_tokens,
     oidc_identities,
     oidc_pending_states,
     oidc_user_credentials,
@@ -2245,7 +2245,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
             conn.execute(
                 sa.delete(oidc_user_credentials).where(oidc_user_credentials.c.user_id == user_id)
             )
-            conn.execute(sa.delete(mcp_user_tokens).where(mcp_user_tokens.c.user_id == user_id))
+            conn.execute(sa.delete(oauth_tokens).where(oauth_tokens.c.user_id == user_id))
             conn.execute(sa.delete(mcp_oauth_pending).where(mcp_oauth_pending.c.user_id == user_id))
             result = conn.execute(sa.delete(users).where(users.c.user_id == user_id))
             conn.commit()
@@ -5828,10 +5828,10 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
             conn.commit()
             return result.rowcount > 0
 
-    def create_mcp_user_token(
+    def create_oauth_token(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token_ct: bytes,
         refresh_token_ct: bytes | None,
@@ -5840,14 +5840,14 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         as_issuer: str,
         audience: str,
     ) -> None:
-        """Insert a new per-(user, server) token row. No-op on conflict."""
+        """Insert a new per-(user, token key) token row. No-op on conflict."""
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
             conn.execute(
-                sa.insert(mcp_user_tokens).prefix_with("OR IGNORE"),
+                sa.insert(oauth_tokens).prefix_with("OR IGNORE"),
                 {
                     "user_id": user_id,
-                    "server_name": server_name,
+                    "token_key": token_key,
                     "access_token_ct": access_token_ct,
                     "refresh_token_ct": refresh_token_ct,
                     "expires_at": expires_at,
@@ -5860,21 +5860,20 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
             )
             conn.commit()
 
-    def get_mcp_user_token(self, user_id: str, server_name: str) -> MCPUserToken | None:
-        """Return the per-(user, server) token row or None."""
+    def get_oauth_token(self, user_id: str, token_key: str) -> OAuthToken | None:
+        """Return the per-(user, token key) token row or None."""
         with self._conn() as conn:
             row = conn.execute(
-                sa.select(mcp_user_tokens).where(
-                    (mcp_user_tokens.c.user_id == user_id)
-                    & (mcp_user_tokens.c.server_name == server_name)
+                sa.select(oauth_tokens).where(
+                    (oauth_tokens.c.user_id == user_id) & (oauth_tokens.c.token_key == token_key)
                 )
             ).fetchone()
             if row is None:
                 return None
             m = row._mapping
-            return MCPUserToken(
+            return OAuthToken(
                 user_id=m["user_id"],
-                server_name=m["server_name"],
+                token_key=m["token_key"],
                 access_token_ct=bytes(m["access_token_ct"]),
                 refresh_token_ct=(
                     bytes(m["refresh_token_ct"]) if m["refresh_token_ct"] is not None else None
@@ -5887,10 +5886,10 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                 last_refreshed=m["last_refreshed"],
             )
 
-    def update_mcp_user_token_after_refresh(
+    def update_oauth_token_after_refresh(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token_ct: bytes,
         refresh_token_ct: bytes | None,
@@ -5905,10 +5904,9 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
             result = conn.execute(
-                sa.update(mcp_user_tokens)
+                sa.update(oauth_tokens)
                 .where(
-                    (mcp_user_tokens.c.user_id == user_id)
-                    & (mcp_user_tokens.c.server_name == server_name)
+                    (oauth_tokens.c.user_id == user_id) & (oauth_tokens.c.token_key == token_key)
                 )
                 .values(
                     access_token_ct=access_token_ct,
@@ -5920,19 +5918,18 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
             conn.commit()
             return result.rowcount > 0
 
-    def delete_mcp_user_token(self, user_id: str, server_name: str) -> bool:
-        """Delete the per-(user, server) token row. Returns True if existed."""
+    def delete_oauth_token(self, user_id: str, token_key: str) -> bool:
+        """Delete the per-(user, token key) token row. Returns True if existed."""
         with self._conn() as conn:
             result = conn.execute(
-                sa.delete(mcp_user_tokens).where(
-                    (mcp_user_tokens.c.user_id == user_id)
-                    & (mcp_user_tokens.c.server_name == server_name)
+                sa.delete(oauth_tokens).where(
+                    (oauth_tokens.c.user_id == user_id) & (oauth_tokens.c.token_key == token_key)
                 )
             )
             conn.commit()
             return result.rowcount > 0
 
-    def list_mcp_user_token_metadata_by_user(self, user_id: str) -> list[MCPUserTokenMetadataRow]:
+    def list_oauth_token_metadata_by_user(self, user_id: str) -> list[OAuthTokenMetadataRow]:
         """Return non-secret metadata rows for ``user_id``, ordered by ``created`` ASC.
 
         Projects metadata columns at the SQL boundary so ciphertext
@@ -5942,25 +5939,25 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         with self._conn() as conn:
             rows = conn.execute(
                 sa.select(
-                    mcp_user_tokens.c.user_id,
-                    mcp_user_tokens.c.server_name,
-                    mcp_user_tokens.c.expires_at,
-                    mcp_user_tokens.c.scopes,
-                    mcp_user_tokens.c.as_issuer,
-                    mcp_user_tokens.c.audience,
-                    mcp_user_tokens.c.created,
-                    mcp_user_tokens.c.last_refreshed,
+                    oauth_tokens.c.user_id,
+                    oauth_tokens.c.token_key,
+                    oauth_tokens.c.expires_at,
+                    oauth_tokens.c.scopes,
+                    oauth_tokens.c.as_issuer,
+                    oauth_tokens.c.audience,
+                    oauth_tokens.c.created,
+                    oauth_tokens.c.last_refreshed,
                 )
-                .where(mcp_user_tokens.c.user_id == user_id)
-                .order_by(mcp_user_tokens.c.created)
+                .where(oauth_tokens.c.user_id == user_id)
+                .order_by(oauth_tokens.c.created)
             ).fetchall()
-            out: list[MCPUserTokenMetadataRow] = []
+            out: list[OAuthTokenMetadataRow] = []
             for row in rows:
                 m = row._mapping
                 out.append(
-                    MCPUserTokenMetadataRow(
+                    OAuthTokenMetadataRow(
                         user_id=m["user_id"],
-                        server_name=m["server_name"],
+                        token_key=m["token_key"],
                         expires_at=m["expires_at"],
                         scopes=m["scopes"],
                         as_issuer=m["as_issuer"],
@@ -5970,6 +5967,15 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
                     )
                 )
             return out
+
+    def delete_oauth_tokens_by_key(self, token_key: str) -> int:
+        """Delete token rows for *token_key* without touching other auth state."""
+        with self._conn() as conn:
+            result = conn.execute(
+                sa.delete(oauth_tokens).where(oauth_tokens.c.token_key == token_key)
+            )
+            conn.commit()
+            return int(result.rowcount or 0)
 
     def list_mcp_user_token_reconcile_targets(self) -> list[tuple[str, str, str | None]]:
         """Return ``(user_id, server_name, COALESCE(last_refreshed, created))`` per
@@ -5983,14 +5989,14 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         with self._conn() as conn:
             rows = conn.execute(
                 sa.select(
-                    mcp_user_tokens.c.user_id,
-                    mcp_user_tokens.c.server_name,
-                    sa.func.coalesce(mcp_user_tokens.c.last_refreshed, mcp_user_tokens.c.created),
+                    oauth_tokens.c.user_id,
+                    oauth_tokens.c.token_key,
+                    sa.func.coalesce(oauth_tokens.c.last_refreshed, oauth_tokens.c.created),
                 )
                 .select_from(
-                    mcp_user_tokens.join(
+                    oauth_tokens.join(
                         mcp_servers,
-                        mcp_servers.c.name == mcp_user_tokens.c.server_name,
+                        mcp_servers.c.name == oauth_tokens.c.token_key,
                     )
                 )
                 .where(mcp_servers.c.auth_type == "oauth_user")
@@ -6001,7 +6007,7 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         """Purge user tokens + pending OAuth state for *server_name*."""
         with self._conn() as conn:
             tokens_result = conn.execute(
-                sa.delete(mcp_user_tokens).where(mcp_user_tokens.c.server_name == server_name)
+                sa.delete(oauth_tokens).where(oauth_tokens.c.token_key == server_name)
             )
             pending_result = conn.execute(
                 sa.delete(mcp_oauth_pending).where(mcp_oauth_pending.c.server_name == server_name)
@@ -6175,12 +6181,12 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         now_iso = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
         with self._conn() as conn:
             result = conn.execute(
-                sa.select(sa.func.count(sa.distinct(mcp_user_tokens.c.user_id)))
-                .where(mcp_user_tokens.c.server_name == server_name)
+                sa.select(sa.func.count(sa.distinct(oauth_tokens.c.user_id)))
+                .where(oauth_tokens.c.token_key == server_name)
                 .where(
                     sa.or_(
-                        mcp_user_tokens.c.expires_at.is_(None),
-                        mcp_user_tokens.c.expires_at > now_iso,
+                        oauth_tokens.c.expires_at.is_(None),
+                        oauth_tokens.c.expires_at > now_iso,
                     )
                 )
             ).scalar()
@@ -6191,16 +6197,16 @@ class SQLiteBackend(_KeyedAttachmentSaveWrappers):
         with self._conn() as conn:
             rows = conn.execute(
                 sa.select(
-                    mcp_user_tokens.c.server_name,
-                    sa.func.count(sa.distinct(mcp_user_tokens.c.user_id)),
+                    oauth_tokens.c.token_key,
+                    sa.func.count(sa.distinct(oauth_tokens.c.user_id)),
                 )
                 .where(
                     sa.or_(
-                        mcp_user_tokens.c.expires_at.is_(None),
-                        mcp_user_tokens.c.expires_at > now_iso,
+                        oauth_tokens.c.expires_at.is_(None),
+                        oauth_tokens.c.expires_at > now_iso,
                     )
                 )
-                .group_by(mcp_user_tokens.c.server_name)
+                .group_by(oauth_tokens.c.token_key)
             ).fetchall()
         return {row[0]: int(row[1] or 0) for row in rows}
 

--- a/turnstone/core/storage/migrations/versions/077_oauth_tokens.py
+++ b/turnstone/core/storage/migrations/versions/077_oauth_tokens.py
@@ -1,0 +1,45 @@
+"""Give the shared OAuth token store consumer-neutral names.
+
+Rename the table and its identity column without changing keys, ciphertext,
+or expiry metadata. Older processes cannot query this storage until upgraded.
+
+Revision ID: 077
+Revises: 076
+Create Date: 2026-09-11
+"""
+
+from alembic import op
+
+revision = "077"
+down_revision = "076"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.rename_table("mcp_user_tokens", "oauth_tokens")
+    op.execute("ALTER TABLE oauth_tokens RENAME COLUMN server_name TO token_key")
+    if op.get_bind().dialect.name == "postgresql":
+        # PostgreSQL renames the PK's backing index with the constraint.
+        op.execute(
+            "ALTER TABLE oauth_tokens RENAME CONSTRAINT mcp_user_tokens_pkey TO oauth_tokens_pkey"
+        )
+        op.execute("ALTER INDEX idx_mcp_user_tokens_server RENAME TO idx_oauth_tokens_key")
+    else:
+        # SQLite's unnamed PK autoindex follows the table rename; its named
+        # secondary index does not. SQLite has no ALTER INDEX RENAME syntax.
+        op.drop_index("idx_mcp_user_tokens_server", table_name="oauth_tokens")
+        op.create_index("idx_oauth_tokens_key", "oauth_tokens", ["token_key", "expires_at"])
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("ALTER INDEX idx_oauth_tokens_key RENAME TO idx_mcp_user_tokens_server")
+        op.execute(
+            "ALTER TABLE oauth_tokens RENAME CONSTRAINT oauth_tokens_pkey TO mcp_user_tokens_pkey"
+        )
+    else:
+        op.drop_index("idx_oauth_tokens_key", table_name="oauth_tokens")
+        op.create_index("idx_mcp_user_tokens_server", "oauth_tokens", ["token_key", "expires_at"])
+    op.execute("ALTER TABLE oauth_tokens RENAME COLUMN token_key TO server_name")
+    op.rename_table("oauth_tokens", "mcp_user_tokens")

--- a/turnstone/core/token_store/store.py
+++ b/turnstone/core/token_store/store.py
@@ -38,12 +38,12 @@ SYNTHETIC_TOKEN_PREFIXES = (MODEL_OBO_CACHE_PREFIX, MODEL_APP_CACHE_PREFIX)
 class UserTokenPlain(TypedDict):
     """Plaintext shape returned by ``TokenStore.get_user_token``.
 
-    Mirrors ``MCPUserToken`` (storage row shape) minus the ``_ct`` suffix
+    Mirrors ``OAuthToken`` (storage row shape) minus the ``_ct`` suffix
     on token columns and with plaintext bytes-decoded values.
     """
 
     user_id: str
-    server_name: str
+    token_key: str
     access_token: str
     refresh_token: str | None
     expires_at: str | None
@@ -78,7 +78,7 @@ class UserTokenMetadata(TypedDict):
     """
 
     user_id: str
-    server_name: str
+    token_key: str
     expires_at: str | None
     scopes: str | None
     as_issuer: str
@@ -91,7 +91,7 @@ class TokenStore:
     """Encrypt and decrypt token rows and captured OIDC credentials.
 
     Consumer-specific audit presentation is supplied through ``on_decrypt_failure``.
-    SQL row and column names retain their existing storage contract.
+    Token keys are opaque identities shared by custodial grants and mint caches.
     """
 
     def __init__(
@@ -119,7 +119,7 @@ class TokenStore:
     def create_user_token(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token: str,
         refresh_token: str | None,
@@ -131,9 +131,9 @@ class TokenStore:
         """Encrypt the access (and optional refresh) token and persist."""
         access_ct = self._cipher.encrypt(access_token.encode("utf-8"))
         refresh_ct = self._cipher.encrypt(refresh_token.encode("utf-8")) if refresh_token else None
-        self._storage.create_mcp_user_token(
+        self._storage.create_oauth_token(
             user_id,
-            server_name,
+            token_key,
             access_token_ct=access_ct,
             refresh_token_ct=refresh_ct,
             expires_at=expires_at,
@@ -142,14 +142,14 @@ class TokenStore:
             audience=audience,
         )
 
-    def get_user_token(self, user_id: str, server_name: str) -> UserTokenPlain | None:
+    def get_user_token(self, user_id: str, token_key: str) -> UserTokenPlain | None:
         """Returns plaintext dict or None.
 
         Raises ``TokenDecryptError`` on key mismatch — caller MUST NOT
         auto-delete the row. The configured decrypt-failure hook receives the
         token identity and attempted key fingerprints.
         """
-        row = self._storage.get_mcp_user_token(user_id, server_name)
+        row = self._storage.get_oauth_token(user_id, token_key)
         if row is None:
             return None
         try:
@@ -160,11 +160,11 @@ class TokenStore:
             else:
                 refresh_pt = None
         except token_store_crypto.TokenDecryptError as exc:
-            self._decrypt_failure(server_name, exc.key_fingerprints_attempted)
+            self._decrypt_failure(token_key, exc.key_fingerprints_attempted)
             raise
         return UserTokenPlain(
             user_id=row["user_id"],
-            server_name=row["server_name"],
+            token_key=row["token_key"],
             access_token=access_pt,
             refresh_token=refresh_pt,
             expires_at=row["expires_at"],
@@ -178,7 +178,7 @@ class TokenStore:
     def update_user_token_after_refresh(
         self,
         user_id: str,
-        server_name: str,
+        token_key: str,
         *,
         access_token: str,
         refresh_token: str | None,
@@ -197,17 +197,17 @@ class TokenStore:
         """
         access_ct = self._cipher.encrypt(access_token.encode("utf-8"))
         refresh_ct = self._cipher.encrypt(refresh_token.encode("utf-8")) if refresh_token else None
-        return self._storage.update_mcp_user_token_after_refresh(
+        return self._storage.update_oauth_token_after_refresh(
             user_id,
-            server_name,
+            token_key,
             access_token_ct=access_ct,
             refresh_token_ct=refresh_ct,
             expires_at=expires_at,
         )
 
-    def delete_user_token(self, user_id: str, server_name: str) -> bool:
+    def delete_user_token(self, user_id: str, token_key: str) -> bool:
         """Delete the user-token row. Returns True if existed."""
-        return self._storage.delete_mcp_user_token(user_id, server_name)
+        return self._storage.delete_oauth_token(user_id, token_key)
 
     def upsert_oidc_credential(self, user_id: str, issuer: str, *, refresh_token: str) -> None:
         """Encrypt and create-or-replace the user's captured IdP refresh token."""
@@ -272,16 +272,16 @@ class TokenStore:
         """Return non-secret metadata for every token row owned by ``user_id``.
 
         Storage layer projects the metadata columns at the SQL boundary
-        (``list_mcp_user_token_metadata_by_user``) so ciphertext blobs
+        (``list_oauth_token_metadata_by_user``) so ciphertext blobs
         never cross the wire on this list-view path. Rows arrive in
         ``created`` ASC order. Decrypt is intentionally skipped — the
         list view has no need for the secret material.
         """
-        rows = self._storage.list_mcp_user_token_metadata_by_user(user_id)
+        rows = self._storage.list_oauth_token_metadata_by_user(user_id)
         return [
             UserTokenMetadata(
                 user_id=row["user_id"],
-                server_name=row["server_name"],
+                token_key=row["token_key"],
                 expires_at=row["expires_at"],
                 scopes=row["scopes"],
                 as_issuer=row["as_issuer"],


### PR DESCRIPTION
MCP grants and model mint caches already share one token store, but its SQL table, identity column, and storage API still describe everything as an MCP server token. This step renames them to `oauth_tokens`, opaque `token_key`, and neutral OAuth row/CRUD names. Existing identity values, ciphertext, expiry, and reserved model prefixes are preserved.

Existing cleanup when a model is renamed, its authentication configuration changes, or it is deleted now uses a dedicated helper that deletes only that alias's cached tokens. MCP purges keep their transaction across tokens and pending browser authorization state; pending consent and captured credentials are untouched by either purge. MCP connections retain their public `server_name` field through an explicit metadata projection. Identity unlink and all storage callers consume the renamed internal field.

Migration 077 supports SQLite and PostgreSQL upgrades and downgrades, including PK and secondary-index names, without deleting data rows. Older processes cannot query this storage between migration and code upgrade; the changelog records that window. The shared operator guide covers keyring configuration, rotation, and credential lifecycle, with updated architecture diagrams.

Internal API changes: `MCPUserToken` / `MCPUserTokenMetadataRow` become `OAuthToken` / `OAuthTokenMetadataRow`; generic storage methods use OAuth names; `TokenStore` keeps its method names but changes the identity parameter and returned token/metadata field from `server_name` to `token_key`.

Validation:

- Full offline SQLite: 13,935 passed; PostgreSQL: 13,958 passed. Both completed with no failures.
- Populated migration round-trips preserve every field and ciphertext byte. Both backends pin fresh/migrated column, PK, and index parity, model purge isolation, MCP purge rollback, user deletion, counts/sweep targets, and the public connections response.
- Live Keycloak before and after: 12 OBO and 17 per-user checks passed in each run, including refresh, uncached discovery, and separate client owner loops.
- Ruff lint/format and mypy passed. Generated diagrams were visually checked. Entra passed before extraction and was not rerun for this change.

Step 2 of #963. Runtime ownership is the remaining step; the expiry sweep in #962 remains separate.
