### PR TITLE
fix: handle MCP shutdown races and malformed consent return URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ frozen.
 
 ### Fixed
 
+- **MCP OAuth consent return URLs.** Malformed URLs no longer abort consent; the callback
+  falls back to the home page when the return URL contains invalid ports or brackets.
 - **MCP submissions during shutdown.** Pool priming, catalog eviction and static server
   reconnection tolerate the loop closing between admission and scheduling. Rejected coroutines
   are closed, and reconnection reports its normal failure instead of an internal attribute error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ frozen.
 
 ### Fixed
 
+- **MCP submissions during shutdown.** Pool priming, catalog eviction and static server
+  reconnection tolerate the loop closing between admission and scheduling. Rejected coroutines
+  are closed, and reconnection reports its normal failure instead of an internal attribute error.
 - **Per-user MCP OAuth refresh.** Discovery and refresh requests now use their owner's HTTP
   client, preventing cross-loop failures after browser sign-in.
 - **OAuth cancellation and shutdown.** Cancelled requests settle started token writes before

--- a/tests/test_mcp_background_submission.py
+++ b/tests/test_mcp_background_submission.py
@@ -1,0 +1,215 @@
+"""MCP submissions must tolerate shutdown before scheduling."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import inspect
+import threading
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from turnstone.core import mcp_client
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine, Iterator
+
+_BODIES = {
+    "prime_user_pools": "_prime_user_pools",
+    "schedule_prime_user_server": "_prime_user_server_logged",
+    "evict_user_session": "_drop_catalog_locked",
+}
+
+
+class _SubmissionProbe:
+    """Observe real submissions, optionally pausing before argument evaluation.
+
+    Pausing attribute lookup allows shutdown to clear the manager's loop between
+    the admission guard and submission. The scheduler itself is never stubbed.
+    Other threads, including the one running shutdown, use asyncio unchanged.
+    """
+
+    def __init__(self) -> None:
+        self.caller = threading.current_thread()
+        self.before_submit: Callable[[], None] | None = None
+        self.coroutines: list[Coroutine[Any, Any, Any]] = []
+        self.futures: list[concurrent.futures.Future[Any]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "run_coroutine_threadsafe" and threading.current_thread() is self.caller:
+            if self.before_submit is not None:
+                self.before_submit()
+            return self.submit
+        return getattr(asyncio, name)
+
+    def submit(
+        self, coro: Coroutine[Any, Any, Any], loop: asyncio.AbstractEventLoop
+    ) -> concurrent.futures.Future[Any]:
+        self.coroutines.append(coro)
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        self.futures.append(future)
+        return future
+
+
+@pytest.fixture
+def manager(monkeypatch: pytest.MonkeyPatch) -> Iterator[mcp_client.MCPClientManager]:
+    monkeypatch.setattr(mcp_client, "load_config", lambda *_: {})
+    manager = mcp_client.MCPClientManager({})
+    manager._user_token_sweep_s = 0
+    manager._static_health_check_s = 0
+    manager._oauth_user_server_names = {"sample"}
+    manager._app_state = SimpleNamespace()
+    manager._storage = MagicMock()
+    for name in (*_BODIES.values(), "_ensure_static_connected"):
+        monkeypatch.setattr(manager, name, AsyncMock())
+    monkeypatch.setattr(manager, "_cb_record_failure", MagicMock())
+    try:
+        yield manager
+    finally:
+        manager.shutdown()
+
+
+@pytest.fixture
+def probe(monkeypatch: pytest.MonkeyPatch) -> Iterator[_SubmissionProbe]:
+    probe = _SubmissionProbe()
+    monkeypatch.setattr(mcp_client, "asyncio", probe)
+    try:
+        yield probe
+    finally:
+        # Clean rejected allocations even when a negative control fails an
+        # assertion, so its warning cannot bleed into another test.
+        for coro in probe.coroutines:
+            if inspect.getcoroutinestate(coro) == inspect.CORO_CREATED:
+                coro.close()
+
+
+def _invoke(manager: mcp_client.MCPClientManager, bridge: str) -> object:
+    # Observe the runtime return even though these APIs are annotated as void.
+    method: Callable[..., object] = getattr(manager, bridge)
+    if bridge == "_cb_auto_reconnect":
+        return method("sample")
+    if bridge == "prime_user_pools":
+        return method("user-1")
+    if bridge == "schedule_prime_user_server":
+        return method(
+            user_id="user-1",
+            server_name="sample",
+            access_token="synthetic-token",
+            server_row={"transport": "streamable-http", "url": "https://mcp.example.com"},
+        )
+    return method("user-1", "sample")
+
+
+def _assert_no_body_ran(manager: mcp_client.MCPClientManager) -> None:
+    for name in (*_BODIES.values(), "_ensure_static_connected"):
+        getattr(manager, name).assert_not_awaited()
+    cast("MagicMock", manager._cb_record_failure).assert_not_called()
+    assert manager._storage.mock_calls == []
+
+
+@pytest.mark.parametrize("bridge", _BODIES)
+def test_no_loop_does_not_allocate_or_run(
+    manager: mcp_client.MCPClientManager, probe: _SubmissionProbe, bridge: str
+) -> None:
+    assert _invoke(manager, bridge) is None
+    assert probe.coroutines == []
+    for name in _BODIES.values():
+        getattr(manager, name).assert_not_called()
+    _assert_no_body_ran(manager)
+
+
+@pytest.mark.parametrize("bridge", [*_BODIES, "_cb_auto_reconnect"])
+def test_closed_loop_closes_rejected_coroutine(
+    manager: mcp_client.MCPClientManager, probe: _SubmissionProbe, bridge: str
+) -> None:
+    loop = asyncio.new_event_loop()
+    loop.close()
+    manager._loop = loop
+    manager._server_configs["sample"] = {"url": "https://mcp.example.com"}
+    try:
+        if bridge == "_cb_auto_reconnect":
+            with pytest.raises(RuntimeError, match="MCP server 'sample' reconnect failed:"):
+                _invoke(manager, bridge)
+        else:
+            assert _invoke(manager, bridge) is None
+        assert len(probe.coroutines) == 1
+        assert inspect.getcoroutinestate(probe.coroutines[0]) == inspect.CORO_CLOSED
+        assert probe.futures == []
+        _assert_no_body_ran(manager)
+    finally:
+        manager._loop = None
+
+
+@pytest.mark.parametrize("bridge", _BODIES)
+def test_successful_submission_runs_on_manager_loop(
+    manager: mcp_client.MCPClientManager, probe: _SubmissionProbe, bridge: str
+) -> None:
+    manager.start()
+    probe.coroutines.clear()
+    probe.futures.clear()
+    ran = threading.Event()
+    loops = []
+
+    async def body(*args: Any) -> None:
+        loops.append(asyncio.get_running_loop())
+        ran.set()
+
+    getattr(manager, _BODIES[bridge]).side_effect = body
+    assert _invoke(manager, bridge) is None
+    assert ran.wait(5)
+    assert len(probe.futures) == 1
+    probe.futures[0].result(timeout=5)
+    getattr(manager, _BODIES[bridge]).assert_awaited_once()
+    assert loops == [manager._loop]
+
+
+@pytest.mark.parametrize("bridge", [*_BODIES, "_cb_auto_reconnect"])
+def test_shutdown_between_admission_and_submission(
+    manager: mcp_client.MCPClientManager, probe: _SubmissionProbe, bridge: str
+) -> None:
+    manager.start()
+    manager._server_configs["sample"] = {"url": "https://mcp.example.com"}
+    loop, loop_thread = manager._loop, manager._thread
+    assert loop is not None and loop_thread is not None
+    probe.coroutines.clear()
+    probe.futures.clear()
+    entered, release = threading.Event(), threading.Event()
+    result: concurrent.futures.Future[object] = concurrent.futures.Future()
+
+    def pause() -> None:
+        entered.set()
+        assert release.wait(5), "shutdown did not release the submitting thread"
+
+    def invoke() -> None:
+        try:
+            result.set_result(_invoke(manager, bridge))
+        except BaseException as exc:
+            result.set_exception(exc)
+
+    caller = threading.Thread(target=invoke, name="mcp-submission-test")
+    probe.caller = caller
+    probe.before_submit = pause
+    caller.start()
+    try:
+        assert entered.wait(5), "caller did not reach submission"
+        manager.shutdown()
+        assert manager._loop is None
+        assert loop.is_closed()
+        assert not loop_thread.is_alive()
+    finally:
+        release.set()
+        caller.join(timeout=5)
+        assert not caller.is_alive()
+
+    if bridge == "_cb_auto_reconnect":
+        with pytest.raises(RuntimeError, match="MCP server 'sample' reconnect failed:"):
+            result.result(timeout=5)
+    else:
+        assert result.result(timeout=5) is None
+    assert len(probe.coroutines) == 1
+    assert inspect.getcoroutinestate(probe.coroutines[0]) == inspect.CORO_CLOSED
+    assert probe.futures == []
+    _assert_no_body_ran(manager)

--- a/tests/test_mcp_oauth_handlers.py
+++ b/tests/test_mcp_oauth_handlers.py
@@ -288,8 +288,18 @@ class TestAuthorize:
         assert pending["user_id"] == "user-1"
         assert pending["server_name"] == "srv-oauth"
 
-    def test_return_url_cross_origin_falls_back(
-        self, storage: SQLiteBackend, http_client_mock: MagicMock
+    @pytest.mark.parametrize(
+        "return_url",
+        [
+            "https://attacker.example.com/x",
+            "https://testserver:bad/x",
+            "https://testserver:65536/x",
+            "https://[broken/x",
+        ],
+        ids=["cross-origin", "non-numeric-port", "out-of-range-port", "malformed-bracket"],
+    )
+    def test_return_url_invalid_falls_back(
+        self, storage: SQLiteBackend, http_client_mock: MagicMock, return_url: str
     ) -> None:
         _seed_oauth_user_server(storage)
         token_store = _make_token_store(storage)
@@ -300,13 +310,14 @@ class TestAuthorize:
 
         with _public_addr_patch():
             resp = client.get(
-                "/v1/api/mcp/oauth/start"
-                "?server=srv-oauth&return_url=https://attacker.example.com/x",
+                "/v1/api/mcp/oauth/start",
+                params={"server": "srv-oauth", "return_url": return_url},
                 follow_redirects=False,
             )
 
         assert resp.status_code == 302
         location = resp.headers["location"]
+        assert location.startswith("https://as.example.com/authorize?")
         params = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
         # Pull pending and verify the return_url was sanitised to "/".
         pending = storage.pop_mcp_oauth_pending_state(params["state"][0])

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -3083,12 +3083,11 @@ class MCPClientManager:
             return
         cfg = _pool_cfg_from_row(server_row)
         key = (user_id, server_name)
+        coro = self._prime_user_server_logged(key, cfg, access_token, user_id, server_name)
         try:
-            asyncio.run_coroutine_threadsafe(
-                self._prime_user_server_logged(key, cfg, access_token, user_id, server_name),
-                loop,
-            )
+            asyncio.run_coroutine_threadsafe(coro, loop)
         except RuntimeError:
+            coro.close()
             # mcp-loop is shutting down — skip; lazy dispatch is the backstop.
             log.debug("mcp pool prime skipped: loop closed user=%s server=%s", user_id, server_name)
 
@@ -3129,7 +3128,8 @@ class MCPClientManager:
         token / captured credential for; skips servers already connected.
         Non-blocking: schedules onto the mcp-loop and returns immediately.
         """
-        if not user_id or self._loop is None:
+        loop = self._loop
+        if not user_id or loop is None:
             return
         if not self._oauth_user_server_names and not self._obo_server_names:
             return  # no pool-backed servers — nothing to prime (no set allocation)
@@ -3137,9 +3137,11 @@ class MCPClientManager:
             return
         # run_coroutine_threadsafe keeps the task referenced by the loop while
         # it runs, so no strong-ref bookkeeping is needed here.
+        coro = self._prime_user_pools(user_id)
         try:
-            asyncio.run_coroutine_threadsafe(self._prime_user_pools(user_id), self._loop)
+            asyncio.run_coroutine_threadsafe(coro, loop)
         except RuntimeError:
+            coro.close()
             # mcp-loop is shutting down — skip; lazy dispatch is the backstop.
             log.debug("mcp pool prime skipped: loop closed user=%s", user_id)
 
@@ -6866,7 +6868,8 @@ class MCPClientManager:
         recorded where it is observed.
         """
         cfg = self._server_configs.get(server_name)
-        if not cfg or self._loop is None:
+        loop = self._loop
+        if not cfg or loop is None:
             raise RuntimeError(f"MCP server '{server_name}' is not connected")
 
         async def _reconnect_for_dispatch() -> Any:
@@ -6878,7 +6881,12 @@ class MCPClientManager:
         # A fresh coroutine/task per attempt: a timed-out attempt is cancelled
         # below, and the next dispatch starts clean instead of re-entering a
         # half-cancelled anyio scope.
-        reconnect_future = asyncio.run_coroutine_threadsafe(_reconnect_for_dispatch(), self._loop)
+        coro = _reconnect_for_dispatch()
+        try:
+            reconnect_future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except RuntimeError as exc:
+            coro.close()
+            raise RuntimeError(f"MCP server '{server_name}' reconnect failed: {exc}") from None
         try:
             session = reconnect_future.result(timeout=self._STATIC_RECONNECT_CALLER_TIMEOUT_S)
         except concurrent.futures.TimeoutError:
@@ -6917,7 +6925,7 @@ class MCPClientManager:
                     exc_info=True,
                 )
 
-        self._loop.call_soon_threadsafe(_schedule_refresh)
+        loop.call_soon_threadsafe(_schedule_refresh)
         return session
 
     def _record_and_evict_on_dead_transport(self, server_name: str, exc: BaseException) -> None:
@@ -8839,7 +8847,8 @@ class MCPClientManager:
         the future. Best-effort: a closed loop or scheduling failure
         logs at info level; never raises.
         """
-        if self._loop is None:
+        loop = self._loop
+        if loop is None:
             return
         key = (user_id, server_name)
 
@@ -8855,12 +8864,14 @@ class MCPClientManager:
                 f"revocation catalog drop for '{server_name}'",
             )
 
+        coro = _spawn_tracked()
         try:
             # Locked: an in-flight connect completing its discovery
             # after an unserialized drop would republish (resurrect)
             # the revoked catalog with nothing left to clear it.
-            asyncio.run_coroutine_threadsafe(_spawn_tracked(), self._loop)
+            asyncio.run_coroutine_threadsafe(coro, loop)
         except RuntimeError as exc:
+            coro.close()
             log.info(
                 "mcp_pool.evict_user_session_failed server=%s user=%s error=%s",
                 server_name,

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -2723,14 +2723,20 @@ def _validate_return_url(return_url: str, redirect_base: str) -> str | None:
         return None
     if "\\" in return_url or return_url.startswith("//"):
         return None
-    parsed = urllib.parse.urlparse(return_url)
-    # Allow path-only return URLs.
-    if not parsed.scheme and not parsed.netloc:
-        if parsed.path.startswith("/"):
-            return return_url
-        return None
-    base = urllib.parse.urlparse(redirect_base)
-    if _origin_tuple(parsed) != _origin_tuple(base):
+    try:
+        parsed = urllib.parse.urlparse(return_url)
+        # Like OIDC redirect-base validation, force the port check: urlparse
+        # accepts "host:abc" silently. Parsing itself rejects malformed brackets.
+        parsed.port  # noqa: B018 — triggers ValueError on an invalid port
+        # Allow path-only return URLs.
+        if not parsed.scheme and not parsed.netloc:
+            if parsed.path.startswith("/"):
+                return return_url
+            return None
+        base = urllib.parse.urlparse(redirect_base)
+        if _origin_tuple(parsed) != _origin_tuple(base):
+            return None
+    except ValueError:
         return None
     return return_url
 


### PR DESCRIPTION
Pool priming, catalog eviction and static server reconnection can race manager shutdown between their loop guard and submission, raising `AttributeError` or leaking an unawaited coroutine. Capture the loop once and close the coroutine when scheduling rejects it. Priming and eviction retain their best-effort return; reconnect reports its normal failure without advancing the circuit breaker. The first commit covers these paths with real shutdown races and the existing successful-reconnection controls.

MCP consent also returned HTTP 500 when a return URL contained an invalid port or malformed brackets. The second commit mirrors OIDC's explicit port check, contains parsing errors in the validator and preserves the existing `/` fallback. Handler tests verify the authorization redirect and saved pending state.

Validation: 494 focused tests passed after the reconnect fix, including 14 submission tests and the existing reconnect, contention, breaker and deadline cases. Package plus test-file mypy, Ruff and formatting pass. The new reconnect cases fail on the prior implementation. The earlier full offline SQLite run passed 14,005 tests before this follow-up; the full suite, PostgreSQL and live IdP harnesses were not rerun for the narrow reconnect guard.

Follow-up from #963. Accepted priming and upstream-revoke shutdown ownership are tracked separately in #1147.
