### PR TITLE
refactor: remove unused MCP ownership residue

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -9,7 +9,7 @@ import inspect
 import json
 import threading
 import time
-from contextlib import AsyncExitStack, suppress
+from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -944,9 +944,7 @@ class TestServerNameValidation:
 
         async def _run() -> None:
             mgr = MCPClientManager({"my__bad": {"command": "echo"}})
-            async with AsyncExitStack() as stack:
-                mgr._exit_stack = stack
-                await mgr._connect_one("my__bad", {"command": "echo"})
+            await mgr._connect_one("my__bad", {"command": "echo"})
             # Should not have connected
             assert "my__bad" not in mgr._static_servers
             assert mgr.get_tools() == []

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -6625,7 +6625,7 @@ async def admin_delete_oidc_identity(request: Request) -> JSONResponse:
     user_id = identity["user_id"]
     credential_revoked = False
     obo_cache_purged = 0
-    token_store = cast("MCPTokenStore | None", oauth_context(request.app.state).token_store)
+    token_store = oauth_context(request.app.state).token_store
     if token_store is not None:
         try:
             credential_revoked = bool(token_store.delete_oidc_credential(user_id, issuer))

--- a/turnstone/core/mcp_client.py
+++ b/turnstone/core/mcp_client.py
@@ -693,7 +693,6 @@ class MCPClientManager:
         self._server_configs = server_configs
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
-        self._exit_stack: AsyncExitStack | None = None
 
         # Per-server state for auth_type ∈ {none, static}.  Each entry holds
         # session/owner-task/streams/catalog/capability flags for one
@@ -1065,9 +1064,6 @@ class MCPClientManager:
 
     async def _connect_all(self) -> None:
         """Connect to every configured server (runs on the background loop)."""
-        self._exit_stack = AsyncExitStack()
-        await self._exit_stack.__aenter__()
-
         for name, cfg in self._server_configs.items():
             try:
                 await self._connect_one(name, cfg)
@@ -5496,14 +5492,6 @@ class MCPClientManager:
                 future.result(timeout=12)
             except Exception:
                 log.debug("Error closing MCP sessions", exc_info=True)
-
-        # Close legacy shared stack (if any resources were registered on it)
-        if self._loop and self._exit_stack:
-            future = asyncio.run_coroutine_threadsafe(self._exit_stack.aclose(), self._loop)
-            try:
-                future.result(timeout=10)
-            except Exception:
-                log.debug("Error closing MCP exit stack", exc_info=True)
 
         if self._loop:
             self._loop.call_soon_threadsafe(self._loop.stop)

--- a/turnstone/core/mcp_oauth.py
+++ b/turnstone/core/mcp_oauth.py
@@ -721,7 +721,6 @@ def _as_metadata_from_document(
     *,
     profile: str,
     issuer: str,
-    normalized_issuer: str,
 ) -> oauth_http.ASMetadata:
     """Validate one AS metadata document completely and build :class:`oauth_http.ASMetadata`.
 
@@ -939,7 +938,6 @@ async def _fetch_as_metadata(
                 doc,
                 profile=profile,
                 issuer=issuer,
-                normalized_issuer=normalized_issuer,
             )
         except _DiscoveryDocumentRejectedError as exc:
             document_error = document_error or exc


### PR DESCRIPTION
Remove three unused pieces identified after #963: the manager's empty exit stack and obsolete test setup, the concrete MCP-store cast in identity unlink, and the metadata converter's unread `normalized_issuer` parameter.

Validation: 533 client, transport-owner, pool-owner, identity-handler, discovery and submission-race tests passed. Package mypy, Ruff and formatting passed. Both live Keycloak harnesses passed: 12 OBO checks and 17 per-user checks, including refresh and discovery across separate client loops.
