### PR TITLE
fix: serialize node MCP reloads

### DIFF
--- a/tests/test_mcp_admin_api.py
+++ b/tests/test_mcp_admin_api.py
@@ -3603,11 +3603,11 @@ class TestEnsureConsoleMcpClient:
         assert getattr(app.state, "mcp_client", None) is None
 
     def test_concurrent_triggers_construct_exactly_once(self):
-        """Two rapid triggers with no manager built must construct exactly
-        ONE manager — the module lock serializes them; the loser of an
-        unserialized race would leak its mcp-loop thread and connections
-        (the node's internal_mcp_reload has this latent race, #873; the
-        console must not)."""
+        """Two rapid triggers with no manager built must construct exactly one manager.
+
+        The module lock prevents an orphaned manager from leaking its event-loop thread and
+        connections.
+        """
         import time
         from concurrent.futures import ThreadPoolExecutor
         from unittest.mock import patch

--- a/tests/test_mcp_reload_concurrency.py
+++ b/tests/test_mcp_reload_concurrency.py
@@ -1,0 +1,202 @@
+"""Concurrent node MCP reloads must share one manager and serialize reconciliation."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from turnstone import server
+from turnstone.core import mcp_client
+from turnstone.core.mcp_client import MCPClientManager
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+    from turnstone.core.storage._sqlite import SQLiteBackend
+
+
+class _ObservedReloadLock:
+    """Expose contention while retaining real thread-lock acquisition and release."""
+
+    def __init__(self, lock: threading.Lock) -> None:
+        self.contended = threading.Event()
+        self._lock = lock
+
+    def __enter__(self) -> None:
+        if not self._lock.acquire(blocking=False):
+            self.contended.set()
+            assert self._lock.acquire(timeout=5), "MCP reload lock was not released"
+
+    def __exit__(self, *exc: Any) -> None:
+        self._lock.release()
+
+
+_Node = tuple[Starlette, _ObservedReloadLock, list[MCPClientManager]]
+
+
+@pytest.fixture
+def node(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sqlite_backend_factory: Callable[[str], SQLiteBackend],
+) -> Iterator[_Node]:
+    storage = sqlite_backend_factory(str(tmp_path / "reload.db"))
+    app = Starlette(
+        routes=[Route("/v1/api/_internal/mcp-reload", server.internal_mcp_reload, methods=["POST"])]
+    )
+    app.state.auth_storage = storage
+    app.state.mcp_client = None
+    app.state.mcp_ref = [None]
+    lock = _ObservedReloadLock(getattr(server, "_MCP_RELOAD_LOCK", threading.Lock()))
+    # The absent-lock baseline can still reach the competing startup/reconcile,
+    # letting the tests fail on duplicate managers or overlapping reconciliation.
+    monkeypatch.setattr(server, "_MCP_RELOAD_LOCK", lock, raising=False)
+    monkeypatch.setattr("turnstone.core.storage._registry.get_storage", lambda: storage)
+    monkeypatch.setattr(mcp_client, "load_config", lambda _section: {"user_token_sweep_seconds": 0})
+
+    managers: list[MCPClientManager] = []
+    threads: list[threading.Thread] = []
+    real_start = MCPClientManager.start
+
+    def track_start(manager: MCPClientManager) -> None:
+        managers.append(manager)
+        real_start(manager)
+        assert manager._thread is not None
+        threads.append(manager._thread)
+
+    monkeypatch.setattr(MCPClientManager, "start", track_start)
+    try:
+        yield app, lock, managers
+    finally:
+        for manager in managers:
+            if manager._thread is not None:
+                manager.shutdown()
+        assert all(not thread.is_alive() for thread in threads)
+
+
+def _reload_pair(app: Starlette, *, concurrent: bool = True) -> list[httpx.Response]:
+    async def run() -> list[httpx.Response]:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://node.example.com",
+        ) as client:
+            if concurrent:
+                return list(
+                    await asyncio.gather(
+                        client.post("/v1/api/_internal/mcp-reload"),
+                        client.post("/v1/api/_internal/mcp-reload"),
+                    )
+                )
+            return [await client.post("/v1/api/_internal/mcp-reload") for _ in range(2)]
+
+    return asyncio.run(run())
+
+
+def test_concurrent_reload_constructs_one_manager(
+    node: _Node, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, lock, managers = node
+    tracked_start = MCPClientManager.start
+    count_lock = threading.Lock()
+    starts = 0
+
+    def pause_start(manager: MCPClientManager) -> None:
+        nonlocal starts
+        tracked_start(manager)
+        with count_lock:
+            starts += 1
+            first = starts == 1
+        if first:
+            assert lock.contended.wait(timeout=5), "second reload never reached startup"
+        else:
+            # Without serialization the second request starts another manager.
+            lock.contended.set()
+
+    monkeypatch.setattr(MCPClientManager, "start", pause_start)
+    responses = _reload_pair(app)
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert len(managers) == 1
+    manager = managers[0]
+    assert app.state.mcp_client is manager
+    assert app.state.mcp_ref[0] is manager
+    assert manager._storage is app.state.auth_storage
+    assert manager._app_state is app.state
+    thread = manager._thread
+    assert thread is not None and thread.is_alive()
+    app.state.mcp_client.shutdown()
+    assert not thread.is_alive()
+
+
+def test_concurrent_reload_serializes_existing_manager_reconciliation(
+    node: _Node, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, lock, managers = node
+    manager = MCPClientManager({})
+    manager.start()
+    manager.set_storage(app.state.auth_storage)
+    manager.set_app_state(app.state)
+    app.state.mcp_client = manager
+    app.state.mcp_ref[0] = manager
+    real_reconcile = MCPClientManager.reconcile_sync
+    count_lock = threading.Lock()
+    calls = active = peak = 0
+
+    def pause_reconcile(manager: MCPClientManager, storage: Any) -> dict[str, Any]:
+        nonlocal calls, active, peak
+        with count_lock:
+            calls += 1
+            active += 1
+            peak = max(peak, active)
+            first = calls == 1
+        try:
+            if first:
+                assert lock.contended.wait(timeout=5), "second reload never reached reconciliation"
+            else:
+                lock.contended.set()
+            return real_reconcile(manager, storage)
+        finally:
+            with count_lock:
+                active -= 1
+
+    monkeypatch.setattr(MCPClientManager, "reconcile_sync", pause_reconcile)
+    responses = _reload_pair(app)
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert calls == 2
+    assert peak == 1
+    assert managers == [manager]
+    assert app.state.mcp_client is manager
+    assert app.state.mcp_ref[0] is manager
+
+
+def test_reconcile_exception_releases_reload_lock(
+    node: _Node, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, _lock, managers = node
+    real_reconcile = MCPClientManager.reconcile_sync
+    calls = 0
+
+    def fail_once(manager: MCPClientManager, storage: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("reconciliation failed")
+        return real_reconcile(manager, storage)
+
+    monkeypatch.setattr(MCPClientManager, "reconcile_sync", fail_once)
+    responses = _reload_pair(app, concurrent=False)
+
+    assert [response.status_code for response in responses] == [500, 200]
+    assert responses[1].json() == {"status": "ok", "added": [], "removed": [], "updated": []}
+    assert calls == 2
+    assert len(managers) == 1
+    assert app.state.mcp_client is managers[0]
+    assert app.state.mcp_ref[0] is managers[0]

--- a/turnstone/console/server.py
+++ b/turnstone/console/server.py
@@ -11888,14 +11888,9 @@ async def admin_delete_mcp_server(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"}, background=_schedule_mcp_reload(request))
 
 
-# Guards concurrent construction of the console's own MCP client manager
-# (lifespan boot racing an admin-write fan-out, or two rapid fan-outs
-# while ``app.state.mcp_client`` is still None).  Two winners would each
-# start an mcp-loop daemon thread and a static connection set; the second
-# assignment clobbers the first ref and the loser leaks both forever.
-# The node's ``internal_mcp_reload`` lazy-construct carries exactly this
-# latent race (turnstone/server.py internal_mcp_reload) — the console
-# does not replicate it.  Same shape as ``_COORD_BOOTSTRAP_LOCK``.
+# Guards construction and reconciliation of the console's MCP client manager. Overlapping
+# admin-write fan-outs must share one manager; creating two would leave an unreferenced
+# manager's event-loop thread and connections running.
 _CONSOLE_MCP_ENSURE_LOCK = threading.Lock()
 
 
@@ -11910,12 +11905,9 @@ def _ensure_console_mcp_client(app: Any) -> dict[str, Any]:
     the reconcile arm runs whenever a manager exists, so running
     coordinators track admin edits exactly like node sessions do.
 
-    This is the ONE lazy-construct/reconcile path for every post-boot
-    trigger — the admin-write reload fan-out and the operator
-    ``POST /reload`` — mirroring the node's ``internal_mcp_reload``.
-    Unlike the node's arm, the body holds a lock: two concurrent
-    triggers on a managerless console must not double-construct (the
-    node's unlocked equivalent is issue #873).
+    This is the ONE lazy-construct/reconcile path for every post-boot trigger — the admin-write
+    reload fan-out and the operator ``POST /reload`` — mirroring the node's ``internal_mcp_reload``.
+    Both hosts serialize construction and reconciliation so concurrent triggers share one manager.
 
     Plain SYNC function: construction connects to static servers and
     ``reconcile_sync`` performs bounded sync waits, so every caller

--- a/turnstone/server.py
+++ b/turnstone/server.py
@@ -4486,8 +4486,18 @@ def config_reload(request: Request) -> JSONResponse:
 # -- internal MCP management -----------------------------------------------
 
 
+# Serialize manager construction and reconciliation on this node. Concurrent
+# reloads must share one manager and apply database snapshots in sequence.
+_MCP_RELOAD_LOCK = threading.Lock()
+
+
 def internal_mcp_reload(request: Request) -> JSONResponse:
     """POST /v1/api/_internal/mcp-reload — re-read mcp_servers table and reconcile."""
+    with _MCP_RELOAD_LOCK:
+        return _internal_mcp_reload_locked(request)
+
+
+def _internal_mcp_reload_locked(request: Request) -> JSONResponse:
     from turnstone.core.storage._registry import get_storage
 
     storage = get_storage()


### PR DESCRIPTION
Concurrent MCP reload requests on a node without a manager could each start one, leaving an
orphaned event-loop thread after the last assignment won. Reloads of an existing manager could
also overlap their reconciliations.

Hold one thread lock across manager lookup, construction, publication, and reconciliation.
Each waiting request then reconciles in sequence, matching the console's existing discipline.
Update the stale comments that described the node path as unlocked.

Add three regressions using the real HTTP handler, manager threads, and SQLite storage to check
single construction and clean shutdown, serialized reconciliation, and lock release after an
exception. Both concurrency tests detect the original races.

Validation: 208 focused MCP tests passed; Ruff and mypy passed. Review found no actionable
regressions and independently confirmed both concurrency tests with an in-memory negative control.

Closes #873
